### PR TITLE
refactor: store download status in SwiftData and use @Query in detail views

### DIFF
--- a/KMReader/Models/Book/DownloadStatus.swift
+++ b/KMReader/Models/Book/DownloadStatus.swift
@@ -1,0 +1,16 @@
+//
+//  DownloadStatus.swift
+//  KMReader
+//
+//  Created by Komga iOS Client
+//
+
+import Foundation
+
+/// Status of an offline book download.
+enum DownloadStatus: Equatable, Sendable {
+  case notDownloaded
+  case downloading(progress: Double)
+  case downloaded
+  case failed(error: String)
+}

--- a/KMReader/Services/Cache/CacheManager.swift
+++ b/KMReader/Services/Cache/CacheManager.swift
@@ -36,11 +36,9 @@ enum CacheManager {
   }
 
   /// Remove all cached data for a specific Komga instance.
-  static func clearCaches(instanceId: String) async {
-    await Task.detached(priority: .utility) {
-      CacheNamespace.removeNamespace(for: "KomgaImageCache", instanceId: instanceId)
-      CacheNamespace.removeNamespace(for: "KomgaBookFileCache", instanceId: instanceId)
-      CacheNamespace.removeNamespace(for: "KomgaThumbnailCache", instanceId: instanceId)
-    }.value
+  static func clearCaches(instanceId: String) {
+    CacheNamespace.removeNamespace(for: "KomgaImageCache", instanceId: instanceId)
+    CacheNamespace.removeNamespace(for: "KomgaBookFileCache", instanceId: instanceId)
+    CacheNamespace.removeNamespace(for: "KomgaThumbnailCache", instanceId: instanceId)
   }
 }

--- a/KMReader/Services/Sync/SyncService.swift
+++ b/KMReader/Services/Sync/SyncService.swift
@@ -368,6 +368,27 @@ class SyncService {
     // And persist the associated books/series
   }
 
+  // MARK: - Cleanup
+
+  /// Remove all SwiftData entities associated with a specific Komga instance.
+  func clearInstanceData(instanceId: String) {
+    guard let context = makeContext() else { return }
+
+    do {
+      try context.delete(model: KomgaBook.self, where: #Predicate { $0.instanceId == instanceId })
+      try context.delete(model: KomgaSeries.self, where: #Predicate { $0.instanceId == instanceId })
+      try context.delete(
+        model: KomgaCollection.self, where: #Predicate { $0.instanceId == instanceId })
+      try context.delete(
+        model: KomgaReadList.self, where: #Predicate { $0.instanceId == instanceId })
+
+      try context.save()
+      logger.info("Cleared all SwiftData entities for instance: \(instanceId)")
+    } catch {
+      logger.error("Failed to clear instance data: \(error)")
+    }
+  }
+
   // MARK: - Upsert Helpers
 
   private func upsertBook(dto: Book, instanceId: String, context: ModelContext) async {

--- a/KMReader/ViewModels/Reader/EpubReaderViewModel.swift
+++ b/KMReader/ViewModels/Reader/EpubReaderViewModel.swift
@@ -76,9 +76,9 @@
         let epubURL: URL
 
         // 1. Check OfflineManager
-        if let offlineURL = await MainActor.run(body: {
-          OfflineManager.shared.getOfflineEpubURL(bookId: bookId)
-        }) {
+        if let offlineURL = await OfflineManager.shared.getOfflineEpubURL(
+          instanceId: AppConfig.currentInstanceId, bookId: bookId
+        ) {
           epubURL = offlineURL
         }
         // 2. Check BookFileCache

--- a/KMReader/ViewModels/Reader/ReaderViewModel.swift
+++ b/KMReader/ViewModels/Reader/ReaderViewModel.swift
@@ -132,9 +132,10 @@ class ReaderViewModel {
     }
 
     // 1. Check OfflineManager (Persistent Offline Content)
-    if let offlineURL = await MainActor.run(body: {
-      OfflineManager.shared.getOfflinePageImageURL(bookId: bookId, page: page)
-    }) {
+    let ext = page.detectedUTType?.preferredFilenameExtension ?? "jpg"
+    if let offlineURL = await OfflineManager.shared.getOfflinePageImageURL(
+      instanceId: AppConfig.currentInstanceId, bookId: bookId, pageNumber: page.number, fileExtension: ext
+    ) {
       logger.debug(
         "✅ Using offline downloaded image for page \(page.number) for book \(self.bookId)")
       return offlineURL

--- a/KMReader/Views/Settings/SettingsServersView.swift
+++ b/KMReader/Views/Settings/SettingsServersView.swift
@@ -457,10 +457,19 @@ struct SettingsServersView: View {
     modelContext.delete(instance)
     saveChanges()
     instancePendingDeletion = nil
+
+    let instanceId = instance.id.uuidString
+
+    // Clear SwiftData entities
+    LibraryManager.shared.removeLibraries(for: instanceId)
+    SyncService.shared.clearInstanceData(instanceId: instanceId)
+
+    // Clear offline downloads and caches (async)
     Task {
-      await CacheManager.clearCaches(instanceId: instance.id.uuidString)
+      await OfflineManager.shared.cancelAllDownloads()
+      OfflineManager.removeOfflineData(for: instanceId)
+      CacheManager.clearCaches(instanceId: instanceId)
     }
-    LibraryManager.shared.removeLibraries(for: instance.id.uuidString)
   }
 
   private func saveChanges() {


### PR DESCRIPTION
- Add DownloadStatus.swift for shared enum definition
- Store downloadStatusRaw, downloadProgress, downloadError in KomgaBook
- Add computed downloadStatus property to KomgaBook
- Refactor OfflineManager as actor with SwiftData-based status tracking
- Remove in-memory downloadStatuses dictionary from OfflineManager
- Add getDownloadStatus/updateDownloadStatus to KomgaBookStore
- Refactor all 4 detail views to use Query for reactive SwiftData updates:
  - BookDetailView: reactive download status without manual refresh
  - SeriesDetailView: reactive series data
  - CollectionDetailView: reactive collection data
  - ReadListDetailView: reactive read list data
- Add clearInstanceData to SyncService for cleanup on instance deletion
- Make CacheManager.clearCaches non-async for consistency