### PR TITLE
feat(offline): implement sequential download queue and offline tasks view

### DIFF
--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -38,6 +38,12 @@
     },
     " • %@" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " • %@"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -51,6 +57,18 @@
           }
         },
         "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " • %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " • %@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : " • %@"
@@ -80,6 +98,18 @@
           }
         },
         "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "#%1$@ - %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "#%1$@ - %2$@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "#%1$@ - %2$@"
@@ -119,6 +149,12 @@
     },
     "%.1f%%" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%.1f%%"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -132,6 +168,18 @@
           }
         },
         "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%.1f%%"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%.1f%%"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%.1f%%"
@@ -161,6 +209,18 @@
           }
         },
         "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ - %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ - %2$@"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ - %2$@"
@@ -200,6 +260,12 @@
     },
     "%@:" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@:"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -217,12 +283,30 @@
             "state" : "translated",
             "value" : "%@:"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@:"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@:"
+          }
         }
       },
       "shouldTranslate" : false
     },
     "%lld" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -406,6 +490,12 @@
     },
     "%lld GB" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld GB"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -423,12 +513,30 @@
             "state" : "translated",
             "value" : "%lld GB"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld GB"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld GB"
+          }
         }
       },
       "shouldTranslate" : false
     },
     "%lld in progress" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld in progress"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -583,6 +691,12 @@
     },
     "%lld%%" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%%"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -600,12 +714,30 @@
             "state" : "translated",
             "value" : "%lld%%"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%%"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%%"
+          }
         }
       },
       "shouldTranslate" : false
     },
     "%lld+" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld+"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -629,6 +761,12 @@
     },
     "•" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "•"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -642,6 +780,18 @@
           }
         },
         "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "•"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "•"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "•"
@@ -692,6 +842,12 @@
     },
     "Abandoned" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abandoned"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -806,6 +962,12 @@
     },
     "Active" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -960,6 +1122,12 @@
     },
     "Add Another Server" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Another Server"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1354,6 +1522,12 @@
     },
     "Admin Access" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Admin Access"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1988,6 +2162,12 @@
     },
     "API Keys" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API Keys"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2822,6 +3002,12 @@
     },
     "Auto" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4296,6 +4482,12 @@
     },
     "Choose an existing Komga server or add a new one to begin." : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose an existing Komga server or add a new one to begin."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4970,6 +5162,12 @@
     },
     "Complete" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Complete"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5004,6 +5202,12 @@
     },
     "Completed" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completed"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5238,6 +5442,12 @@
     },
     "Continuous Scroll" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuous Scroll"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5512,6 +5722,12 @@
     },
     "Created: %@" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Created: %@"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5826,6 +6042,12 @@
     },
     "Dark" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dark"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6460,6 +6682,12 @@
     },
     "Delete (%lld)" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete (%lld)"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6974,6 +7202,12 @@
     },
     "Deselect All" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deselect All"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7366,47 +7600,6 @@
         }
       }
     },
-    "Download" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Télécharger"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダウンロード"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "다운로드"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下载"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下載"
-          }
-        }
-      }
-    },
     "Download complete" : {
       "localizations" : {
         "en" : {
@@ -7443,6 +7636,86 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下載完成"
+          }
+        }
+      }
+    },
+    "Downloading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloading"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargement en cours"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드 중"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載中"
+          }
+        }
+      }
+    },
+    "Downloading %lld%%" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloading %lld%%"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargement %lld%%"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード中 %lld%%"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드 중 %lld%%"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载中 %lld%%"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載中 %lld%%"
           }
         }
       }
@@ -7527,8 +7800,54 @@
         }
       }
     },
+    "Downloads are currently paused." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloads are currently paused."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les téléchargements sont actuellement en pause."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードは現在一時停止されています。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드가 현재 일시 중지되었습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载目前已暂停。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載目前已暫停。"
+          }
+        }
+      }
+    },
     "Dual Page" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dual Page"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8003,6 +8322,12 @@
     },
     "Ended" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ended"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8277,6 +8602,12 @@
     },
     "EPUB reading is only supported on iOS." : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB reading is only supported on iOS."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10472,6 +10803,12 @@
     },
     "Hiatus" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hiatus"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10586,6 +10923,12 @@
     },
     "Instance Name (Optional)" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instance Name (Optional)"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10821,6 +11164,36 @@
     "ISBN" : {
       "localizations" : {
         "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ISBN"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ISBN"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ISBN"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ISBN"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ISBN"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ISBN"
@@ -11116,6 +11489,36 @@
             "state" : "translated",
             "value" : "KMReader"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
         }
       },
       "shouldTranslate" : false
@@ -11282,6 +11685,12 @@
     },
     "Last used %@" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last used %@"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11836,6 +12245,12 @@
     },
     "Light" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12670,6 +13085,12 @@
     },
     "Modified: %@" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modified: %@"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12942,8 +13363,54 @@
         }
       }
     },
+    "No books are currently queued for offline reading." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No books are currently queued for offline reading."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun livre n'est actuellement en file d'attente pour la lecture hors ligne."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在、オフライン読書用のキューに入っている本はありません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 오프라인 독서를 위해 대기 중인 도서가 없습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前没有加入离线阅读队列的图书。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前沒有加入離线閱讀隊列的圖書。"
+          }
+        }
+      }
+    },
     "No books found" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No books found"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13176,6 +13643,46 @@
         }
       }
     },
+    "No Offline Tasks" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Offline Tasks"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune tâche hors ligne"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインタスクはありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 작업 없음"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有离线任务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有离線任務"
+          }
+        }
+      }
+    },
     "No Pages Available" : {
       "localizations" : {
         "en" : {
@@ -13338,6 +13845,12 @@
     },
     "No series found" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No series found"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14810,6 +15323,46 @@
         }
       }
     },
+    "Offline Tasks" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline Tasks"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tâches hors ligne"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインタスク"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 작업"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线任务"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离線任務"
+          }
+        }
+      }
+    },
     "OK" : {
       "localizations" : {
         "en" : {
@@ -14892,6 +15445,12 @@
     },
     "Ongoing" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ongoing"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15488,6 +16047,12 @@
     },
     "Paged" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paged"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15676,6 +16241,126 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密碼"
+          }
+        }
+      }
+    },
+    "Paused" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paused"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En pause"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時停止中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일시 중지됨"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已暂停"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已暫停"
+          }
+        }
+      }
+    },
+    "Pending" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pending"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En attente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대기 중"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待中"
+          }
+        }
+      }
+    },
+    "Pending in queue..." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pending in queue..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En file d'attente..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "待機列にあります..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대기열에서 대기 중..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "队列中等待..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隊列中等待..."
           }
         }
       }
@@ -15922,6 +16607,12 @@
     },
     "Publisher Default" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publisher Default"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17716,6 +18407,12 @@
     },
     "Release Date (YYYY-MM-DD)" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Release Date (YYYY-MM-DD)"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18104,6 +18801,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "角色"
+          }
+        }
+      }
+    },
+    "Running" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Running"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En cours d'exécution"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "実行中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "실행 중"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "运行中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "執行中"
           }
         }
       }
@@ -18590,6 +19327,12 @@
     },
     "Select All" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select All"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18744,6 +19487,12 @@
     },
     "Sepia" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sepia"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21658,6 +22407,12 @@
     },
     "Single Page" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Single Page"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22250,8 +23005,54 @@
         }
       }
     },
+    "Sync Status" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Status"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "État de la synchronisation"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同期ステータス"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "동기화 상태"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步状态"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步狀態"
+          }
+        }
+      }
+    },
     "System" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23806,6 +24607,12 @@
     },
     "Try selecting a different library." : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try selecting a different library."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24080,6 +24887,12 @@
     },
     "Unread" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unread"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24154,6 +24967,12 @@
     },
     "UP NEXT IN READ LIST: %@" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "UP NEXT IN READ LIST: %@"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24188,6 +25007,12 @@
     },
     "UP NEXT IN SERIES: %@" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "UP NEXT IN SERIES: %@"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24382,6 +25207,12 @@
     },
     "User Access" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "User Access"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",

--- a/KMReader/Models/Book/DownloadStatus.swift
+++ b/KMReader/Models/Book/DownloadStatus.swift
@@ -11,6 +11,7 @@ import SwiftUI
 /// Status of an offline book download.
 enum DownloadStatus: Equatable, Sendable {
   case notDownloaded
+  case pending
   case downloading(progress: Double)
   case downloaded
   case failed(error: String)
@@ -22,7 +23,7 @@ enum DownloadStatus: Equatable, Sendable {
     switch self {
     case .downloaded:
       return String(localized: "Remove Offline")
-    case .downloading:
+    case .downloading, .pending:
       return String(localized: "Cancel Download")
     case .notDownloaded, .failed:
       return String(localized: "Make Offline")
@@ -33,27 +34,21 @@ enum DownloadStatus: Equatable, Sendable {
   var menuIcon: String {
     switch self {
     case .downloaded:
-      return "square.and.arrow.down.badge.xmark"
-    case .downloading:
-      return "square.and.arrow.down.badge.clock"
-    case .notDownloaded:
+      return "trash"
+    case .downloading, .pending:
+      return "xmark.circle"
+    case .notDownloaded, .failed:
       return "square.and.arrow.down"
-    case .failed:
-      return "exclamationmark.triangle"
     }
   }
 
   /// Color for the status icon.
   var menuColor: Color {
     switch self {
-    case .downloaded:
+    case .downloaded, .downloading, .pending:
       return .red
-    case .downloading:
-      return .blue
-    case .notDownloaded:
+    case .notDownloaded, .failed:
       return .primary
-    case .failed:
-      return .orange
     }
   }
 }

--- a/KMReader/Models/Book/KomgaBook.swift
+++ b/KMReader/Models/Book/KomgaBook.swift
@@ -70,11 +70,14 @@ final class KomgaBook {
   var downloadStatusRaw: String = "notDownloaded"
   var downloadProgress: Double = 0.0
   var downloadError: String?
+  var downloadAt: Date?
 
   /// Computed property for download status.
   var downloadStatus: DownloadStatus {
     get {
       switch downloadStatusRaw {
+      case "pending":
+        return .pending
       case "downloading":
         return .downloading(progress: downloadProgress)
       case "downloaded":
@@ -91,6 +94,12 @@ final class KomgaBook {
         downloadStatusRaw = "notDownloaded"
         downloadProgress = 0.0
         downloadError = nil
+        downloadAt = nil
+      case .pending:
+        downloadStatusRaw = "pending"
+        downloadProgress = 0.0
+        downloadError = nil
+        // downloadAt should be set by the caller if needed
       case .downloading(let progress):
         downloadStatusRaw = "downloading"
         downloadProgress = progress
@@ -99,10 +108,12 @@ final class KomgaBook {
         downloadStatusRaw = "downloaded"
         downloadProgress = 1.0
         downloadError = nil
+        downloadAt = nil
       case .failed(let error):
         downloadStatusRaw = "failed"
         downloadProgress = 0.0
         downloadError = error
+        downloadAt = nil
       }
     }
   }

--- a/KMReader/Models/Common/NavDestination.swift
+++ b/KMReader/Models/Common/NavDestination.swift
@@ -24,4 +24,5 @@ enum NavDestination: Hashable {
   case settingsAuthenticationActivity
   case settingsApiKey
   case settingsServers
+  case settingsOfflineTasks
 }

--- a/KMReader/Services/Core/AppConfig.swift
+++ b/KMReader/Services/Core/AppConfig.swift
@@ -140,6 +140,11 @@ enum AppConfig {
     }
   }
 
+  static nonisolated var offlinePaused: Bool {
+    get { UserDefaults.standard.bool(forKey: "offlinePaused") }
+    set { UserDefaults.standard.set(newValue, forKey: "offlinePaused") }
+  }
+
   // MARK: - Dashboard
 
   static var dashboardConfiguration: DashboardConfiguration {

--- a/KMReader/Views/Extensions/View+Navigation.swift
+++ b/KMReader/Views/Extensions/View+Navigation.swift
@@ -58,6 +58,8 @@ extension View {
             AuthenticationActivityView()
           case .settingsServers:
             SettingsServersView()
+          case .settingsOfflineTasks:
+            SettingsOfflineTasksView()
         #else
           case .settingsLibraries,
             .settingsAppearance,
@@ -69,7 +71,8 @@ extension View {
             .settingsMetrics,
             .settingsApiKey,
             .settingsAuthenticationActivity,
-            .settingsServers:
+            .settingsServers,
+            .settingsOfflineTasks:
             VStack(spacing: 16) {
               Image(systemName: "gearshape")
                 .font(.system(size: 48))

--- a/KMReader/Views/Settings/SettingsOfflineTasksView.swift
+++ b/KMReader/Views/Settings/SettingsOfflineTasksView.swift
@@ -1,0 +1,153 @@
+//
+//  SettingsOfflineTasksView.swift
+//  KMReader
+//
+//  Created by Komga iOS Client
+//
+
+import SwiftData
+import SwiftUI
+
+struct SettingsOfflineTasksView: View {
+  @Environment(\.modelContext) private var modelContext
+  @AppStorage("currentInstanceId") private var instanceId: String = ""
+  @AppStorage("offlinePaused") private var isPaused: Bool = false
+
+  @Query private var books: [KomgaBook]
+
+  init() {
+    let instanceId = AppConfig.currentInstanceId
+    _books = Query(
+      filter: #Predicate<KomgaBook> { book in
+        book.instanceId == instanceId && (
+          book.downloadStatusRaw == "pending" ||
+          book.downloadStatusRaw == "downloading" ||
+          book.downloadStatusRaw == "failed"
+        )
+      },
+      sort: [SortDescriptor(\KomgaBook.downloadAt, order: .forward)]
+    )
+  }
+
+  private var downloadingBooks: [KomgaBook] {
+    books.filter { $0.downloadStatusRaw == "downloading" }
+  }
+
+  private var pendingBooks: [KomgaBook] {
+    books.filter { $0.downloadStatusRaw == "pending" }
+  }
+
+  private var failedBooks: [KomgaBook] {
+    books.filter { $0.downloadStatusRaw == "failed" }
+  }
+
+  var body: some View {
+    List {
+      Section {
+        Toggle(isOn: Binding(
+          get: { isPaused },
+          set: { newValue in
+            Task {
+              if newValue {
+                await OfflineManager.shared.pauseSync()
+              } else {
+                await OfflineManager.shared.resumeSync(instanceId: instanceId)
+              }
+            }
+          }
+        )) {
+          Label(isPaused ? "Paused" : "Running", systemImage: isPaused ? "pause.circle.fill" : "play.circle.fill")
+            .foregroundColor(isPaused ? .orange : .green)
+        }
+      } header: {
+        Text("Sync Status")
+      } footer: {
+        if isPaused {
+          Text("Downloads are currently paused.")
+        }
+      }
+
+      if !downloadingBooks.isEmpty {
+        Section("Downloading") {
+          ForEach(downloadingBooks) { book in
+            OfflineTaskRow(book: book)
+          }
+        }
+      }
+
+      if !pendingBooks.isEmpty {
+        Section("Pending") {
+          ForEach(pendingBooks) { book in
+            OfflineTaskRow(book: book)
+          }
+        }
+      }
+
+      if !failedBooks.isEmpty {
+        Section("Failed") {
+          ForEach(failedBooks) { book in
+            OfflineTaskRow(book: book)
+          }
+        }
+      }
+
+      if books.isEmpty {
+        ContentUnavailableView {
+          Label("No Offline Tasks", systemImage: "square.and.arrow.down")
+        } description: {
+          Text("No books are currently queued for offline reading.")
+        }
+      }
+    }
+    .inlineNavigationBarTitle("Offline Tasks")
+  }
+}
+
+struct OfflineTaskRow: View {
+  let book: KomgaBook
+
+  var body: some View {
+    HStack(alignment: .center, spacing: 12) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text(book.name)
+          .font(.headline)
+          .lineLimit(1)
+
+        switch book.downloadStatus {
+        case .downloading(let progress):
+          ProgressView(value: progress) {
+            Text("Downloading \(Int(progress * 100))%")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+        case .pending:
+          Text("Pending in queue...")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        case .failed(let error):
+          Text(error)
+            .font(.caption)
+            .foregroundColor(.red)
+            .lineLimit(2)
+        default:
+          EmptyView()
+        }
+      }
+
+      Spacer()
+
+      Button(role: .destructive) {
+        Task {
+          await OfflineManager.shared.cancelDownload(bookId: book.bookId)
+          let instanceId = AppConfig.currentInstanceId
+          await OfflineManager.shared.syncDownloadQueue(instanceId: instanceId)
+        }
+      } label: {
+        Image(systemName: "xmark.circle")
+          .foregroundColor(.red)
+      }
+      .buttonStyle(.plain)
+    }
+    .padding(.vertical, 4)
+  }
+}

--- a/KMReader/Views/Settings/SettingsView.swift
+++ b/KMReader/Views/Settings/SettingsView.swift
@@ -34,6 +34,9 @@ import SwiftUI
             NavigationLink(value: NavDestination.settingsSSE) {
               Label("Real-time Updates", systemImage: "antenna.radiowaves.left.and.right")
             }
+            NavigationLink(value: NavDestination.settingsOfflineTasks) {
+              Label("Offline Tasks", systemImage: "square.and.arrow.down.on.square")
+            }
           }
 
           Section(header: Text("Management")) {


### PR DESCRIPTION
- Add sequential download queue logic in OfflineManager with pause/resume support
- Implement SettingsOfflineTasksView to monitor and manage download tasks
- Support categorizing tasks by Downloading, Pending, and Failed states
- Persist sync pause state in AppConfig
- Add 'Offline Tasks' entry in Settings menu