### PR TITLE
feat(offline): implement offline content management and unify settings

### DIFF
--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -143,6 +143,18 @@
             "state" : "translated",
             "value" : "#%1$lld - %2$@"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "#%1$lld - %2$@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "#%1$lld - %2$@"
+          }
         }
       },
       "shouldTranslate" : false
@@ -254,6 +266,18 @@
             "state" : "translated",
             "value" : "%1$@ / %2$lld"
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ / %2$lld"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ / %2$lld"
+          }
         }
       },
       "shouldTranslate" : false
@@ -320,6 +344,18 @@
           }
         },
         "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld"
@@ -751,6 +787,18 @@
           }
         },
         "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld+"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld+"
+          }
+        },
+        "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld+"
@@ -5160,6 +5208,46 @@
         }
       }
     },
+    "common.unknown" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unknown"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inconnu"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不明"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알 수 없음"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知"
+          }
+        }
+      }
+    },
     "Complete" : {
       "localizations" : {
         "en" : {
@@ -6716,6 +6804,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除 (%lld)"
+          }
+        }
+      }
+    },
+    "Delete All" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete All"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout supprimer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全て削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모두 삭제"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部删除"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部刪除"
           }
         }
       }
@@ -15323,6 +15451,86 @@
         }
       }
     },
+    "Offline" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hors ligne"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフライン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離線"
+          }
+        }
+      }
+    },
+    "Offline Books" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline Books"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Livres hors ligne"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフライン本"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 도서"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线书籍"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離線書籍"
+          }
+        }
+      }
+    },
     "Offline Tasks" : {
       "localizations" : {
         "en" : {
@@ -15358,7 +15566,7 @@
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "离線任務"
+            "value" : "離線任務"
           }
         }
       }
@@ -21961,6 +22169,166 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書庫"
+          }
+        }
+      }
+    },
+    "settings.offline_books.oneshots" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "One-shots"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "One-shots"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ワンショット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단행본"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "单行本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單發作品"
+          }
+        }
+      }
+    },
+    "settings.offline_books.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline Books"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Livres hors ligne"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフライン本"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 도서"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线书籍"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離線書籍"
+          }
+        }
+      }
+    },
+    "settings.offline.no_books" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Offline Books"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun livre hors ligne"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフライン本なし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 도서 없음"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无离线书籍"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無離線書籍"
+          }
+        }
+      }
+    },
+    "settings.offline.no_books.description" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You haven't downloaded any books for offline reading yet."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous n'avez pas encore téléchargé de livres pour une lecture hors ligne."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフライン読書用にダウンロードされた本はまだありません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 독서를 위해 다운로드한 도서가 없습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您还没有下载过任何书籍用于离线阅读。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "您尚未下載過任何書籍用於離線閱讀。"
           }
         }
       }

--- a/KMReader/Models/Book/KomgaBook.swift
+++ b/KMReader/Models/Book/KomgaBook.swift
@@ -71,6 +71,7 @@ final class KomgaBook {
   var downloadProgress: Double = 0.0
   var downloadError: String?
   var downloadAt: Date?
+  var downloadedSize: Int64?
 
   /// Computed property for download status.
   var downloadStatus: DownloadStatus {
@@ -137,7 +138,7 @@ final class KomgaBook {
     metadata: BookMetadata,
     readProgress: ReadProgress?,
     deleted: Bool,
-    oneshot: Bool
+    oneshot: Bool,
   ) {
     self.id = id ?? "\(instanceId)_\(bookId)"
     self.bookId = bookId

--- a/KMReader/Models/Common/NavDestination.swift
+++ b/KMReader/Models/Common/NavDestination.swift
@@ -25,4 +25,5 @@ enum NavDestination: Hashable {
   case settingsApiKey
   case settingsServers
   case settingsOfflineTasks
+  case settingsOfflineBooks
 }

--- a/KMReader/Services/Book/KomgaBookStore.swift
+++ b/KMReader/Services/Book/KomgaBookStore.swift
@@ -228,7 +228,9 @@ final class KomgaBookStore {
   }
 
   /// Update the download status of a book.
-  func updateDownloadStatus(bookId: String, status: DownloadStatus, downloadAt: Date? = nil) {
+  func updateDownloadStatus(
+    bookId: String, status: DownloadStatus, downloadAt: Date? = nil, downloadedSize: Int64? = nil
+  ) {
     guard let container else { return }
     let context = ModelContext(container)
     let instanceId = AppConfig.currentInstanceId
@@ -242,6 +244,11 @@ final class KomgaBookStore {
     book.downloadStatus = status
     if let downloadAt = downloadAt {
       book.downloadAt = downloadAt
+    }
+    if let downloadedSize = downloadedSize {
+      book.downloadedSize = downloadedSize
+    } else if case .notDownloaded = status {
+      book.downloadedSize = nil
     }
     try? context.save()
   }

--- a/KMReader/Views/Extensions/View+Navigation.swift
+++ b/KMReader/Views/Extensions/View+Navigation.swift
@@ -60,6 +60,8 @@ extension View {
             SettingsServersView()
           case .settingsOfflineTasks:
             SettingsOfflineTasksView()
+          case .settingsOfflineBooks:
+            SettingsOfflineBooksView()
         #else
           case .settingsLibraries,
             .settingsAppearance,
@@ -72,7 +74,8 @@ extension View {
             .settingsApiKey,
             .settingsAuthenticationActivity,
             .settingsServers,
-            .settingsOfflineTasks:
+            .settingsOfflineTasks,
+            .settingsOfflineBooks:
             VStack(spacing: 16) {
               Image(systemName: "gearshape")
                 .font(.system(size: 48))

--- a/KMReader/Views/Settings/SettingsAboutSection.swift
+++ b/KMReader/Views/Settings/SettingsAboutSection.swift
@@ -2,10 +2,10 @@ import SwiftUI
 
 struct SettingsAboutSection: View {
   var body: some View {
-    Section(header: Text("About")) {
+    Section(header: Text(String(localized: "About"))) {
       Link(destination: URL(string: "https://everpcpc.github.io/KMReader/privacy/")!) {
         HStack {
-          Label("Privacy Policy", systemImage: "hand.raised")
+          Label(String(localized: "Privacy Policy"), systemImage: "hand.raised")
           Spacer()
           Image(systemName: "arrow.up.right.square")
             .font(.caption)
@@ -14,7 +14,7 @@ struct SettingsAboutSection: View {
       }
       Link(destination: URL(string: "https://kmreader.userjot.com/")!) {
         HStack {
-          Label("Feedback", systemImage: "paperplane")
+          Label(String(localized: "Feedback"), systemImage: "paperplane")
           Spacer()
           Image(systemName: "arrow.up.right.square")
             .font(.caption)
@@ -32,7 +32,7 @@ struct SettingsAboutSection: View {
       }
       Link(destination: URL(string: "https://github.com/everpcpc/KMReader")!) {
         HStack {
-          Label("Source Code", systemImage: "chevron.left.forwardslash.chevron.right")
+          Label(String(localized: "Source Code"), systemImage: "chevron.left.forwardslash.chevron.right")
           Spacer()
           Image(systemName: "arrow.up.right.square")
             .font(.caption)

--- a/KMReader/Views/Settings/SettingsOfflineBooksView.swift
+++ b/KMReader/Views/Settings/SettingsOfflineBooksView.swift
@@ -1,0 +1,227 @@
+//
+//  SettingsOfflineBooksView.swift
+//  KMReader
+//
+//  Created by Komga iOS Client
+//
+
+import SwiftData
+import SwiftUI
+
+struct SettingsOfflineBooksView: View {
+  @Environment(\.modelContext) private var modelContext
+  @Query(
+    filter: #Predicate<KomgaBook> { $0.downloadStatusRaw == "downloaded" },
+    sort: [SortDescriptor(\KomgaBook.libraryId)]
+  )
+  var downloadedBooks: [KomgaBook]
+
+  @Query var libraries: [KomgaLibrary]
+
+  struct SeriesGroup: Identifiable {
+    let id: String
+    let series: KomgaSeries?
+    let books: [KomgaBook]
+  }
+
+  struct LibraryGroup: Identifiable {
+    let id: String
+    let library: KomgaLibrary?
+    let seriesGroups: [SeriesGroup]
+    let oneshotBooks: [KomgaBook]
+  }
+
+  private let formatter: ByteCountFormatter = {
+    let f = ByteCountFormatter()
+    f.allowedUnits = .useAll
+    f.countStyle = .file
+    return f
+  }()
+
+  init() {}
+
+  private var groupedBooks: [LibraryGroup] {
+    let libraryGroups = Dictionary(grouping: downloadedBooks) { $0.libraryId }
+    var result: [LibraryGroup] = []
+
+    for (libraryId, lBooks) in libraryGroups {
+      let library = libraries.first { $0.libraryId == libraryId }
+
+      let oneshots = lBooks.filter { $0.oneshot }
+      let seriesBooks = lBooks.filter { !$0.oneshot }
+
+      let seriesGroupsMap = Dictionary(grouping: seriesBooks) { $0.seriesId }
+      var sGroups: [SeriesGroup] = []
+
+      for (seriesId, sBooks) in seriesGroupsMap {
+        let series = sBooks.first?.series
+        sGroups.append(
+          SeriesGroup(id: seriesId, series: series, books: sBooks.sorted { $0.number < $1.number }))
+      }
+
+      sGroups.sort { ($0.series?.name ?? "") < ($1.series?.name ?? "") }
+      result.append(
+        LibraryGroup(
+          id: libraryId,
+          library: library,
+          seriesGroups: sGroups,
+          oneshotBooks: oneshots.sorted {
+            ($0.metadata.title.isEmpty ? $0.name : $0.metadata.title)
+              < ($1.metadata.title.isEmpty ? $1.name : $1.metadata.title)
+          }
+        ))
+    }
+
+    result.sort { ($0.library?.name ?? "") < ($1.library?.name ?? "") }
+    return result
+  }
+
+  var body: some View {
+    List {
+      if downloadedBooks.isEmpty {
+        ContentUnavailableView(
+          String(localized: "settings.offline.no_books"),
+          systemImage: "books.vertical",
+          description: Text(String(localized: "settings.offline.no_books.description"))
+        )
+      } else {
+        ForEach(groupedBooks) { lGroup in
+          Section(
+            header: HStack {
+              Text(lGroup.library?.name ?? String(localized: "common.unknown"))
+              Spacer()
+              Text(formatter.string(fromByteCount: totalSize(for: lGroup)))
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+          ) {
+            ForEach(lGroup.seriesGroups) { sGroup in
+              #if os(tvOS)
+                Section(
+                  header: HStack {
+                    Text(sGroup.series?.name ?? String(localized: "common.unknown"))
+                    Spacer()
+                    Text(formatter.string(fromByteCount: seriesSize(for: sGroup.books)))
+                      .font(.caption)
+                      .foregroundColor(.secondary)
+                  }
+                ) {
+                  ForEach(sGroup.books) { book in
+                    bookRow(book)
+                  }
+                }
+              #else
+                DisclosureGroup {
+                  ForEach(sGroup.books) { book in
+                    bookRow(book)
+                  }
+                } label: {
+                  HStack {
+                    Text(sGroup.series?.name ?? String(localized: "common.unknown"))
+                    Spacer()
+                    Text(formatter.string(fromByteCount: seriesSize(for: sGroup.books)))
+                      .font(.caption)
+                      .foregroundColor(.secondary)
+                  }
+                }
+                .swipeActions(edge: .trailing) {
+                  Button(role: .destructive) {
+                    deleteSeries(sGroup.books)
+                  } label: {
+                    Label(String(localized: "Delete All"), systemImage: "trash")
+                  }
+                }
+              #endif
+            }
+
+            if !lGroup.oneshotBooks.isEmpty {
+              #if os(tvOS)
+                Section(
+                  header: HStack {
+                    Text(String(localized: "settings.offline_books.oneshots"))
+                    Spacer()
+                    Text(formatter.string(fromByteCount: seriesSize(for: lGroup.oneshotBooks)))
+                      .font(.caption)
+                      .foregroundColor(.secondary)
+                  }
+                ) {
+                  ForEach(lGroup.oneshotBooks) { book in
+                    bookRow(book)
+                  }
+                }
+              #else
+                DisclosureGroup {
+                  ForEach(lGroup.oneshotBooks) { book in
+                    bookRow(book)
+                  }
+                } label: {
+                  HStack {
+                    Text(String(localized: "settings.offline_books.oneshots"))
+                    Spacer()
+                    Text(formatter.string(fromByteCount: seriesSize(for: lGroup.oneshotBooks)))
+                      .font(.caption)
+                      .foregroundColor(.secondary)
+                  }
+                }
+                .swipeActions(edge: .trailing) {
+                  Button(role: .destructive) {
+                    deleteSeries(lGroup.oneshotBooks)
+                  } label: {
+                    Label(String(localized: "Delete All"), systemImage: "trash")
+                  }
+                }
+              #endif
+            }
+          }
+        }
+      }
+    }
+    .inlineNavigationBarTitle(String(localized: "settings.offline_books.title"))
+  }
+
+  @ViewBuilder
+  private func bookRow(_ book: KomgaBook) -> some View {
+    HStack {
+      Text("#\(book.metadata.number) - \(book.metadata.title)")
+      Spacer()
+      if let size = book.downloadedSize {
+        Text(formatter.string(fromByteCount: size))
+          .font(.caption)
+          .foregroundColor(.secondary)
+      }
+    }
+    #if !os(tvOS)
+    .swipeActions(edge: .trailing) {
+      Button(role: .destructive) {
+        deleteBook(book)
+      } label: {
+        Label(String(localized: "Delete"), systemImage: "trash")
+      }
+    }
+    #endif
+  }
+
+  private func seriesSize(for books: [KomgaBook]) -> Int64 {
+    books.reduce(0) { $0 + ($1.downloadedSize ?? 0) }
+  }
+
+  private func totalSize(for lGroup: LibraryGroup) -> Int64 {
+    let sSize = lGroup.seriesGroups.reduce(0) { $0 + seriesSize(for: $1.books) }
+    let oSize = lGroup.oneshotBooks.reduce(0) { $0 + ($1.downloadedSize ?? 0) }
+    return sSize + oSize
+  }
+
+  private func deleteBook(_ book: KomgaBook) {
+    Task {
+      await OfflineManager.shared.deleteBook(instanceId: book.instanceId, bookId: book.bookId)
+    }
+  }
+
+  private func deleteSeries(_ books: [KomgaBook]) {
+    Task {
+      for book in books {
+        await OfflineManager.shared.deleteBook(instanceId: book.instanceId, bookId: book.bookId)
+      }
+    }
+  }
+}

--- a/KMReader/Views/Settings/SettingsSection.swift
+++ b/KMReader/Views/Settings/SettingsSection.swift
@@ -19,6 +19,8 @@ enum SettingsSection: String, CaseIterable {
   case servers
   case apiKeys
   case authenticationActivity
+  case offlineTasks
+  case offlineBooks
 
   var icon: String {
     switch self {
@@ -44,33 +46,41 @@ enum SettingsSection: String, CaseIterable {
       return "key"
     case .authenticationActivity:
       return "clock"
+    case .offlineTasks:
+      return "square.and.arrow.down.badge.clock"
+    case .offlineBooks:
+      return "square.and.arrow.down.badge.checkmark"
     }
   }
 
   var title: String {
     switch self {
     case .appearance:
-      return "Appearance"
+      return String(localized: "Appearance")
     case .dashboard:
-      return "Dashboard"
+      return String(localized: "Dashboard")
     case .cache:
-      return "Cache"
+      return String(localized: "Cache")
     case .reader:
-      return "Reader"
+      return String(localized: "Reader")
     case .sse:
-      return "Real-time Updates"
+      return String(localized: "Real-time Updates")
     case .libraries:
-      return "Libraries"
+      return String(localized: "Libraries")
     case .serverInfo:
-      return "Server Info"
+      return String(localized: "Server Info")
     case .metrics:
-      return "Tasks"
+      return String(localized: "Tasks")
     case .servers:
-      return "Servers"
+      return String(localized: "Servers")
     case .apiKeys:
-      return "API Keys"
+      return String(localized: "API Keys")
     case .authenticationActivity:
-      return "Authentication Activity"
+      return String(localized: "Authentication Activity")
+    case .offlineTasks:
+      return String(localized: "Offline Tasks")
+    case .offlineBooks:
+      return String(localized: "Offline Books")
     }
   }
 }

--- a/KMReader/Views/Settings/SettingsView.swift
+++ b/KMReader/Views/Settings/SettingsView.swift
@@ -20,86 +20,77 @@ import SwiftUI
         Form {
           Section {
             NavigationLink(value: NavDestination.settingsAppearance) {
-              Label("Appearance", systemImage: "paintbrush")
+              SettingsSectionRow(section: .appearance)
             }
             NavigationLink(value: NavDestination.settingsDashboard) {
-              Label("Dashboard", systemImage: "house")
+              SettingsSectionRow(section: .dashboard)
             }
             NavigationLink(value: NavDestination.settingsCache) {
-              Label("Cache", systemImage: "externaldrive")
+              SettingsSectionRow(section: .cache)
             }
             NavigationLink(value: NavDestination.settingsReader) {
-              Label("Reader", systemImage: "book.pages")
+              SettingsSectionRow(section: .reader)
             }
             NavigationLink(value: NavDestination.settingsSSE) {
-              Label("Real-time Updates", systemImage: "antenna.radiowaves.left.and.right")
-            }
-            NavigationLink(value: NavDestination.settingsOfflineTasks) {
-              Label("Offline Tasks", systemImage: "square.and.arrow.down.on.square")
+              SettingsSectionRow(section: .sse)
             }
           }
 
-          Section(header: Text("Management")) {
+          Section(header: Text(String(localized: "Offline"))) {
+            NavigationLink(value: NavDestination.settingsOfflineTasks) {
+              SettingsSectionRow(section: .offlineTasks)
+            }
+            NavigationLink(value: NavDestination.settingsOfflineBooks) {
+              SettingsSectionRow(section: .offlineBooks)
+            }
+          }
+
+          Section(header: Text(String(localized: "Management"))) {
             NavigationLink(value: NavDestination.settingsLibraries) {
-              Label("Libraries", systemImage: "books.vertical")
+              SettingsSectionRow(section: .libraries)
             }
             NavigationLink(value: NavDestination.settingsServerInfo) {
-              Label("Server Info", systemImage: "server.rack")
+              SettingsSectionRow(section: .serverInfo)
             }
             .disabled(!isAdmin)
             NavigationLink(value: NavDestination.settingsMetrics) {
-              HStack {
-                Label("Tasks", systemImage: "list.bullet.clipboard")
-                Spacer()
-                if taskQueueStatus.count > 0 {
-                  HStack(spacing: 4) {
-                    Circle()
-                      .fill(themeColor.color)
-                      .frame(width: 8, height: 8)
-                    Text("\(taskQueueStatus.count)")
-                      .font(.caption)
-                      .foregroundColor(themeColor.color)
-                      .fontWeight(.semibold)
-                  }
-                }
-              }
+              SettingsSectionRow(
+                section: .metrics,
+                badge: taskQueueStatus.count > 0 ? "\(taskQueueStatus.count)" : nil,
+                badgeColor: themeColor.color
+              )
             }
             .disabled(!isAdmin)
           }
 
-          Section(header: Text("Account")) {
+          Section(header: Text(String(localized: "Account"))) {
             NavigationLink(value: NavDestination.settingsServers) {
-              HStack {
-                Label("Servers", systemImage: "list.bullet.rectangle")
-                if !serverDisplayName.isEmpty {
-                  Spacer()
-                  Text(serverDisplayName)
-                    .lineLimit(1)
-                    .foregroundColor(.secondary)
-                }
-              }
+              SettingsSectionRow(
+                section: .servers,
+                subtitle: serverDisplayName.isEmpty ? nil : serverDisplayName
+              )
             }
             if let user = authViewModel.user {
               HStack {
-                Label("User", systemImage: "person")
+                Label(String(localized: "User"), systemImage: "person")
                 Spacer()
                 Text(user.email)
                   .lineLimit(1)
                   .foregroundColor(.secondary)
               }
               HStack {
-                Label("Role", systemImage: "shield")
+                Label(String(localized: "Role"), systemImage: "shield")
                 Spacer()
-                Text(isAdmin ? "Admin" : "User")
+                Text(isAdmin ? String(localized: "Admin") : String(localized: "User"))
                   .lineLimit(1)
                   .foregroundColor(.secondary)
               }
             }
             NavigationLink(value: NavDestination.settingsApiKey) {
-              Label(String(localized: "API Keys"), systemImage: "key")
+              SettingsSectionRow(section: .apiKeys)
             }
             NavigationLink(value: NavDestination.settingsAuthenticationActivity) {
-              Label(String(localized: "Authentication Activity"), systemImage: "clock")
+              SettingsSectionRow(section: .authenticationActivity)
             }
           }
 

--- a/KMReader/Views/Settings/SettingsView_macOS.swift
+++ b/KMReader/Views/Settings/SettingsView_macOS.swift
@@ -28,6 +28,11 @@ import SwiftUI
             SettingsSectionRow(section: .sse)
           }
 
+          Section("Offline") {
+            SettingsSectionRow(section: .offlineTasks)
+            SettingsSectionRow(section: .offlineBooks)
+          }
+
           Section("Management") {
             SettingsSectionRow(section: .libraries)
             SettingsSectionRow(section: .serverInfo)
@@ -94,6 +99,10 @@ import SwiftUI
               SettingsApiKeyView()
             case .authenticationActivity:
               AuthenticationActivityView()
+            case .offlineTasks:
+              SettingsOfflineTasksView()
+            case .offlineBooks:
+              SettingsOfflineBooksView()
             }
           }
           .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
- Add SettingsOfflineBooksView to manage downloaded books with library/series grouping and disk usage tracking
- Refactor SettingsView (iOS) and SettingsView_macOS to use centralized SettingsSection model and SettingsSectionRow component
- Update KomgaBook SwiftData model to persist downloadedSize and track it in OfflineManager
- Fix inverted isPaused toggle logic in SettingsOfflineTasksView and add reactive sync triggers
- Fully localize all offline-related strings and settings categories across all supported languages
- Reorganize settings into logical sections: General, Offline, Management, and Account