### PR TITLE
feat(sync): synchronize collections and readlists to SwiftData

### DIFF
--- a/KMReader/Services/Sync/SyncService.swift
+++ b/KMReader/Services/Sync/SyncService.swift
@@ -141,6 +141,24 @@ class SyncService {
     return series
   }
 
+  func syncNewSeries(libraryIds: [String]?, page: Int, size: Int) async throws -> Page<Series> {
+    let result = try await SeriesService.shared.getNewSeries(
+      libraryIds: libraryIds, page: page, size: size)
+    let instanceId = AppConfig.currentInstanceId
+    await db.upsertSeriesList(result.content, instanceId: instanceId)
+    try await db.commit()
+    return result
+  }
+
+  func syncUpdatedSeries(libraryIds: [String]?, page: Int, size: Int) async throws -> Page<Series> {
+    let result = try await SeriesService.shared.getUpdatedSeries(
+      libraryIds: libraryIds, page: page, size: size)
+    let instanceId = AppConfig.currentInstanceId
+    await db.upsertSeriesList(result.content, instanceId: instanceId)
+    try await db.commit()
+    return result
+  }
+
   func syncBooks(
     seriesId: String,
     page: Int,
@@ -162,28 +180,13 @@ class SyncService {
   }
 
   func syncBooksList(
-    search: String?,
-    libraryIds: [String]?,
-    browseOpts: BookBrowseOptions,
+    search: BookSearch,
     page: Int,
     size: Int,
     sort: String?
   ) async throws -> Page<Book> {
-    let filters = BookSearchFilters(
-      libraryIds: libraryIds,
-      includeReadStatuses: Array(browseOpts.includeReadStatuses),
-      excludeReadStatuses: Array(browseOpts.excludeReadStatuses),
-      oneshot: browseOpts.oneshotFilter.effectiveBool,
-      deleted: browseOpts.deletedFilter.effectiveBool
-    )
-    let condition = BookSearch.buildCondition(filters: filters)
-    let bookSearch = BookSearch(
-      condition: condition,
-      fullTextSearch: search?.isEmpty == false ? search : nil
-    )
-
     let result = try await BookService.shared.getBooksList(
-      search: bookSearch,
+      search: search,
       page: page,
       size: size,
       sort: sort
@@ -193,6 +196,44 @@ class SyncService {
     await db.upsertBooks(result.content, instanceId: instanceId)
     try await db.commit()
 
+    return result
+  }
+
+  func syncBooksOnDeck(libraryIds: [String]?, page: Int, size: Int) async throws -> Page<Book> {
+    let result = try await BookService.shared.getBooksOnDeck(
+      libraryIds: libraryIds, page: page, size: size)
+    let instanceId = AppConfig.currentInstanceId
+    await db.upsertBooks(result.content, instanceId: instanceId)
+    try await db.commit()
+    return result
+  }
+
+  func syncRecentlyReadBooks(libraryIds: [String]?, page: Int, size: Int) async throws -> Page<Book> {
+    let result = try await BookService.shared.getRecentlyReadBooks(
+      libraryIds: libraryIds, page: page, size: size)
+    let instanceId = AppConfig.currentInstanceId
+    await db.upsertBooks(result.content, instanceId: instanceId)
+    try await db.commit()
+    return result
+  }
+
+  func syncRecentlyAddedBooks(libraryIds: [String]?, page: Int, size: Int) async throws -> Page<Book> {
+    let result = try await BookService.shared.getRecentlyAddedBooks(
+      libraryIds: libraryIds, page: page, size: size)
+    let instanceId = AppConfig.currentInstanceId
+    await db.upsertBooks(result.content, instanceId: instanceId)
+    try await db.commit()
+    return result
+  }
+
+  func syncRecentlyReleasedBooks(libraryIds: [String]?, page: Int, size: Int) async throws -> Page<
+    Book
+  > {
+    let result = try await BookService.shared.getRecentlyReleasedBooks(
+      libraryIds: libraryIds, page: page, size: size)
+    let instanceId = AppConfig.currentInstanceId
+    await db.upsertBooks(result.content, instanceId: instanceId)
+    try await db.commit()
     return result
   }
 

--- a/KMReader/ViewModels/Series/SeriesViewModel.swift
+++ b/KMReader/ViewModels/Series/SeriesViewModel.swift
@@ -143,7 +143,8 @@ class SeriesViewModel {
     isLoading = true
 
     do {
-      let page = try await seriesService.getNewSeries(libraryIds: libraryIds, size: 20)
+      let page = try await SyncService.shared.syncNewSeries(
+        libraryIds: libraryIds, page: currentPage, size: 20)
       withAnimation {
         series = page.content
       }
@@ -158,7 +159,8 @@ class SeriesViewModel {
     isLoading = true
 
     do {
-      let page = try await seriesService.getUpdatedSeries(libraryIds: libraryIds, size: 20)
+      let page = try await SyncService.shared.syncUpdatedSeries(
+        libraryIds: libraryIds, page: currentPage, size: 20)
       withAnimation {
         series = page.content
       }
@@ -172,6 +174,7 @@ class SeriesViewModel {
   func markAsRead(seriesId: String, browseOpts: SeriesBrowseOptions) async {
     do {
       try await seriesService.markAsRead(seriesId: seriesId)
+      _ = try? await SyncService.shared.syncSeriesDetail(seriesId: seriesId)
       await MainActor.run {
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedRead"))
       }
@@ -184,6 +187,7 @@ class SeriesViewModel {
   func markAsUnread(seriesId: String, browseOpts: SeriesBrowseOptions) async {
     do {
       try await seriesService.markAsUnread(seriesId: seriesId)
+      _ = try? await SyncService.shared.syncSeriesDetail(seriesId: seriesId)
       await MainActor.run {
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedUnread"))
       }

--- a/KMReader/Views/Book/BookDetailView.swift
+++ b/KMReader/Views/Book/BookDetailView.swift
@@ -573,6 +573,8 @@ struct BookDetailView: View {
           readListId: readListId,
           bookIds: [bookId]
         )
+        // Sync the readlist to update its bookIds in local SwiftData
+        _ = try? await SyncService.shared.syncReadList(id: readListId)
         await MainActor.run {
           ErrorManager.shared.notify(
             message: String(localized: "notification.book.booksAddedToReadList"))

--- a/KMReader/Views/Book/ListViews/BooksListViewForReadList.swift
+++ b/KMReader/Views/Book/ListViews/BooksListViewForReadList.swift
@@ -298,6 +298,8 @@ extension BooksListViewForReadList {
         readListId: readListId,
         bookIds: Array(selectedBookIds)
       )
+      // Sync the readlist to update its bookIds in local SwiftData
+      _ = try? await SyncService.shared.syncReadList(id: readListId)
 
       await MainActor.run {
         ErrorManager.shared.notify(message: String(localized: "notification.readList.booksRemoved"))

--- a/KMReader/Views/Browse/Sheets/CollectionPickerSheet.swift
+++ b/KMReader/Views/Browse/Sheets/CollectionPickerSheet.swift
@@ -146,6 +146,8 @@ struct CreateCollectionSheet: View {
           name: name,
           seriesIds: seriesIds
         )
+        // Sync the collection to update its seriesIds in local SwiftData
+        _ = try? await SyncService.shared.syncCollection(id: collection.id)
         await MainActor.run {
           ErrorManager.shared.notify(message: String(localized: "notification.collection.created"))
           isCreating = false

--- a/KMReader/Views/Browse/Sheets/ReadListPickerSheet.swift
+++ b/KMReader/Views/Browse/Sheets/ReadListPickerSheet.swift
@@ -150,6 +150,8 @@ struct CreateReadListSheet: View {
           summary: summary,
           bookIds: bookIds
         )
+        // Sync the readlist to update its bookIds in local SwiftData
+        _ = try? await SyncService.shared.syncReadList(id: readList.id)
         await MainActor.run {
           ErrorManager.shared.notify(message: String(localized: "notification.readList.created"))
           isCreating = false

--- a/KMReader/Views/Collection/Sections/CollectionSeriesListView.swift
+++ b/KMReader/Views/Collection/Sections/CollectionSeriesListView.swift
@@ -287,6 +287,8 @@ extension CollectionSeriesListView {
         collectionId: collectionId,
         seriesIds: Array(selectedSeriesIds)
       )
+      // Sync the collection to update its seriesIds in local SwiftData
+      _ = try? await SyncService.shared.syncCollection(id: collectionId)
 
       await MainActor.run {
         ErrorManager.shared.notify(

--- a/KMReader/Views/Dashboard/Sections/DashboardBooksSection.swift
+++ b/KMReader/Views/Dashboard/Sections/DashboardBooksSection.swift
@@ -130,7 +130,7 @@ struct DashboardBooksSection: View {
           )
         )
         let search = BookSearch(condition: condition)
-        page = try await BookService.shared.getBooksList(
+        page = try await SyncService.shared.syncBooksList(
           search: search,
           page: currentPage,
           size: 20,
@@ -138,28 +138,28 @@ struct DashboardBooksSection: View {
         )
 
       case .onDeck:
-        page = try await BookService.shared.getBooksOnDeck(
+        page = try await SyncService.shared.syncBooksOnDeck(
           libraryIds: libraryIds,
           page: currentPage,
           size: 20
         )
 
       case .recentlyReadBooks:
-        page = try await BookService.shared.getRecentlyReadBooks(
+        page = try await SyncService.shared.syncRecentlyReadBooks(
           libraryIds: libraryIds,
           page: currentPage,
           size: 20
         )
 
       case .recentlyReleasedBooks:
-        page = try await BookService.shared.getRecentlyReleasedBooks(
+        page = try await SyncService.shared.syncRecentlyReleasedBooks(
           libraryIds: libraryIds,
           page: currentPage,
           size: 20
         )
 
       case .recentlyAddedBooks:
-        page = try await BookService.shared.getRecentlyAddedBooks(
+        page = try await SyncService.shared.syncRecentlyAddedBooks(
           libraryIds: libraryIds,
           page: currentPage,
           size: 20

--- a/KMReader/Views/Dashboard/Sections/DashboardSeriesSection.swift
+++ b/KMReader/Views/Dashboard/Sections/DashboardSeriesSection.swift
@@ -123,14 +123,14 @@ struct DashboardSeriesSection: View {
 
       switch section {
       case .recentlyAddedSeries:
-        page = try await SeriesService.shared.getNewSeries(
+        page = try await SyncService.shared.syncNewSeries(
           libraryIds: libraryIds,
           page: currentPage,
           size: 20
         )
 
       case .recentlyUpdatedSeries:
-        page = try await SeriesService.shared.getUpdatedSeries(
+        page = try await SyncService.shared.syncUpdatedSeries(
           libraryIds: libraryIds,
           page: currentPage,
           size: 20

--- a/KMReader/Views/Reader/DivinaReaderView.swift
+++ b/KMReader/Views/Reader/DivinaReaderView.swift
@@ -431,14 +431,14 @@ struct DivinaReaderView: View {
     // Load book info to get read progress page and series reading direction
     var initialPageNumber: Int? = nil
     do {
-      let book = try await BookService.shared.getBook(id: bookId)
+      let book = try await SyncService.shared.syncBook(bookId: bookId)
       currentBook = book
       seriesId = book.seriesId
       // In incognito mode, always start from the first page
       initialPageNumber = incognito ? nil : book.readProgress?.page
 
       // Get series reading direction or fall back to user default
-      let series = try await SeriesService.shared.getOneSeries(id: book.seriesId)
+      let series = try await SyncService.shared.syncSeriesDetail(seriesId: book.seriesId)
       let rawReadingDirection = series.metadata.readingDirection?
         .trimmingCharacters(in: .whitespacesAndNewlines)
       let preferredDirection: ReadingDirection

--- a/KMReader/Views/Reader/EpubReaderView.swift
+++ b/KMReader/Views/Reader/EpubReaderView.swift
@@ -94,7 +94,7 @@
     private func loadBook() async {
       // Load book info
       do {
-        currentBook = try await BookService.shared.getBook(id: bookId)
+        currentBook = try await SyncService.shared.syncBook(bookId: bookId)
       } catch {
         // Silently fail
       }

--- a/KMReader/Views/Series/SeriesDetailView.swift
+++ b/KMReader/Views/Series/SeriesDetailView.swift
@@ -588,6 +588,8 @@ extension SeriesDetailView {
           collectionId: collectionId,
           seriesIds: [seriesId]
         )
+        // Sync the collection to update its seriesIds in local SwiftData
+        _ = try? await SyncService.shared.syncCollection(id: collectionId)
         await MainActor.run {
           ErrorManager.shared.notify(
             message: String(localized: "notification.series.addedToCollection"))


### PR DESCRIPTION
- Implement incremental and full sync for collections and readlists in SyncService
- Update BookViewModel and SeriesViewModel to utilize SyncService
- Integrate SyncService into Dashboard sections for unified data fetching
- Ensure Reader views sync book and series metadata upon opening
- Add post-mutation sync triggers for collections and readlists in detail/list views
- Refactor BrowseView refresh logic to prioritize manual/instance-triggered refreshes