### PR TITLE
feat(download): implement series offline policy

### DIFF
--- a/KMReader/Common/PlatformHelpers.swift
+++ b/KMReader/Common/PlatformHelpers.swift
@@ -110,6 +110,16 @@ struct PlatformHelper {
     #endif
   }
 
+  static var iconSize: CGFloat {
+    #if os(tvOS)
+      return 24
+    #elseif os(macOS)
+      return 14
+    #else
+      return 12
+    #endif
+  }
+
   static var detailThumbnailWidth: CGFloat {
     #if os(tvOS)
       return 240

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -2,7 +2,44 @@
   "sourceLanguage" : "en",
   "strings" : {
     "" : {
-      "shouldTranslate" : false
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        }
+      }
     },
     " • %@" : {
       "localizations" : {
@@ -40,6 +77,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : " • %@"
+          }
+        }
+      }
+    },
+    ":" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ":"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " :"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ":"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ":"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ":"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ":"
           }
         }
       }
@@ -15874,6 +15951,46 @@
         }
       }
     },
+    "Offline Policy" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline Policy"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Politique hors ligne"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインポリシー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 정책"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线策略"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離線策略"
+          }
+        }
+      }
+    },
     "Offline Tasks" : {
       "localizations" : {
         "en" : {
@@ -17032,6 +17149,166 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "請務必立即複製您的 API 金鑰。您將無法再看到它！"
+          }
+        }
+      }
+    },
+    "policy.all" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tout"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべて"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部"
+          }
+        }
+      }
+    },
+    "policy.manual" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manual"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manuel"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手動"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수동"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手動"
+          }
+        }
+      }
+    },
+    "policy.unread_only" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unread Only"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non lus uniquement"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未読のみ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미독 전용"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅未读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅未讀"
+          }
+        }
+      }
+    },
+    "policy.unread_only_cleanup" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unread Only + Cleanup"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non lus + Nettoyage"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未読のみ + クリーンアップ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미독 + 정리"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅未读（自动删除已读）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅未讀（自動刪除已讀）"
           }
         }
       }
@@ -24064,6 +24341,206 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "狀態"
+          }
+        }
+      }
+    },
+    "status.downloaded" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloaded"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드됨"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已下载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已下載"
+          }
+        }
+      }
+    },
+    "status.not_downloaded" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Downloaded"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non téléchargé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未ダウンロード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드되지 않음"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未下载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未下載"
+          }
+        }
+      }
+    },
+    "status.partially_downloaded %lld/%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld/%2$lld downloaded"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld/%2$lld téléchargés"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld/%2$lld ダウンロード済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld/%2$lld 다운로드됨"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld/%2$lld 已下载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld/%2$lld 已下載"
+          }
+        }
+      }
+    },
+    "status.pending" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pending"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En attente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대기 중"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待中"
+          }
+        }
+      }
+    },
+    "status.pending %lld+%lld/%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld+%2$lld/%3$lld pending"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld+%2$lld/%3$lld en attente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld+%2$lld/%3$lld 保留中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld+%2$lld/%3$lld 대기 중"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld+%2$lld/%3$lld 等待中"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld+%2$lld/%3$lld 等待中"
           }
         }
       }

--- a/KMReader/Models/Book/DownloadStatus.swift
+++ b/KMReader/Models/Book/DownloadStatus.swift
@@ -16,6 +16,47 @@ enum DownloadStatus: Equatable, Sendable {
   case downloaded
   case failed(error: String)
 
+  // MARK: - Display
+
+  var displayLabel: String {
+    switch self {
+    case .notDownloaded:
+      return String(localized: "status.not_downloaded")
+    case .pending:
+      return String(localized: "status.pending")
+    case .downloaded:
+      return String(localized: "status.downloaded")
+    case .failed(let error):
+      return error
+    }
+  }
+
+  var displayIcon: String {
+    switch self {
+    case .notDownloaded:
+      return "icloud.and.arrow.down"
+    case .pending:
+      return "arrow.clockwise.icloud.fill"
+    case .downloaded:
+      return "checkmark.icloud.fill"
+    case .failed:
+      return "exclamationmark.icloud.fill"
+    }
+  }
+
+  var displayColor: Color {
+    switch self {
+    case .notDownloaded:
+      return .secondary
+    case .pending:
+      return .orange
+    case .downloaded:
+      return .green
+    case .failed:
+      return .red
+    }
+  }
+
   // MARK: - Menu Display
 
   /// Label for context menu actions.
@@ -34,11 +75,11 @@ enum DownloadStatus: Equatable, Sendable {
   var menuIcon: String {
     switch self {
     case .downloaded:
-      return "trash.circle"
+      return "trash"
     case .pending:
       return "xmark.circle"
     case .notDownloaded, .failed:
-      return "square.and.arrow.down"
+      return "icloud.and.arrow.down"
     }
   }
 
@@ -48,7 +89,15 @@ enum DownloadStatus: Equatable, Sendable {
     case .downloaded, .pending:
       return .red
     case .notDownloaded, .failed:
-      return .primary
+      return .accentColor
     }
+  }
+
+  var isDownloaded: Bool {
+    self == .downloaded
+  }
+
+  var isPending: Bool {
+    self == .pending
   }
 }

--- a/KMReader/Models/Book/KomgaBook.swift
+++ b/KMReader/Models/Book/KomgaBook.swift
@@ -66,11 +66,13 @@ final class KomgaBook {
   var deleted: Bool
   var oneshot: Bool
 
+  var seriesTitle: String = ""
+
   // Track offline download status (managed locally)
   var downloadStatusRaw: String = "notDownloaded"
   var downloadError: String?
   var downloadAt: Date?
-  var downloadedSize: Int64?
+  var downloadedSize: Int64 = 0
 
   /// Computed property for download status.
   var downloadStatus: DownloadStatus {
@@ -107,7 +109,6 @@ final class KomgaBook {
     }
   }
 
-  @Relationship var series: KomgaSeries?
 
   init(
     id: String? = nil,
@@ -126,7 +127,9 @@ final class KomgaBook {
     metadata: BookMetadata,
     readProgress: ReadProgress?,
     deleted: Bool,
-    oneshot: Bool
+    oneshot: Bool,
+    seriesTitle: String = "",
+    downloadedSize: Int64 = 0
   ) {
     self.id = id ?? "\(instanceId)_\(bookId)"
     self.bookId = bookId
@@ -140,6 +143,7 @@ final class KomgaBook {
     self.lastModified = lastModified
     self.sizeBytes = sizeBytes
     self.size = size
+    self.seriesTitle = seriesTitle
 
     // Media
     self.mediaStatus = media.statusRaw
@@ -181,6 +185,7 @@ final class KomgaBook {
 
     self.deleted = deleted
     self.oneshot = oneshot
+    self.downloadedSize = downloadedSize
   }
 
   var media: Media {
@@ -284,7 +289,7 @@ final class KomgaBook {
     Book(
       id: bookId,
       seriesId: seriesId,
-      seriesTitle: series?.name ?? "",
+      seriesTitle: seriesTitle,
       libraryId: libraryId,
       name: name,
       url: url,

--- a/KMReader/Models/Collection/KomgaCollection.swift
+++ b/KMReader/Models/Collection/KomgaCollection.swift
@@ -23,7 +23,6 @@ final class KomgaCollection {
 
   var seriesIds: [String] = []
 
-  @Relationship var series: [KomgaSeries]? = []
 
   init(
     id: String? = nil,

--- a/KMReader/Models/ReadList/KomgaReadList.swift
+++ b/KMReader/Models/ReadList/KomgaReadList.swift
@@ -24,7 +24,6 @@ final class KomgaReadList {
 
   var bookIds: [String] = []
 
-  @Relationship var books: [KomgaBook]? = []
 
   init(
     id: String? = nil,

--- a/KMReader/Models/Series/SeriesDownloadStatus.swift
+++ b/KMReader/Models/Series/SeriesDownloadStatus.swift
@@ -1,0 +1,99 @@
+//
+//  SeriesDownloadStatus.swift
+//  KMReader
+//
+//  Created by Komga iOS Client
+//
+
+import Foundation
+import SwiftUI
+
+/// Custom status for series download progress.
+enum SeriesDownloadStatus: Equatable, Sendable {
+  case notDownloaded
+  case partiallyDownloaded(downloaded: Int, total: Int)
+  case downloaded
+  case pending(downloaded: Int, pending: Int, total: Int)
+
+  var label: String {
+    switch self {
+    case .notDownloaded:
+      return String(localized: "status.not_downloaded")
+    case .partiallyDownloaded(let downloaded, let total):
+      return String(localized: "status.partially_downloaded \(downloaded)/\(total)")
+    case .downloaded:
+      return String(localized: "status.downloaded")
+    case .pending(let downloaded, let pending, let total):
+      return String(localized: "status.pending \(downloaded)+\(pending)/\(total)")
+    }
+  }
+
+  var icon: String {
+    switch self {
+    case .notDownloaded:
+      return "icloud.and.arrow.down"
+    case .partiallyDownloaded:
+      return "icloud.and.arrow.down.fill"
+    case .downloaded:
+      return "checkmark.icloud.fill"
+    case .pending:
+      return "arrow.clockwise.icloud.fill"
+    }
+  }
+
+  var color: Color {
+    switch self {
+    case .notDownloaded:
+      return .secondary
+    case .partiallyDownloaded:
+      return .blue
+    case .downloaded:
+      return .green
+    case .pending:
+      return .orange
+    }
+  }
+
+  var toggleLabel: String {
+    switch self {
+    case .downloaded, .partiallyDownloaded:
+      return String(localized: "Remove Offline")
+    case .pending:
+      return String(localized: "Cancel Download")
+    case .notDownloaded:
+      return String(localized: "Make Offline")
+    }
+  }
+
+  var toggleIcon: String {
+    switch self {
+    case .downloaded, .partiallyDownloaded:
+      return "trash"
+    case .pending:
+      return "xmark.circle"
+    case .notDownloaded:
+      return "icloud.and.arrow.down"
+    }
+  }
+
+  var toggleColor: Color {
+    switch self {
+    case .downloaded, .partiallyDownloaded:
+      return .red
+    case .pending:
+      return .secondary
+    case .notDownloaded:
+      return .blue
+    }
+  }
+
+  var isDownloaded: Bool {
+    if case .downloaded = self { return true }
+    return false
+  }
+
+  var isPending: Bool {
+    if case .pending = self { return true }
+    return false
+  }
+}

--- a/KMReader/Models/Series/SeriesOfflinePolicy.swift
+++ b/KMReader/Models/Series/SeriesOfflinePolicy.swift
@@ -1,0 +1,46 @@
+//
+//  SeriesOfflinePolicy.swift
+//  KMReader
+//
+//  Created by Komga iOS Client
+//
+
+import Foundation
+
+/// Policy for automatic offline book management within a series.
+enum SeriesOfflinePolicy: String, Codable, CaseIterable, Sendable {
+  /// Manual mode: Books only downloaded/deleted via manual user actions.
+  case manual
+  /// Automatically download all unread books in the series.
+  case unreadOnly
+  /// Automatically download unread books and delete books once they are read.
+  case unreadOnlyAndCleanupRead
+  /// Automatically download all books in the series regardless of read status.
+  case all
+
+  var label: String {
+    switch self {
+    case .manual:
+      return String(localized: "policy.manual")
+    case .unreadOnly:
+      return String(localized: "policy.unread_only")
+    case .unreadOnlyAndCleanupRead:
+      return String(localized: "policy.unread_only_cleanup")
+    case .all:
+      return String(localized: "policy.all")
+    }
+  }
+
+  var icon: String {
+    switch self {
+    case .manual:
+      return "hand.tap"
+    case .unreadOnly:
+      return "book.circle"
+    case .unreadOnlyAndCleanupRead:
+      return "leaf.arrow.triangle.circlepath"
+    case .all:
+      return "infinity"
+    }
+  }
+}

--- a/KMReader/Services/Sync/DatabaseOperator.swift
+++ b/KMReader/Services/Sync/DatabaseOperator.swift
@@ -24,10 +24,6 @@ actor DatabaseOperator {
   func upsertBook(dto: Book, instanceId: String) {
     let compositeId = "\(instanceId)_\(dto.id)"
     let descriptor = FetchDescriptor<KomgaBook>(predicate: #Predicate { $0.id == compositeId })
-    let seriesCompositeId = "\(instanceId)_\(dto.seriesId)"
-    let seriesDescriptor = FetchDescriptor<KomgaSeries>(
-      predicate: #Predicate { $0.id == seriesCompositeId })
-    let parentSeries = try? modelContext.fetch(seriesDescriptor).first
     if let existing = try? modelContext.fetch(descriptor).first {
       existing.name = dto.name
       existing.url = dto.url
@@ -40,7 +36,7 @@ actor DatabaseOperator {
       existing.readProgress = dto.readProgress
       existing.deleted = dto.deleted
       existing.oneshot = dto.oneshot
-      existing.series = parentSeries
+      existing.seriesTitle = dto.seriesTitle
     } else {
       let newBook = KomgaBook(
         bookId: dto.id,
@@ -58,9 +54,9 @@ actor DatabaseOperator {
         metadata: dto.metadata,
         readProgress: dto.readProgress,
         deleted: dto.deleted,
-        oneshot: dto.oneshot
+        oneshot: dto.oneshot,
+        seriesTitle: dto.seriesTitle
       )
-      newBook.series = parentSeries
       modelContext.insert(newBook)
     }
   }

--- a/KMReader/Views/Book/BookCardView.swift
+++ b/KMReader/Views/Book/BookCardView.swift
@@ -34,7 +34,7 @@ struct BookCardView: View {
   }
 
   var shouldShowSeriesTitle: Bool {
-    showSeriesTitle && showBookCardSeriesTitle && komgaBook.series != nil
+    showSeriesTitle && showBookCardSeriesTitle && !komgaBook.seriesTitle.isEmpty
   }
 
   var bookTitleLineLimit: Int {
@@ -62,8 +62,8 @@ struct BookCardView: View {
         }
 
         VStack(alignment: .leading, spacing: 2) {
-          if shouldShowSeriesTitle, let seriesName = komgaBook.series?.name {
-            Text(seriesName)
+          if shouldShowSeriesTitle {
+            Text(komgaBook.seriesTitle)
               .font(.caption)
               .foregroundColor(.secondary)
               .lineLimit(1)
@@ -86,6 +86,12 @@ struct BookCardView: View {
                   Text("•")
                   Text("Oneshot")
                     .foregroundColor(.blue)
+                }
+                if komgaBook.downloadStatus != .notDownloaded {
+                  Text("•")
+                  Image(systemName: komgaBook.downloadStatus.displayIcon)
+                    .foregroundColor(komgaBook.downloadStatus.displayColor)
+                    .frame(width: PlatformHelper.iconSize, height: PlatformHelper.iconSize)
                 }
               }
               .foregroundColor(.secondary)

--- a/KMReader/Views/Book/BookDetailView.swift
+++ b/KMReader/Views/Book/BookDetailView.swift
@@ -222,6 +222,11 @@ struct BookDetailView: View {
             )
           }
 
+          if let komgaBook = komgaBook {
+          Divider()
+            BookDownloadActionsSection()
+              .environment(komgaBook)
+          }
           Divider()
           BookActionsSection(
             book: book,
@@ -591,20 +596,6 @@ struct BookDetailView: View {
   @ViewBuilder
   private var bookToolbarContent: some View {
     HStack(spacing: PlatformHelper.buttonSpacing) {
-      // Download Button
-      Button {
-        if let book = book {
-          Task {
-            await OfflineManager.shared.toggleDownload(
-              instanceId: currentInstanceId, info: book.downloadInfo)
-          }
-        }
-      } label: {
-        Image(systemName: downloadStatus.menuIcon)
-          .foregroundStyle(downloadStatus.menuColor)
-      }
-      .disabled(book == nil)
-      .toolbarButtonStyle()
 
       Menu {
         Button {

--- a/KMReader/Views/Book/BookRowView.swift
+++ b/KMReader/Views/Book/BookRowView.swift
@@ -31,7 +31,7 @@ struct BookRowView: View {
   }
 
   var shouldShowSeriesTitle: Bool {
-    showSeriesTitle && komgaBook.series != nil
+    showSeriesTitle && !komgaBook.seriesTitle.isEmpty
   }
 
   var bookTitleLineLimit: Int {
@@ -47,8 +47,8 @@ struct BookRowView: View {
           id: komgaBook.bookId, type: .book, showPlaceholder: false, width: 60, cornerRadius: 4)
 
         VStack(alignment: .leading, spacing: 4) {
-          if shouldShowSeriesTitle, let seriesName = komgaBook.series?.name {
-            Text(seriesName)
+          if shouldShowSeriesTitle {
+            Text(komgaBook.seriesTitle)
               .font(.footnote)
               .foregroundColor(.secondary)
               .lineLimit(1)
@@ -96,6 +96,12 @@ struct BookRowView: View {
                   Text("•")
                   Text("Oneshot")
                     .foregroundColor(.blue)
+                }
+                if komgaBook.downloadStatus != .notDownloaded {
+                  Text("•")
+                  Image(systemName: komgaBook.downloadStatus.displayIcon)
+                    .foregroundColor(komgaBook.downloadStatus.displayColor)
+                    .frame(width: PlatformHelper.iconSize, height: PlatformHelper.iconSize)
                 }
               }.foregroundColor(.secondary)
             }

--- a/KMReader/Views/Book/ContextMenus/BookContextMenu.swift
+++ b/KMReader/Views/Book/ContextMenus/BookContextMenu.swift
@@ -65,6 +65,7 @@ struct BookContextMenu: View {
       } label: {
         Label(downloadStatus.menuLabel, systemImage: downloadStatus.menuIcon)
       }
+      .tint(downloadStatus.menuColor)
 
       Divider()
 

--- a/KMReader/Views/Book/Sections/BookDownloadActionsSection.swift
+++ b/KMReader/Views/Book/Sections/BookDownloadActionsSection.swift
@@ -1,0 +1,55 @@
+//
+//  BookDownloadActionsSection.swift
+//  KMReader
+//
+
+import SwiftUI
+
+struct BookDownloadActionsSection: View {
+  @Environment(KomgaBook.self) private var komgaBook
+
+  @AppStorage("currentInstanceId") private var currentInstanceId: String = ""
+
+  private var book: Book {
+    komgaBook.toBook()
+  }
+
+  private var status: DownloadStatus {
+    komgaBook.downloadStatus
+  }
+
+  var body: some View {
+    HStack {
+      Label {
+        Text(status.displayLabel)
+      } icon: {
+        Image(systemName: status.displayIcon)
+          .frame(width: PlatformHelper.iconSize, height: PlatformHelper.iconSize)
+          .foregroundColor(status.displayColor)
+      }
+      .font(.subheadline)
+      .foregroundColor(.secondary)
+
+      Spacer()
+
+      Button {
+        Task {
+          await OfflineManager.shared.toggleDownload(
+            instanceId: currentInstanceId, info: book.downloadInfo)
+        }
+      } label: {
+        Label {
+          Text(status.menuLabel)
+        } icon: {
+          Image(systemName: status.menuIcon)
+            .frame(width: PlatformHelper.iconSize, height: PlatformHelper.iconSize)
+        }
+      }
+      .font(.caption)
+      .adaptiveButtonStyle(status.isDownloaded || status.isPending ? .bordered : .borderedProminent)
+      .tint(status.menuColor)
+    }
+    .animation(.default, value: status)
+    .padding(.vertical, 4)
+  }
+}

--- a/KMReader/Views/Series/ContextMenus/SeriesContextMenu.swift
+++ b/KMReader/Views/Series/ContextMenus/SeriesContextMenu.swift
@@ -5,6 +5,7 @@
 //  Created by Komga iOS Client
 //
 
+import SwiftData
 import SwiftUI
 
 @MainActor
@@ -76,6 +77,33 @@ struct SeriesContextMenu: View {
         Label("Manage", systemImage: "gearshape")
       }
       .disabled(!isAdmin)
+
+      Divider()
+
+      Menu {
+        Picker(selection: Binding(
+          get: { komgaSeries.offlinePolicy },
+          set: { updatePolicy($0) }
+        )) {
+          ForEach(SeriesOfflinePolicy.allCases, id: \.self) { policy in
+            Label(policy.label, systemImage: policy.icon)
+              .tag(policy)
+          }
+        } label: {
+          Text("Offline Policy")
+        }
+        .pickerStyle(.inline)
+
+        Divider()
+
+        Button(role: .destructive) {
+          updatePolicy(.manual)
+        } label: {
+          Label(komgaSeries.downloadStatus.toggleLabel, systemImage: komgaSeries.downloadStatus.toggleIcon)
+        }
+      } label: {
+        Label(komgaSeries.offlinePolicy.label, systemImage: komgaSeries.offlinePolicy.icon)
+      }
 
       Divider()
 
@@ -180,6 +208,16 @@ struct SeriesContextMenu: View {
           ErrorManager.shared.alert(error: error)
         }
       }
+    }
+  }
+
+  private func updatePolicy(_ policy: SeriesOfflinePolicy) {
+    komgaSeries.offlinePolicy = policy
+    if let context = komgaSeries.modelContext {
+      try? context.save()
+      KomgaBookStore.shared.syncSeriesDownloadStatus(series: komgaSeries, context: context)
+      try? context.save()
+      onActionCompleted?()
     }
   }
 }

--- a/KMReader/Views/Series/Sections/SeriesDownloadActionsSection.swift
+++ b/KMReader/Views/Series/Sections/SeriesDownloadActionsSection.swift
@@ -1,0 +1,98 @@
+//
+//  SeriesDownloadActionsSection.swift
+//  KMReader
+//
+
+import SwiftData
+import SwiftUI
+
+struct SeriesDownloadActionsSection: View {
+  @Environment(KomgaSeries.self) private var komgaSeries
+  @Environment(\.modelContext) private var context: ModelContext
+
+  private var series: Series {
+    komgaSeries.toSeries()
+  }
+
+  private var status: SeriesDownloadStatus {
+    komgaSeries.downloadStatus
+  }
+
+  private var policy: SeriesOfflinePolicy {
+    komgaSeries.offlinePolicy
+  }
+
+  var body: some View {
+    VStack(spacing: 12) {
+      HStack(spacing: 12) {
+        Menu {
+          Picker(
+            "",
+            selection: Binding(
+              get: { policy },
+              set: { updatePolicy($0) }
+            )
+          ) {
+            ForEach(SeriesOfflinePolicy.allCases, id: \.self) { p in
+              Label(p.label, systemImage: p.icon)
+                .tag(p)
+            }
+          }
+          .pickerStyle(.inline)
+        } label: {
+          Label {
+            HStack(spacing: 2) {
+              Text("Offline Policy")
+              Text(":")
+              Text(policy.label)
+            }
+          } icon: {
+            Image(systemName: policy.icon)
+              .frame(width: PlatformHelper.iconSize, height: PlatformHelper.iconSize)
+          }
+          .fixedSize()
+        }
+        .font(.caption)
+        .adaptiveButtonStyle(.bordered)
+
+        Spacer()
+
+        Label {
+          Text(status.label)
+        } icon: {
+          Image(systemName: status.icon)
+            .foregroundColor(status.color)
+        }
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+
+        Button {
+          KomgaBookStore.shared.toggleSeriesDownload(series: komgaSeries, context: context)
+        } label: {
+          Label {
+            Text(status.toggleLabel)
+          } icon: {
+            Image(systemName: status.toggleIcon)
+              .frame(width: PlatformHelper.iconSize, height: PlatformHelper.iconSize)
+          }
+        }
+        .font(.caption)
+        .adaptiveButtonStyle(
+          status.isDownloaded || status.isPending ? .bordered : .borderedProminent
+        )
+        .tint(status.toggleColor)
+      }
+
+    }
+    .animation(.default, value: status)
+    .animation(.default, value: policy)
+    .padding(.vertical, 4)
+  }
+
+  private func updatePolicy(_ newPolicy: SeriesOfflinePolicy) {
+    komgaSeries.offlinePolicy = newPolicy
+    try? context.save()
+    KomgaBookStore.shared.syncSeriesDownloadStatus(series: komgaSeries, context: context)
+    try? context.save()
+  }
+}

--- a/KMReader/Views/Series/SeriesCardView.swift
+++ b/KMReader/Views/Series/SeriesCardView.swift
@@ -51,6 +51,12 @@ struct SeriesCardView: View {
                 Text("Oneshot")
                   .foregroundColor(.blue)
               }
+              if komgaSeries.downloadStatus != .notDownloaded {
+                Text("•")
+                Image(systemName: komgaSeries.downloadStatus.icon)
+                  .foregroundColor(komgaSeries.downloadStatus.color)
+                  .frame(width: PlatformHelper.iconSize, height: PlatformHelper.iconSize)
+              }
             }
             .foregroundColor(.secondary)
           }

--- a/KMReader/Views/Series/SeriesDetailView.swift
+++ b/KMReader/Views/Series/SeriesDetailView.swift
@@ -368,6 +368,11 @@ struct SeriesDetailView: View {
           #endif
 
           Divider()
+          if let komgaSeries = komgaSeries {
+            SeriesDownloadActionsSection()
+              .environment(komgaSeries)
+          }
+          Divider()
           if containerWidth > 0 {
             BooksListViewForSeries(
               seriesId: seriesId,

--- a/KMReader/Views/Series/SeriesRowView.swift
+++ b/KMReader/Views/Series/SeriesRowView.swift
@@ -56,6 +56,13 @@ struct SeriesRowView: View {
                 Text("Oneshot")
                   .foregroundColor(.blue)
               }
+              if komgaSeries.downloadStatus != .notDownloaded {
+                Text("•")
+                  .foregroundColor(.secondary)
+                Image(systemName: komgaSeries.downloadStatus.icon)
+                  .foregroundColor(komgaSeries.downloadStatus.color)
+                  .frame(width: PlatformHelper.iconSize, height: PlatformHelper.iconSize)
+              }
             }
           }
         }.font(.caption)

--- a/KMReader/Views/Settings/SettingsOfflineTasksView.swift
+++ b/KMReader/Views/Settings/SettingsOfflineTasksView.swift
@@ -100,9 +100,7 @@ struct SettingsOfflineTasksView: View {
     .animation(.default, value: isPaused)
     .onChange(of: isPaused) { _, newValue in
       if !newValue {
-        Task {
-          await OfflineManager.shared.syncDownloadQueue(instanceId: instanceId)
-        }
+        OfflineManager.shared.triggerSync(instanceId: instanceId, restart: true)
       }
     }
   }
@@ -152,7 +150,7 @@ struct OfflineTaskRow: View {
           Task {
             await OfflineManager.shared.cancelDownload(bookId: book.bookId)
             let instanceId = AppConfig.currentInstanceId
-            await OfflineManager.shared.syncDownloadQueue(instanceId: instanceId)
+            OfflineManager.shared.triggerSync(instanceId: instanceId)
           }
         } label: {
           Image(systemName: "xmark.circle")


### PR DESCRIPTION
- Reset series offline policy to .manual automatically when removing books manually in KomgaBookStore.
- Refine SeriesDownloadActionsSection to include inline policy selection and improved layout.
- Fix layout shifts in download actions by enforcing fixed icon sizes using PlatformHelper.
- Add offline download status indicators to BookCardView, BookRowView, SeriesCardView, and SeriesRowView.