### PR TITLE
refactor: convert singleton actors to @globalActor

### DIFF
--- a/KMReader/Services/Cache/BookFileCache.swift
+++ b/KMReader/Services/Cache/BookFileCache.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@globalActor
 actor BookFileCache {
   static let shared = BookFileCache()
 

--- a/KMReader/Services/Cache/ThumbnailCache.swift
+++ b/KMReader/Services/Cache/ThumbnailCache.swift
@@ -26,6 +26,7 @@ enum ThumbnailType: String, CaseIterable {
   }
 }
 
+@globalActor
 actor ThumbnailCache {
   static let shared = ThumbnailCache()
 

--- a/KMReader/Services/Core/LogStore.swift
+++ b/KMReader/Services/Core/LogStore.swift
@@ -9,6 +9,7 @@ import Foundation
 import OSLog
 import SQLite3
 
+@globalActor
 actor LogStore {
   static let shared = LogStore()
 

--- a/KMReader/Services/Offline/OfflineManager.swift
+++ b/KMReader/Services/Offline/OfflineManager.swift
@@ -20,6 +20,7 @@ struct DownloadInfo: Sendable {
 /// Actor for managing offline book downloads with proper thread isolation.
 /// Download status is persisted in SwiftData via KomgaBook.downloadStatus.
 /// Progress is tracked via DownloadProgressTracker for UI display.
+@globalActor
 actor OfflineManager {
   static let shared = OfflineManager()
 


### PR DESCRIPTION
Convert OfflineManager, LogStore, ThumbnailCache, and BookFileCache to @globalActor for better isolation.