### PR TITLE
refactor: use layoutDirection for RTL in PageView and EndPageView

### DIFF
--- a/KMReader/Features/Views/Reader/ArcEffectShape.swift
+++ b/KMReader/Features/Views/Reader/ArcEffectShape.swift
@@ -110,7 +110,6 @@ struct ArcEffectView: View {
         }
       }
     }
-    .allowsHitTesting(false)
   }
 }
 

--- a/KMReader/Features/Views/Reader/EndPageView/EndPageView.swift
+++ b/KMReader/Features/Views/Reader/EndPageView/EndPageView.swift
@@ -105,6 +105,8 @@ struct EndPageView: View {
             readingDirection: readingDirection,
             themeColor: themeColor.color
           )
+          .environment(\.layoutDirection, .leftToRight)
+          .allowsHitTesting(false)
         }
       #endif
 
@@ -146,36 +148,15 @@ struct EndPageView: View {
   private var content: some View {
     VStack(spacing: PlatformHelper.buttonSpacing) {
       HStack(spacing: PlatformHelper.buttonSpacing) {
-
-        // Next book button for RTL
-        if readingDirection == .rtl, let nextBook = nextBook {
-          Button {
-            onNextBook(nextBook.id)
-          } label: {
-            HStack(spacing: 8) {
-              Image(systemName: "arrow.left")
-              Text(String(localized: "reader.nextBook"))
-            }
-          }
-          .controlSize(.large)
-          .adaptiveButtonStyle(.borderedProminent)
-          .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
-          #if os(tvOS)
-            .focused($focusedButton, equals: .next)
-          #endif
-        }
-
-        // Hidden button for navigation
+        // Hidden button for navigation (leading side)
         #if os(tvOS)
-          if readingDirection != .rtl {
-            Button {
-            } label: {
-              Color.clear
-                .frame(width: 1, height: 1)
-            }
-            .adaptiveButtonStyle(.plain)
-            .focused($focusedButton, equals: .hidden)
+          Button {
+          } label: {
+            Color.clear
+              .frame(width: 1, height: 1)
           }
+          .adaptiveButtonStyle(.plain)
+          .focused($focusedButton, equals: .hidden)
         #endif
 
         // Dismiss button
@@ -183,46 +164,26 @@ struct EndPageView: View {
           onDismiss()
         } label: {
           HStack(spacing: 8) {
-            if readingDirection != .rtl {
-              Image(systemName: "xmark")
-            }
+            Image(systemName: "xmark")
             Text("Close")
-            if readingDirection == .rtl {
-              Image(systemName: "xmark")
-            }
           }
         }
-        .controlSize(.large)
         .adaptiveButtonStyle(.bordered)
         .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
         #if os(tvOS)
           .focused($focusedButton, equals: .close)
         #endif
 
-        // Hidden button for navigation
-        #if os(tvOS)
-          if readingDirection == .rtl {
-            Button {
-            } label: {
-              Color.clear
-                .frame(width: 1, height: 1)
-            }
-            .adaptiveButtonStyle(.plain)
-            .focused($focusedButton, equals: .hidden)
-          }
-        #endif
-
         // Next book button
-        if readingDirection != .rtl, let nextBook = nextBook {
+        if let nextBook = nextBook {
           Button {
             onNextBook(nextBook.id)
           } label: {
             HStack(spacing: 8) {
               Text(String(localized: "reader.nextBook"))
-              Image(systemName: "arrow.right")
+              Image(systemName: readingDirection == .rtl ? "arrow.left" : "arrow.right")
             }
           }
-          .controlSize(.large)
           .adaptiveButtonStyle(.borderedProminent)
           .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
           #if os(tvOS)
@@ -231,8 +192,11 @@ struct EndPageView: View {
         }
       }
       NextBookInfoView(nextBook: nextBook, readList: readList)
+        .environment(\.layoutDirection, .leftToRight)
         .allowsHitTesting(false)
     }
+    .environment(\.layoutDirection, readingDirection == .rtl ? .rightToLeft : .leftToRight)
+    .padding()
   }
 
 }

--- a/KMReader/Features/Views/Reader/EndPageView/NextBookInfoView.swift
+++ b/KMReader/Features/Views/Reader/EndPageView/NextBookInfoView.swift
@@ -33,48 +33,52 @@ struct NextBookInfoView: View {
   }
 
   var body: some View {
-    if let nextBook = nextBook {
-      VStack(spacing: 4) {
-        HStack(spacing: 6) {
-          Image(systemName: "arrow.right.circle")
-          Text(upNextLabel)
-        }
-        if let readList = readList {
-          HStack(spacing: 4) {
-            Image(systemName: "list.bullet.rectangle")
-              .font(.caption2)
-            Text("From: \(readList.name)")
-              .font(.caption)
+    Group {
+      if let nextBook = nextBook {
+        VStack(spacing: 4) {
+          HStack(spacing: 6) {
+            Text(upNextLabel)
           }
-          .foregroundColor(.white)
+          if let readList = readList {
+            HStack(spacing: 4) {
+              Image(systemName: "list.bullet.rectangle")
+                .font(.caption2)
+              Text("From: \(readList.name)")
+                .font(.caption)
+            }
+            .foregroundColor(.white)
+          }
+          Text(nextBook.metadata.title)
+            .font(.footnote)
+            .multilineTextAlignment(.center)
+          HStack(spacing: 4) {
+            Text("\(nextBook.media.pagesCount)")
+            Text("•")
+            Text(nextBook.size)
+          }
+          .font(.footnote)
         }
-        Text(nextBook.metadata.title)
-        HStack(spacing: 4) {
-          Text("\(nextBook.media.pagesCount) pages")
-          Text("•")
-          Text(nextBook.size)
+
+        .foregroundColor(.white)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(
+          RoundedRectangle(cornerRadius: 12)
+            .fill(themeColor.color.opacity(0.8))
+        )
+      } else {
+        HStack(spacing: 8) {
+          Image(systemName: "checkmark.circle")
+          Text(String(localized: "You're all caught up!"))
         }
-        .font(.footnote)
+        .foregroundColor(.white)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(
+          RoundedRectangle(cornerRadius: 12)
+            .fill(themeColor.color.opacity(0.8))
+        )
       }
-      .foregroundColor(.white)
-      .padding(.horizontal, 16)
-      .padding(.vertical, 8)
-      .background(
-        RoundedRectangle(cornerRadius: 12)
-          .fill(themeColor.color.opacity(0.8))
-      )
-    } else {
-      HStack(spacing: 8) {
-        Image(systemName: "checkmark.circle")
-        Text(String(localized: "You're all caught up!"))
-      }
-      .foregroundColor(.white)
-      .padding(.horizontal, 16)
-      .padding(.vertical, 8)
-      .background(
-        RoundedRectangle(cornerRadius: 12)
-          .fill(themeColor.color.opacity(0.8))
-      )
     }
   }
 }


### PR DESCRIPTION
- Simplify PageView by using layoutDirection environment instead of manual array reversal for RTL
- Update EndPageView button layout to use layoutDirection
- Fix ArcEffectView and NextBookInfoView to use LTR layout explicitly
- Remove duplicate helper functions in PageView