### PR TITLE
feat(reader): preload images into memory cache for instant display

### DIFF
--- a/KMReader/Core/Storage/Cache/CacheManager.swift
+++ b/KMReader/Core/Storage/Cache/CacheManager.swift
@@ -31,7 +31,6 @@ enum CacheManager {
     await ThumbnailCache.clearAllDiskCache()
     await MainActor.run {
       SDImageCacheProvider.thumbnailCache.clearMemory()
-      SDImageCacheProvider.thumbnailCache.clearDisk()
     }
   }
 

--- a/KMReader/Core/Storage/Cache/SDImageCacheProvider.swift
+++ b/KMReader/Core/Storage/Cache/SDImageCacheProvider.swift
@@ -11,22 +11,18 @@ import SDWebImageWebPCoder
 
 enum SDImageCacheProvider {
   static let thumbnailCache: SDImageCache = {
-    let cache = SDImageCache(namespace: "KomgaThumbnailCache")
+    let cache = SDImageCache(namespace: "KomgaThumbnailCache", diskCacheDirectory: nil)
     cache.config.shouldCacheImagesInMemory = true
     cache.config.maxMemoryCost = 50 * 1024 * 1024  // 50 MB decoded thumbnails
-    cache.config.maxMemoryCount = 150
-    cache.config.maxDiskSize = 10 * 1024 * 1024  // Minimal disk footprint; actual storage handled elsewhere
-    cache.config.diskCacheExpireType = .accessDate
+    cache.config.maxMemoryCount = 200
     return cache
   }()
 
   static let pageImageCache: SDImageCache = {
-    let cache = SDImageCache(namespace: "KomgaPageImageCache")
+    let cache = SDImageCache(namespace: "KomgaPageImageCache", diskCacheDirectory: nil)
     cache.config.shouldCacheImagesInMemory = true
-    cache.config.maxMemoryCost = 300 * 1024 * 1024  // 300 MB decoded pages
-    cache.config.maxMemoryCount = 60
-    cache.config.maxDiskSize = 10 * 1024 * 1024  // Minimal disk footprint; actual storage handled elsewhere
-    cache.config.diskCacheExpireType = .accessDate
+    cache.config.maxMemoryCost = 200 * 1024 * 1024  // 200 MB decoded pages
+    cache.config.maxMemoryCount = 50
     return cache
   }()
 

--- a/KMReader/Features/Views/Dashboard/DashboardView.swift
+++ b/KMReader/Features/Views/Dashboard/DashboardView.swift
@@ -161,7 +161,6 @@ struct DashboardView: View {
                   refreshDashboard(reason: "Book action completed")
                 }
               )
-              .transition(.move(edge: .top).combined(with: .opacity))
 
             case .recentlyUpdatedSeries, .recentlyAddedSeries:
               DashboardSeriesSection(
@@ -172,7 +171,6 @@ struct DashboardView: View {
                   refreshDashboard(reason: "Series action completed")
                 }
               )
-              .transition(.move(edge: .top).combined(with: .opacity))
             }
           }
         }

--- a/KMReader/Features/Views/Reader/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Views/Reader/Webtoon/WebtoonReaderView_iOS.swift
@@ -738,8 +738,9 @@
 
           for i in max(0, minVisible - 2)...min(self.pages.count - 1, maxVisible + 2) {
             let page = self.pages[i]
-            if !(await viewModel.pageImageCache.hasImage(bookId: viewModel.bookId, page: page)) {
-              await self.loadImageForPage(i)
+            if let fileURL = await viewModel.getPageImageFileURL(page: page) {
+              // Preload into SDWebImage memory cache for instant display
+              await viewModel.preloadImageToMemory(fileURL: fileURL)
             }
           }
         }

--- a/KMReader/Features/Views/Reader/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Views/Reader/Webtoon/WebtoonReaderView_macOS.swift
@@ -478,8 +478,9 @@
           guard let self = self, let vm = self.viewModel else { return }
           for i in max(0, minV - 2)...min(self.pages.count - 1, maxV + 2) {
             let page = self.pages[i]
-            if !(await vm.pageImageCache.hasImage(bookId: vm.bookId, page: page)) {
-              await self.loadImageForPage(i)
+            if let fileURL = await vm.getPageImageFileURL(page: page) {
+              // Preload into SDWebImage memory cache for instant display
+              await vm.preloadImageToMemory(fileURL: fileURL)
             }
           }
         }

--- a/KMReader/Features/Views/Settings/SettingsTasksView.swift
+++ b/KMReader/Features/Views/Settings/SettingsTasksView.swift
@@ -112,7 +112,6 @@ struct SettingsTasksView: View {
               }
             }
           }
-          .transition(.opacity.combined(with: .move(edge: .top)))
           .animation(.spring(response: 0.3, dampingFraction: 0.7), value: taskQueueStatus.count)
           .animation(
             .spring(response: 0.3, dampingFraction: 0.7), value: taskQueueStatus.countByType)


### PR DESCRIPTION
- Add preloadImageToMemory() to load images into SDWebImage memory cache after downloading to disk, eliminating loading spinner on preloaded pages
- Skip preload if image already in memory cache (optimization)
- Disable SDImageCache disk cache (use only memory, disk handled by ImageCache)
- Tune memory cache limits: thumbnails 50MB/200 items, pages 200MB/50 items