### PR TITLE
refactor(storage): compare individual fields in upsert methods

### DIFF
--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -31,14 +31,84 @@ actor DatabaseOperator {
       if existing.lastModified != dto.lastModified { existing.lastModified = dto.lastModified }
       if existing.sizeBytes != dto.sizeBytes { existing.sizeBytes = dto.sizeBytes }
       if existing.size != dto.size { existing.size = dto.size }
-      // Use lastModified to detect changes in complex types
-      if existing.lastModified != dto.lastModified {
-        existing.media = dto.media
-        existing.metadata = dto.metadata
+      // Media fields
+      if existing.mediaStatus != dto.media.statusRaw { existing.mediaStatus = dto.media.statusRaw }
+      if existing.mediaType != dto.media.mediaType { existing.mediaType = dto.media.mediaType }
+      if existing.mediaPagesCount != dto.media.pagesCount {
+        existing.mediaPagesCount = dto.media.pagesCount
       }
-      // readProgress has its own lastModified field
-      if existing.readProgress?.lastModified != dto.readProgress?.lastModified {
-        existing.readProgress = dto.readProgress
+      if existing.mediaComment != dto.media.comment { existing.mediaComment = dto.media.comment }
+      if existing.mediaProfile != dto.media.mediaProfileRaw {
+        existing.mediaProfile = dto.media.mediaProfileRaw
+      }
+      if existing.mediaEpubDivinaCompatible != dto.media.epubDivinaCompatible {
+        existing.mediaEpubDivinaCompatible = dto.media.epubDivinaCompatible
+      }
+      if existing.mediaEpubIsKepub != dto.media.epubIsKepub {
+        existing.mediaEpubIsKepub = dto.media.epubIsKepub
+      }
+      // Metadata fields
+      if existing.metaCreated != dto.metadata.created { existing.metaCreated = dto.metadata.created }
+      if existing.metaLastModified != dto.metadata.lastModified {
+        existing.metaLastModified = dto.metadata.lastModified
+      }
+      if existing.metaTitle != dto.metadata.title { existing.metaTitle = dto.metadata.title }
+      if existing.metaTitleLock != dto.metadata.titleLock {
+        existing.metaTitleLock = dto.metadata.titleLock
+      }
+      if existing.metaSummary != dto.metadata.summary { existing.metaSummary = dto.metadata.summary }
+      if existing.metaSummaryLock != dto.metadata.summaryLock {
+        existing.metaSummaryLock = dto.metadata.summaryLock
+      }
+      if existing.metaNumber != dto.metadata.number { existing.metaNumber = dto.metadata.number }
+      if existing.metaNumberLock != dto.metadata.numberLock {
+        existing.metaNumberLock = dto.metadata.numberLock
+      }
+      if existing.metaNumberSort != dto.metadata.numberSort {
+        existing.metaNumberSort = dto.metadata.numberSort
+      }
+      if existing.metaNumberSortLock != dto.metadata.numberSortLock {
+        existing.metaNumberSortLock = dto.metadata.numberSortLock
+      }
+      if existing.metaReleaseDate != dto.metadata.releaseDate {
+        existing.metaReleaseDate = dto.metadata.releaseDate
+      }
+      if existing.metaReleaseDateLock != dto.metadata.releaseDateLock {
+        existing.metaReleaseDateLock = dto.metadata.releaseDateLock
+      }
+      let newAuthorsRaw = try? JSONEncoder().encode(dto.metadata.authors)
+      if existing.metaAuthorsRaw != newAuthorsRaw { existing.metaAuthorsRaw = newAuthorsRaw }
+      if existing.metaAuthorsLock != dto.metadata.authorsLock {
+        existing.metaAuthorsLock = dto.metadata.authorsLock
+      }
+      if existing.metaTags != dto.metadata.tags { existing.metaTags = dto.metadata.tags }
+      if existing.metaTagsLock != dto.metadata.tagsLock {
+        existing.metaTagsLock = dto.metadata.tagsLock
+      }
+      if existing.metaIsbn != dto.metadata.isbn { existing.metaIsbn = dto.metadata.isbn }
+      if existing.metaIsbnLock != dto.metadata.isbnLock {
+        existing.metaIsbnLock = dto.metadata.isbnLock
+      }
+      let newLinksRaw = try? JSONEncoder().encode(dto.metadata.links)
+      if existing.metaLinksRaw != newLinksRaw { existing.metaLinksRaw = newLinksRaw }
+      if existing.metaLinksLock != dto.metadata.linksLock {
+        existing.metaLinksLock = dto.metadata.linksLock
+      }
+      // ReadProgress fields
+      if existing.progressPage != dto.readProgress?.page {
+        existing.progressPage = dto.readProgress?.page
+      }
+      if existing.progressCompleted != dto.readProgress?.completed {
+        existing.progressCompleted = dto.readProgress?.completed
+      }
+      if existing.progressReadDate != dto.readProgress?.readDate {
+        existing.progressReadDate = dto.readProgress?.readDate
+      }
+      if existing.progressCreated != dto.readProgress?.created {
+        existing.progressCreated = dto.readProgress?.created
+      }
+      if existing.progressLastModified != dto.readProgress?.lastModified {
+        existing.progressLastModified = dto.readProgress?.lastModified
       }
       if existing.deleted != dto.deleted { existing.deleted = dto.deleted }
       if existing.oneshot != dto.oneshot { existing.oneshot = dto.oneshot }
@@ -183,10 +253,111 @@ actor DatabaseOperator {
       if existing.booksInProgressCount != dto.booksInProgressCount {
         existing.booksInProgressCount = dto.booksInProgressCount
       }
-      // Use lastModified to detect changes in complex types
-      if existing.lastModified != dto.lastModified {
-        existing.metadata = dto.metadata
-        existing.booksMetadata = dto.booksMetadata
+      // SeriesMetadata fields
+      if existing.metaStatus != dto.metadata.status { existing.metaStatus = dto.metadata.status }
+      if existing.metaStatusLock != dto.metadata.statusLock {
+        existing.metaStatusLock = dto.metadata.statusLock
+      }
+      if existing.metaCreated != dto.metadata.created {
+        existing.metaCreated = dto.metadata.created
+      }
+      if existing.metaLastModified != dto.metadata.lastModified {
+        existing.metaLastModified = dto.metadata.lastModified
+      }
+      if existing.metaTitle != dto.metadata.title { existing.metaTitle = dto.metadata.title }
+      if existing.metaTitleLock != dto.metadata.titleLock {
+        existing.metaTitleLock = dto.metadata.titleLock
+      }
+      if existing.metaTitleSort != dto.metadata.titleSort {
+        existing.metaTitleSort = dto.metadata.titleSort
+      }
+      if existing.metaTitleSortLock != dto.metadata.titleSortLock {
+        existing.metaTitleSortLock = dto.metadata.titleSortLock
+      }
+      if existing.metaSummary != dto.metadata.summary {
+        existing.metaSummary = dto.metadata.summary
+      }
+      if existing.metaSummaryLock != dto.metadata.summaryLock {
+        existing.metaSummaryLock = dto.metadata.summaryLock
+      }
+      if existing.metaReadingDirection != dto.metadata.readingDirection {
+        existing.metaReadingDirection = dto.metadata.readingDirection
+      }
+      if existing.metaReadingDirectionLock != dto.metadata.readingDirectionLock {
+        existing.metaReadingDirectionLock = dto.metadata.readingDirectionLock
+      }
+      if existing.metaPublisher != dto.metadata.publisher {
+        existing.metaPublisher = dto.metadata.publisher
+      }
+      if existing.metaPublisherLock != dto.metadata.publisherLock {
+        existing.metaPublisherLock = dto.metadata.publisherLock
+      }
+      if existing.metaAgeRating != dto.metadata.ageRating {
+        existing.metaAgeRating = dto.metadata.ageRating
+      }
+      if existing.metaAgeRatingLock != dto.metadata.ageRatingLock {
+        existing.metaAgeRatingLock = dto.metadata.ageRatingLock
+      }
+      if existing.metaLanguage != dto.metadata.language {
+        existing.metaLanguage = dto.metadata.language
+      }
+      if existing.metaLanguageLock != dto.metadata.languageLock {
+        existing.metaLanguageLock = dto.metadata.languageLock
+      }
+      if existing.metaGenres != dto.metadata.genres { existing.metaGenres = dto.metadata.genres }
+      if existing.metaGenresLock != dto.metadata.genresLock {
+        existing.metaGenresLock = dto.metadata.genresLock
+      }
+      if existing.metaTags != dto.metadata.tags { existing.metaTags = dto.metadata.tags }
+      if existing.metaTagsLock != dto.metadata.tagsLock {
+        existing.metaTagsLock = dto.metadata.tagsLock
+      }
+      if existing.metaTotalBookCount != dto.metadata.totalBookCount {
+        existing.metaTotalBookCount = dto.metadata.totalBookCount
+      }
+      if existing.metaTotalBookCountLock != dto.metadata.totalBookCountLock {
+        existing.metaTotalBookCountLock = dto.metadata.totalBookCountLock
+      }
+      if existing.metaSharingLabels != dto.metadata.sharingLabels {
+        existing.metaSharingLabels = dto.metadata.sharingLabels
+      }
+      if existing.metaSharingLabelsLock != dto.metadata.sharingLabelsLock {
+        existing.metaSharingLabelsLock = dto.metadata.sharingLabelsLock
+      }
+      let newLinksRaw = try? JSONEncoder().encode(dto.metadata.links)
+      if existing.metaLinksRaw != newLinksRaw { existing.metaLinksRaw = newLinksRaw }
+      if existing.metaLinksLock != dto.metadata.linksLock {
+        existing.metaLinksLock = dto.metadata.linksLock
+      }
+      let newAlternateTitlesRaw = try? JSONEncoder().encode(dto.metadata.alternateTitles)
+      if existing.metaAlternateTitlesRaw != newAlternateTitlesRaw {
+        existing.metaAlternateTitlesRaw = newAlternateTitlesRaw
+      }
+      if existing.metaAlternateTitlesLock != dto.metadata.alternateTitlesLock {
+        existing.metaAlternateTitlesLock = dto.metadata.alternateTitlesLock
+      }
+      // SeriesBooksMetadata fields
+      if existing.booksMetaCreated != dto.booksMetadata.created {
+        existing.booksMetaCreated = dto.booksMetadata.created
+      }
+      if existing.booksMetaLastModified != dto.booksMetadata.lastModified {
+        existing.booksMetaLastModified = dto.booksMetadata.lastModified
+      }
+      let newAuthorsRaw = try? JSONEncoder().encode(dto.booksMetadata.authors)
+      if existing.booksMetaAuthorsRaw != newAuthorsRaw {
+        existing.booksMetaAuthorsRaw = newAuthorsRaw
+      }
+      if existing.booksMetaTags != dto.booksMetadata.tags {
+        existing.booksMetaTags = dto.booksMetadata.tags
+      }
+      if existing.booksMetaReleaseDate != dto.booksMetadata.releaseDate {
+        existing.booksMetaReleaseDate = dto.booksMetadata.releaseDate
+      }
+      if existing.booksMetaSummary != dto.booksMetadata.summary {
+        existing.booksMetaSummary = dto.booksMetadata.summary
+      }
+      if existing.booksMetaSummaryNumber != dto.booksMetadata.summaryNumber {
+        existing.booksMetaSummaryNumber = dto.booksMetadata.summaryNumber
       }
       if existing.deleted != dto.deleted { existing.deleted = dto.deleted }
       if existing.oneshot != dto.oneshot { existing.oneshot = dto.oneshot }

--- a/KMReader/Features/Models/Book/KomgaBook.swift
+++ b/KMReader/Features/Models/Book/KomgaBook.swift
@@ -191,100 +191,56 @@ final class KomgaBook {
   }
 
   var media: Media {
-    get {
-      Media(
-        status: MediaStatus(rawValue: mediaStatus) ?? .unknown,
-        mediaType: mediaType,
-        pagesCount: mediaPagesCount,
-        comment: mediaComment,
-        mediaProfile: mediaProfile.flatMap(MediaProfile.init),
-        epubDivinaCompatible: mediaEpubDivinaCompatible,
-        epubIsKepub: mediaEpubIsKepub
-      )
-    }
-    set {
-      self.mediaStatus = newValue.status.rawValue
-      self.mediaType = newValue.mediaType
-      self.mediaPagesCount = newValue.pagesCount
-      self.mediaComment = newValue.comment
-      self.mediaProfile = newValue.mediaProfile?.rawValue
-      self.mediaEpubDivinaCompatible = newValue.epubDivinaCompatible
-      self.mediaEpubIsKepub = newValue.epubIsKepub
-    }
+    Media(
+      status: MediaStatus(rawValue: mediaStatus) ?? .unknown,
+      mediaType: mediaType,
+      pagesCount: mediaPagesCount,
+      comment: mediaComment,
+      mediaProfile: mediaProfile.flatMap(MediaProfile.init),
+      epubDivinaCompatible: mediaEpubDivinaCompatible,
+      epubIsKepub: mediaEpubIsKepub
+    )
   }
 
   var metadata: BookMetadata {
-    get {
-      BookMetadata(
-        created: metaCreated,
-        lastModified: metaLastModified,
-        title: metaTitle,
-        titleLock: metaTitleLock,
-        summary: metaSummary,
-        summaryLock: metaSummaryLock,
-        number: metaNumber,
-        numberLock: metaNumberLock,
-        numberSort: metaNumberSort,
-        numberSortLock: metaNumberSortLock,
-        releaseDate: metaReleaseDate,
-        releaseDateLock: metaReleaseDateLock,
-        authors: metaAuthorsRaw.flatMap { try? JSONDecoder().decode([Author].self, from: $0) },
-        authorsLock: metaAuthorsLock,
-        tags: metaTags,
-        tagsLock: metaTagsLock,
-        isbn: metaIsbn,
-        isbnLock: metaIsbnLock,
-        links: metaLinksRaw.flatMap { try? JSONDecoder().decode([WebLink].self, from: $0) },
-        linksLock: metaLinksLock
-      )
-    }
-    set {
-      self.metaCreated = newValue.created
-      self.metaLastModified = newValue.lastModified
-      self.metaTitle = newValue.title
-      self.metaTitleLock = newValue.titleLock
-      self.metaSummary = newValue.summary
-      self.metaSummaryLock = newValue.summaryLock
-      self.metaNumber = newValue.number
-      self.metaNumberLock = newValue.numberLock
-      self.metaNumberSort = newValue.numberSort
-      self.metaNumberSortLock = newValue.numberSortLock
-      self.metaReleaseDate = newValue.releaseDate
-      self.metaReleaseDateLock = newValue.releaseDateLock
-      self.metaAuthorsRaw = try? JSONEncoder().encode(newValue.authors)
-      self.metaAuthorsLock = newValue.authorsLock
-      self.metaTags = newValue.tags
-      self.metaTagsLock = newValue.tagsLock
-      self.metaIsbn = newValue.isbn
-      self.metaIsbnLock = newValue.isbnLock
-      self.metaLinksRaw = try? JSONEncoder().encode(newValue.links)
-      self.metaLinksLock = newValue.linksLock
-    }
+    BookMetadata(
+      created: metaCreated,
+      lastModified: metaLastModified,
+      title: metaTitle,
+      titleLock: metaTitleLock,
+      summary: metaSummary,
+      summaryLock: metaSummaryLock,
+      number: metaNumber,
+      numberLock: metaNumberLock,
+      numberSort: metaNumberSort,
+      numberSortLock: metaNumberSortLock,
+      releaseDate: metaReleaseDate,
+      releaseDateLock: metaReleaseDateLock,
+      authors: metaAuthorsRaw.flatMap { try? JSONDecoder().decode([Author].self, from: $0) },
+      authorsLock: metaAuthorsLock,
+      tags: metaTags,
+      tagsLock: metaTagsLock,
+      isbn: metaIsbn,
+      isbnLock: metaIsbnLock,
+      links: metaLinksRaw.flatMap { try? JSONDecoder().decode([WebLink].self, from: $0) },
+      linksLock: metaLinksLock
+    )
   }
 
   var readProgress: ReadProgress? {
-    get {
-      guard let page = progressPage,
-        let completed = progressCompleted,
-        let readDate = progressReadDate,
-        let created = progressCreated,
-        let lastModified = progressLastModified
-      else { return nil }
-      return ReadProgress(
-        page: page,
-        completed: completed,
-        readDate: readDate,
-        created: created,
-        lastModified: lastModified
-      )
-    }
-    set {
-      self.progressPage = newValue?.page
-      self.progressCompleted = newValue?.completed
-      self.progressReadDate = newValue?.readDate
-      self.progressCreated = newValue?.created
-      self.progressLastModified = newValue?.lastModified
-    }
+    guard let page = progressPage,
+      let completed = progressCompleted,
+      let readDate = progressReadDate,
+      let created = progressCreated,
+      let lastModified = progressLastModified
+    else { return nil }
+    return ReadProgress(
+      page: page,
+      completed: completed,
+      readDate: readDate,
+      created: created,
+      lastModified: lastModified
+    )
   }
 
   func toBook() -> Book {

--- a/KMReader/Features/Models/Series/KomgaSeries.swift
+++ b/KMReader/Features/Models/Series/KomgaSeries.swift
@@ -196,97 +196,52 @@ final class KomgaSeries {
   }
 
   var metadata: SeriesMetadata {
-    get {
-      SeriesMetadata(
-        status: metaStatus,
-        statusLock: metaStatusLock,
-        created: metaCreated,
-        lastModified: metaLastModified,
-        title: metaTitle,
-        titleLock: metaTitleLock,
-        titleSort: metaTitleSort,
-        titleSortLock: metaTitleSortLock,
-        summary: metaSummary,
-        summaryLock: metaSummaryLock,
-        readingDirection: metaReadingDirection,
-        readingDirectionLock: metaReadingDirectionLock,
-        publisher: metaPublisher,
-        publisherLock: metaPublisherLock,
-        ageRating: metaAgeRating,
-        ageRatingLock: metaAgeRatingLock,
-        language: metaLanguage,
-        languageLock: metaLanguageLock,
-        genres: metaGenres,
-        genresLock: metaGenresLock,
-        tags: metaTags,
-        tagsLock: metaTagsLock,
-        totalBookCount: metaTotalBookCount,
-        totalBookCountLock: metaTotalBookCountLock,
-        sharingLabels: metaSharingLabels,
-        sharingLabelsLock: metaSharingLabelsLock,
-        links: metaLinksRaw.flatMap { try? JSONDecoder().decode([WebLink].self, from: $0) },
-        linksLock: metaLinksLock,
-        alternateTitles: metaAlternateTitlesRaw.flatMap {
-          try? JSONDecoder().decode([AlternateTitle].self, from: $0)
-        },
-        alternateTitlesLock: metaAlternateTitlesLock
-      )
-    }
-    set {
-      self.metaStatus = newValue.status
-      self.metaStatusLock = newValue.statusLock
-      self.metaCreated = newValue.created
-      self.metaLastModified = newValue.lastModified
-      self.metaTitle = newValue.title
-      self.metaTitleLock = newValue.titleLock
-      self.metaTitleSort = newValue.titleSort
-      self.metaTitleSortLock = newValue.titleSortLock
-      self.metaSummary = newValue.summary
-      self.metaSummaryLock = newValue.summaryLock
-      self.metaReadingDirection = newValue.readingDirection
-      self.metaReadingDirectionLock = newValue.readingDirectionLock
-      self.metaPublisher = newValue.publisher
-      self.metaPublisherLock = newValue.publisherLock
-      self.metaAgeRating = newValue.ageRating
-      self.metaAgeRatingLock = newValue.ageRatingLock
-      self.metaLanguage = newValue.language
-      self.metaLanguageLock = newValue.languageLock
-      self.metaGenres = newValue.genres
-      self.metaGenresLock = newValue.genresLock
-      self.metaTags = newValue.tags
-      self.metaTagsLock = newValue.tagsLock
-      self.metaTotalBookCount = newValue.totalBookCount
-      self.metaTotalBookCountLock = newValue.totalBookCountLock
-      self.metaSharingLabels = newValue.sharingLabels
-      self.metaSharingLabelsLock = newValue.sharingLabelsLock
-      self.metaLinksRaw = try? JSONEncoder().encode(newValue.links)
-      self.metaLinksLock = newValue.linksLock
-      self.metaAlternateTitlesRaw = try? JSONEncoder().encode(newValue.alternateTitles)
-      self.metaAlternateTitlesLock = newValue.alternateTitlesLock
-    }
+    SeriesMetadata(
+      status: metaStatus,
+      statusLock: metaStatusLock,
+      created: metaCreated,
+      lastModified: metaLastModified,
+      title: metaTitle,
+      titleLock: metaTitleLock,
+      titleSort: metaTitleSort,
+      titleSortLock: metaTitleSortLock,
+      summary: metaSummary,
+      summaryLock: metaSummaryLock,
+      readingDirection: metaReadingDirection,
+      readingDirectionLock: metaReadingDirectionLock,
+      publisher: metaPublisher,
+      publisherLock: metaPublisherLock,
+      ageRating: metaAgeRating,
+      ageRatingLock: metaAgeRatingLock,
+      language: metaLanguage,
+      languageLock: metaLanguageLock,
+      genres: metaGenres,
+      genresLock: metaGenresLock,
+      tags: metaTags,
+      tagsLock: metaTagsLock,
+      totalBookCount: metaTotalBookCount,
+      totalBookCountLock: metaTotalBookCountLock,
+      sharingLabels: metaSharingLabels,
+      sharingLabelsLock: metaSharingLabelsLock,
+      links: metaLinksRaw.flatMap { try? JSONDecoder().decode([WebLink].self, from: $0) },
+      linksLock: metaLinksLock,
+      alternateTitles: metaAlternateTitlesRaw.flatMap {
+        try? JSONDecoder().decode([AlternateTitle].self, from: $0)
+      },
+      alternateTitlesLock: metaAlternateTitlesLock
+    )
   }
 
   var booksMetadata: SeriesBooksMetadata {
-    get {
-      SeriesBooksMetadata(
-        created: booksMetaCreated,
-        lastModified: booksMetaLastModified,
-        authors: booksMetaAuthorsRaw.flatMap { try? JSONDecoder().decode([Author].self, from: $0) },
-        tags: booksMetaTags,
-        releaseDate: booksMetaReleaseDate,
-        summary: booksMetaSummary,
-        summaryNumber: booksMetaSummaryNumber
-      )
-    }
-    set {
-      self.booksMetaCreated = newValue.created
-      self.booksMetaLastModified = newValue.lastModified
-      self.booksMetaAuthorsRaw = try? JSONEncoder().encode(newValue.authors)
-      self.booksMetaTags = newValue.tags
-      self.booksMetaReleaseDate = newValue.releaseDate
-      self.booksMetaSummary = newValue.summary
-      self.booksMetaSummaryNumber = newValue.summaryNumber
-    }
+    SeriesBooksMetadata(
+      created: booksMetaCreated,
+      lastModified: booksMetaLastModified,
+      authors: booksMetaAuthorsRaw.flatMap { try? JSONDecoder().decode([Author].self, from: $0) },
+      tags: booksMetaTags,
+      releaseDate: booksMetaReleaseDate,
+      summary: booksMetaSummary,
+      summaryNumber: booksMetaSummaryNumber
+    )
   }
 
   func toSeries() -> Series {


### PR DESCRIPTION
Replace lastModified-based comparisons with field-by-field comparisons for complex types (media, metadata, readProgress, booksMetadata) to ensure accurate change detection. Remove computed property setters from model classes since fields are now set directly.

---

- fix: https://github.com/everpcpc/KMReader/issues/95