### PR TITLE
fix: restore gesture recognizer delegates when reader dismisses

### DIFF
--- a/KMReader/Features/Views/Reader/DivinaReaderView.swift
+++ b/KMReader/Features/Views/Reader/DivinaReaderView.swift
@@ -402,11 +402,21 @@ struct DivinaReaderView: View {
         readerPresentation.hideStatusBar = !newValue
       }
     }
+    #if os(iOS)
+      .onAppear {
+        if readingDirection != readerPresentation.readingDirection {
+          readerPresentation.readingDirection = readingDirection
+        }
+      }
+    #endif
     #if os(iOS) || os(macOS)
-      .onChange(of: readingDirection) { _, _ in
+      .onChange(of: readingDirection) { _, newDirection in
         // When switching read mode via settings, briefly show overlays again
         triggerTapZoneOverlay(timeout: 1)
         triggerKeyboardHelp(timeout: 2)
+        if readingDirection != readerPresentation.readingDirection {
+          readerPresentation.readingDirection = newDirection
+        }
       }
     #endif
     #if os(macOS) || os(tvOS)
@@ -433,10 +443,6 @@ struct DivinaReaderView: View {
       }
     #endif
     .environment(\.readerBackgroundPreference, readerBackground)
-    #if os(iOS)
-      .readerDismissGesture(
-        isVerticalReading: readingDirection == .vertical || readingDirection == .webtoon)
-    #endif
   }
 
   private func loadBook(bookId: String, preserveReaderOptions: Bool) async {

--- a/KMReader/Features/Views/Reader/EpubReaderView.swift
+++ b/KMReader/Features/Views/Reader/EpubReaderView.swift
@@ -120,7 +120,11 @@
         }
       }
       .ignoresSafeArea()
-      .readerDismissGesture(isVerticalReading: false)
+      .onAppear {
+        if .ltr != readerPresentation.readingDirection {
+          readerPresentation.readingDirection = .ltr
+        }
+      }
     }
 
     @ViewBuilder

--- a/KMReader/Features/Views/Reader/ReaderPresentationManager.swift
+++ b/KMReader/Features/Views/Reader/ReaderPresentationManager.swift
@@ -16,6 +16,7 @@ final class ReaderPresentationManager {
 
   var hideStatusBar: Bool = false
   var isDismissing: Bool = false
+  var readingDirection: ReadingDirection = .ltr
 
   /// Book ID used as source for zoom transition (iOS 18+)
   private(set) var sourceBookId: String?

--- a/KMReader/Shared/UI/ReaderOverlay.swift
+++ b/KMReader/Shared/UI/ReaderOverlay.swift
@@ -34,11 +34,20 @@ extension EnvironmentValues {
               set: { if !$0 { readerPresentation.closeReader() } }
             )
           ) {
-            ReaderContentView()
-              .navigationTransitionZoomIfAvailable(
-                sourceID: readerPresentation.sourceBookId ?? "",
-                in: namespace
-              )
+            #if os(iOS)
+              ReaderContentView()
+                .readerDismissGesture(readingDirection: readerPresentation.readingDirection)
+                .navigationTransitionZoomIfAvailable(
+                  sourceID: readerPresentation.sourceBookId ?? "",
+                  in: namespace
+                )
+            #else
+              ReaderContentView()
+                .navigationTransitionZoomIfAvailable(
+                  sourceID: readerPresentation.sourceBookId ?? "",
+                  in: namespace
+                )
+            #endif
           }
       } else {
         // iOS 17 and earlier: Use overlay with opacity/scale animation


### PR DESCRIPTION
- Move readerDismissGesture to ReaderOverlay level
- Track and restore original delegates on viewWillDisappear
- Pass ReadingDirection directly, handle logic internally
- Prevent reader gesture config from affecting detail page navigation