### PR TITLE
perf(reader): replace SDWebImage with native image cache

### DIFF
--- a/KMReader/Core/Storage/Cache/CacheManager.swift
+++ b/KMReader/Core/Storage/Cache/CacheManager.swift
@@ -19,11 +19,8 @@ enum CacheManager {
     // Clear BookFileCache (KomgaBookFileCache)
     await BookFileCache.clearDiskCache(forBookId: bookId)
 
-    // Clear SDWebImage caches
-    // Note: SDWebImage doesn't support clearing by bookId directly,
-    // but we clear memory cache which may contain images for this book
+    // Clear SDWebImage thumbnail memory cache
     SDImageCacheProvider.thumbnailCache.clearMemory()
-    SDImageCacheProvider.pageImageCache.clearMemory()
   }
 
   /// Clear thumbnail cache

--- a/KMReader/Core/Storage/Cache/SDImageCacheProvider.swift
+++ b/KMReader/Core/Storage/Cache/SDImageCacheProvider.swift
@@ -18,20 +18,8 @@ enum SDImageCacheProvider {
     return cache
   }()
 
-  static let pageImageCache: SDImageCache = {
-    let cache = SDImageCache(namespace: "KomgaPageImageCache", diskCacheDirectory: nil)
-    cache.config.shouldCacheImagesInMemory = true
-    cache.config.maxMemoryCost = 200 * 1024 * 1024  // 200 MB decoded pages
-    cache.config.maxMemoryCount = 50
-    return cache
-  }()
-
   static let thumbnailManager: SDWebImageManager = {
     SDWebImageManager(cache: thumbnailCache, loader: SDWebImageDownloader.shared)
-  }()
-
-  static let pageImageManager: SDWebImageManager = {
-    SDWebImageManager(cache: pageImageCache, loader: SDWebImageDownloader.shared)
   }()
 
   static func configureSDWebImage() {


### PR DESCRIPTION
- Instant display and better memory management
- Implement a custom image cache in ReaderViewModel to store decoded PlatformImage objects
- Achieve instant page transitions by synchronously accessing preloaded images
- Move to native SwiftUI Image and remove SDWebImage/WebImage dependency for reader content
- Implement timely memory release via a sliding window cleanup of preloaded images
- Update WebtoonPageCell to use native UIImageView/NSImageView with optimized loading
- Remove SDImageCacheProvider.pageImageCache to fully centralize image management

This refactor eliminates loading indicators and perceived delays while ensuring efficient memory consumption by only keeping relevant pages in memory.