### PR TITLE
fix: prevent scroll position reset in ForEach lists

### DIFF
--- a/KMReader/Features/Views/Book/BooksQueryView.swift
+++ b/KMReader/Features/Views/Book/BooksQueryView.swift
@@ -34,7 +34,7 @@ struct BooksQueryView: View {
       switch browseLayout {
       case .grid:
         LazyVGrid(columns: layoutHelper.columns, spacing: layoutHelper.spacing) {
-          ForEach(Array(viewModel.browseBookIds.enumerated()), id: \.element) { index, bookId in
+          ForEach(viewModel.browseBookIds, id: \.self) { bookId in
             BookQueryItemView(
               bookId: bookId,
               cardWidth: layoutHelper.cardWidth,
@@ -47,7 +47,7 @@ struct BooksQueryView: View {
             )
             .padding(.bottom)
             .onAppear {
-              if index >= viewModel.browseBookIds.count - 3 {
+              if viewModel.browseBookIds.suffix(3).contains(bookId) {
                 Task {
                   await loadMore(false)
                 }
@@ -58,7 +58,7 @@ struct BooksQueryView: View {
         .padding(.horizontal, layoutHelper.spacing)
       case .list:
         LazyVStack {
-          ForEach(Array(viewModel.browseBookIds.enumerated()), id: \.element) { index, bookId in
+          ForEach(viewModel.browseBookIds, id: \.self) { bookId in
             BookQueryItemView(
               bookId: bookId,
               cardWidth: layoutHelper.cardWidth,
@@ -70,13 +70,13 @@ struct BooksQueryView: View {
               }
             )
             .onAppear {
-              if index >= viewModel.browseBookIds.count - 3 {
+              if viewModel.browseBookIds.suffix(3).contains(bookId) {
                 Task {
                   await loadMore(false)
                 }
               }
             }
-            if index < viewModel.browseBookIds.count - 1 {
+            if bookId != viewModel.browseBookIds.last {
               Divider()
             }
           }

--- a/KMReader/Features/Views/Book/ListViews/ReadListBooksQueryView.swift
+++ b/KMReader/Features/Views/Book/ListViews/ReadListBooksQueryView.swift
@@ -32,8 +32,7 @@ struct ReadListBooksQueryView: View {
         switch browseLayout {
         case .grid:
           LazyVGrid(columns: layoutHelper.columns, spacing: layoutHelper.spacing) {
-            ForEach(Array(bookViewModel.browseBookIds.enumerated()), id: \.element) {
-              index, bookId in
+            ForEach(bookViewModel.browseBookIds, id: \.self) { bookId in
               Group {
                 if isSelectionMode && isAdmin {
                   BookSelectionItemView(
@@ -56,7 +55,7 @@ struct ReadListBooksQueryView: View {
               }
               .padding(.bottom)
               .onAppear {
-                if index >= bookViewModel.browseBookIds.count - 3 {
+                if bookViewModel.browseBookIds.suffix(3).contains(bookId) {
                   Task { await loadMore(refresh: false) }
                 }
               }
@@ -65,8 +64,7 @@ struct ReadListBooksQueryView: View {
           .padding(.horizontal, layoutHelper.spacing)
         case .list:
           LazyVStack {
-            ForEach(Array(bookViewModel.browseBookIds.enumerated()), id: \.element) {
-              index, bookId in
+            ForEach(bookViewModel.browseBookIds, id: \.self) { bookId in
               Group {
                 if isSelectionMode && isAdmin {
                   BookSelectionItemView(
@@ -88,11 +86,11 @@ struct ReadListBooksQueryView: View {
                 }
               }
               .onAppear {
-                if index >= bookViewModel.browseBookIds.count - 3 {
+                if bookViewModel.browseBookIds.suffix(3).contains(bookId) {
                   Task { await loadMore(refresh: false) }
                 }
               }
-              if index < bookViewModel.browseBookIds.count - 1 {
+              if bookId != bookViewModel.browseBookIds.last {
                 Divider()
               }
             }

--- a/KMReader/Features/Views/Book/ListViews/SeriesBooksQueryView.swift
+++ b/KMReader/Features/Views/Book/ListViews/SeriesBooksQueryView.swift
@@ -26,8 +26,7 @@ struct SeriesBooksQueryView: View {
         switch browseLayout {
         case .grid:
           LazyVGrid(columns: layoutHelper.columns, spacing: layoutHelper.spacing) {
-            ForEach(Array(bookViewModel.browseBookIds.enumerated()), id: \.element) {
-              index, bookId in
+            ForEach(bookViewModel.browseBookIds, id: \.self) { bookId in
               BookQueryItemView(
                 bookId: bookId,
                 cardWidth: layoutHelper.cardWidth,
@@ -38,7 +37,7 @@ struct SeriesBooksQueryView: View {
               )
               .padding(.bottom)
               .onAppear {
-                if index >= bookViewModel.browseBookIds.count - 3 {
+                if bookViewModel.browseBookIds.suffix(3).contains(bookId) {
                   Task { await loadMore(false) }
                 }
               }
@@ -47,8 +46,7 @@ struct SeriesBooksQueryView: View {
           .padding(.horizontal, layoutHelper.spacing)
         case .list:
           LazyVStack {
-            ForEach(Array(bookViewModel.browseBookIds.enumerated()), id: \.element) {
-              index, bookId in
+            ForEach(bookViewModel.browseBookIds, id: \.self) { bookId in
               BookQueryItemView(
                 bookId: bookId,
                 cardWidth: layoutHelper.cardWidth,
@@ -58,11 +56,11 @@ struct SeriesBooksQueryView: View {
                 showSeriesNavigation: false
               )
               .onAppear {
-                if index >= bookViewModel.browseBookIds.count - 3 {
+                if bookViewModel.browseBookIds.suffix(3).contains(bookId) {
                   Task { await loadMore(false) }
                 }
               }
-              if index < bookViewModel.browseBookIds.count - 1 {
+              if bookId != bookViewModel.browseBookIds.last {
                 Divider()
               }
             }

--- a/KMReader/Features/Views/Collection/CollectionsBrowseView.swift
+++ b/KMReader/Features/Views/Collection/CollectionsBrowseView.swift
@@ -41,8 +41,7 @@ struct CollectionsBrowseView: View {
         switch browseLayout {
         case .grid:
           LazyVGrid(columns: layoutHelper.columns, spacing: layoutHelper.spacing) {
-            ForEach(Array(viewModel.collectionIds.enumerated()), id: \.element) {
-              index, collectionId in
+            ForEach(viewModel.collectionIds, id: \.self) { collectionId in
               CollectionQueryItemView(
                 collectionId: collectionId,
                 width: layoutHelper.cardWidth,
@@ -54,7 +53,7 @@ struct CollectionsBrowseView: View {
               )
               .padding(.bottom)
               .onAppear {
-                if index >= viewModel.collectionIds.count - 3 {
+                if viewModel.collectionIds.suffix(3).contains(collectionId) {
                   Task {
                     await loadCollections(refresh: false)
                   }
@@ -65,8 +64,7 @@ struct CollectionsBrowseView: View {
           .padding(.horizontal, layoutHelper.spacing)
         case .list:
           LazyVStack {
-            ForEach(Array(viewModel.collectionIds.enumerated()), id: \.element) {
-              index, collectionId in
+            ForEach(viewModel.collectionIds, id: \.self) { collectionId in
               CollectionQueryItemView(
                 collectionId: collectionId,
                 layout: .list,
@@ -77,13 +75,13 @@ struct CollectionsBrowseView: View {
                 }
               )
               .onAppear {
-                if index >= viewModel.collectionIds.count - 3 {
+                if viewModel.collectionIds.suffix(3).contains(collectionId) {
                   Task {
                     await loadCollections(refresh: false)
                   }
                 }
               }
-              if index < viewModel.collectionIds.count - 1 {
+              if collectionId != viewModel.collectionIds.last {
                 Divider()
               }
             }

--- a/KMReader/Features/Views/Collection/Sections/CollectionSeriesQueryView.swift
+++ b/KMReader/Features/Views/Collection/Sections/CollectionSeriesQueryView.swift
@@ -31,8 +31,7 @@ struct CollectionSeriesQueryView: View {
         switch browseLayout {
         case .grid:
           LazyVGrid(columns: layoutHelper.columns, spacing: layoutHelper.spacing) {
-            ForEach(Array(seriesViewModel.browseSeriesIds.enumerated()), id: \.element) {
-              index, seriesId in
+            ForEach(seriesViewModel.browseSeriesIds, id: \.self) { seriesId in
               Group {
                 if isSelectionMode && isAdmin {
                   SeriesSelectionItemView(
@@ -53,7 +52,7 @@ struct CollectionSeriesQueryView: View {
               }
               .padding(.bottom)
               .onAppear {
-                if index >= seriesViewModel.browseSeriesIds.count - 3 {
+                if seriesViewModel.browseSeriesIds.suffix(3).contains(seriesId) {
                   Task { await loadMore(refresh: false) }
                 }
               }
@@ -62,8 +61,7 @@ struct CollectionSeriesQueryView: View {
           .padding(.horizontal, layoutHelper.spacing)
         case .list:
           LazyVStack {
-            ForEach(Array(seriesViewModel.browseSeriesIds.enumerated()), id: \.element) {
-              index, seriesId in
+            ForEach(seriesViewModel.browseSeriesIds, id: \.self) { seriesId in
               Group {
                 if isSelectionMode && isAdmin {
                   SeriesSelectionItemView(
@@ -83,11 +81,11 @@ struct CollectionSeriesQueryView: View {
                 }
               }
               .onAppear {
-                if index >= seriesViewModel.browseSeriesIds.count - 3 {
+                if seriesViewModel.browseSeriesIds.suffix(3).contains(seriesId) {
                   Task { await loadMore(refresh: false) }
                 }
               }
-              if index < seriesViewModel.browseSeriesIds.count - 1 {
+              if seriesId != seriesViewModel.browseSeriesIds.last {
                 Divider()
               }
             }

--- a/KMReader/Features/Views/Dashboard/DashboardSectionDetailView.swift
+++ b/KMReader/Features/Views/Dashboard/DashboardSectionDetailView.swift
@@ -67,7 +67,7 @@ struct DashboardSectionDetailView: View {
     switch browseLayout {
     case .grid:
       LazyVGrid(columns: layoutHelper.columns, spacing: layoutHelper.spacing) {
-        ForEach(Array(itemIds.enumerated()), id: \.element) { index, bookId in
+        ForEach(itemIds, id: \.self) { bookId in
           BookQueryItemView(
             bookId: bookId,
             cardWidth: layoutHelper.cardWidth,
@@ -79,7 +79,7 @@ struct DashboardSectionDetailView: View {
           )
           .padding(.bottom)
           .onAppear {
-            if index >= itemIds.count - 3 {
+            if itemIds.suffix(3).contains(bookId) {
               Task { await loadItems(refresh: false) }
             }
           }
@@ -87,7 +87,7 @@ struct DashboardSectionDetailView: View {
       }
     case .list:
       LazyVStack {
-        ForEach(Array(itemIds.enumerated()), id: \.element) { index, bookId in
+        ForEach(itemIds, id: \.self) { bookId in
           BookQueryItemView(
             bookId: bookId,
             cardWidth: layoutHelper.cardWidth,
@@ -98,11 +98,11 @@ struct DashboardSectionDetailView: View {
             showSeriesTitle: true
           )
           .onAppear {
-            if index >= itemIds.count - 3 {
+            if itemIds.suffix(3).contains(bookId) {
               Task { await loadItems(refresh: false) }
             }
           }
-          if index < itemIds.count - 1 {
+          if bookId != itemIds.last {
             Divider()
           }
         }
@@ -115,7 +115,7 @@ struct DashboardSectionDetailView: View {
     switch browseLayout {
     case .grid:
       LazyVGrid(columns: layoutHelper.columns, spacing: layoutHelper.spacing) {
-        ForEach(Array(itemIds.enumerated()), id: \.element) { index, seriesId in
+        ForEach(itemIds, id: \.self) { seriesId in
           SeriesQueryItemView(
             seriesId: seriesId,
             cardWidth: layoutHelper.cardWidth,
@@ -126,7 +126,7 @@ struct DashboardSectionDetailView: View {
           )
           .padding(.bottom)
           .onAppear {
-            if index >= itemIds.count - 3 {
+            if itemIds.suffix(3).contains(seriesId) {
               Task { await loadItems(refresh: false) }
             }
           }
@@ -134,7 +134,7 @@ struct DashboardSectionDetailView: View {
       }
     case .list:
       LazyVStack {
-        ForEach(Array(itemIds.enumerated()), id: \.element) { index, seriesId in
+        ForEach(itemIds, id: \.self) { seriesId in
           SeriesQueryItemView(
             seriesId: seriesId,
             cardWidth: layoutHelper.cardWidth,
@@ -144,11 +144,11 @@ struct DashboardSectionDetailView: View {
             }
           )
           .onAppear {
-            if index >= itemIds.count - 3 {
+            if itemIds.suffix(3).contains(seriesId) {
               Task { await loadItems(refresh: false) }
             }
           }
-          if index < itemIds.count - 1 {
+          if seriesId != itemIds.last {
             Divider()
           }
         }

--- a/KMReader/Features/Views/Dashboard/DashboardSectionView.swift
+++ b/KMReader/Features/Views/Dashboard/DashboardSectionView.swift
@@ -62,10 +62,11 @@ struct DashboardSectionView: View {
 
       ScrollView(.horizontal, showsIndicators: false) {
         LazyHStack(alignment: .top, spacing: 16) {
-          ForEach(Array(itemIds.enumerated()), id: \.element) { index, itemId in
+          ForEach(itemIds, id: \.self) { itemId in
             itemView(for: itemId)
               .onAppear {
-                if index >= itemIds.count - 3 {
+                // O(1): suffix is a slice, contains checks only 3 elements
+                if itemIds.suffix(3).contains(itemId) {
                   Task {
                     await loadMore()
                   }

--- a/KMReader/Features/Views/ReadList/ReadListsBrowseView.swift
+++ b/KMReader/Features/Views/ReadList/ReadListsBrowseView.swift
@@ -41,8 +41,7 @@ struct ReadListsBrowseView: View {
         switch browseLayout {
         case .grid:
           LazyVGrid(columns: layoutHelper.columns, spacing: layoutHelper.spacing) {
-            ForEach(Array(viewModel.readListIds.enumerated()), id: \.element) {
-              index, readListId in
+            ForEach(viewModel.readListIds, id: \.self) { readListId in
               ReadListQueryItemView(
                 readListId: readListId,
                 width: layoutHelper.cardWidth,
@@ -54,7 +53,7 @@ struct ReadListsBrowseView: View {
               )
               .padding(.bottom)
               .onAppear {
-                if index >= viewModel.readListIds.count - 3 {
+                if viewModel.readListIds.suffix(3).contains(readListId) {
                   Task {
                     await loadReadLists(refresh: false)
                   }
@@ -65,8 +64,7 @@ struct ReadListsBrowseView: View {
           .padding(.horizontal, layoutHelper.spacing)
         case .list:
           LazyVStack {
-            ForEach(Array(viewModel.readListIds.enumerated()), id: \.element) {
-              index, readListId in
+            ForEach(viewModel.readListIds, id: \.self) { readListId in
               ReadListQueryItemView(
                 readListId: readListId,
                 layout: .list,
@@ -77,13 +75,13 @@ struct ReadListsBrowseView: View {
                 }
               )
               .onAppear {
-                if index >= viewModel.readListIds.count - 3 {
+                if viewModel.readListIds.suffix(3).contains(readListId) {
                   Task {
                     await loadReadLists(refresh: false)
                   }
                 }
               }
-              if index < viewModel.readListIds.count - 1 {
+              if readListId != viewModel.readListIds.last {
                 Divider()
               }
             }

--- a/KMReader/Features/Views/Series/SeriesQueryView.swift
+++ b/KMReader/Features/Views/Series/SeriesQueryView.swift
@@ -34,7 +34,7 @@ struct SeriesQueryView: View {
       switch browseLayout {
       case .grid:
         LazyVGrid(columns: layoutHelper.columns, spacing: layoutHelper.spacing) {
-          ForEach(Array(viewModel.browseSeriesIds.enumerated()), id: \.element) { index, seriesId in
+          ForEach(viewModel.browseSeriesIds, id: \.self) { seriesId in
             SeriesQueryItemView(
               seriesId: seriesId,
               cardWidth: layoutHelper.cardWidth,
@@ -47,7 +47,7 @@ struct SeriesQueryView: View {
             )
             .padding(.bottom)
             .onAppear {
-              if index >= viewModel.browseSeriesIds.count - 3 {
+              if viewModel.browseSeriesIds.suffix(3).contains(seriesId) {
                 Task {
                   await loadMore(false)
                 }
@@ -58,7 +58,7 @@ struct SeriesQueryView: View {
         .padding(.horizontal, layoutHelper.spacing)
       case .list:
         LazyVStack {
-          ForEach(Array(viewModel.browseSeriesIds.enumerated()), id: \.element) { index, seriesId in
+          ForEach(viewModel.browseSeriesIds, id: \.self) { seriesId in
             SeriesQueryItemView(
               seriesId: seriesId,
               cardWidth: layoutHelper.cardWidth,
@@ -70,13 +70,13 @@ struct SeriesQueryView: View {
               }
             )
             .onAppear {
-              if index >= viewModel.browseSeriesIds.count - 3 {
+              if viewModel.browseSeriesIds.suffix(3).contains(seriesId) {
                 Task {
                   await loadMore(false)
                 }
               }
             }
-            if index < viewModel.browseSeriesIds.count - 1 {
+            if seriesId != viewModel.browseSeriesIds.last {
               Divider()
             }
           }


### PR DESCRIPTION
Replace enumerated() pattern with direct array iteration to prevent SwiftUI from recreating views when array updates, which was causing scroll position to jump back to the beginning.

- Use ForEach(ids, id: \.self) instead of ForEach(Array(ids.enumerated()))
- Use suffix(3).contains() for O(1) load-more detection
- Use id != ids.last for Divider visibility check

---

- fix: https://github.com/everpcpc/KMReader/issues/120