### PR TITLE
fix: add .id() to context menu subviews to prevent stale cached content

### DIFF
--- a/KMReader/Features/Views/Book/BookCardView.swift
+++ b/KMReader/Features/Views/Book/BookCardView.swift
@@ -87,6 +87,7 @@ struct BookCardView: View {
           },
           showSeriesNavigation: showSeriesNavigation
         )
+        .id(komgaBook.bookId)
       }
 
       if !coverOnlyCards {

--- a/KMReader/Features/Views/Book/BookRowView.swift
+++ b/KMReader/Features/Views/Book/BookRowView.swift
@@ -155,6 +155,7 @@ struct BookRowView: View {
                   },
                   showSeriesNavigation: showSeriesNavigation
                 )
+                .id(komgaBook.bookId)
               } label: {
                 Image(systemName: "ellipsis")
                   .foregroundColor(.secondary)

--- a/KMReader/Features/Views/Collection/CollectionCardView.swift
+++ b/KMReader/Features/Views/Collection/CollectionCardView.swift
@@ -38,6 +38,7 @@ struct CollectionCardView: View {
             showEditSheet = true
           }
         )
+        .id(komgaCollection.collectionId)
       }
 
       if !coverOnlyCards {

--- a/KMReader/Features/Views/Collection/CollectionRowView.swift
+++ b/KMReader/Features/Views/Collection/CollectionRowView.swift
@@ -61,6 +61,7 @@ struct CollectionRowView: View {
                     showEditSheet = true
                   }
                 )
+                .id(komgaCollection.collectionId)
               } label: {
                 Image(systemName: "ellipsis")
                   .foregroundColor(.secondary)

--- a/KMReader/Features/Views/ReadList/ReadListCardView.swift
+++ b/KMReader/Features/Views/ReadList/ReadListCardView.swift
@@ -36,6 +36,7 @@ struct ReadListCardView: View {
             showEditSheet = true
           }
         )
+        .id(komgaReadList.readListId)
       }
 
       if !coverOnlyCards {

--- a/KMReader/Features/Views/ReadList/ReadListRowView.swift
+++ b/KMReader/Features/Views/ReadList/ReadListRowView.swift
@@ -64,6 +64,7 @@ struct ReadListRowView: View {
                     showEditSheet = true
                   }
                 )
+                .id(komgaReadList.readListId)
               } label: {
                 Image(systemName: "ellipsis")
                   .foregroundColor(.secondary)

--- a/KMReader/Features/Views/Series/SeriesCardView.swift
+++ b/KMReader/Features/Views/Series/SeriesCardView.swift
@@ -63,6 +63,7 @@ struct SeriesCardView: View {
             showEditSheet = true
           }
         )
+        .id(komgaSeries.seriesId)
       }
 
       if !coverOnlyCards {

--- a/KMReader/Features/Views/Series/SeriesRowView.swift
+++ b/KMReader/Features/Views/Series/SeriesRowView.swift
@@ -119,6 +119,7 @@ struct SeriesRowView: View {
                     showEditSheet = true
                   }
                 )
+                .id(komgaSeries.seriesId)
               } label: {
                 Image(systemName: "ellipsis")
                   .foregroundColor(.secondary)


### PR DESCRIPTION
SwiftUI caches context menu content when using subviews. Adding .id() modifier forces re-creation when displaying different items.

Affected views:
- BookCardView, BookRowView (BookContextMenu)
- SeriesCardView, SeriesRowView (SeriesContextMenu)
- CollectionCardView, CollectionRowView (CollectionContextMenu)
- ReadListCardView, ReadListRowView (ReadListContextMenu)