### PR TITLE
fix(macos): dashboard ui fixes

### DIFF
--- a/KMReader/Features/Views/Dashboard/DashboardSectionView.swift
+++ b/KMReader/Features/Views/Dashboard/DashboardSectionView.swift
@@ -53,6 +53,14 @@ struct DashboardSectionView: View {
     }
   }
 
+  private var cardWidth: CGFloat {
+    LayoutConfig.cardWidth(for: gridDensity)
+  }
+
+  private var spacing: CGFloat {
+    LayoutConfig.spacing(for: gridDensity)
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 4) {
       NavigationLink(value: NavDestination.dashboardSectionDetail(section: section)) {
@@ -69,11 +77,11 @@ struct DashboardSectionView: View {
 
       ScrollViewReader { proxy in
         ScrollView(.horizontal, showsIndicators: false) {
-          LazyHStack(alignment: .top, spacing: 16) {
+          LazyHStack(alignment: .top, spacing: spacing) {
             ForEach(pagination.items) { item in
               itemView(for: item.id)
                 .id(item.id)
-                .frame(width: LayoutConfig.cardWidth(for: gridDensity))
+                .frame(width: cardWidth)
                 .onAppear {
                   if pagination.shouldLoadMore(after: item) {
                     Task {
@@ -83,8 +91,9 @@ struct DashboardSectionView: View {
                 }
             }
           }
-          .padding()
+          .padding(.vertical)
         }
+        .contentMargins(.horizontal, spacing, for: .scrollContent)
         .scrollClipDisabled()
         .overlay {
           HorizontalScrollButtons(

--- a/KMReader/Features/Views/Dashboard/DashboardView.swift
+++ b/KMReader/Features/Views/Dashboard/DashboardView.swift
@@ -46,7 +46,7 @@ struct DashboardView: View {
     logger.debug("Dashboard partial refresh: \(reason)")
     refreshTrigger = DashboardRefreshTrigger(
       id: UUID(),
-      source: .auto,
+      source: .manual,
       sectionsToRefresh: sections
     )
   }

--- a/KMReader/MainSplitView.swift
+++ b/KMReader/MainSplitView.swift
@@ -18,7 +18,11 @@ import SwiftUI
       [KomgaLibrary]
 
     @State private var nav: NavDestination? = .home
-    @State private var columnVisibility: NavigationSplitViewVisibility = .detailOnly
+    #if os(macOS)
+      @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    #else
+      @State private var columnVisibility: NavigationSplitViewVisibility = .detailOnly
+    #endif
 
     private var libraries: [KomgaLibrary] {
       guard !currentInstanceId.isEmpty else { return [] }


### PR DESCRIPTION
- Change refreshSections source from .auto to .manual so refresh isn't skipped
- Replace .padding() with .contentMargins() for proper scroll positioning
- Use density-aware spacing for horizontal scroll sections
- Show sidebar by default on macOS, hide on iPad