### PR TITLE
fix: zoom-back cover disappearance by limiting transition sources

### DIFF
--- a/KMReader/Features/Views/Book/BookDetailContentView.swift
+++ b/KMReader/Features/Views/Book/BookDetailContentView.swift
@@ -31,7 +31,10 @@ struct BookDetailContentView: View {
 
       HStack(alignment: .top) {
         ThumbnailImage(
-          id: book.id, type: .book, width: PlatformHelper.detailThumbnailWidth
+          id: book.id,
+          type: .book,
+          width: PlatformHelper.detailThumbnailWidth,
+          isTransitionSource: false
         )
         .id(thumbnailRefreshKey)
         .contextMenu {

--- a/KMReader/Features/Views/Collection/CollectionDetailContentView.swift
+++ b/KMReader/Features/Views/Collection/CollectionDetailContentView.swift
@@ -18,8 +18,10 @@ struct CollectionDetailContentView: View {
 
       HStack(alignment: .top) {
         ThumbnailImage(
-          id: collection.id, type: .collection,
-          width: PlatformHelper.detailThumbnailWidth
+          id: collection.id,
+          type: .collection,
+          width: PlatformHelper.detailThumbnailWidth,
+          isTransitionSource: false
         )
         .id(thumbnailRefreshKey)
         .contextMenu {

--- a/KMReader/Features/Views/OneShot/OneShotDetailContentView.swift
+++ b/KMReader/Features/Views/OneShot/OneShotDetailContentView.swift
@@ -44,8 +44,10 @@ struct OneShotDetailContentView: View {
 
       HStack(alignment: .top) {
         ThumbnailImage(
-          id: book.id, type: .book,
-          width: PlatformHelper.detailThumbnailWidth
+          id: book.id,
+          type: .book,
+          width: PlatformHelper.detailThumbnailWidth,
+          isTransitionSource: false
         )
         .id(thumbnailRefreshKey)
         .contextMenu {

--- a/KMReader/Features/Views/ReadList/ReadListDetailContentView.swift
+++ b/KMReader/Features/Views/ReadList/ReadListDetailContentView.swift
@@ -18,8 +18,10 @@ struct ReadListDetailContentView: View {
 
       HStack(alignment: .top) {
         ThumbnailImage(
-          id: readList.id, type: .readlist,
-          width: PlatformHelper.detailThumbnailWidth
+          id: readList.id,
+          type: .readlist,
+          width: PlatformHelper.detailThumbnailWidth,
+          isTransitionSource: false
         )
         .id(thumbnailRefreshKey)
         .contextMenu {

--- a/KMReader/Features/Views/Series/SeriesDetailContentView.swift
+++ b/KMReader/Features/Views/Series/SeriesDetailContentView.swift
@@ -28,7 +28,8 @@ struct SeriesDetailContentView: View {
         ThumbnailImage(
           id: series.id,
           type: .series,
-          width: PlatformHelper.detailThumbnailWidth
+          width: PlatformHelper.detailThumbnailWidth,
+          isTransitionSource: false
         )
         .id(thumbnailRefreshKey)
         .contextMenu {

--- a/KMReader/Shared/UI/ThumbnailImage.swift
+++ b/KMReader/Shared/UI/ThumbnailImage.swift
@@ -16,6 +16,7 @@ struct ThumbnailImage<Overlay: View>: View {
   let cornerRadius: CGFloat
   let alignment: Alignment
   let overlay: (() -> Overlay)?
+  let isTransitionSource: Bool
 
   let ratio: CGFloat = 1.414
 
@@ -44,6 +45,7 @@ struct ThumbnailImage<Overlay: View>: View {
     width: CGFloat? = nil,
     cornerRadius: CGFloat = 8,
     alignment: Alignment = .center,
+    isTransitionSource: Bool = true,
     @ViewBuilder overlay: @escaping () -> Overlay
   ) {
     self.id = id
@@ -53,6 +55,7 @@ struct ThumbnailImage<Overlay: View>: View {
     self.cornerRadius = cornerRadius
     self.alignment = alignment
     self.overlay = overlay
+    self.isTransitionSource = isTransitionSource
   }
 
   private var baseKey: String {
@@ -90,7 +93,7 @@ struct ThumbnailImage<Overlay: View>: View {
                 }
               }
               .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
-              .ifLet(zoomNamespace) { view, namespace in
+              .ifLet(isTransitionSource ? zoomNamespace : nil) { view, namespace in
                 view.matchedTransitionSourceIfAvailable(id: id, in: namespace)
               }
               #if os(iOS)
@@ -108,7 +111,7 @@ struct ThumbnailImage<Overlay: View>: View {
                 .clipped()
             }
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
-            .ifLet(zoomNamespace) { view, namespace in
+            .ifLet(isTransitionSource ? zoomNamespace : nil) { view, namespace in
               view.matchedTransitionSourceIfAvailable(id: id, in: namespace)
             }
             #if os(iOS)
@@ -151,12 +154,14 @@ extension ThumbnailImage where Overlay == EmptyView {
     shadowStyle: ShadowStyle = .basic,
     width: CGFloat? = nil,
     cornerRadius: CGFloat = 8,
-    alignment: Alignment = .center
+    alignment: Alignment = .center,
+    isTransitionSource: Bool = true
   ) {
     self.init(
       id: id, type: type, shadowStyle: shadowStyle,
       width: width, cornerRadius: cornerRadius,
-      alignment: alignment
+      alignment: alignment,
+      isTransitionSource: isTransitionSource
     ) {}
   }
 }


### PR DESCRIPTION
Reason: matched transition source was applied to both card and detail thumbnails,  quick back during zoom navigation could hide the card cover after return.

Method: add isTransitionSource to ThumbnailImage and disable it in detail views  so only cards register as sources.

---

- fix: https://github.com/everpcpc/KMReader/issues/185#issuecomment-3704602870