### PR TITLE
feat: add auto full screen option on reader open for macOS

### DIFF
--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -417,6 +417,18 @@ enum AppConfig {
     }
   }
 
+  static var autoFullscreenOnOpen: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "autoFullscreenOnOpen") != nil {
+        return UserDefaults.standard.bool(forKey: "autoFullscreenOnOpen")
+      }
+      return false
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: "autoFullscreenOnOpen")
+    }
+  }
+
   static var readerBackground: ReaderBackground {
     get {
       if let stored = UserDefaults.standard.string(forKey: "readerBackground"),

--- a/KMReader/Features/Views/Reader/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Views/Reader/Sheets/ReaderSettingsSheet.swift
@@ -25,6 +25,7 @@ struct ReaderSettingsSheet: View {
   @AppStorage("showTapZoneHints") private var showTapZoneHints: Bool = true
   @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.2
   @AppStorage("showKeyboardHelpOverlay") private var showKeyboardHelpOverlay: Bool = true
+  @AppStorage("autoFullscreenOnOpen") private var autoFullscreenOnOpen: Bool = false
 
   var body: some View {
     SheetView(
@@ -122,6 +123,12 @@ struct ReaderSettingsSheet: View {
                   step: 5
                 )
               }
+            }
+          #endif
+
+          #if os(macOS)
+            Toggle(isOn: $autoFullscreenOnOpen) {
+              Text("Auto Full Screen on Open")
             }
           #endif
         }

--- a/KMReader/Features/Views/Settings/SettingsReaderView.swift
+++ b/KMReader/Features/Views/Settings/SettingsReaderView.swift
@@ -11,6 +11,7 @@ struct SettingsReaderView: View {
   @AppStorage("showTapZoneHints") private var showTapZoneHints: Bool = true
   @AppStorage("disableTapToTurnPage") private var disableTapToTurnPage: Bool = false
   @AppStorage("showKeyboardHelpOverlay") private var showKeyboardHelpOverlay: Bool = true
+  @AppStorage("autoFullscreenOnOpen") private var autoFullscreenOnOpen: Bool = false
   @AppStorage("readerBackground") private var readerBackground: ReaderBackground = .system
   @AppStorage("pageLayout") private var pageLayout: PageLayout = .auto
   @AppStorage("dualPageNoCover") private var dualPageNoCover: Bool = false
@@ -82,6 +83,17 @@ struct SettingsReaderView: View {
             Text("Adjust the width of webtoon pages as a percentage of screen width")
               .font(.caption)
               .foregroundColor(.secondary)
+          }
+        #endif
+
+        #if os(macOS)
+          Toggle(isOn: $autoFullscreenOnOpen) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Auto Full Screen on Open")
+              Text("Automatically enter full screen when opening the reader")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
           }
         #endif
       }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -3603,6 +3603,46 @@
         }
       }
     },
+    "Auto Full Screen on Open" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto Full Screen on Open"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plein écran automatique à l'ouverture"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開くと自動でフルスクリーン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "열 때 자동으로 전체 화면"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开时自动全屏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟時自動全螢幕"
+          }
+        }
+      }
+    },
     "Auto-refresh" : {
       "localizations" : {
         "en" : {
@@ -3679,6 +3719,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自動刷新主頁"
+          }
+        }
+      }
+    },
+    "Automatically enter full screen when opening the reader" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatically enter full screen when opening the reader"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passer automatiquement en plein écran lors de l'ouverture du lecteur"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リーダーを開くと自動的にフルスクリーンに切り替えます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "리더를 열 때 자동으로 전체 화면으로 전환합니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开阅读器时自动进入全屏模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟閱讀器時自動進入全螢幕模式"
           }
         }
       }


### PR DESCRIPTION
- Introduced a new setting to automatically enter full screen when opening the reader.
- Added localization support for the new feature in multiple languages.
- Implemented the necessary logic in the ReaderWindowView and settings sheets to manage this functionality.

---
- fix: https://github.com/everpcpc/KMReader/issues/205