### PR TITLE
refactor: optimize add to readlist and collection picker

### DIFF
--- a/KMReader/Features/Views/Book/BookCardView.swift
+++ b/KMReader/Features/Views/Book/BookCardView.swift
@@ -154,7 +154,7 @@ struct BookCardView: View {
     }
     .sheet(isPresented: $showReadListPicker) {
       ReadListPickerSheet(
-        bookIds: [komgaBook.bookId],
+        bookId: komgaBook.bookId,
         onSelect: { readListId in
           addToReadList(readListId: readListId)
         }

--- a/KMReader/Features/Views/Book/BookDetailView.swift
+++ b/KMReader/Features/Views/Book/BookDetailView.swift
@@ -94,7 +94,7 @@ struct BookDetailView: View {
     }
     .sheet(isPresented: $showReadListPicker) {
       ReadListPickerSheet(
-        bookIds: [bookId],
+        bookId: bookId,
         onSelect: { readListId in
           addToReadList(readListId: readListId)
         }

--- a/KMReader/Features/Views/Book/BookRowView.swift
+++ b/KMReader/Features/Views/Book/BookRowView.swift
@@ -170,7 +170,7 @@ struct BookRowView: View {
     }
     .sheet(isPresented: $showReadListPicker) {
       ReadListPickerSheet(
-        bookIds: [komgaBook.bookId],
+        bookId: komgaBook.bookId,
         onSelect: { readListId in
           addToReadList(readListId: readListId)
         }

--- a/KMReader/Features/Views/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/Views/OneShot/OneShotDetailView.swift
@@ -112,7 +112,7 @@ struct OneshotDetailView: View {
     }
     .sheet(isPresented: $showCollectionPicker) {
       CollectionPickerSheet(
-        seriesIds: [seriesId],
+        seriesId: seriesId,
         onSelect: { collectionId in
           addToCollection(collectionId: collectionId)
         }
@@ -121,7 +121,7 @@ struct OneshotDetailView: View {
     .sheet(isPresented: $showReadListPicker) {
       if let book = book {
         ReadListPickerSheet(
-          bookIds: [book.id],
+          bookId: book.id,
           onSelect: { readListId in
             addToReadList(readListId: readListId, bookId: book.id)
           }

--- a/KMReader/Features/Views/Series/SeriesCardView.swift
+++ b/KMReader/Features/Views/Series/SeriesCardView.swift
@@ -114,7 +114,7 @@ struct SeriesCardView: View {
     }
     .sheet(isPresented: $showCollectionPicker) {
       CollectionPickerSheet(
-        seriesIds: [komgaSeries.seriesId],
+        seriesId: komgaSeries.seriesId,
         onSelect: { collectionId in
           addToCollection(collectionId: collectionId)
         }

--- a/KMReader/Features/Views/Series/SeriesDetailView.swift
+++ b/KMReader/Features/Views/Series/SeriesDetailView.swift
@@ -108,7 +108,7 @@ struct SeriesDetailView: View {
     }
     .sheet(isPresented: $showCollectionPicker) {
       CollectionPickerSheet(
-        seriesIds: [seriesId],
+        seriesId: seriesId,
         onSelect: { collectionId in
           addToCollection(collectionId: collectionId)
         }

--- a/KMReader/Features/Views/Series/SeriesRowView.swift
+++ b/KMReader/Features/Views/Series/SeriesRowView.swift
@@ -139,7 +139,7 @@ struct SeriesRowView: View {
     }
     .sheet(isPresented: $showCollectionPicker) {
       CollectionPickerSheet(
-        seriesIds: [series.id],
+        seriesId: series.id,
         onSelect: { collectionId in
           addToCollection(collectionId: collectionId)
         }

--- a/KMReader/Features/Views/Settings/SettingsHistoryView.swift
+++ b/KMReader/Features/Views/Settings/SettingsHistoryView.swift
@@ -131,20 +131,17 @@ struct SettingsHistoryView: View {
     HStack(alignment: .top, spacing: 12) {
       Image(systemName: iconName(for: event.type))
         .foregroundColor(.secondary)
-        .font(.headline)
         .frame(width: 24)
 
       VStack(alignment: .leading, spacing: 6) {
         Text(event.type)
-          .font(.headline)
-          .lineLimit(2)
+          .lineLimit(1)
 
         if let seriesId = event.seriesId, !seriesId.isEmpty {
           HStack(spacing: 6) {
             Image(systemName: "rectangle.stack")
               .font(.caption)
             Text(seriesNameById[seriesId] ?? seriesId)
-              .font(.subheadline)
               .foregroundColor(.secondary)
               .lineLimit(1)
           }
@@ -155,7 +152,6 @@ struct SettingsHistoryView: View {
             Image(systemName: "book")
               .font(.caption)
             Text(bookNameById[bookId] ?? bookId)
-              .font(.subheadline)
               .foregroundColor(.secondary)
               .lineLimit(1)
           }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -5800,6 +5800,7 @@
       }
     },
     "Collection" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -21134,6 +21135,7 @@
       }
     },
     "Read List" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {


### PR DESCRIPTION
- Standardize parameter naming in picker sheets
- Updated `ReadListPickerSheet`, `CollectionPickerSheet`, and related views to use singular `bookId` and `seriesId` parameters instead of arrays for improved clarity and consistency.
- Refactored collection and read list loading logic to enhance filtering and item representation.
- Simplified the UI components to better reflect the new parameter structure.