### PR TITLE
feat(library): add create and edit library support

### DIFF
--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -1168,13 +1168,11 @@ actor DatabaseOperator {
     var existingMap = Dictionary(
       uniqueKeysWithValues: existing.map { ($0.libraryId, $0) }
     )
-    var didChange = false
 
     for library in libraries {
       if let existingLibrary = existingMap[library.id] {
         if existingLibrary.name != library.name {
           existingLibrary.name = library.name
-          didChange = true
         }
         existingMap.removeValue(forKey: library.id)
       } else {
@@ -1184,7 +1182,6 @@ actor DatabaseOperator {
             libraryId: library.id,
             name: library.name
           ))
-        didChange = true
       }
     }
 
@@ -1192,11 +1189,7 @@ actor DatabaseOperator {
     for (_, library) in existingMap {
       if library.libraryId != allLibrariesId {
         modelContext.delete(library)
-        didChange = true
       }
-    }
-
-    if didChange {
     }
   }
 

--- a/KMReader/Features/Models/Filesystem/DirectoryListingResult.swift
+++ b/KMReader/Features/Models/Filesystem/DirectoryListingResult.swift
@@ -1,0 +1,26 @@
+//
+//  DirectoryListingResult.swift
+//  KMReader
+//
+//  Created by Komga iOS Client
+//
+
+import Foundation
+
+/// Response from filesystem directory listing API
+struct DirectoryListingResult: Codable {
+  let parent: String?
+  let directories: [PathItem]
+  let files: [PathItem]
+}
+
+/// A path item representing a file or directory
+struct PathItem: Codable, Identifiable {
+  let type: String
+  let name: String
+  let path: String
+
+  var id: String { path }
+
+  var isDirectory: Bool { type == "directory" }
+}

--- a/KMReader/Features/Models/Library/LibraryCreation.swift
+++ b/KMReader/Features/Models/Library/LibraryCreation.swift
@@ -1,0 +1,123 @@
+//
+//  LibraryCreation.swift
+//  KMReader
+//
+//  Created by Komga iOS Client
+//
+
+import Foundation
+
+/// Scan interval options for library scanning
+enum ScanInterval: String, Codable, CaseIterable, Identifiable {
+  case disabled = "DISABLED"
+  case hourly = "HOURLY"
+  case every6h = "EVERY_6H"
+  case every12h = "EVERY_12H"
+  case daily = "DAILY"
+  case weekly = "WEEKLY"
+
+  var id: String { rawValue }
+
+  var localizedName: String {
+    switch self {
+    case .disabled: return String(localized: "Disabled")
+    case .hourly: return String(localized: "Hourly")
+    case .every6h: return String(localized: "Every 6 hours")
+    case .every12h: return String(localized: "Every 12 hours")
+    case .daily: return String(localized: "Daily")
+    case .weekly: return String(localized: "Weekly")
+    }
+  }
+}
+
+/// Series cover selection mode
+enum SeriesCoverMode: String, Codable, CaseIterable, Identifiable {
+  case first = "FIRST"
+  case firstUnreadOrFirst = "FIRST_UNREAD_OR_FIRST"
+  case firstUnreadOrLast = "FIRST_UNREAD_OR_LAST"
+  case last = "LAST"
+
+  var id: String { rawValue }
+
+  var localizedName: String {
+    switch self {
+    case .first: return String(localized: "First")
+    case .firstUnreadOrFirst: return String(localized: "First Unread or First")
+    case .firstUnreadOrLast: return String(localized: "First Unread or Last")
+    case .last: return String(localized: "Last")
+    }
+  }
+}
+
+/// Request body for creating a new library
+struct LibraryCreation: Codable {
+  // General
+  var name: String
+  var root: String
+
+  // Scanner settings
+  var emptyTrashAfterScan: Bool
+  var scanForceModifiedTime: Bool
+  var scanOnStartup: Bool
+  var scanInterval: ScanInterval
+  var scanCbx: Bool
+  var scanPdf: Bool
+  var scanEpub: Bool
+  var scanDirectoryExclusions: [String]
+  var oneshotsDirectory: String
+
+  // Options
+  var hashFiles: Bool
+  var hashPages: Bool
+  var hashKoreader: Bool
+  var analyzeDimensions: Bool
+  var repairExtensions: Bool
+  var convertToCbz: Bool
+  var seriesCover: SeriesCoverMode
+
+  // Metadata
+  var importComicInfoBook: Bool
+  var importComicInfoSeries: Bool
+  var importComicInfoCollection: Bool
+  var importComicInfoReadList: Bool
+  var importComicInfoSeriesAppendVolume: Bool
+  var importEpubBook: Bool
+  var importEpubSeries: Bool
+  var importMylarSeries: Bool
+  var importLocalArtwork: Bool
+  var importBarcodeIsbn: Bool
+
+  /// Create a new LibraryCreation with default values
+  static func createDefault(name: String = "", root: String = "") -> LibraryCreation {
+    LibraryCreation(
+      name: name,
+      root: root,
+      emptyTrashAfterScan: false,
+      scanForceModifiedTime: false,
+      scanOnStartup: false,
+      scanInterval: .every6h,
+      scanCbx: true,
+      scanPdf: true,
+      scanEpub: true,
+      scanDirectoryExclusions: ["#recycle", "@eaDir", "@Recycle"],
+      oneshotsDirectory: "",
+      hashFiles: true,
+      hashPages: false,
+      hashKoreader: false,
+      analyzeDimensions: true,
+      repairExtensions: false,
+      convertToCbz: false,
+      seriesCover: .first,
+      importComicInfoBook: true,
+      importComicInfoSeries: true,
+      importComicInfoCollection: true,
+      importComicInfoReadList: true,
+      importComicInfoSeriesAppendVolume: true,
+      importEpubBook: true,
+      importEpubSeries: true,
+      importMylarSeries: true,
+      importLocalArtwork: true,
+      importBarcodeIsbn: false
+    )
+  }
+}

--- a/KMReader/Features/Models/Library/LibraryUpdate.swift
+++ b/KMReader/Features/Models/Library/LibraryUpdate.swift
@@ -1,0 +1,81 @@
+//
+//  LibraryUpdate.swift
+//  KMReader
+//
+//  Created by Komga iOS Client
+//
+
+import Foundation
+
+/// Request body for updating an existing library
+struct LibraryUpdate: Codable {
+  // General
+  var name: String
+  var root: String
+
+  // Scanner settings
+  var emptyTrashAfterScan: Bool
+  var scanForceModifiedTime: Bool
+  var scanOnStartup: Bool
+  var scanInterval: ScanInterval
+  var scanCbx: Bool
+  var scanPdf: Bool
+  var scanEpub: Bool
+  var scanDirectoryExclusions: [String]
+  var oneshotsDirectory: String
+
+  // Options
+  var hashFiles: Bool
+  var hashPages: Bool
+  var hashKoreader: Bool
+  var analyzeDimensions: Bool
+  var repairExtensions: Bool
+  var convertToCbz: Bool
+  var seriesCover: SeriesCoverMode
+
+  // Metadata
+  var importComicInfoBook: Bool
+  var importComicInfoSeries: Bool
+  var importComicInfoCollection: Bool
+  var importComicInfoReadList: Bool
+  var importComicInfoSeriesAppendVolume: Bool
+  var importEpubBook: Bool
+  var importEpubSeries: Bool
+  var importMylarSeries: Bool
+  var importLocalArtwork: Bool
+  var importBarcodeIsbn: Bool
+
+  /// Create a LibraryUpdate from an existing Library
+  static func from(_ library: Library) -> LibraryUpdate {
+    LibraryUpdate(
+      name: library.name,
+      root: library.root,
+      emptyTrashAfterScan: library.emptyTrashAfterScan ?? false,
+      scanForceModifiedTime: library.scanForceModifiedTime ?? false,
+      scanOnStartup: library.scanOnStartup ?? false,
+      scanInterval: ScanInterval(rawValue: library.scanInterval ?? "EVERY_6H") ?? .every6h,
+      scanCbx: library.scanCbx ?? true,
+      scanPdf: library.scanPdf ?? true,
+      scanEpub: library.scanEpub ?? true,
+      scanDirectoryExclusions: library.scanDirectoryExclusions ?? [],
+      oneshotsDirectory: library.oneshotsDirectory ?? "",
+      hashFiles: library.hashFiles ?? true,
+      hashPages: library.hashPages ?? false,
+      hashKoreader: library.hashKoreader ?? false,
+      analyzeDimensions: library.analyzeDimensions ?? true,
+      repairExtensions: library.repairExtensions ?? false,
+      convertToCbz: library.convertToCbz ?? false,
+      seriesCover: SeriesCoverMode(rawValue: library.seriesCover ?? "FIRST") ?? .first,
+      importComicInfoBook: library.importComicInfoBook ?? true,
+      importComicInfoSeries: library.importComicInfoSeries ?? true,
+      importComicInfoCollection: library.importComicInfoCollection ?? true,
+      importComicInfoReadList: library.importComicInfoReadList ?? true,
+      importComicInfoSeriesAppendVolume: library.importComicInfoSeriesAppendVolume ?? true,
+      importEpubBook: library.importEpubBook ?? true,
+      importEpubSeries: library.importEpubSeries ?? true,
+      importMylarSeries: library.importMylarSeries ?? true,
+      importLocalArtwork: library.importLocalArtwork ?? true,
+      importBarcodeIsbn: library.importBarcodeIsbn ?? false
+    )
+  }
+}

--- a/KMReader/Features/Services/Filesystem/FilesystemService.swift
+++ b/KMReader/Features/Services/Filesystem/FilesystemService.swift
@@ -1,0 +1,38 @@
+//
+//  FilesystemService.swift
+//  KMReader
+//
+//  Created by Komga iOS Client
+//
+
+import Foundation
+
+class FilesystemService {
+  static let shared = FilesystemService()
+  private let apiClient = APIClient.shared
+
+  private init() {}
+
+  /// Get directory listing from the server
+  /// - Parameters:
+  ///   - path: The directory path to list (empty for root)
+  ///   - showFiles: Whether to include files in the listing
+  /// - Returns: The directory listing result
+  func getDirectoryListing(path: String = "", showFiles: Bool = false) async throws
+    -> DirectoryListingResult
+  {
+    struct RequestBody: Codable {
+      let path: String
+      let showFiles: Bool
+    }
+
+    let body = RequestBody(path: path, showFiles: showFiles)
+    let bodyData = try JSONEncoder().encode(body)
+
+    return try await apiClient.request(
+      path: "/api/v1/filesystem",
+      method: "POST",
+      body: bodyData
+    )
+  }
+}

--- a/KMReader/Features/Services/Library/LibraryManager.swift
+++ b/KMReader/Features/Services/Library/LibraryManager.swift
@@ -40,6 +40,7 @@ class LibraryManager {
       let fullLibraries = try await libraryService.getLibraries()
       let infos = fullLibraries.map { LibraryInfo(id: $0.id, name: $0.name) }
       try await DatabaseOperator.shared.replaceLibraries(infos, for: instanceId)
+      await DatabaseOperator.shared.commit()
       hasLoaded = true
     } catch {
       ErrorManager.shared.alert(error: error)

--- a/KMReader/Features/Services/Library/LibraryService.swift
+++ b/KMReader/Features/Services/Library/LibraryService.swift
@@ -21,6 +21,23 @@ class LibraryService {
     return try await apiClient.request(path: "/api/v1/libraries/\(id)")
   }
 
+  func createLibrary(_ creation: LibraryCreation) async throws -> Library {
+    let bodyData = try JSONEncoder().encode(creation)
+    return try await apiClient.request(
+      path: "/api/v1/libraries",
+      method: "POST",
+      body: bodyData
+    )
+  }
+
+  func updateLibrary(id: String, update: LibraryUpdate) async throws {
+    let bodyData = try JSONEncoder().encode(update)
+    let _: EmptyResponse = try await apiClient.request(
+      path: "/api/v1/libraries/\(id)",
+      method: "PATCH",
+      body: bodyData
+    )
+  }
   func scanLibrary(id: String, deep: Bool = false) async throws {
     var queryItems: [URLQueryItem]? = nil
     if deep {

--- a/KMReader/Features/Views/Browse/SavedFiltersView.swift
+++ b/KMReader/Features/Views/Browse/SavedFiltersView.swift
@@ -29,7 +29,9 @@ struct SavedFiltersView: View {
         ContentUnavailableView {
           Label("No Saved Filters", systemImage: "bookmark.slash")
         } description: {
-          Text("Save your frequently used \(filterType.displayName.lowercased()) filters for quick access")
+          Text(
+            "Save your frequently used \(filterType.displayName.lowercased()) filters for quick access"
+          )
         }
       } else {
         List {

--- a/KMReader/Features/Views/Browse/Sheets/LibraryPickerSheet.swift
+++ b/KMReader/Features/Views/Browse/Sheets/LibraryPickerSheet.swift
@@ -38,7 +38,6 @@ struct LibraryPickerSheet: View {
   var body: some View {
     SheetView(title: String(localized: "Libraries"), size: .large, applyFormStyle: true) {
       LibraryListContent(
-        showDeleteAction: false,
         forceMetricsOnAppear: false,
         enablePullToRefresh: false
       )

--- a/KMReader/Features/Views/Settings/DirectoryBrowserSheet.swift
+++ b/KMReader/Features/Views/Settings/DirectoryBrowserSheet.swift
@@ -1,0 +1,142 @@
+//
+//  DirectoryBrowserSheet.swift
+//  KMReader
+//
+//  Created by Komga iOS Client
+//
+
+import SwiftUI
+
+struct DirectoryBrowserSheet: View {
+  @Binding var selectedPath: String
+  @Environment(\.dismiss) private var dismiss
+  @State private var directoryListing: DirectoryListingResult?
+  @State private var currentPath: String = ""
+  @State private var isLoading = false
+  @State private var error: Error?
+
+  var body: some View {
+    SheetView(
+      title: String(localized: "library.add.browse.title", defaultValue: "Select Folder"),
+      size: .large,
+      applyFormStyle: false
+    ) {
+      VStack(spacing: 0) {
+        // Current path display
+        HStack {
+          Text(currentPath.isEmpty ? "/" : currentPath)
+            .font(.footnote)
+            .foregroundColor(.secondary)
+            .lineLimit(1)
+            .truncationMode(.head)
+          Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(Color.secondary.opacity(0.1))
+
+        if isLoading {
+          Spacer()
+          ProgressView()
+          Spacer()
+        } else if let error {
+          Spacer()
+          VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+              .font(.largeTitle)
+              .foregroundColor(.orange)
+            Text(error.localizedDescription)
+              .font(.caption)
+              .foregroundColor(.secondary)
+              .multilineTextAlignment(.center)
+            Button(String(localized: "common.retry")) {
+              loadDirectory(path: currentPath)
+            }
+          }
+          .padding()
+          Spacer()
+        } else if let listing = directoryListing {
+          List {
+            // Parent directory
+            if let parent = listing.parent {
+              Button {
+                navigateTo(parent)
+              } label: {
+                HStack {
+                  Image(systemName: "arrow.left")
+                    .foregroundColor(.accentColor)
+                  Text(
+                    String(localized: "library.add.browse.parent", defaultValue: "Parent Directory")
+                  )
+                  .foregroundColor(.primary)
+                  Spacer()
+                }
+              }
+            }
+
+            // Directories
+            ForEach(listing.directories) { item in
+              Button {
+                navigateTo(item.path)
+              } label: {
+                HStack {
+                  Image(systemName: "folder")
+                    .foregroundColor(.accentColor)
+                  Text(item.name)
+                    .foregroundColor(.primary)
+                  Spacer()
+                  Image(systemName: "chevron.right")
+                    .foregroundColor(.secondary)
+                    .font(.caption)
+                }
+              }
+            }
+          }
+          .listStyle(.plain)
+        }
+      }
+    } controls: {
+      Button {
+        selectedPath = currentPath
+        dismiss()
+      } label: {
+        Label(String(localized: "common.select"), systemImage: "checkmark")
+      }
+      .disabled(currentPath.isEmpty)
+    }
+    .task {
+      loadDirectory(path: selectedPath.isEmpty ? "" : selectedPath)
+    }
+  }
+
+  private func navigateTo(_ path: String) {
+    currentPath = path
+    loadDirectory(path: path)
+  }
+
+  private func loadDirectory(path: String) {
+    isLoading = true
+    error = nil
+    Task {
+      do {
+        let result = try await FilesystemService.shared.getDirectoryListing(path: path)
+        await MainActor.run {
+          directoryListing = result
+          // Update currentPath based on the directory we're viewing
+          if path.isEmpty, result.directories.first != nil {
+            // We're at root, keep path empty or use parent to determine
+            currentPath = result.parent ?? path
+          } else {
+            currentPath = path
+          }
+          isLoading = false
+        }
+      } catch {
+        await MainActor.run {
+          self.error = error
+          isLoading = false
+        }
+      }
+    }
+  }
+}

--- a/KMReader/Features/Views/Settings/LibraryAddSheet.swift
+++ b/KMReader/Features/Views/Settings/LibraryAddSheet.swift
@@ -1,0 +1,364 @@
+//
+//  LibraryAddSheet.swift
+//  KMReader
+//
+//  Created by Komga iOS Client
+//
+
+import SwiftUI
+
+struct LibraryAddSheet: View {
+  @Environment(\.dismiss) private var dismiss
+  @State private var libraryCreation = LibraryCreation.createDefault()
+  @State private var isCreating = false
+  @State private var showDirectoryBrowser = false
+  @State private var selectedTab = 0
+
+  // For directory exclusions input
+  @State private var newExclusion = ""
+
+  private var isValid: Bool {
+    !libraryCreation.name.isEmpty && !libraryCreation.root.isEmpty
+  }
+
+  var body: some View {
+    SheetView(
+      title: String(localized: "library.add.title", defaultValue: "Add Library"),
+      size: .large,
+      applyFormStyle: true
+    ) {
+      Form {
+        #if os(tvOS)
+          generalSection
+          scannerSection
+          optionsSection
+          metadataSection
+        #else
+          Picker("", selection: $selectedTab) {
+            Text(String(localized: "library.add.tab.general", defaultValue: "General")).tag(0)
+            Text(String(localized: "library.add.tab.scanner", defaultValue: "Scanner")).tag(1)
+            Text(String(localized: "library.add.tab.options", defaultValue: "Options")).tag(2)
+            Text(String(localized: "library.add.tab.metadata", defaultValue: "Metadata")).tag(3)
+          }
+          .pickerStyle(.segmented)
+          .listRowBackground(Color.clear)
+          .listRowInsets(EdgeInsets())
+
+          switch selectedTab {
+          case 0: generalSection
+          case 1: scannerSection
+          case 2: optionsSection
+          case 3: metadataSection
+          default: EmptyView()
+          }
+        #endif
+      }
+    } controls: {
+      Button(action: createLibrary) {
+        if isCreating {
+          ProgressView()
+        } else {
+          Label(String(localized: "common.create"), systemImage: "plus")
+        }
+      }
+      .disabled(isCreating || !isValid)
+    }
+    .sheet(isPresented: $showDirectoryBrowser) {
+      DirectoryBrowserSheet(selectedPath: $libraryCreation.root)
+    }
+  }
+
+  // MARK: - General Section
+
+  private var generalSection: some View {
+    Section(header: Text(String(localized: "library.add.section.general", defaultValue: "General")))
+    {
+      TextField(
+        String(localized: "library.add.field.name", defaultValue: "Name"),
+        text: $libraryCreation.name
+      )
+
+      HStack {
+        TextField(
+          String(localized: "library.add.field.root", defaultValue: "Root Folder"),
+          text: $libraryCreation.root
+        )
+        #if !os(tvOS)
+          Button {
+            showDirectoryBrowser = true
+          } label: {
+            Image(systemName: "folder")
+          }
+        #endif
+      }
+    }
+  }
+
+  // MARK: - Scanner Section
+
+  private var scannerSection: some View {
+    Section(header: Text(String(localized: "library.add.section.scanner", defaultValue: "Scanner")))
+    {
+      Toggle(
+        String(
+          localized: "library.add.field.emptyTrashAfterScan", defaultValue: "Empty trash after scan"
+        ),
+        isOn: $libraryCreation.emptyTrashAfterScan
+      )
+
+      Toggle(
+        String(
+          localized: "library.add.field.scanForceModifiedTime",
+          defaultValue: "Force directory modified time"),
+        isOn: $libraryCreation.scanForceModifiedTime
+      )
+
+      Toggle(
+        String(localized: "library.add.field.scanOnStartup", defaultValue: "Scan on startup"),
+        isOn: $libraryCreation.scanOnStartup
+      )
+
+      Picker(
+        String(localized: "library.add.field.scanInterval", defaultValue: "Scan interval"),
+        selection: $libraryCreation.scanInterval
+      ) {
+        ForEach(ScanInterval.allCases) { interval in
+          Text(interval.localizedName).tag(interval)
+        }
+      }
+
+      // Scan types
+      Group {
+        Toggle("CBX", isOn: $libraryCreation.scanCbx)
+        Toggle("PDF", isOn: $libraryCreation.scanPdf)
+        Toggle("EPUB", isOn: $libraryCreation.scanEpub)
+      }
+
+      TextField(
+        String(
+          localized: "library.add.field.oneshotsDirectory", defaultValue: "Oneshots directory"),
+        text: $libraryCreation.oneshotsDirectory
+      )
+
+      // Directory exclusions
+      VStack(alignment: .leading, spacing: 8) {
+        Text(
+          String(localized: "library.add.field.exclusions", defaultValue: "Directory exclusions")
+        )
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+
+        ForEach(libraryCreation.scanDirectoryExclusions, id: \.self) { exclusion in
+          HStack {
+            Text(exclusion)
+            Spacer()
+            Button {
+              libraryCreation.scanDirectoryExclusions.removeAll { $0 == exclusion }
+            } label: {
+              Image(systemName: "minus.circle.fill")
+                .foregroundColor(.red)
+            }
+            .buttonStyle(.plain)
+          }
+        }
+
+        HStack {
+          TextField(
+            String(localized: "library.add.field.newExclusion", defaultValue: "Add exclusion"),
+            text: $newExclusion
+          )
+          Button {
+            guard !newExclusion.isEmpty else { return }
+            libraryCreation.scanDirectoryExclusions.append(newExclusion)
+            newExclusion = ""
+          } label: {
+            Image(systemName: "plus.circle.fill")
+              .foregroundColor(.green)
+          }
+          .buttonStyle(.plain)
+          .disabled(newExclusion.isEmpty)
+        }
+      }
+    }
+  }
+
+  // MARK: - Options Section
+
+  private var optionsSection: some View {
+    Section(header: Text(String(localized: "library.add.section.options", defaultValue: "Options")))
+    {
+      Group {
+        Text(String(localized: "library.add.subsection.analysis", defaultValue: "Analysis"))
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+
+        Toggle(
+          String(localized: "library.add.field.hashFiles", defaultValue: "Hash files"),
+          isOn: $libraryCreation.hashFiles
+        )
+
+        Toggle(
+          String(localized: "library.add.field.hashPages", defaultValue: "Hash pages"),
+          isOn: $libraryCreation.hashPages
+        )
+
+        Toggle(
+          String(localized: "library.add.field.hashKoreader", defaultValue: "Hash KOReader"),
+          isOn: $libraryCreation.hashKoreader
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.analyzeDimensions", defaultValue: "Analyze dimensions"),
+          isOn: $libraryCreation.analyzeDimensions
+        )
+      }
+
+      Group {
+        Text(
+          String(
+            localized: "library.add.subsection.fileManagement", defaultValue: "File Management")
+        )
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+
+        Toggle(
+          String(
+            localized: "library.add.field.repairExtensions", defaultValue: "Repair extensions"),
+          isOn: $libraryCreation.repairExtensions
+        )
+
+        Toggle(
+          String(localized: "library.add.field.convertToCbz", defaultValue: "Convert to CBZ"),
+          isOn: $libraryCreation.convertToCbz
+        )
+      }
+
+      Picker(
+        String(localized: "library.add.field.seriesCover", defaultValue: "Series cover"),
+        selection: $libraryCreation.seriesCover
+      ) {
+        ForEach(SeriesCoverMode.allCases) { mode in
+          Text(mode.localizedName).tag(mode)
+        }
+      }
+    }
+  }
+
+  // MARK: - Metadata Section
+
+  private var metadataSection: some View {
+    Section(
+      header: Text(String(localized: "library.add.section.metadata", defaultValue: "Metadata"))
+    ) {
+      Group {
+        Text(String(localized: "library.add.subsection.comicinfo", defaultValue: "ComicInfo"))
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+
+        Toggle(
+          String(
+            localized: "library.add.field.importComicInfoBook", defaultValue: "Import book metadata"
+          ),
+          isOn: $libraryCreation.importComicInfoBook
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importComicInfoSeries",
+            defaultValue: "Import series metadata"),
+          isOn: $libraryCreation.importComicInfoSeries
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importComicInfoSeriesAppendVolume",
+            defaultValue: "Append volume to series"),
+          isOn: $libraryCreation.importComicInfoSeriesAppendVolume
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importComicInfoCollection",
+            defaultValue: "Import collections"),
+          isOn: $libraryCreation.importComicInfoCollection
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importComicInfoReadList",
+            defaultValue: "Import read lists"),
+          isOn: $libraryCreation.importComicInfoReadList
+        )
+      }
+
+      Group {
+        Text(String(localized: "library.add.subsection.epub", defaultValue: "EPUB"))
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+
+        Toggle(
+          String(
+            localized: "library.add.field.importEpubBook", defaultValue: "Import book metadata"),
+          isOn: $libraryCreation.importEpubBook
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importEpubSeries", defaultValue: "Import series metadata"),
+          isOn: $libraryCreation.importEpubSeries
+        )
+      }
+
+      Group {
+        Text(String(localized: "library.add.subsection.other", defaultValue: "Other"))
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+
+        Toggle(
+          String(
+            localized: "library.add.field.importMylarSeries", defaultValue: "Import Mylar series"),
+          isOn: $libraryCreation.importMylarSeries
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importLocalArtwork", defaultValue: "Import local artwork"),
+          isOn: $libraryCreation.importLocalArtwork
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importBarcodeIsbn", defaultValue: "Import barcode ISBN"),
+          isOn: $libraryCreation.importBarcodeIsbn
+        )
+      }
+    }
+  }
+
+  // MARK: - Actions
+
+  private func createLibrary() {
+    isCreating = true
+    Task {
+      do {
+        _ = try await LibraryService.shared.createLibrary(libraryCreation)
+        await LibraryManager.shared.refreshLibraries()
+        await MainActor.run {
+          ErrorManager.shared.notify(
+            message: String(
+              localized: "notification.library.created", defaultValue: "Library created")
+          )
+          dismiss()
+        }
+      } catch {
+        await MainActor.run {
+          ErrorManager.shared.alert(error: error)
+        }
+      }
+      await MainActor.run {
+        isCreating = false
+      }
+    }
+  }
+}

--- a/KMReader/Features/Views/Settings/LibraryEditSheet.swift
+++ b/KMReader/Features/Views/Settings/LibraryEditSheet.swift
@@ -1,0 +1,370 @@
+//
+//  LibraryEditSheet.swift
+//  KMReader
+//
+//  Created by Komga iOS Client
+//
+
+import SwiftUI
+
+struct LibraryEditSheet: View {
+  let library: Library
+  @Environment(\.dismiss) private var dismiss
+  @State private var libraryUpdate: LibraryUpdate
+  @State private var isSaving = false
+  @State private var showDirectoryBrowser = false
+  @State private var selectedTab = 0
+
+  // For directory exclusions input
+  @State private var newExclusion = ""
+
+  init(library: Library) {
+    self.library = library
+    _libraryUpdate = State(initialValue: LibraryUpdate.from(library))
+  }
+
+  private var isValid: Bool {
+    !libraryUpdate.name.isEmpty && !libraryUpdate.root.isEmpty
+  }
+
+  var body: some View {
+    SheetView(
+      title: String(localized: "library.edit.title", defaultValue: "Edit Library"),
+      size: .large,
+      applyFormStyle: true
+    ) {
+      Form {
+        #if os(tvOS)
+          generalSection
+          scannerSection
+          optionsSection
+          metadataSection
+        #else
+          Picker("", selection: $selectedTab) {
+            Text(String(localized: "library.add.tab.general", defaultValue: "General")).tag(0)
+            Text(String(localized: "library.add.tab.scanner", defaultValue: "Scanner")).tag(1)
+            Text(String(localized: "library.add.tab.options", defaultValue: "Options")).tag(2)
+            Text(String(localized: "library.add.tab.metadata", defaultValue: "Metadata")).tag(3)
+          }
+          .pickerStyle(.segmented)
+          .listRowBackground(Color.clear)
+          .listRowInsets(EdgeInsets())
+
+          switch selectedTab {
+          case 0: generalSection
+          case 1: scannerSection
+          case 2: optionsSection
+          case 3: metadataSection
+          default: EmptyView()
+          }
+        #endif
+      }
+    } controls: {
+      Button(action: saveLibrary) {
+        if isSaving {
+          ProgressView()
+        } else {
+          Label(String(localized: "common.save"), systemImage: "checkmark")
+        }
+      }
+      .disabled(isSaving || !isValid)
+    }
+    .sheet(isPresented: $showDirectoryBrowser) {
+      DirectoryBrowserSheet(selectedPath: $libraryUpdate.root)
+    }
+  }
+
+  // MARK: - General Section
+
+  private var generalSection: some View {
+    Section(header: Text(String(localized: "library.add.section.general", defaultValue: "General")))
+    {
+      TextField(
+        String(localized: "library.add.field.name", defaultValue: "Name"),
+        text: $libraryUpdate.name
+      )
+
+      HStack {
+        TextField(
+          String(localized: "library.add.field.root", defaultValue: "Root Folder"),
+          text: $libraryUpdate.root
+        )
+        #if !os(tvOS)
+          Button {
+            showDirectoryBrowser = true
+          } label: {
+            Image(systemName: "folder")
+          }
+        #endif
+      }
+    }
+  }
+
+  // MARK: - Scanner Section
+
+  private var scannerSection: some View {
+    Section(header: Text(String(localized: "library.add.section.scanner", defaultValue: "Scanner")))
+    {
+      Toggle(
+        String(
+          localized: "library.add.field.emptyTrashAfterScan", defaultValue: "Empty trash after scan"
+        ),
+        isOn: $libraryUpdate.emptyTrashAfterScan
+      )
+
+      Toggle(
+        String(
+          localized: "library.add.field.scanForceModifiedTime",
+          defaultValue: "Force directory modified time"),
+        isOn: $libraryUpdate.scanForceModifiedTime
+      )
+
+      Toggle(
+        String(localized: "library.add.field.scanOnStartup", defaultValue: "Scan on startup"),
+        isOn: $libraryUpdate.scanOnStartup
+      )
+
+      Picker(
+        String(localized: "library.add.field.scanInterval", defaultValue: "Scan interval"),
+        selection: $libraryUpdate.scanInterval
+      ) {
+        ForEach(ScanInterval.allCases) { interval in
+          Text(interval.localizedName).tag(interval)
+        }
+      }
+
+      // Scan types
+      Group {
+        Toggle("CBX", isOn: $libraryUpdate.scanCbx)
+        Toggle("PDF", isOn: $libraryUpdate.scanPdf)
+        Toggle("EPUB", isOn: $libraryUpdate.scanEpub)
+      }
+
+      TextField(
+        String(
+          localized: "library.add.field.oneshotsDirectory", defaultValue: "Oneshots directory"),
+        text: $libraryUpdate.oneshotsDirectory
+      )
+
+      // Directory exclusions
+      VStack(alignment: .leading, spacing: 8) {
+        Text(
+          String(localized: "library.add.field.exclusions", defaultValue: "Directory exclusions")
+        )
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+
+        ForEach(libraryUpdate.scanDirectoryExclusions, id: \.self) { exclusion in
+          HStack {
+            Text(exclusion)
+            Spacer()
+            Button {
+              libraryUpdate.scanDirectoryExclusions.removeAll { $0 == exclusion }
+            } label: {
+              Image(systemName: "minus.circle.fill")
+                .foregroundColor(.red)
+            }
+            .buttonStyle(.plain)
+          }
+        }
+
+        HStack {
+          TextField(
+            String(localized: "library.add.field.newExclusion", defaultValue: "Add exclusion"),
+            text: $newExclusion
+          )
+          Button {
+            guard !newExclusion.isEmpty else { return }
+            libraryUpdate.scanDirectoryExclusions.append(newExclusion)
+            newExclusion = ""
+          } label: {
+            Image(systemName: "plus.circle.fill")
+              .foregroundColor(.green)
+          }
+          .buttonStyle(.plain)
+          .disabled(newExclusion.isEmpty)
+        }
+      }
+    }
+  }
+
+  // MARK: - Options Section
+
+  private var optionsSection: some View {
+    Section(header: Text(String(localized: "library.add.section.options", defaultValue: "Options")))
+    {
+      Group {
+        Text(String(localized: "library.add.subsection.analysis", defaultValue: "Analysis"))
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+
+        Toggle(
+          String(localized: "library.add.field.hashFiles", defaultValue: "Hash files"),
+          isOn: $libraryUpdate.hashFiles
+        )
+
+        Toggle(
+          String(localized: "library.add.field.hashPages", defaultValue: "Hash pages"),
+          isOn: $libraryUpdate.hashPages
+        )
+
+        Toggle(
+          String(localized: "library.add.field.hashKoreader", defaultValue: "Hash KOReader"),
+          isOn: $libraryUpdate.hashKoreader
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.analyzeDimensions", defaultValue: "Analyze dimensions"),
+          isOn: $libraryUpdate.analyzeDimensions
+        )
+      }
+
+      Group {
+        Text(
+          String(
+            localized: "library.add.subsection.fileManagement", defaultValue: "File Management")
+        )
+        .font(.subheadline)
+        .foregroundColor(.secondary)
+
+        Toggle(
+          String(
+            localized: "library.add.field.repairExtensions", defaultValue: "Repair extensions"),
+          isOn: $libraryUpdate.repairExtensions
+        )
+
+        Toggle(
+          String(localized: "library.add.field.convertToCbz", defaultValue: "Convert to CBZ"),
+          isOn: $libraryUpdate.convertToCbz
+        )
+      }
+
+      Picker(
+        String(localized: "library.add.field.seriesCover", defaultValue: "Series cover"),
+        selection: $libraryUpdate.seriesCover
+      ) {
+        ForEach(SeriesCoverMode.allCases) { mode in
+          Text(mode.localizedName).tag(mode)
+        }
+      }
+    }
+  }
+
+  // MARK: - Metadata Section
+
+  private var metadataSection: some View {
+    Section(
+      header: Text(String(localized: "library.add.section.metadata", defaultValue: "Metadata"))
+    ) {
+      Group {
+        Text(String(localized: "library.add.subsection.comicinfo", defaultValue: "ComicInfo"))
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+
+        Toggle(
+          String(
+            localized: "library.add.field.importComicInfoBook", defaultValue: "Import book metadata"
+          ),
+          isOn: $libraryUpdate.importComicInfoBook
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importComicInfoSeries",
+            defaultValue: "Import series metadata"),
+          isOn: $libraryUpdate.importComicInfoSeries
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importComicInfoSeriesAppendVolume",
+            defaultValue: "Append volume to series"),
+          isOn: $libraryUpdate.importComicInfoSeriesAppendVolume
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importComicInfoCollection",
+            defaultValue: "Import collections"),
+          isOn: $libraryUpdate.importComicInfoCollection
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importComicInfoReadList",
+            defaultValue: "Import read lists"),
+          isOn: $libraryUpdate.importComicInfoReadList
+        )
+      }
+
+      Group {
+        Text(String(localized: "library.add.subsection.epub", defaultValue: "EPUB"))
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+
+        Toggle(
+          String(
+            localized: "library.add.field.importEpubBook", defaultValue: "Import book metadata"),
+          isOn: $libraryUpdate.importEpubBook
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importEpubSeries", defaultValue: "Import series metadata"),
+          isOn: $libraryUpdate.importEpubSeries
+        )
+      }
+
+      Group {
+        Text(String(localized: "library.add.subsection.other", defaultValue: "Other"))
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+
+        Toggle(
+          String(
+            localized: "library.add.field.importMylarSeries", defaultValue: "Import Mylar series"),
+          isOn: $libraryUpdate.importMylarSeries
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importLocalArtwork", defaultValue: "Import local artwork"),
+          isOn: $libraryUpdate.importLocalArtwork
+        )
+
+        Toggle(
+          String(
+            localized: "library.add.field.importBarcodeIsbn", defaultValue: "Import barcode ISBN"),
+          isOn: $libraryUpdate.importBarcodeIsbn
+        )
+      }
+    }
+  }
+
+  // MARK: - Actions
+
+  private func saveLibrary() {
+    isSaving = true
+    Task {
+      do {
+        try await LibraryService.shared.updateLibrary(id: library.id, update: libraryUpdate)
+        await LibraryManager.shared.refreshLibraries()
+        await MainActor.run {
+          ErrorManager.shared.notify(
+            message: String(
+              localized: "notification.library.updated", defaultValue: "Library updated")
+          )
+          dismiss()
+        }
+      } catch {
+        await MainActor.run {
+          ErrorManager.shared.alert(error: error)
+        }
+      }
+      await MainActor.run {
+        isSaving = false
+      }
+    }
+  }
+}

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -5201,6 +5201,46 @@
         }
       }
     },
+    "CBX" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CBX"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CBX"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CBX"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CBX"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CBX"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CBX"
+          }
+        }
+      }
+    },
     "Character & Word" : {
       "localizations" : {
         "en" : {
@@ -6119,6 +6159,46 @@
         }
       }
     },
+    "common.create" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作成"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "생성"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建立"
+          }
+        }
+      }
+    },
     "common.delete" : {
       "localizations" : {
         "en" : {
@@ -6195,6 +6275,126 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "確定"
+          }
+        }
+      }
+    },
+    "common.retry" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réessayer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再試行"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다시 시도"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重试"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重試"
+          }
+        }
+      }
+    },
+    "common.save" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrer"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저장"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "儲存"
+          }
+        }
+      }
+    },
+    "common.select" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionner"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇"
           }
         }
       }
@@ -7355,6 +7555,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自訂角色"
+          }
+        }
+      }
+    },
+    "Daily" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daily"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quotidien"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毎日"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "매일"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每天"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每天"
           }
         }
       }
@@ -8821,6 +9061,46 @@
         }
       }
     },
+    "Disabled" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disabled"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactivé"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無効"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비활성화"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "禁用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "禁用"
+          }
+        }
+      }
+    },
     "Display" : {
       "localizations" : {
         "en" : {
@@ -10209,6 +10489,46 @@
         }
       }
     },
+    "EPUB" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        }
+      }
+    },
     "EPUB Reader Not Available" : {
       "localizations" : {
         "en" : {
@@ -11523,6 +11843,86 @@
         }
       }
     },
+    "Every 6 hours" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Every 6 hours"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toutes les 6 heures"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6時間ごと"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6시간마다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每6小时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每6小時"
+          }
+        }
+      }
+    },
+    "Every 12 hours" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Every 12 hours"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toutes les 12 heures"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12時間ごと"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12시간마다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每12小时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每12小時"
+          }
+        }
+      }
+    },
     "Failed" : {
       "localizations" : {
         "en" : {
@@ -12033,6 +12433,126 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "篩選器名稱"
+          }
+        }
+      }
+    },
+    "First" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Premier"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最初"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "첫 번째"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首本"
+          }
+        }
+      }
+    },
+    "First Unread or First" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First Unread or First"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Premier non lu ou premier"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未読の最初または最初"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "첫 번째 미읽음 또는 첫 번째"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首本未读或首本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首本未讀或首本"
+          }
+        }
+      }
+    },
+    "First Unread or Last" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First Unread or Last"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Premier non lu ou dernier"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未読の最初または最後"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "첫 번째 미읽음 또는 마지막"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首本未读或末本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首本未讀或末本"
           }
         }
       }
@@ -12667,6 +13187,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "歷史詳情"
+          }
+        }
+      }
+    },
+    "Hourly" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hourly"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toutes les heures"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毎時"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "매시간"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每小时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每小時"
           }
         }
       }
@@ -13733,6 +14293,46 @@
         }
       }
     },
+    "Last" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dernier"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最後"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마지막"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "末本"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "末本"
+          }
+        }
+      }
+    },
     "Last Read: %@" : {
       "localizations" : {
         "en" : {
@@ -14089,6 +14689,1810 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書庫"
+          }
+        }
+      }
+    },
+    "library.action.edit" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Library"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifier la bibliothèque"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライブラリを編集"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "라이브러리 편집"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑书库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯書庫"
+          }
+        }
+      }
+    },
+    "library.add.browse.parent" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Parent Directory"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Répertoire parent"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "親ディレクトリ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상위 디렉토리"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上级目录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上層目錄"
+          }
+        }
+      }
+    },
+    "library.add.browse.title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select Folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionner le répertoire"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ディレクトリを選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "디렉토리 선택"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择目录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇目錄"
+          }
+        }
+      }
+    },
+    "library.add.field.analyzeDimensions" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Analyze dimensions"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analyser les dimensions"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サイズを分析"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "크기 분석"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分析尺寸"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分析尺寸"
+          }
+        }
+      }
+    },
+    "library.add.field.convertToCbz" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Convert to CBZ"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Convertir en CBZ"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CBZに変換"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CBZ로 변환"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "转换为 CBZ"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "轉換為 CBZ"
+          }
+        }
+      }
+    },
+    "library.add.field.emptyTrashAfterScan" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Empty trash after scan"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider la corbeille après le scan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スキャン後にゴミ箱を空にする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스캔 후 휴지통 비우기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "扫描后清空回收站"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "掃描後清空回收站"
+          }
+        }
+      }
+    },
+    "library.add.field.exclusions" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Directory exclusions"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Répertoires exclus"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "除外ディレクトリ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제외 디렉토리"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排除目录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排除目錄"
+          }
+        }
+      }
+    },
+    "library.add.field.hashFiles" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hash files"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hacher les fichiers"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイルハッシュ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "파일 해시"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "计算文件哈希"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計算檔案雜湊"
+          }
+        }
+      }
+    },
+    "library.add.field.hashKoreader" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hash KOReader"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hacher KOReader"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KOReaderハッシュ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KOReader 해시"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "计算 KOReader 哈希"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計算 KOReader 雜湊"
+          }
+        }
+      }
+    },
+    "library.add.field.hashPages" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Hash pages"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hacher les pages"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページハッシュ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 해시"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "计算页面哈希"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "計算頁面雜湊"
+          }
+        }
+      }
+    },
+    "library.add.field.importBarcodeIsbn" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Import barcode ISBN"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer le code-barres ISBN"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バーコードISBNをインポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "바코드 ISBN 가져오기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入条形码 ISBN"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入條碼 ISBN"
+          }
+        }
+      }
+    },
+    "library.add.field.importComicInfoBook" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Import book metadata"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer les métadonnées du livre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書籍メタデータをインポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "책 메타데이터 가져오기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入书籍元数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入書籍元資料"
+          }
+        }
+      }
+    },
+    "library.add.field.importComicInfoCollection" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Import collections"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer les collections"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コレクションをインポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "컬렉션 가져오기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入收藏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入收藏"
+          }
+        }
+      }
+    },
+    "library.add.field.importComicInfoReadList" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Import read lists"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer les listes de lecture"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書リストをインポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽기 목록 가져오기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入阅读列表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入閱讀清單"
+          }
+        }
+      }
+    },
+    "library.add.field.importComicInfoSeries" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Import series metadata"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer les métadonnées de la série"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シリーズメタデータをインポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시리즈 메타데이터 가져오기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入系列元数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入系列元資料"
+          }
+        }
+      }
+    },
+    "library.add.field.importComicInfoSeriesAppendVolume" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Append volume to series"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter le volume à la série"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シリーズに巻を追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시리즈에 권 추가"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加卷号到系列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "追加卷號到系列"
+          }
+        }
+      }
+    },
+    "library.add.field.importEpubBook" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Import book metadata"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer les métadonnées du livre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書籍メタデータをインポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "책 메타데이터 가져오기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入书籍元数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入書籍元資料"
+          }
+        }
+      }
+    },
+    "library.add.field.importEpubSeries" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Import series metadata"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer les métadonnées de la série"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シリーズメタデータをインポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시리즈 메타데이터 가져오기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入系列元数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入系列元資料"
+          }
+        }
+      }
+    },
+    "library.add.field.importLocalArtwork" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Import local artwork"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer les illustrations locales"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ローカルアートワークをインポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로컬 아트워크 가져오기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入本地封面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入本地封面"
+          }
+        }
+      }
+    },
+    "library.add.field.importMylarSeries" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Import Mylar series"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer les séries Mylar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mylarシリーズをインポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mylar 시리즈 가져오기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导入 Mylar 系列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "匯入 Mylar 系列"
+          }
+        }
+      }
+    },
+    "library.add.field.name" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Name"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名前"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이름"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名称"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名稱"
+          }
+        }
+      }
+    },
+    "library.add.field.newExclusion" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add exclusion"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter une exclusion"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "除外を追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제외 추가"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加排除项"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增排除項"
+          }
+        }
+      }
+    },
+    "library.add.field.oneshotsDirectory" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oneshots directory"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Répertoire des one-shots"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "単発ディレクトリ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단편 디렉토리"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "单本目录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單本目錄"
+          }
+        }
+      }
+    },
+    "library.add.field.repairExtensions" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Repair extensions"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réparer les extensions"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拡張子を修復"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확장자 복구"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "修复扩展名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "修復副檔名"
+          }
+        }
+      }
+    },
+    "library.add.field.root" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Root Folder"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dossier racine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ルートフォルダ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "루트 폴더"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "根目录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "根目錄"
+          }
+        }
+      }
+    },
+    "library.add.field.scanForceModifiedTime" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Force directory modified time"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forcer l'heure de modification du répertoire"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ディレクトリ変更時刻を強制"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "디렉토리 수정 시간 강제"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "强制使用目录修改时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強制使用目錄修改時間"
+          }
+        }
+      }
+    },
+    "library.add.field.scanInterval" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan interval"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervalle de scan"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スキャン間隔"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스캔 간격"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "扫描间隔"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "掃描間隔"
+          }
+        }
+      }
+    },
+    "library.add.field.scanOnStartup" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan on startup"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scanner au démarrage"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "起動時にスキャン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시작 시 스캔"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动时扫描"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟動時掃描"
+          }
+        }
+      }
+    },
+    "library.add.field.seriesCover" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Series cover"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couverture de la série"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シリーズカバー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시리즈 표지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系列封面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系列封面"
+          }
+        }
+      }
+    },
+    "library.add.section.general" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Général"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일반"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常规"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
+        }
+      }
+    },
+    "library.add.section.metadata" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Metadata"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Métadonnées"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メタデータ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메타데이터"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "元数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "元資料"
+          }
+        }
+      }
+    },
+    "library.add.section.options" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Options"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Options"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オプション"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "옵션"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选项"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選項"
+          }
+        }
+      }
+    },
+    "library.add.section.scanner" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scanner"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scanner"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スキャナー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스캐너"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "扫描器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "掃描器"
+          }
+        }
+      }
+    },
+    "library.add.subsection.analysis" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Analysis"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analyse"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分析"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "분석"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分析"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "分析"
+          }
+        }
+      }
+    },
+    "library.add.subsection.comicinfo" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "ComicInfo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ComicInfo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ComicInfo"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ComicInfo"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ComicInfo"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ComicInfo"
+          }
+        }
+      }
+    },
+    "library.add.subsection.epub" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "EPUB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        }
+      }
+    },
+    "library.add.subsection.fileManagement" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "File Management"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestion des fichiers"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイル管理"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "파일 관리"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文件管理"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "檔案管理"
+          }
+        }
+      }
+    },
+    "library.add.subsection.other" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Other"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기타"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他"
+          }
+        }
+      }
+    },
+    "library.add.tab.general" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "General"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Général"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일반"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常规"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
+        }
+      }
+    },
+    "library.add.tab.metadata" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Metadata"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Métadonnées"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メタデータ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메타데이터"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "元数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "元資料"
+          }
+        }
+      }
+    },
+    "library.add.tab.options" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Options"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Options"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オプション"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "옵션"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选项"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選項"
+          }
+        }
+      }
+    },
+    "library.add.tab.scanner" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scanner"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scanner"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スキャナー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스캐너"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "扫描器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "掃描器"
+          }
+        }
+      }
+    },
+    "library.add.title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add Library"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter une bibliothèque"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライブラリを追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "라이브러리 추가"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加书库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增書庫"
+          }
+        }
+      }
+    },
+    "library.edit.title" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Edit Library"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifier la bibliothèque"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライブラリを編集"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "라이브러리 편집"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑书库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編輯書庫"
           }
         }
       }
@@ -17897,6 +20301,47 @@
         }
       }
     },
+    "notification.library.created" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Library created"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bibliothèque créée"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライブラリが作成されました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "라이브러리가 생성되었습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "书库已创建"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書庫已建立"
+          }
+        }
+      }
+    },
     "notification.library.deleted" : {
       "localizations" : {
         "en" : {
@@ -17933,6 +20378,47 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已刪除書庫"
+          }
+        }
+      }
+    },
+    "notification.library.updated" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Library updated"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bibliothèque mise à jour"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライブラリが更新されました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "라이브러리가 업데이트되었습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "书库已更新"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書庫已更新"
           }
         }
       }
@@ -20255,6 +22741,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已暫停"
+          }
+        }
+      }
+    },
+    "PDF" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF"
           }
         }
       }
@@ -32691,6 +35217,46 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Webtoon 點擊捲動高度"
+          }
+        }
+      }
+    },
+    "Weekly" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weekly"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hebdomadaire"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毎週"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "매주"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每周"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每週"
           }
         }
       }

--- a/KMReader/Shared/UI/LibraryRowView.swift
+++ b/KMReader/Shared/UI/LibraryRowView.swift
@@ -11,10 +11,26 @@ struct LibraryRowView: View {
   @AppStorage("isAdmin") private var isAdmin: Bool = false
   @Bindable var library: KomgaLibrary
   let isSelected: Bool
-  let showDeleteAction: Bool
   let onSelect: () -> Void
   let onAction: (LibraryAction) -> Void
-  let onDelete: () -> Void
+  let onEdit: (() -> Void)?
+  let onDelete: (() -> Void)?
+
+  init(
+    library: KomgaLibrary,
+    isSelected: Bool,
+    onSelect: @escaping () -> Void,
+    onAction: @escaping (LibraryAction) -> Void,
+    onEdit: (() -> Void)? = nil,
+    onDelete: (() -> Void)? = nil
+  ) {
+    self.library = library
+    self.isSelected = isSelected
+    self.onSelect = onSelect
+    self.onAction = onAction
+    self.onEdit = onEdit
+    self.onDelete = onDelete
+  }
 
   var body: some View {
     HStack(spacing: 12) {
@@ -50,6 +66,18 @@ struct LibraryRowView: View {
     .contentShape(Rectangle())
     .contextMenu {
       if isAdmin && !isOffline {
+        if let onEdit {
+          Button {
+            onEdit()
+          } label: {
+            Label(
+              String(localized: "library.action.edit", defaultValue: "Edit Library"),
+              systemImage: "pencil")
+          }
+
+          Divider()
+        }
+
         ForEach(LibraryAction.allCases, id: \.self) { action in
           Button {
             onAction(action)
@@ -58,7 +86,7 @@ struct LibraryRowView: View {
           }
         }
 
-        if showDeleteAction {
+        if let onDelete {
           Divider()
 
           Button(role: .destructive) {


### PR DESCRIPTION
- Add LibraryCreation and LibraryUpdate models for API requests
- Add FilesystemService for directory browsing
- Add DirectoryBrowserSheet for selecting root folder from server
- Add LibraryAddSheet and LibraryEditSheet with 4 sections (General, Scanner, Options, Metadata)
- Add createLibrary and updateLibrary methods to LibraryService
- Add edit action to LibraryRowView context menu
- Add commit call to LibraryManager to persist SwiftData changes
- Simplify LibraryListContent by removing showDeleteAction param
- Add translations for all supported languages