### PR TITLE
fix(webtoon): use viewport bottom for page detection

### DIFF
--- a/KMReader/Features/Views/Reader/Helpers/WebtoonConstants.swift
+++ b/KMReader/Features/Views/Reader/Helpers/WebtoonConstants.swift
@@ -15,7 +15,6 @@ enum WebtoonConstants {
   static let bottomThreshold: CGFloat = 60
   static let footerHeight: CGFloat = 480
   static let footerPadding: CGFloat = 120
-  static let scrollAmountMultiplier: CGFloat = 0.8
 
   static var topAreaThreshold: CGFloat { AppConfig.tapZoneSize.value }
   static var bottomAreaThreshold: CGFloat { 1.0 - AppConfig.tapZoneSize.value }


### PR DESCRIPTION
- Change page detection logic from center-point to viewport-bottom
- Page is considered read when its bottom passes viewport bottom
- Show END in UI when scrolled to bottom (currentPage = pages.count)
- Fixes progress not completing when last page has small height

---

- fix: https://github.com/everpcpc/KMReader/issues/250