### PR TITLE
fix(webtoon): incorrect page spacing

### DIFF
--- a/KMReader/Features/Views/Reader/Webtoon/WebtoonPageCell_iOS.swift
+++ b/KMReader/Features/Views/Reader/Webtoon/WebtoonPageCell_iOS.swift
@@ -36,8 +36,8 @@
 
     private func setupUI() {
       applyBackground()
-      imageView.contentMode = .scaleAspectFit
-      imageView.clipsToBounds = false
+      imageView.contentMode = .scaleToFill
+      imageView.clipsToBounds = true
       imageView.translatesAutoresizingMaskIntoConstraints = false
       contentView.addSubview(imageView)
 

--- a/KMReader/Features/Views/Reader/Webtoon/WebtoonPageCell_macOS.swift
+++ b/KMReader/Features/Views/Reader/Webtoon/WebtoonPageCell_macOS.swift
@@ -33,7 +33,7 @@
 
     private func setupUI() {
       applyBackground()
-      pageImageView.imageScaling = .scaleProportionallyUpOrDown
+      pageImageView.imageScaling = .scaleAxesIndependently
       pageImageView.wantsLayer = true
       pageImageView.imageAlignment = .alignCenter
       pageImageView.autoresizingMask = [.width, .height]

--- a/KMReader/Features/Views/Reader/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Views/Reader/Webtoon/WebtoonReaderView_iOS.swift
@@ -436,7 +436,9 @@
         }
         let page = pages[indexPath.item]
         let height = heightCache.height(for: indexPath.item, page: page, pageWidth: pageWidth)
-        return CGSize(width: pageWidth, height: height)
+        let scale = collectionView.traitCollection.displayScale
+        let alignedHeight = scale > 0 ? ceil(height * scale) / scale : height
+        return CGSize(width: pageWidth, height: alignedHeight)
       }
 
       // MARK: - UICollectionViewDelegate

--- a/KMReader/Features/Views/Reader/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Views/Reader/Webtoon/WebtoonReaderView_macOS.swift
@@ -384,7 +384,9 @@
         }
         let page = pages[indexPath.item]
         let height = heightCache.height(for: indexPath.item, page: page, pageWidth: pageWidth)
-        return NSSize(width: pageWidth, height: height)
+        let scale = collectionView.window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1.0
+        let alignedHeight = scale > 0 ? ceil(height * scale) / scale : height
+        return NSSize(width: pageWidth, height: alignedHeight)
       }
 
       // MARK: - Scroll


### PR DESCRIPTION
- Correctly calculate cell height on pixel boundary to avoid gaps between pages
- Adjust image scaling to full-fill the cell content to avoid gaps between pages

---

- fix: https://github.com/everpcpc/KMReader/issues/257