### PR TITLE
fix(dashboard): optimize sse auto-refresh logic

### DIFF
--- a/KMReader/Features/Services/Sync/InstanceInitializer.swift
+++ b/KMReader/Features/Services/Sync/InstanceInitializer.swift
@@ -256,7 +256,7 @@ final class InstanceInitializer {
       while shouldContinue {
         let search = BookSearch(condition: nil)
         let result = try await BookService.shared.getBooksList(
-          search: search, page: page, size: 500, sort: "lastModified,desc")
+          search: search, page: page, size: 100, sort: "lastModified,desc")
 
         var itemsToSync: [Book] = []
         for book in result.content {

--- a/KMReader/Features/Views/Dashboard/DashboardLocalSectionView.swift
+++ b/KMReader/Features/Views/Dashboard/DashboardLocalSectionView.swift
@@ -155,6 +155,8 @@ private struct DashboardLocalSectionContent<
   @State private var hoverShowDelayTask: Task<Void, Never>?
   @State private var hoverHideDelayTask: Task<Void, Never>?
 
+  private let logger = AppLogger(.dashboard)
+
   private let cardWidth: CGFloat = 240
 
   private var backgroundColors: [Color] {


### PR DESCRIPTION
- Reduce refresh debounce interval to 3s
- Fix pagination logic preventing auto-refresh on first page
- Use explicit onChange detection for reliable updates
- Add debug logging for refresh lifecycle
- Adjust incremental sync page size to 100