### PR TITLE
feat: add metadata filter support with FilterLogic for BrowseOptions

### DIFF
--- a/KMReader/Features/Models/Book/BookSearch.swift
+++ b/KMReader/Features/Models/Book/BookSearch.swift
@@ -51,7 +51,9 @@ struct BookSearchFilters {
 
   // Metadata filters
   var authors: [String]? = nil
+  var authorsLogic: FilterLogic = .all
   var tags: [String]? = nil
+  var tagsLogic: FilterLogic = .all
 }
 
 // Helper functions to build conditions
@@ -122,14 +124,16 @@ extension BookSearch {
       let authorConditions = authors.map { author in
         ["author": ["operator": "is", "value": ["name": author]]]
       }
-      conditions.append(["anyOf": authorConditions])
+      let wrapperKey = filters.authorsLogic == .all ? "allOf" : "anyOf"
+      conditions.append([wrapperKey: authorConditions])
     }
 
     if let tags = filters.tags, !tags.isEmpty {
       let tagConditions = tags.map { tag in
         ["tag": ["operator": "is", "value": tag]]
       }
-      conditions.append(["anyOf": tagConditions])
+      let wrapperKey = filters.tagsLogic == .all ? "allOf" : "anyOf"
+      conditions.append([wrapperKey: tagConditions])
     }
 
     if conditions.isEmpty {

--- a/KMReader/Features/Models/Common/MetadataFilterConfig.swift
+++ b/KMReader/Features/Models/Common/MetadataFilterConfig.swift
@@ -8,27 +8,117 @@
 import Foundation
 
 /// Configuration for metadata-based filtering
-struct MetadataFilterConfig: Equatable {
+struct MetadataFilterConfig: Equatable, RawRepresentable {
+  typealias RawValue = String
+
   var publisher: String?
   var authors: [String]?
+  var authorsLogic: FilterLogic = .all
   var genres: [String]?
+  var genresLogic: FilterLogic = .all
   var tags: [String]?
+  var tagsLogic: FilterLogic = .all
+  var languages: [String]?
+  var languagesLogic: FilterLogic = .all
 
   init(
     publisher: String? = nil,
     authors: [String]? = nil,
+    authorsLogic: FilterLogic = .all,
     genres: [String]? = nil,
-    tags: [String]? = nil
+    genresLogic: FilterLogic = .all,
+    tags: [String]? = nil,
+    tagsLogic: FilterLogic = .all,
+    languages: [String]? = nil,
+    languagesLogic: FilterLogic = .all
   ) {
     self.publisher = publisher
     self.authors = authors
+    self.authorsLogic = authorsLogic
     self.genres = genres
+    self.genresLogic = genresLogic
     self.tags = tags
+    self.tagsLogic = tagsLogic
+    self.languages = languages
+    self.languagesLogic = languagesLogic
   }
 
   /// Check if any filter is active
   var hasAnyFilter: Bool {
-    return publisher != nil || authors != nil || genres != nil || tags != nil
+    return publisher != nil || authors != nil || genres != nil || tags != nil || languages != nil
+  }
+
+  var rawValue: String {
+    var dict: [String: Any] = [:]
+    if let publisher = publisher {
+      dict["publisher"] = publisher
+    }
+    if let authors = authors {
+      dict["authors"] = authors
+    }
+    dict["authorsLogic"] = authorsLogic.rawValue
+    if let genres = genres {
+      dict["genres"] = genres
+    }
+    dict["genresLogic"] = genresLogic.rawValue
+    if let tags = tags {
+      dict["tags"] = tags
+    }
+    dict["tagsLogic"] = tagsLogic.rawValue
+    if let languages = languages {
+      dict["languages"] = languages
+    }
+    dict["languagesLogic"] = languagesLogic.rawValue
+    if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+      let json = String(data: data, encoding: .utf8)
+    {
+      return json
+    }
+    return "{}"
+  }
+
+  init?(rawValue: String) {
+    guard !rawValue.isEmpty else {
+      return nil
+    }
+    guard let data = rawValue.data(using: .utf8),
+      let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+      return nil
+    }
+    self.publisher = dict["publisher"] as? String
+    self.authors = dict["authors"] as? [String]
+    if let authorsLogicRaw = dict["authorsLogic"] as? String,
+      let logic = FilterLogic(rawValue: authorsLogicRaw)
+    {
+      self.authorsLogic = logic
+    } else {
+      self.authorsLogic = .all
+    }
+    self.genres = dict["genres"] as? [String]
+    if let genresLogicRaw = dict["genresLogic"] as? String,
+      let logic = FilterLogic(rawValue: genresLogicRaw)
+    {
+      self.genresLogic = logic
+    } else {
+      self.genresLogic = .all
+    }
+    self.tags = dict["tags"] as? [String]
+    if let tagsLogicRaw = dict["tagsLogic"] as? String,
+      let logic = FilterLogic(rawValue: tagsLogicRaw)
+    {
+      self.tagsLogic = logic
+    } else {
+      self.tagsLogic = .all
+    }
+    self.languages = dict["languages"] as? [String]
+    if let languagesLogicRaw = dict["languagesLogic"] as? String,
+      let logic = FilterLogic(rawValue: languagesLogicRaw)
+    {
+      self.languagesLogic = logic
+    } else {
+      self.languagesLogic = .all
+    }
   }
 
   /// Create config for publisher filter

--- a/KMReader/Features/Models/Common/Shared/TriStateFilter.swift
+++ b/KMReader/Features/Models/Common/Shared/TriStateFilter.swift
@@ -13,7 +13,7 @@ enum TriStateSelection: String, Codable {
   case exclude
 }
 
-enum StatusFilterLogic: String, Codable {
+enum FilterLogic: String, Codable {
   case all = "ALL"
   case any = "ANY"
 }

--- a/KMReader/Features/Models/Series/SeriesSearch.swift
+++ b/KMReader/Features/Models/Series/SeriesSearch.swift
@@ -44,7 +44,7 @@ struct SeriesSearchFilters {
   var excludeReadStatuses: [ReadStatus] = []
   var includeSeriesStatuses: [String] = []
   var excludeSeriesStatuses: [String] = []
-  var seriesStatusLogic: StatusFilterLogic = .all
+  var seriesStatusLogic: FilterLogic = .all
   /// oneshot = true / false / nil
   var oneshot: Bool? = nil
   /// deleted = true / false / nil
@@ -56,8 +56,13 @@ struct SeriesSearchFilters {
   // Metadata filters
   var publisher: String? = nil
   var authors: [String]? = nil
+  var authorsLogic: FilterLogic = .all
   var genres: [String]? = nil
+  var genresLogic: FilterLogic = .all
   var tags: [String]? = nil
+  var tagsLogic: FilterLogic = .all
+  var languages: [String]? = nil
+  var languagesLogic: FilterLogic = .all
 }
 
 // Helper functions to build conditions
@@ -152,21 +157,32 @@ extension SeriesSearch {
       let authorConditions = authors.map { author in
         ["author": ["operator": "is", "value": ["name": author]]]
       }
-      conditions.append(["anyOf": authorConditions])
+      let wrapperKey = filters.authorsLogic == .all ? "allOf" : "anyOf"
+      conditions.append([wrapperKey: authorConditions])
     }
 
     if let genres = filters.genres, !genres.isEmpty {
       let genreConditions = genres.map { genre in
         ["genre": ["operator": "is", "value": genre]]
       }
-      conditions.append(["anyOf": genreConditions])
+      let wrapperKey = filters.genresLogic == .all ? "allOf" : "anyOf"
+      conditions.append([wrapperKey: genreConditions])
     }
 
     if let tags = filters.tags, !tags.isEmpty {
       let tagConditions = tags.map { tag in
         ["tag": ["operator": "is", "value": tag]]
       }
-      conditions.append(["anyOf": tagConditions])
+      let wrapperKey = filters.tagsLogic == .all ? "allOf" : "anyOf"
+      conditions.append([wrapperKey: tagConditions])
+    }
+
+    if let languages = filters.languages, !languages.isEmpty {
+      let languageConditions = languages.map { language in
+        ["language": ["operator": "is", "value": language]]
+      }
+      let wrapperKey = filters.languagesLogic == .all ? "allOf" : "anyOf"
+      conditions.append([wrapperKey: languageConditions])
     }
 
     if conditions.isEmpty {

--- a/KMReader/Features/Services/Book/BookService.swift
+++ b/KMReader/Features/Services/Book/BookService.swift
@@ -34,7 +34,11 @@ class BookService {
       oneshot: browseOpts.oneshotFilter.effectiveBool,
       deleted: browseOpts.deletedFilter.effectiveBool,
       seriesId: seriesId,
-      readListId: nil
+      readListId: nil,
+      authors: browseOpts.metadataFilter.authors,
+      authorsLogic: browseOpts.metadataFilter.authorsLogic,
+      tags: browseOpts.metadataFilter.tags,
+      tagsLogic: browseOpts.metadataFilter.tagsLogic
     )
     let condition = BookSearch.buildCondition(filters: filters)
     let search = BookSearch(condition: condition)

--- a/KMReader/Features/Services/Collection/CollectionService.swift
+++ b/KMReader/Features/Services/Collection/CollectionService.swift
@@ -87,6 +87,35 @@ class CollectionService {
       queryItems.append(URLQueryItem(name: "complete", value: String(complete)))
     }
 
+    // Metadata filters
+    if let publisher = browseOpts.metadataFilter.publisher {
+      queryItems.append(URLQueryItem(name: "publisher", value: publisher))
+    }
+
+    if let authors = browseOpts.metadataFilter.authors, !authors.isEmpty {
+      for author in authors {
+        queryItems.append(URLQueryItem(name: "author", value: "\(author),"))
+      }
+    }
+
+    if let genres = browseOpts.metadataFilter.genres, !genres.isEmpty {
+      for genre in genres {
+        queryItems.append(URLQueryItem(name: "genre", value: genre))
+      }
+    }
+
+    if let tags = browseOpts.metadataFilter.tags, !tags.isEmpty {
+      for tag in tags {
+        queryItems.append(URLQueryItem(name: "tag", value: tag))
+      }
+    }
+
+    if let languages = browseOpts.metadataFilter.languages, !languages.isEmpty {
+      for language in languages {
+        queryItems.append(URLQueryItem(name: "language", value: language))
+      }
+    }
+
     return try await apiClient.request(
       path: "/api/v1/collections/\(collectionId)/series",
       queryItems: queryItems

--- a/KMReader/Features/Services/ReadList/ReadListService.swift
+++ b/KMReader/Features/Services/ReadList/ReadListService.swift
@@ -79,6 +79,19 @@ class ReadListService {
       queryItems.append(URLQueryItem(name: "deleted", value: String(deleted)))
     }
 
+    // Metadata filters
+    if let authors = browseOpts.metadataFilter.authors, !authors.isEmpty {
+      for author in authors {
+        queryItems.append(URLQueryItem(name: "author", value: "\(author),"))
+      }
+    }
+
+    if let tags = browseOpts.metadataFilter.tags, !tags.isEmpty {
+      for tag in tags {
+        queryItems.append(URLQueryItem(name: "tag", value: tag))
+      }
+    }
+
     return try await apiClient.request(
       path: "/api/v1/readlists/\(readListId)/books",
       queryItems: queryItems

--- a/KMReader/Features/Services/Series/SeriesService.swift
+++ b/KMReader/Features/Services/Series/SeriesService.swift
@@ -22,7 +22,7 @@ class SeriesService {
     excludeReadStatuses: Set<ReadStatus>,
     includeSeriesStatuses: Set<SeriesStatus>,
     excludeSeriesStatuses: Set<SeriesStatus>,
-    seriesStatusLogic: StatusFilterLogic,
+    seriesStatusLogic: FilterLogic,
     completeFilter: TriStateFilter<BoolTriStateFlag>,
     oneshotFilter: TriStateFilter<BoolTriStateFlag>,
     deletedFilter: TriStateFilter<BoolTriStateFlag>,
@@ -39,7 +39,8 @@ class SeriesService {
     let hasMetadataFilter =
       metadataFilter != nil
       && (metadataFilter!.publisher != nil || !(metadataFilter!.authors?.isEmpty ?? true)
-        || !(metadataFilter!.genres?.isEmpty ?? true) || !(metadataFilter!.tags?.isEmpty ?? true))
+        || !(metadataFilter!.genres?.isEmpty ?? true) || !(metadataFilter!.tags?.isEmpty ?? true)
+        || !(metadataFilter!.languages?.isEmpty ?? true))
 
     if hasLibraryFilter || hasReadStatusFilter || hasSeriesStatusFilter || hasMetadataFilter {
       let condition = SeriesSearch.buildCondition(
@@ -55,8 +56,13 @@ class SeriesService {
           complete: completeFilter.effectiveBool,
           publisher: metadataFilter?.publisher,
           authors: metadataFilter?.authors,
+          authorsLogic: metadataFilter?.authorsLogic ?? .all,
           genres: metadataFilter?.genres,
-          tags: metadataFilter?.tags
+          genresLogic: metadataFilter?.genresLogic ?? .all,
+          tags: metadataFilter?.tags,
+          tagsLogic: metadataFilter?.tagsLogic ?? .all,
+          languages: metadataFilter?.languages,
+          languagesLogic: metadataFilter?.languagesLogic ?? .all
         ))
 
       let search = SeriesSearch(

--- a/KMReader/Features/ViewModels/Book/BookBrowseOptions.swift
+++ b/KMReader/Features/ViewModels/Book/BookBrowseOptions.swift
@@ -15,6 +15,7 @@ struct BookBrowseOptions: Equatable, RawRepresentable {
   var excludeReadStatuses: Set<ReadStatus> = []
   var oneshotFilter: TriStateFilter<BoolTriStateFlag> = TriStateFilter()
   var deletedFilter: TriStateFilter<BoolTriStateFlag> = TriStateFilter()
+  var metadataFilter: MetadataFilterConfig = MetadataFilterConfig()
   var sortField: BookSortField = .series
   var sortDirection: SortDirection = .ascending
 
@@ -32,6 +33,7 @@ struct BookBrowseOptions: Equatable, RawRepresentable {
       ),
       "oneshotFilter": oneshotFilter.storageValue,
       "deletedFilter": deletedFilter.storageValue,
+      "metadataFilter": metadataFilter.rawValue,
       "sortField": sortField.rawValue,
       "sortDirection": sortDirection.rawValue,
     ]
@@ -61,6 +63,8 @@ struct BookBrowseOptions: Equatable, RawRepresentable {
 
     self.oneshotFilter = TriStateFilter.decode(dict["oneshotFilter"])
     self.deletedFilter = TriStateFilter.decode(dict["deletedFilter"])
+    self.metadataFilter =
+      MetadataFilterConfig(rawValue: dict["metadataFilter"] ?? "") ?? MetadataFilterConfig()
 
     // backward compatibility with legacy tri-state
     if includeReadStatuses.isEmpty && excludeReadStatuses.isEmpty,

--- a/KMReader/Features/ViewModels/Collection/CollectionSeriesBrowseOptions.swift
+++ b/KMReader/Features/ViewModels/Collection/CollectionSeriesBrowseOptions.swift
@@ -15,10 +15,11 @@ struct CollectionSeriesBrowseOptions: Equatable, RawRepresentable {
   var excludeReadStatuses: Set<ReadStatus> = []
   var includeSeriesStatuses: Set<SeriesStatus> = []
   var excludeSeriesStatuses: Set<SeriesStatus> = []
-  var seriesStatusLogic: StatusFilterLogic = .all
+  var seriesStatusLogic: FilterLogic = .all
   var completeFilter: TriStateFilter<BoolTriStateFlag> = TriStateFilter()
   var oneshotFilter: TriStateFilter<BoolTriStateFlag> = TriStateFilter()
   var deletedFilter: TriStateFilter<BoolTriStateFlag> = TriStateFilter()
+  var metadataFilter: MetadataFilterConfig = MetadataFilterConfig()
 
   var rawValue: String {
     let dict: [String: String] = [
@@ -38,6 +39,7 @@ struct CollectionSeriesBrowseOptions: Equatable, RawRepresentable {
       "completeFilter": completeFilter.storageValue,
       "oneshotFilter": oneshotFilter.storageValue,
       "deletedFilter": deletedFilter.storageValue,
+      "metadataFilter": metadataFilter.rawValue,
     ]
     if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
       let json = String(data: data, encoding: .utf8)
@@ -97,11 +99,13 @@ struct CollectionSeriesBrowseOptions: Equatable, RawRepresentable {
 
     let logicRaw = dict["seriesStatusLogic"] ?? ""
     self.seriesStatusLogic =
-      StatusFilterLogic(rawValue: logicRaw)
+      FilterLogic(rawValue: logicRaw)
       ?? (logicRaw == "AND" ? .all : logicRaw == "OR" ? .any : .all)
     self.completeFilter = TriStateFilter.decode(dict["completeFilter"])
     self.oneshotFilter = TriStateFilter.decode(dict["oneshotFilter"])
     self.deletedFilter = TriStateFilter.decode(dict["deletedFilter"])
+    self.metadataFilter =
+      MetadataFilterConfig(rawValue: dict["metadataFilter"] ?? "") ?? MetadataFilterConfig()
   }
 
   init() {}

--- a/KMReader/Features/ViewModels/ReadList/ReadListBookBrowseOptions.swift
+++ b/KMReader/Features/ViewModels/ReadList/ReadListBookBrowseOptions.swift
@@ -15,6 +15,7 @@ struct ReadListBookBrowseOptions: Equatable, RawRepresentable {
   var excludeReadStatuses: Set<ReadStatus> = []
   var oneshotFilter: TriStateFilter<BoolTriStateFlag> = TriStateFilter()
   var deletedFilter: TriStateFilter<BoolTriStateFlag> = TriStateFilter()
+  var metadataFilter: MetadataFilterConfig = MetadataFilterConfig()
 
   var rawValue: String {
     let dict: [String: String] = [
@@ -26,6 +27,7 @@ struct ReadListBookBrowseOptions: Equatable, RawRepresentable {
       ),
       "oneshotFilter": oneshotFilter.storageValue,
       "deletedFilter": deletedFilter.storageValue,
+      "metadataFilter": metadataFilter.rawValue,
     ]
     if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
       let json = String(data: data, encoding: .utf8)
@@ -53,6 +55,8 @@ struct ReadListBookBrowseOptions: Equatable, RawRepresentable {
 
     self.oneshotFilter = TriStateFilter.decode(dict["oneshotFilter"])
     self.deletedFilter = TriStateFilter.decode(dict["deletedFilter"])
+    self.metadataFilter =
+      MetadataFilterConfig(rawValue: dict["metadataFilter"] ?? "") ?? MetadataFilterConfig()
 
     if includeReadStatuses.isEmpty && excludeReadStatuses.isEmpty,
       let legacy = dict["readStatusFilter"]

--- a/KMReader/Features/ViewModels/Series/SeriesBrowseOptions.swift
+++ b/KMReader/Features/ViewModels/Series/SeriesBrowseOptions.swift
@@ -15,10 +15,11 @@ struct SeriesBrowseOptions: Equatable, RawRepresentable {
   var excludeReadStatuses: Set<ReadStatus> = []
   var includeSeriesStatuses: Set<SeriesStatus> = []
   var excludeSeriesStatuses: Set<SeriesStatus> = []
-  var seriesStatusLogic: StatusFilterLogic = .all
+  var seriesStatusLogic: FilterLogic = .all
   var completeFilter: TriStateFilter<BoolTriStateFlag> = TriStateFilter()
   var oneshotFilter: TriStateFilter<BoolTriStateFlag> = TriStateFilter()
   var deletedFilter: TriStateFilter<BoolTriStateFlag> = TriStateFilter()
+  var metadataFilter: MetadataFilterConfig = MetadataFilterConfig()
   var sortField: SeriesSortField = .name
   var sortDirection: SortDirection = .ascending
 
@@ -47,6 +48,7 @@ struct SeriesBrowseOptions: Equatable, RawRepresentable {
       "completeFilter": completeFilter.storageValue,
       "oneshotFilter": oneshotFilter.storageValue,
       "deletedFilter": deletedFilter.storageValue,
+      "metadataFilter": metadataFilter.rawValue,
       "sortField": sortField.rawValue,
       "sortDirection": sortDirection.rawValue,
     ]
@@ -110,11 +112,13 @@ struct SeriesBrowseOptions: Equatable, RawRepresentable {
 
     let logicRaw = dict["seriesStatusLogic"] ?? ""
     self.seriesStatusLogic =
-      StatusFilterLogic(rawValue: logicRaw)
+      FilterLogic(rawValue: logicRaw)
       ?? (logicRaw == "AND" ? .all : logicRaw == "OR" ? .any : .all)
     self.completeFilter = TriStateFilter.decode(dict["completeFilter"])
     self.oneshotFilter = TriStateFilter.decode(dict["oneshotFilter"])
     self.deletedFilter = TriStateFilter.decode(dict["deletedFilter"])
+    self.metadataFilter =
+      MetadataFilterConfig(rawValue: dict["metadataFilter"] ?? "") ?? MetadataFilterConfig()
     self.sortField = SeriesSortField(rawValue: dict["sortField"] ?? "") ?? .name
     self.sortDirection = SortDirection(rawValue: dict["sortDirection"] ?? "") ?? .ascending
   }

--- a/KMReader/Features/Views/Collection/CollectionSeriesBrowseOptionsSheet.swift
+++ b/KMReader/Features/Views/Collection/CollectionSeriesBrowseOptionsSheet.swift
@@ -47,8 +47,8 @@ struct CollectionSeriesBrowseOptionsSheet: View {
 
         Section("Series Status") {
           Picker("Logic", selection: $tempOpts.seriesStatusLogic) {
-            Text("All").tag(StatusFilterLogic.all)
-            Text("Any").tag(StatusFilterLogic.any)
+            Text("All").tag(FilterLogic.all)
+            Text("Any").tag(FilterLogic.any)
           }
           .pickerStyle(.segmented)
 

--- a/KMReader/Features/Views/Series/SeriesBrowseOptionsSheet.swift
+++ b/KMReader/Features/Views/Series/SeriesBrowseOptionsSheet.swift
@@ -53,8 +53,8 @@ struct SeriesBrowseOptionsSheet: View {
 
         Section("Series Status") {
           Picker("Logic", selection: $tempOpts.seriesStatusLogic) {
-            Text("All").tag(StatusFilterLogic.all)
-            Text("Any").tag(StatusFilterLogic.any)
+            Text("All").tag(FilterLogic.all)
+            Text("Any").tag(FilterLogic.any)
           }
           .pickerStyle(.segmented)
 


### PR DESCRIPTION
- Rename StatusFilterLogic to FilterLogic for general use
- Add MetadataFilterConfig with publisher, authors, genres, tags, languages
- Each array field (authors, genres, tags, languages) has FilterLogic (ALL/ANY)
- Implement metadata filters in SeriesBrowseOptions, BookBrowseOptions, CollectionSeriesBrowseOptions, ReadListBookBrowseOptions
- Update SeriesSearch and BookSearch to support metadata filter logic
- Update all services (Series, Book, Collection, ReadList) to pass metadata filters to API