### PR TITLE
feat(storage): migrate collection and metadata properties

### DIFF
--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -107,7 +107,9 @@ actor DatabaseOperator {
       if existing.metaAuthorsLock != dto.metadata.authorsLock {
         existing.metaAuthorsLock = dto.metadata.authorsLock
       }
-      if existing.metaTags != dto.metadata.tags { existing.metaTags = dto.metadata.tags }
+      if existing.metaTags != (dto.metadata.tags ?? []) {
+        existing.metaTags = dto.metadata.tags ?? []
+      }
       if existing.metaTagsLock != dto.metadata.tagsLock {
         existing.metaTagsLock = dto.metadata.tagsLock
       }
@@ -345,11 +347,15 @@ actor DatabaseOperator {
       if existing.metaLanguageLock != dto.metadata.languageLock {
         existing.metaLanguageLock = dto.metadata.languageLock
       }
-      if existing.metaGenres != dto.metadata.genres { existing.metaGenres = dto.metadata.genres }
+      if existing.metaGenres != (dto.metadata.genres ?? []) {
+        existing.metaGenres = dto.metadata.genres ?? []
+      }
       if existing.metaGenresLock != dto.metadata.genresLock {
         existing.metaGenresLock = dto.metadata.genresLock
       }
-      if existing.metaTags != dto.metadata.tags { existing.metaTags = dto.metadata.tags }
+      if existing.metaTags != (dto.metadata.tags ?? []) {
+        existing.metaTags = dto.metadata.tags ?? []
+      }
       if existing.metaTagsLock != dto.metadata.tagsLock {
         existing.metaTagsLock = dto.metadata.tagsLock
       }
@@ -359,8 +365,8 @@ actor DatabaseOperator {
       if existing.metaTotalBookCountLock != dto.metadata.totalBookCountLock {
         existing.metaTotalBookCountLock = dto.metadata.totalBookCountLock
       }
-      if existing.metaSharingLabels != dto.metadata.sharingLabels {
-        existing.metaSharingLabels = dto.metadata.sharingLabels
+      if existing.metaSharingLabels != (dto.metadata.sharingLabels ?? []) {
+        existing.metaSharingLabels = dto.metadata.sharingLabels ?? []
       }
       if existing.metaSharingLabelsLock != dto.metadata.sharingLabelsLock {
         existing.metaSharingLabelsLock = dto.metadata.sharingLabelsLock
@@ -388,8 +394,8 @@ actor DatabaseOperator {
       if existing.booksMetaAuthorsRaw != newAuthorsRaw {
         existing.booksMetaAuthorsRaw = newAuthorsRaw
       }
-      if existing.booksMetaTags != dto.booksMetadata.tags {
-        existing.booksMetaTags = dto.booksMetadata.tags
+      if existing.booksMetaTags != (dto.booksMetadata.tags ?? []) {
+        existing.booksMetaTags = dto.booksMetadata.tags ?? []
       }
       if existing.booksMetaReleaseDate != dto.booksMetadata.releaseDate {
         existing.booksMetaReleaseDate = dto.booksMetadata.releaseDate

--- a/KMReader/Features/Models/Book/KomgaBook.swift
+++ b/KMReader/Features/Models/Book/KomgaBook.swift
@@ -49,7 +49,7 @@ final class KomgaBook {
   var metaReleaseDateLock: Bool?
   var metaAuthorsRaw: Data?  // JSON encoded [Author]
   var metaAuthorsLock: Bool?
-  var metaTags: [String]?
+  var metaTagsRaw: Data?  // JSON encoded [String]
   var metaTagsLock: Bool?
   var metaIsbn: String?
   var metaIsbnLock: Bool?
@@ -78,9 +78,24 @@ final class KomgaBook {
   var downloadedSize: Int64 = 0
 
   // Cached read list IDs containing this book
-  var readListIds: [String] = []
+  var readListIdsRaw: Data?
 
-  var isolatePages: [Int] = []
+  var isolatePagesRaw: Data?
+
+  var metaTags: [String] {
+    get { metaTagsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? [] }
+    set { metaTagsRaw = try? JSONEncoder().encode(newValue) }
+  }
+
+  var readListIds: [String] {
+    get { readListIdsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? [] }
+    set { readListIdsRaw = try? JSONEncoder().encode(newValue) }
+  }
+
+  var isolatePages: [Int] {
+    get { isolatePagesRaw.flatMap { try? JSONDecoder().decode([Int].self, from: $0) } ?? [] }
+    set { isolatePagesRaw = try? JSONEncoder().encode(newValue) }
+  }
 
   /// Computed property for download status.
   var downloadStatus: DownloadStatus {
@@ -176,7 +191,7 @@ final class KomgaBook {
     self.metaReleaseDateLock = metadata.releaseDateLock
     self.metaAuthorsRaw = try? JSONEncoder().encode(metadata.authors)
     self.metaAuthorsLock = metadata.authorsLock
-    self.metaTags = metadata.tags
+    self.metaTagsRaw = try? JSONEncoder().encode(metadata.tags ?? [])
     self.metaTagsLock = metadata.tagsLock
     self.metaIsbn = metadata.isbn
     self.metaIsbnLock = metadata.isbnLock
@@ -193,6 +208,8 @@ final class KomgaBook {
     self.isUnavailable = isUnavailable
     self.oneshot = oneshot
     self.downloadedSize = downloadedSize
+    self.readListIdsRaw = try? JSONEncoder().encode([] as [String])
+    self.isolatePagesRaw = try? JSONEncoder().encode([] as [Int])
   }
 
   var media: Media {

--- a/KMReader/Features/Models/Collection/KomgaCollection.swift
+++ b/KMReader/Features/Models/Collection/KomgaCollection.swift
@@ -21,7 +21,12 @@ final class KomgaCollection {
   var lastModifiedDate: Date
   var filtered: Bool
 
-  var seriesIds: [String] = []
+  var seriesIdsRaw: Data?
+
+  var seriesIds: [String] {
+    get { seriesIdsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? [] }
+    set { seriesIdsRaw = try? JSONEncoder().encode(newValue) }
+  }
 
   init(
     id: String? = nil,
@@ -42,7 +47,7 @@ final class KomgaCollection {
     self.createdDate = createdDate
     self.lastModifiedDate = lastModifiedDate
     self.filtered = filtered
-    self.seriesIds = seriesIds
+    self.seriesIdsRaw = try? JSONEncoder().encode(seriesIds)
   }
 
   func toCollection() -> SeriesCollection {

--- a/KMReader/Features/Models/ReadList/KomgaReadList.swift
+++ b/KMReader/Features/Models/ReadList/KomgaReadList.swift
@@ -22,7 +22,12 @@ final class KomgaReadList {
   var lastModifiedDate: Date
   var filtered: Bool
 
-  var bookIds: [String] = []
+  var bookIdsRaw: Data?
+
+  var bookIds: [String] {
+    get { bookIdsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? [] }
+    set { bookIdsRaw = try? JSONEncoder().encode(newValue) }
+  }
 
   // Track offline download status (managed locally, manual only)
   var downloadStatusRaw: String = "notDownloaded"
@@ -77,7 +82,7 @@ final class KomgaReadList {
     self.createdDate = createdDate
     self.lastModifiedDate = lastModifiedDate
     self.filtered = filtered
-    self.bookIds = bookIds
+    self.bookIdsRaw = try? JSONEncoder().encode(bookIds)
     self.downloadedBooks = downloadedBooks
     self.pendingBooks = pendingBooks
     self.downloadedSize = downloadedSize

--- a/KMReader/Features/Models/Series/KomgaSeries.swift
+++ b/KMReader/Features/Models/Series/KomgaSeries.swift
@@ -45,13 +45,13 @@ final class KomgaSeries {
   var metaAgeRatingLock: Bool?
   var metaLanguage: String?
   var metaLanguageLock: Bool?
-  var metaGenres: [String]?
+  var metaGenresRaw: Data?
   var metaGenresLock: Bool?
-  var metaTags: [String]?
+  var metaTagsRaw: Data?
   var metaTagsLock: Bool?
   var metaTotalBookCount: Int?
   var metaTotalBookCountLock: Bool?
-  var metaSharingLabels: [String]?
+  var metaSharingLabelsRaw: Data?
   var metaSharingLabelsLock: Bool?
   var metaLinksRaw: Data?  // JSON encoded [WebLink]
   var metaLinksLock: Bool?
@@ -62,7 +62,7 @@ final class KomgaSeries {
   var booksMetaCreated: String?
   var booksMetaLastModified: String?
   var booksMetaAuthorsRaw: Data?  // JSON encoded [Author]
-  var booksMetaTags: [String]?
+  var booksMetaTagsRaw: Data?
   var booksMetaReleaseDate: String?
   var booksMetaSummary: String?
   var booksMetaSummaryNumber: String?
@@ -81,7 +81,34 @@ final class KomgaSeries {
   var offlinePolicyLimit: Int = 0
 
   // Cached collection IDs containing this series
-  var collectionIds: [String] = []
+  var collectionIdsRaw: Data?
+
+  var metaGenres: [String] {
+    get { metaGenresRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? [] }
+    set { metaGenresRaw = try? JSONEncoder().encode(newValue) }
+  }
+
+  var metaTags: [String] {
+    get { metaTagsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? [] }
+    set { metaTagsRaw = try? JSONEncoder().encode(newValue) }
+  }
+
+  var metaSharingLabels: [String] {
+    get { metaSharingLabelsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? [] }
+    set { metaSharingLabelsRaw = try? JSONEncoder().encode(newValue) }
+  }
+
+  var booksMetaTags: [String] {
+    get { booksMetaTagsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? [] }
+    set { booksMetaTagsRaw = try? JSONEncoder().encode(newValue) }
+  }
+
+  var collectionIds: [String] {
+    get {
+      collectionIdsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? []
+    }
+    set { collectionIdsRaw = try? JSONEncoder().encode(newValue) }
+  }
 
   /// Computed property for download status.
   var downloadStatus: SeriesDownloadStatus {
@@ -170,13 +197,13 @@ final class KomgaSeries {
     self.metaAgeRatingLock = metadata.ageRatingLock
     self.metaLanguage = metadata.language
     self.metaLanguageLock = metadata.languageLock
-    self.metaGenres = metadata.genres
+    self.metaGenresRaw = try? JSONEncoder().encode(metadata.genres ?? [])
     self.metaGenresLock = metadata.genresLock
-    self.metaTags = metadata.tags
+    self.metaTagsRaw = try? JSONEncoder().encode(metadata.tags ?? [])
     self.metaTagsLock = metadata.tagsLock
     self.metaTotalBookCount = metadata.totalBookCount
     self.metaTotalBookCountLock = metadata.totalBookCountLock
-    self.metaSharingLabels = metadata.sharingLabels
+    self.metaSharingLabelsRaw = try? JSONEncoder().encode(metadata.sharingLabels ?? [])
     self.metaSharingLabelsLock = metadata.sharingLabelsLock
     self.metaLinksRaw = try? JSONEncoder().encode(metadata.links)
     self.metaLinksLock = metadata.linksLock
@@ -187,7 +214,7 @@ final class KomgaSeries {
     self.booksMetaCreated = booksMetadata.created
     self.booksMetaLastModified = booksMetadata.lastModified
     self.booksMetaAuthorsRaw = try? JSONEncoder().encode(booksMetadata.authors)
-    self.booksMetaTags = booksMetadata.tags
+    self.booksMetaTagsRaw = try? JSONEncoder().encode(booksMetadata.tags ?? [])
     self.booksMetaReleaseDate = booksMetadata.releaseDate
     self.booksMetaSummary = booksMetadata.summary
     self.booksMetaSummaryNumber = booksMetadata.summaryNumber
@@ -199,6 +226,7 @@ final class KomgaSeries {
     self.downloadedSize = downloadedSize
     self.offlinePolicyRaw = offlinePolicy.rawValue
     self.offlinePolicyLimit = offlinePolicyLimit
+    self.collectionIdsRaw = try? JSONEncoder().encode([] as [String])
   }
 
   var metadata: SeriesMetadata {


### PR DESCRIPTION
 to use JSON-encoded Data storage

Refactor metadata arrays (tags, genres, sharingLabels, etc.) and relationship IDs (bookIds, seriesIds, readListIds) to store as JSON-encoded Data with computed properties for type-safe access. Update DatabaseOperator comparisons to handle nil array values as empty arrays.