### PR TITLE
feat(reader): add support for nested TOC entries with children links

### DIFF
--- a/KMReader/Features/Models/Book/DivinaManifest.swift
+++ b/KMReader/Features/Models/Book/DivinaManifest.swift
@@ -22,4 +22,5 @@ struct DivinaManifestResource: Codable, Sendable {
 struct DivinaManifestLink: Codable, Sendable {
   let title: String?
   let href: String
+  let children: [DivinaManifestLink]?
 }

--- a/KMReader/Features/Models/WebPub/WebPubManifest.swift
+++ b/KMReader/Features/Models/WebPub/WebPubManifest.swift
@@ -92,6 +92,7 @@ struct WebPubLink: Codable, Sendable {
   let properties: [String: JSONAny]?
   let height: Int?
   let width: Int?
+  let children: [WebPubLink]?
 }
 
 struct WebPubMetadata: Codable, Sendable {

--- a/KMReader/Features/ViewModels/Reader/EpubReaderViewModel.swift
+++ b/KMReader/Features/ViewModels/Reader/EpubReaderViewModel.swift
@@ -782,10 +782,17 @@
       var results: [WebPubPageLocation] = []
 
       var tocTitleByHref: [String: String] = [:]
-      for tocLink in tableOfContents {
-        guard let title = tocLink.title, !title.isEmpty else { continue }
-        tocTitleByHref[Self.normalizedHref(tocLink.href)] = title
+      func collectTOCTitles(_ links: [WebPubLink]) {
+        for tocLink in links {
+          if let title = tocLink.title, !title.isEmpty {
+            tocTitleByHref[Self.normalizedHref(tocLink.href)] = title
+          }
+          if let children = tocLink.children {
+            collectTOCTitles(children)
+          }
+        }
       }
+      collectTOCTitles(tableOfContents)
 
       for (chapterIndex, link) in readingOrder.enumerated() {
         let pageCount = max(1, chapterPageCounts[chapterIndex] ?? 1)

--- a/KMReader/Features/ViewModels/Reader/ReaderManifestService.swift
+++ b/KMReader/Features/ViewModels/Reader/ReaderManifestService.swift
@@ -10,10 +10,18 @@ import OSLog
 import UniformTypeIdentifiers
 
 struct ReaderTOCEntry: Codable, Identifiable, Hashable, Sendable {
-  var id: Int { pageIndex }
+  let id: UUID
   let title: String
   let pageIndex: Int
+  let children: [ReaderTOCEntry]?
   var pageNumber: Int { pageIndex + 1 }
+
+  init(title: String, pageIndex: Int, children: [ReaderTOCEntry]? = nil) {
+    self.id = UUID()
+    self.title = title
+    self.pageIndex = pageIndex
+    self.children = children
+  }
 }
 
 struct ReaderManifestService {
@@ -57,7 +65,13 @@ struct ReaderManifestService {
         ? localizedPageLabel(pageNumber)
         : trimmedTitle
 
-      entries.append(ReaderTOCEntry(title: title, pageIndex: pageIndex))
+      let children: [ReaderTOCEntry]? = if let itemChildren = item.children, !itemChildren.isEmpty {
+        buildTOCEntries(manifestTOC: itemChildren, hrefPageMap: hrefPageMap)
+      } else {
+        nil
+      }
+
+      entries.append(ReaderTOCEntry(title: title, pageIndex: pageIndex, children: children))
     }
 
     return entries

--- a/KMReader/Features/Views/Reader/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Views/Reader/Epub/EpubReaderView.swift
@@ -434,9 +434,19 @@
       guard let currentLocation = viewModel.currentLocation else {
         return nil
       }
-      return viewModel.tableOfContents.first { link in
-        link.href == currentLocation.href
+      return findLink(href: currentLocation.href, in: viewModel.tableOfContents)
+    }
+
+    private func findLink(href: String, in links: [WebPubLink]) -> WebPubLink? {
+      for link in links {
+        if link.href == href {
+          return link
+        }
+        if let children = link.children, let found = findLink(href: href, in: children) {
+          return found
+        }
       }
+      return nil
     }
   }
 #endif

--- a/KMReader/Features/Views/Reader/Sheets/ChapterListSheetView.swift
+++ b/KMReader/Features/Views/Reader/Sheets/ChapterListSheetView.swift
@@ -16,26 +16,14 @@
     var body: some View {
       SheetView(title: String(localized: "title.chapters"), size: .large, applyFormStyle: true) {
         ScrollViewReader { proxy in
-          List(chapters, id: \.href) { link in
-            Button(action: {
-              goToChapter(link)
-            }) {
-              HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                  Text(link.title ?? link.href)
-                }
-                Spacer()
-                if let currentLink,
-                  currentLink.href == link.href
-                {
-                  Image(systemName: "bookmark.fill")
-                    .foregroundColor(Color.accentColor)
-                }
-              }
+          List {
+            ForEach(chapters, id: \.href) { link in
+              ChapterRow(
+                link: link,
+                currentLink: currentLink,
+                goToChapter: goToChapter
+              )
             }
-            .adaptiveButtonStyle(.plain)
-            .contentShape(Rectangle())
-            .id(link.href)
           }
           .optimizedListStyle()
           .onAppear {
@@ -48,6 +36,88 @@
         }
       }
       .presentationDragIndicator(.visible)
+    }
+  }
+
+  private struct ChapterRow: View {
+    let link: WebPubLink
+    let currentLink: WebPubLink?
+    let goToChapter: (WebPubLink) -> Void
+
+    @State private var isExpanded: Bool = false
+
+    init(link: WebPubLink, currentLink: WebPubLink?, goToChapter: @escaping (WebPubLink) -> Void) {
+      self.link = link
+      self.currentLink = currentLink
+      self.goToChapter = goToChapter
+
+      // Initialize isExpanded based on whether this group contains the current link
+      if let children = link.children, !children.isEmpty, let currentLink = currentLink {
+        _isExpanded = State(initialValue: Self.containsLink(currentLink.href, in: children))
+      }
+    }
+
+    var body: some View {
+      if let children = link.children, !children.isEmpty {
+        DisclosureGroup(isExpanded: $isExpanded) {
+          ForEach(children, id: \.href) { child in
+            ChapterRow(
+              link: child,
+              currentLink: currentLink,
+              goToChapter: goToChapter
+            )
+          }
+        } label: {
+          Button(action: {
+            goToChapter(link)
+          }) {
+            ChapterLabel(link: link, currentLink: currentLink)
+          }
+          .adaptiveButtonStyle(.plain)
+        }
+        .id(link.href)
+      } else {
+        Button(action: {
+          goToChapter(link)
+        }) {
+          ChapterLabel(link: link, currentLink: currentLink)
+        }
+        .adaptiveButtonStyle(.plain)
+        .contentShape(Rectangle())
+        .id(link.href)
+      }
+    }
+
+    private static func containsLink(_ href: String, in links: [WebPubLink]) -> Bool {
+      for link in links {
+        if link.href == href {
+          return true
+        }
+        if let children = link.children, containsLink(href, in: children) {
+          return true
+        }
+      }
+      return false
+    }
+  }
+
+  private struct ChapterLabel: View {
+    let link: WebPubLink
+    let currentLink: WebPubLink?
+
+    var body: some View {
+      HStack {
+        VStack(alignment: .leading, spacing: 4) {
+          Text(link.title ?? link.href)
+        }
+        Spacer()
+        if let currentLink,
+          currentLink.href == link.href
+        {
+          Image(systemName: "bookmark.fill")
+            .foregroundColor(Color.accentColor)
+        }
+      }
     }
   }
 #endif

--- a/KMReader/Features/Views/Reader/Sheets/ReaderTOCSheetView.swift
+++ b/KMReader/Features/Views/Reader/Sheets/ReaderTOCSheetView.swift
@@ -14,39 +14,145 @@ struct ReaderTOCSheetView: View {
 
   var body: some View {
     SheetView(title: String(localized: "Table of Contents"), size: .large, applyFormStyle: true) {
-      List {
-        ForEach(entries) { entry in
-          Button {
-            onSelect(entry)
-          } label: {
-            HStack(alignment: .center, spacing: 12) {
-              VStack(alignment: .leading, spacing: 4) {
-                Text(entry.title)
-                Text(
-                  "Page \(entry.pageNumber)",
-                  tableName: nil,
-                  bundle: .main,
-                  comment: "TOC page label"
-                )
-                .font(.caption)
-                .foregroundStyle(.secondary)
-              }
-              Spacer()
-              if entry.pageIndex == currentPageIndex {
-                Image(systemName: "bookmark.fill")
-              }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
+      ScrollViewReader { proxy in
+        List {
+          ForEach(entries) { entry in
+            TOCEntryRow(
+              entry: entry,
+              currentPageIndex: currentPageIndex,
+              onSelect: onSelect
+            )
           }
-          .adaptiveButtonStyle(.plain)
-          #if os(tvOS)
-            .listRowInsets(EdgeInsets(top: 24, leading: 48, bottom: 24, trailing: 48))
-          #endif
+        }
+        .optimizedListStyle()
+        .onAppear {
+          DispatchQueue.main.async {
+            proxy.scrollTo(currentPageIndex, anchor: .center)
+          }
         }
       }
-      .optimizedListStyle()
     }
     .presentationDragIndicator(.visible)
+  }
+}
+
+private struct TOCEntryRow: View {
+  let entry: ReaderTOCEntry
+  let currentPageIndex: Int
+  let onSelect: (ReaderTOCEntry) -> Void
+  let level: Int
+
+  @State private var isExpanded: Bool = false
+
+  init(entry: ReaderTOCEntry, currentPageIndex: Int, onSelect: @escaping (ReaderTOCEntry) -> Void, level: Int = 0) {
+    self.entry = entry
+    self.currentPageIndex = currentPageIndex
+    self.onSelect = onSelect
+    self.level = level
+  }
+
+  var body: some View {
+    #if os(tvOS)
+      Group {
+        Button {
+          onSelect(entry)
+        } label: {
+          TOCEntryLabel(entry: entry, currentPageIndex: currentPageIndex, level: level)
+        }
+        .adaptiveButtonStyle(.plain)
+        .listRowInsets(EdgeInsets(top: 24, leading: 48 + CGFloat(level * 20), bottom: 24, trailing: 48))
+        .id(entry.pageIndex)
+
+        if let children = entry.children, !children.isEmpty {
+          ForEach(children) { child in
+            TOCEntryRow(
+              entry: child,
+              currentPageIndex: currentPageIndex,
+              onSelect: onSelect,
+              level: level + 1
+            )
+          }
+        }
+      }
+    #else
+      if let children = entry.children, !children.isEmpty {
+        DisclosureGroup(isExpanded: $isExpanded) {
+          ForEach(children) { child in
+            TOCEntryRow(
+              entry: child,
+              currentPageIndex: currentPageIndex,
+              onSelect: onSelect,
+              level: level + 1
+            )
+          }
+        } label: {
+          Button(action: {
+            onSelect(entry)
+          }) {
+            TOCEntryLabel(entry: entry, currentPageIndex: currentPageIndex, level: level)
+          }
+          .adaptiveButtonStyle(.plain)
+        }
+        .id(entry.pageIndex)
+        .onAppear {
+          if shouldExpand(entry: entry, children: children) {
+            isExpanded = true
+          }
+        }
+      } else {
+        Button {
+          onSelect(entry)
+        } label: {
+          TOCEntryLabel(entry: entry, currentPageIndex: currentPageIndex, level: level)
+        }
+        .adaptiveButtonStyle(.plain)
+        .contentShape(Rectangle())
+        .id(entry.pageIndex)
+      }
+    #endif
+  }
+
+  private func shouldExpand(entry: ReaderTOCEntry, children: [ReaderTOCEntry]) -> Bool {
+    return containsPageIndex(currentPageIndex, in: children)
+  }
+
+  private func containsPageIndex(_ pageIndex: Int, in entries: [ReaderTOCEntry]) -> Bool {
+    for entry in entries {
+      if entry.pageIndex == pageIndex {
+        return true
+      }
+      if let children = entry.children, containsPageIndex(pageIndex, in: children) {
+        return true
+      }
+    }
+    return false
+  }
+}
+
+private struct TOCEntryLabel: View {
+  let entry: ReaderTOCEntry
+  let currentPageIndex: Int
+  let level: Int
+
+  var body: some View {
+    HStack(alignment: .center, spacing: 12) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text(entry.title)
+        Text(
+          "Page \(entry.pageNumber)",
+          tableName: nil,
+          bundle: .main,
+          comment: "TOC page label"
+        )
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      }
+      Spacer()
+      if entry.pageIndex == currentPageIndex {
+        Image(systemName: "bookmark.fill")
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .contentShape(Rectangle())
   }
 }


### PR DESCRIPTION
Add children property to link models and implement recursive handling in TOC processing and chapter list rendering to support nested table of contents in EPUB reader.