### PR TITLE
fix(reader): centralize double-tap debounce handling

### DIFF
--- a/KMReader/Features/Models/Reader/DoubleTapZoomMode.swift
+++ b/KMReader/Features/Models/Reader/DoubleTapZoomMode.swift
@@ -21,4 +21,12 @@ enum DoubleTapZoomMode: String, CaseIterable, Identifiable {
     case .slow: return String(localized: "Slow")
     }
   }
+
+  var tapDebounceDelay: TimeInterval {
+    switch self {
+    case .disabled: return 0
+    case .fast: return 0.18
+    case .slow: return 0.3
+    }
+  }
 }

--- a/KMReader/Features/Views/Reader/PageImage/PageScrollView_iOS.swift
+++ b/KMReader/Features/Views/Reader/PageImage/PageScrollView_iOS.swift
@@ -356,13 +356,7 @@
         let item = DispatchWorkItem { [weak self] in
           self?.performSingleTapAction(location: location)
         }
-        // Determine delay based on mode
-        let delay: Double
-        switch parent.doubleTapZoomMode {
-        case .disabled: delay = 0
-        case .fast: delay = 0.15
-        case .slow: delay = 0.3
-        }
+        let delay = parent.doubleTapZoomMode.tapDebounceDelay
 
         if delay > 0 {
           singleTapWorkItem = item

--- a/KMReader/Features/Views/Reader/Webtoon/WebtoonPageView.swift
+++ b/KMReader/Features/Views/Reader/Webtoon/WebtoonPageView.swift
@@ -20,6 +20,7 @@
     let readerBackground: ReaderBackground
 
     @AppStorage("tapZoneMode") private var tapZoneMode: TapZoneMode = .auto
+    @AppStorage("doubleTapZoomMode") private var doubleTapZoomMode: DoubleTapZoomMode = .fast
     @AppStorage("showPageNumber") private var showPageNumber: Bool = true
 
     @State private var panUpdateHandler: ((CGFloat) -> Void)?
@@ -41,6 +42,7 @@
             pageWidth: pageWidth(geometry),
             readerBackground: readerBackground,
             tapZoneMode: tapZoneMode,
+            doubleTapZoomMode: doubleTapZoomMode,
             showPageNumber: showPageNumber,
             onPageChange: { pageIndex in
               viewModel.currentPageIndex = pageIndex
@@ -97,12 +99,14 @@
               readerBackground: readerBackground,
               onClose: {
                 viewModel.isZoomed = false
-                self.zoomTargetPageIndex = nil
-                self.zoomAnchor = nil
-                self.zoomRequestID = nil
+                withAnimation(.easeInOut(duration: 0.2)) {
+                  self.zoomTargetPageIndex = nil
+                  self.zoomAnchor = nil
+                  self.zoomRequestID = nil
+                }
               }
             )
-            .transition(.opacity)
+            .transition(.opacity.combined(with: .scale(scale: 0.98)))
             .zIndex(2)
           }
         }
@@ -113,9 +117,11 @@
       guard zoomTargetPageIndex == nil else { return }
       guard pageIndex >= 0, pageIndex < viewModel.pages.count else { return }
 
-      zoomTargetPageIndex = pageIndex
-      zoomAnchor = anchor
-      zoomRequestID = UUID()
+      withAnimation(.easeInOut(duration: 0.2)) {
+        zoomTargetPageIndex = pageIndex
+        zoomAnchor = anchor
+        zoomRequestID = UUID()
+      }
       if viewModel.preloadedImages[pageIndex] == nil {
         let page = viewModel.pages[pageIndex]
         Task {


### PR DESCRIPTION
- Add tapDebounceDelay to DoubleTapZoomMode and use it across PageScrollView and Webtoon reader implementations instead of scattered hardcoded delays.
- Wire doubleTapZoomMode through views and AppStorage.
- Remove legacy macOS click debounce / double-click logic.
- Add small animations for zoom request/clear and view transition scaling.