### PR TITLE
feat: debounce progress sync and tune timeouts

### DIFF
--- a/KMReader/ContentView.swift
+++ b/KMReader/ContentView.swift
@@ -61,7 +61,7 @@ struct ContentView: View {
           }
         }
         .task {
-          let serverReachable = await authViewModel.loadCurrentUser(timeout: 5)
+          let serverReachable = await authViewModel.loadCurrentUser()
           isOffline = !serverReachable
           await SSEService.shared.connect()
         }

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -24,14 +24,34 @@ enum AppConfig {
     }
   }
 
-  static nonisolated var apiTimeout: Double {
+  static nonisolated var requestTimeout: Double {
     get {
-      if UserDefaults.standard.object(forKey: "apiTimeout") != nil {
-        return UserDefaults.standard.double(forKey: "apiTimeout")
+      if UserDefaults.standard.object(forKey: "requestTimeout") != nil {
+        return UserDefaults.standard.double(forKey: "requestTimeout")
+      }
+      return 20.0
+    }
+    set { UserDefaults.standard.set(newValue, forKey: "requestTimeout") }
+  }
+
+  static nonisolated var downloadTimeout: Double {
+    get {
+      if UserDefaults.standard.object(forKey: "downloadTimeout") != nil {
+        return UserDefaults.standard.double(forKey: "downloadTimeout")
+      }
+      return 60.0
+    }
+    set { UserDefaults.standard.set(newValue, forKey: "downloadTimeout") }
+  }
+
+  static nonisolated var authTimeout: Double {
+    get {
+      if UserDefaults.standard.object(forKey: "authTimeout") != nil {
+        return UserDefaults.standard.double(forKey: "authTimeout")
       }
       return 10.0
     }
-    set { UserDefaults.standard.set(newValue, forKey: "apiTimeout") }
+    set { UserDefaults.standard.set(newValue, forKey: "authTimeout") }
   }
 
   static nonisolated var apiRetryCount: Int {

--- a/KMReader/Features/Auth/Services/AuthService.swift
+++ b/KMReader/Features/Auth/Services/AuthService.swift
@@ -97,7 +97,11 @@ class AuthService {
 
   func logout() async throws {
     do {
-      let _: EmptyResponse = try await apiClient.request(path: "/api/logout", method: "POST")
+      let _: EmptyResponse = try await apiClient.request(
+        path: "/api/logout",
+        method: "POST",
+        category: .general
+      )
     } catch {
       // Continue even if logout API fails
     }
@@ -139,7 +143,11 @@ class AuthService {
 
   func getCurrentUser(timeout: TimeInterval? = nil) async throws -> User {
     return try await apiClient.request(
-      path: "/api/v2/users/me", bypassOfflineCheck: true, timeout: timeout)
+      path: "/api/v2/users/me",
+      bypassOfflineCheck: true,
+      timeout: timeout,
+      category: .auth
+    )
   }
 
   func getAuthenticationActivity(page: Int = 0, size: Int = 20) async throws -> Page<
@@ -151,7 +159,8 @@ class AuthService {
     ]
     return try await apiClient.request(
       path: "/api/v2/users/me/authentication-activity",
-      queryItems: queryItems
+      queryItems: queryItems,
+      category: .general
     )
   }
 
@@ -159,12 +168,16 @@ class AuthService {
     let queryItems = [URLQueryItem(name: "apikey_id", value: apiKey.id)]
     return try await apiClient.request(
       path: "/api/v2/users/\(apiKey.userId)/authentication-activity/latest",
-      queryItems: queryItems
+      queryItems: queryItems,
+      category: .general
     )
   }
 
   func getApiKeys() async throws -> [ApiKey] {
-    return try await apiClient.request(path: "/api/v2/users/me/api-keys")
+    return try await apiClient.request(
+      path: "/api/v2/users/me/api-keys",
+      category: .general
+    )
   }
 
   func createApiKey(comment: String) async throws -> ApiKey {
@@ -173,14 +186,16 @@ class AuthService {
     return try await apiClient.request(
       path: "/api/v2/users/me/api-keys",
       method: "POST",
-      body: body
+      body: body,
+      category: .general
     )
   }
 
   func deleteApiKey(id: String) async throws {
     let _: EmptyResponse = try await apiClient.request(
       path: "/api/v2/users/me/api-keys/\(id)",
-      method: "DELETE"
+      method: "DELETE",
+      category: .general
     )
   }
 
@@ -189,7 +204,8 @@ class AuthService {
     let _: EmptyResponse = try await apiClient.request(
       path: "/api/v2/users/\(userId)/password",
       method: "PATCH",
-      body: body
+      body: body,
+      category: .general
     )
   }
 }

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -31,7 +31,7 @@ class AuthViewModel {
 
     // Validate authentication using temporary request
     let result = try await authService.login(
-      username: username, password: password, serverURL: serverURL, timeout: AppConfig.apiTimeout)
+      username: username, password: password, serverURL: serverURL, timeout: AppConfig.authTimeout)
 
     // Apply login configuration
     try await applyLoginConfiguration(
@@ -56,7 +56,7 @@ class AuthViewModel {
 
     // Validate authentication using API Key
     let result = try await authService.loginWithAPIKey(
-      apiKey: apiKey, serverURL: serverURL, timeout: AppConfig.apiTimeout)
+      apiKey: apiKey, serverURL: serverURL, timeout: AppConfig.authTimeout)
 
     // Apply login configuration
     try await applyLoginConfiguration(
@@ -101,7 +101,8 @@ class AuthViewModel {
     isLoading = true
     defer { isLoading = false }
     do {
-      user = try await authService.getCurrentUser(timeout: timeout)
+      let effectiveTimeout = timeout ?? AppConfig.authTimeout
+      user = try await authService.getCurrentUser(timeout: effectiveTimeout)
 
       if let user = user {
         var current = AppConfig.current
@@ -147,7 +148,7 @@ class AuthViewModel {
         serverURL: instance.serverURL,
         authToken: instance.authToken,
         authMethod: instance.resolvedAuthMethod,
-        timeout: AppConfig.apiTimeout
+        timeout: AppConfig.authTimeout
       )
 
       // Apply switch configuration

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -134,6 +134,7 @@ struct DivinaReaderView: View {
   }
 
   private func closeReader() {
+    viewModel.flushProgress()
     if let onClose {
       onClose()
     } else {
@@ -1026,6 +1027,7 @@ struct DivinaReaderView: View {
   }
 
   private func openNextBook(nextBookId: String) {
+    viewModel.flushProgress()
     // Switch to next book by updating currentBookId
     // This will trigger the .task(id: currentBookId) to reload
     preserveReaderOptions = true
@@ -1046,6 +1048,7 @@ struct DivinaReaderView: View {
   }
 
   private func openPreviousBook(previousBookId: String) {
+    viewModel.flushProgress()
     // Switch to previous book by updating currentBookId
     // This will trigger the .task(id: currentBookId) to reload
     preserveReaderOptions = true

--- a/KMReader/Features/Settings/SettingsNetworkView.swift
+++ b/KMReader/Features/Settings/SettingsNetworkView.swift
@@ -8,7 +8,9 @@
 import SwiftUI
 
 struct SettingsNetworkView: View {
-  @AppStorage("apiTimeout") private var apiTimeout: Double = 10
+  @AppStorage("requestTimeout") private var requestTimeout: Double = 20
+  @AppStorage("downloadTimeout") private var downloadTimeout: Double = 60
+  @AppStorage("authTimeout") private var authTimeout: Double = 10
   @AppStorage("apiRetryCount") private var apiRetryCount: Int = 0
   @AppStorage("enableBrowseHandoff") private var enableBrowseHandoff: Bool = true
   @AppStorage("enableReaderHandoff") private var enableReaderHandoff: Bool = false
@@ -16,32 +18,23 @@ struct SettingsNetworkView: View {
   var body: some View {
     Form {
       Section(header: Text(String(localized: "settings.network.general"))) {
-        VStack(alignment: .leading, spacing: 8) {
-          HStack {
-            Label(String(localized: "settings.network.api_timeout.label"), systemImage: "clock")
-            Spacer()
-            #if os(tvOS)
-              Text("\(Int(apiTimeout))s")
-                .foregroundStyle(.secondary)
-            #elseif os(macOS)
-              TextField("", value: $apiTimeout, format: .number)
-                .multilineTextAlignment(.trailing)
-                .frame(width: 50)
-              Text("s")
-                .foregroundStyle(.secondary)
-            #else
-              TextField("Timeout Seconds", value: $apiTimeout, format: .number)
-                .keyboardType(.numbersAndPunctuation)
-                .multilineTextAlignment(.trailing)
-                .frame(width: 50)
-              Text("s")
-                .foregroundStyle(.secondary)
-            #endif
-          }
-          Text(String(localized: "settings.network.api_timeout.description"))
-            .font(.caption)
-            .foregroundStyle(.secondary)
-        }
+        timeoutRow(
+          labelKey: "settings.network.request_timeout.label",
+          descriptionKey: "settings.network.request_timeout.description",
+          value: $requestTimeout
+        )
+
+        timeoutRow(
+          labelKey: "settings.network.download_timeout.label",
+          descriptionKey: "settings.network.download_timeout.description",
+          value: $downloadTimeout
+        )
+
+        timeoutRow(
+          labelKey: "settings.network.auth_timeout.label",
+          descriptionKey: "settings.network.auth_timeout.description",
+          value: $authTimeout
+        )
 
         VStack(alignment: .leading, spacing: 8) {
           #if os(tvOS)
@@ -93,5 +86,39 @@ struct SettingsNetworkView: View {
     }
     .formStyle(.grouped)
     .inlineNavigationBarTitle(SettingsSection.network.title)
+  }
+
+  @ViewBuilder
+  private func timeoutRow(
+    labelKey: String,
+    descriptionKey: String,
+    value: Binding<Double>
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Label(String(localized: .init(labelKey)), systemImage: "clock")
+        Spacer()
+        #if os(tvOS)
+          Text("\(Int(value.wrappedValue))s")
+            .foregroundStyle(.secondary)
+        #elseif os(macOS)
+          TextField("", value: value, format: .number)
+            .multilineTextAlignment(.trailing)
+            .frame(width: 50)
+          Text("s")
+            .foregroundStyle(.secondary)
+        #else
+          TextField("Timeout Seconds", value: value, format: .number)
+            .keyboardType(.numbersAndPunctuation)
+            .multilineTextAlignment(.trailing)
+            .frame(width: 50)
+          Text("s")
+            .foregroundStyle(.secondary)
+        #endif
+      }
+      Text(String(localized: .init(descriptionKey)))
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
   }
 }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -36234,6 +36234,98 @@
         }
       }
     },
+    "settings.appearance.cardTextOverlay.caption" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titel und Details mit einem weichen Verlaufsüberzug über dem Cover anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Display titles and details with a soft gradient overlay on covers"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les titres et les détails avec un léger dégradé superposé aux couvertures"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カバーに柔らかなグラデーションを重ねてタイトルと詳細を表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커버 위에 부드러운 그라데이션 오버레이로 제목과 세부 정보를 표시합니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在封面上使用柔和的渐变遮罩显示标题和详情"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在封面上使用柔和的漸變遮罩顯示標題與詳情"
+          }
+        }
+      }
+    },
+    "settings.appearance.cardTextOverlay.title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Textüberlagerung auf Karten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Card Text Overlay"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Superposition de texte sur les cartes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カードのテキストオーバーレイ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카드 텍스트 오버레이"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "卡片文字覆盖"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "卡片文字覆蓋"
+          }
+        }
+      }
+    },
     "settings.appearance.color" : {
       "localizations" : {
         "de" : {
@@ -36552,98 +36644,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "僅顯示封面"
-          }
-        }
-      }
-    },
-    "settings.appearance.cardTextOverlay.caption" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Titel und Details mit einem weichen Verlaufsüberzug über dem Cover anzeigen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Display titles and details with a soft gradient overlay on covers"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher les titres et les détails avec un léger dégradé superposé aux couvertures"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "カバーに柔らかなグラデーションを重ねてタイトルと詳細を表示"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "커버 위에 부드러운 그라데이션 오버레이로 제목과 세부 정보를 표시합니다"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在封面上使用柔和的渐变遮罩显示标题和详情"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在封面上使用柔和的漸變遮罩顯示標題與詳情"
-          }
-        }
-      }
-    },
-    "settings.appearance.cardTextOverlay.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Textüberlagerung auf Karten"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Card Text Overlay"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Superposition de texte sur les cartes"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "カードのテキストオーバーレイ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "카드 텍스트 오버레이"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "卡片文字覆盖"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "卡片文字覆蓋"
           }
         }
       }
@@ -38258,94 +38258,186 @@
         }
       }
     },
-    "settings.network.api_timeout.description" : {
+    "settings.network.auth_timeout.description" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zeitdauer, bevor eine API-Anfrage abgebrochen wird"
+            "value" : "Zeitdauer, bevor eine Authentifizierungsanfrage abgebrochen wird (Sekunden). Standard: 10s."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Timeout for API requests in seconds. Default is 10s."
+            "value" : "Timeout for authentication requests in seconds. Default is 10s."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Délai d'attente pour les requêtes API en secondes. La valeur par défaut est de 10s."
+            "value" : "Délai d'attente des requêtes d'authentification en secondes. La valeur par défaut est de 10s."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API リクエストのタイムアウト（秒）。デフォルトは 10 秒です。"
+            "value" : "認証リクエストのタイムアウト（秒）。デフォルトは 10 秒です。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API 요청 시간 제한(초). 기본값은 10초입니다."
+            "value" : "인증 요청 시간 제한(초). 기본값은 10초입니다."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API 请求超时时间（秒）。默认为 10 秒。"
+            "value" : "认证请求超时时间（秒）。默认 10 秒。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API 請求超時時間（秒）。默認為 10 秒。"
+            "value" : "認證請求超時時間（秒）。默認 10 秒。"
           }
         }
       }
     },
-    "settings.network.api_timeout.label" : {
+    "settings.network.auth_timeout.label" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API-Zeitüberschreitung"
+            "value" : "Authentifizierungs-Timeout"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API Timeout"
+            "value" : "Auth Timeout"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Délai d'expiration API"
+            "value" : "Délai d'expiration d'authentification"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API タイムアウト"
+            "value" : "認証のタイムアウト"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API 시간 제한"
+            "value" : "인증 시간 제한"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API 超时"
+            "value" : "认证超时"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "API 超時"
+            "value" : "認證超時"
+          }
+        }
+      }
+    },
+    "settings.network.download_timeout.description" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitdauer, bevor ein Download abgebrochen wird (Sekunden). Standard: 60s."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout for download requests in seconds. Default is 60s."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Délai d'attente des téléchargements en secondes. La valeur par défaut est de 60s."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードのタイムアウト（秒）。デフォルトは 60 秒です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드 시간 제한(초). 기본값은 60초입니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载请求超时时间（秒）。默认 60 秒。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載請求超時時間（秒）。默認 60 秒。"
+          }
+        }
+      }
+    },
+    "settings.network.download_timeout.label" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download-Timeout"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download Timeout"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Délai d'expiration des téléchargements"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードのタイムアウト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드 시간 제한"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载超时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載超時"
           }
         }
       }
@@ -38622,6 +38714,98 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀器接力"
+          }
+        }
+      }
+    },
+    "settings.network.request_timeout.description" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitdauer, bevor eine Anfrage abgebrochen wird (Sekunden). Standard: 20s."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout for requests in seconds. Default is 20s."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Délai d'attente des requêtes en secondes. La valeur par défaut est de 20s."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リクエストのタイムアウト（秒）。デフォルトは 20 秒です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요청 시간 제한(초). 기본값은 20초입니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请求超时时间（秒）。默认 20 秒。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請求超時時間（秒）。默認 20 秒。"
+          }
+        }
+      }
+    },
+    "settings.network.request_timeout.label" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anfrage-Timeout"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Request Timeout"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Délai d'expiration des requêtes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リクエストのタイムアウト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요청 시간 제한"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请求超时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請求超時"
           }
         }
       }


### PR DESCRIPTION
## Summary
- debounce read-progress sync with single-flight and flush on close
- split request/download/auth timeouts and update settings + i18n
- debounce offline switching and refine auth vs general request categories

## Testing
- Not run (no XCTest targets in repo)