### PR TITLE
fix(context-menu): add delete actions under manage menu

### DIFF
--- a/KMReader/Features/Book/Views/BookContextMenu.swift
+++ b/KMReader/Features/Book/Views/BookContextMenu.swift
@@ -87,10 +87,19 @@ struct BookContextMenu: View {
             } label: {
               Label("Refresh Metadata", systemImage: "arrow.clockwise")
             }
-            Divider()
+
+            if onDeleteRequested != nil {
+              Divider()
+              Button(role: .destructive) {
+                onDeleteRequested?()
+              } label: {
+                Label("Delete Book", systemImage: "trash")
+              }
+            }
           } label: {
             Label("Manage", systemImage: "gearshape")
           }
+
           Divider()
         }
       }

--- a/KMReader/Features/Series/Views/SeriesContextMenu.swift
+++ b/KMReader/Features/Series/Views/SeriesContextMenu.swift
@@ -117,9 +117,19 @@ struct SeriesContextMenu: View {
             } label: {
               Label("Refresh Metadata", systemImage: "arrow.clockwise")
             }
+
+            if onDeleteRequested != nil {
+              Divider()
+              Button(role: .destructive) {
+                onDeleteRequested?()
+              } label: {
+                Label("Delete Series", systemImage: "trash")
+              }
+            }
           } label: {
             Label("Manage", systemImage: "gearshape")
           }
+
           Divider()
         }
       }


### PR DESCRIPTION
## Summary
- add delete action to Series context menu inside Manage submenu
- add delete action to Book context menu inside Manage submenu
- keep delete item gated by existing admin flow and callback availability

## Notes
- origin and default GitHub repo are both everpcpc/KMReader, so no owner prefix is needed for head branch