### PR TITLE
fix(series): collapse metadata chips by default

### DIFF
--- a/KMReader/Features/Series/Views/SeriesDetailContentView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailContentView.swift
@@ -12,9 +12,8 @@ struct SeriesDetailContentView: View {
   let series: Series
 
   @State private var thumbnailRefreshKey = UUID()
-  @State private var isAuthorsExpanded = false
 
-  private let collapsedAuthorsLimit = 10
+  private let collapsedMetadataChipLimit = 10
 
   var body: some View {
     VStack(alignment: .leading) {
@@ -163,66 +162,35 @@ struct SeriesDetailContentView: View {
               )
             }
 
-            if !sortedAuthors.isEmpty {
-              VStack(alignment: .leading, spacing: 6) {
-                HFlow {
-                  ForEach(displayedAuthors, id: \.self) { author in
-                    TappableInfoChip(
-                      label: author.name,
-                      systemImage: author.role.icon,
-                      color: .purple,
-                      destination: MetadataFilterHelper.seriesDestinationForAuthor(author.name)
-                    )
-                  }
-                }
-
-                if shouldShowAuthorsToggle {
-                  Button {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                      isAuthorsExpanded.toggle()
-                    }
-                  } label: {
-                    Label(
-                      isAuthorsExpanded
-                        ? String(localized: "Show Less")
-                        : String(localized: "Show More"),
-                      systemImage: isAuthorsExpanded ? "chevron.up" : "chevron.down"
-                    )
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                  }
-                  .buttonStyle(.plain)
-                }
-              }
+            CollapsibleChipSection(items: sortedAuthors, collapsedLimit: collapsedMetadataChipLimit) {
+              author in
+              TappableInfoChip(
+                label: author.name,
+                systemImage: author.role.icon,
+                color: .purple,
+                destination: MetadataFilterHelper.seriesDestinationForAuthor(author.name)
+              )
             }
           }
         }
       }
 
-      if let genres = series.metadata.genres, !genres.isEmpty {
-        HFlow {
-          ForEach(genres.sorted(), id: \.self) { genre in
-            TappableInfoChip(
-              label: genre,
-              systemImage: "theatermasks",
-              color: .teal,
-              destination: MetadataFilterHelper.seriesDestinationForGenre(genre)
-            )
-          }
-        }
+      CollapsibleChipSection(items: sortedGenres, collapsedLimit: collapsedMetadataChipLimit) { genre in
+        TappableInfoChip(
+          label: genre,
+          systemImage: "theatermasks",
+          color: .teal,
+          destination: MetadataFilterHelper.seriesDestinationForGenre(genre)
+        )
       }
 
-      if let tags = series.metadata.tags, !tags.isEmpty {
-        HFlow {
-          ForEach(tags.sorted(), id: \.self) { tag in
-            TappableInfoChip(
-              label: tag,
-              systemImage: "tag",
-              color: .secondary,
-              destination: MetadataFilterHelper.seriesDestinationForTag(tag)
-            )
-          }
-        }
+      CollapsibleChipSection(items: sortedTags, collapsedLimit: collapsedMetadataChipLimit) { tag in
+        TappableInfoChip(
+          label: tag,
+          systemImage: "tag",
+          color: .secondary,
+          destination: MetadataFilterHelper.seriesDestinationForTag(tag)
+        )
       }
 
       HStack(spacing: 6) {
@@ -319,15 +287,11 @@ struct SeriesDetailContentView: View {
     (series.booksMetadata.authors ?? []).sortedByRole()
   }
 
-  private var shouldShowAuthorsToggle: Bool {
-    sortedAuthors.count > collapsedAuthorsLimit
+  private var sortedGenres: [String] {
+    (series.metadata.genres ?? []).sorted()
   }
 
-  private var displayedAuthors: [Author] {
-    if isAuthorsExpanded || !shouldShowAuthorsToggle {
-      return sortedAuthors
-    }
-
-    return Array(sortedAuthors.prefix(collapsedAuthorsLimit))
+  private var sortedTags: [String] {
+    (series.metadata.tags ?? []).sorted()
   }
 }

--- a/KMReader/Shared/UI/CollapsibleChipSection.swift
+++ b/KMReader/Shared/UI/CollapsibleChipSection.swift
@@ -1,0 +1,69 @@
+//
+//  CollapsibleChipSection.swift
+//  Komga
+//
+//  Created by Komga iOS Client
+//
+
+import Flow
+import SwiftUI
+
+struct CollapsibleChipSection<Item: Hashable, Chip: View>: View {
+  let items: [Item]
+  let collapsedLimit: Int
+  let chip: (Item) -> Chip
+
+  @State private var isExpanded = false
+
+  init(
+    items: [Item],
+    collapsedLimit: Int = 10,
+    @ViewBuilder chip: @escaping (Item) -> Chip
+  ) {
+    self.items = items
+    self.collapsedLimit = collapsedLimit
+    self.chip = chip
+  }
+
+  var body: some View {
+    if !items.isEmpty {
+      VStack(alignment: .leading, spacing: 6) {
+        HFlow {
+          ForEach(displayedItems, id: \.self) { item in
+            chip(item)
+          }
+        }
+
+        if shouldShowToggle {
+          Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+              isExpanded.toggle()
+            }
+          } label: {
+            Label(
+              isExpanded
+                ? String(localized: "Show Less")
+                : String(localized: "Show More"),
+              systemImage: isExpanded ? "chevron.up" : "chevron.down"
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+          }
+          .adaptiveButtonStyle(.plain)
+        }
+      }
+    }
+  }
+
+  private var shouldShowToggle: Bool {
+    items.count > collapsedLimit
+  }
+
+  private var displayedItems: [Item] {
+    if isExpanded || !shouldShowToggle {
+      return items
+    }
+
+    return Array(items.prefix(collapsedLimit))
+  }
+}


### PR DESCRIPTION
## Summary

Improve Series detail performance and usability for large metadata sets by collapsing chip-heavy sections by default.

## Changes

- Collapse **authors** chips by default in Series detail and require explicit user action to expand.
- Apply the same collapse/expand behavior to **genres** and **tags** to avoid large upfront layout/render cost.
- Add reusable `CollapsibleChipSection` (`KMReader/Shared/UI/CollapsibleChipSection.swift`) to centralize:
  - collapsed display limit
  - Show More / Show Less toggle
  - expand/collapse animation
- Refactor `SeriesDetailContentView` to reuse the new section for authors/genres/tags.
- Use `.adaptiveButtonStyle(.plain)` for the section toggle button to match project style.


---
- fix: https://github.com/everpcpc/KMReader/issues/436
