### PR TITLE
fix(reader): hide reader controls on entry

### DIFF
--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -40,7 +40,7 @@ struct DivinaReaderView: View {
 
   @State private var currentBookId: String
   @State private var viewModel = ReaderViewModel()
-  @State private var showingControls = true
+  @State private var showingControls = false
   @State private var controlsTimer: Timer?
   @State private var currentSeries: Series?
   @State private var currentBook: Book?
@@ -335,7 +335,7 @@ struct DivinaReaderView: View {
       if oldCount == 0 && newCount > 0 {
         triggerTapZoneOverlay(timeout: 1)
         triggerKeyboardHelp(timeout: 1.5)
-        forceInitialAutoHide(timeout: 1.5)
+        applyStatusBarVisibility(controlsHidden: !shouldShowControls)
       }
     }
     .onDisappear {
@@ -909,17 +909,6 @@ struct DivinaReaderView: View {
       }
     }
   #endif
-
-  private func forceInitialAutoHide(timeout: TimeInterval) {
-    controlsTimer?.invalidate()
-    controlsTimer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { _ in
-      Task { @MainActor in
-        withAnimation {
-          showingControls = false
-        }
-      }
-    }
-  }
 
   private func resetControlsTimer(timeout: TimeInterval) {
     // Don't start timer if auto-hide is disabled

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -25,8 +25,7 @@
     @State private var viewModel: EpubReaderViewModel
     @State private var activePreferences: EpubReaderPreferences
     @State private var bookPreferences: EpubReaderPreferences?
-    @State private var showingControls = true
-    @State private var controlsTimer: Timer?
+    @State private var showingControls = false
     @State private var currentSeries: Series?
     @State private var currentBook: Book?
     @State private var showingChapterSheet = false
@@ -123,7 +122,6 @@
           viewModel.updateDownloadProgress(notification: notification)
         }
         .onDisappear {
-          controlsTimer?.invalidate()
           withAnimation {
             readerPresentation.hideStatusBar = false
           }
@@ -131,11 +129,6 @@
         .onChange(of: shouldShowControls) { _, newValue in
           withAnimation {
             readerPresentation.hideStatusBar = !newValue
-          }
-        }
-        .onChange(of: viewModel.isLoading) { _, newValue in
-          if !newValue {
-            forceInitialAutoHide(timeout: 1.5)
           }
         }
     }
@@ -501,17 +494,6 @@
       }
       if !showingControls {
         showingQuickActions = false
-      }
-    }
-
-    private func forceInitialAutoHide(timeout: TimeInterval) {
-      controlsTimer?.invalidate()
-      controlsTimer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { _ in
-        Task { @MainActor in
-          withAnimation(animation) {
-            showingControls = false
-          }
-        }
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure reader controls no longer show briefly on entry
- default showing controls flag to false so they start hidden immediately

## Testing
- Not run (not requested)