### PR TITLE
fix(reader): centralize progress dispatch and close refresh ordering

### DIFF
--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -2065,6 +2065,9 @@ actor DatabaseOperator {
       if existing.completed != completed { existing.completed = completed }
       existing.createdAt = Date()  // Always update timestamp
       if existing.progressionData != progressionData { existing.progressionData = progressionData }
+      logger.debug(
+        "📝 Updated pending progress id=\(existing.id): book=\(bookId), page=\(page), completed=\(completed), hasProgressionData=\(progressionData != nil)"
+      )
     } else {
       let pending = PendingProgress(
         instanceId: instanceId,
@@ -2074,6 +2077,9 @@ actor DatabaseOperator {
         progressionData: progressionData
       )
       modelContext.insert(pending)
+      logger.debug(
+        "🆕 Queued pending progress id=\(pending.id): book=\(bookId), page=\(page), completed=\(completed), hasProgressionData=\(progressionData != nil)"
+      )
     }
   }
 
@@ -2088,6 +2094,9 @@ actor DatabaseOperator {
     }
 
     let results = (try? modelContext.fetch(descriptor)) ?? []
+    logger.debug(
+      "📚 Fetched pending progress items for instance \(instanceId): count=\(results.count), limit=\(limit?.description ?? "nil")"
+    )
     return results.map {
       PendingProgressSummary(
         id: $0.id,
@@ -2108,6 +2117,9 @@ actor DatabaseOperator {
 
     if let pending = try? modelContext.fetch(descriptor).first {
       modelContext.delete(pending)
+      logger.debug("🗑️ Deleted pending progress id=\(id)")
+    } else {
+      logger.warning("⚠️ Pending progress id=\(id) not found when deleting")
     }
   }
 }

--- a/KMReader/Features/Book/Services/BookService.swift
+++ b/KMReader/Features/Book/Services/BookService.swift
@@ -16,6 +16,7 @@ struct BookFileDownloadResult {
 class BookService {
   static let shared = BookService()
   private let apiClient = APIClient.shared
+  private let logger = AppLogger(.api)
 
   private init() {}
 
@@ -86,6 +87,9 @@ class BookService {
   }
 
   func updateWebPubProgression(bookId: String, progression: R2Progression) async throws {
+    logger.debug(
+      "📤 Sending EPUB progression for book \(bookId): href=\(progression.locator.href), progression=\(progression.locator.locations?.progression ?? 0), totalProgression=\(progression.locator.locations?.totalProgression ?? 0)"
+    )
     let encoder = JSONEncoder()
     encoder.dateEncodingStrategy = .iso8601
     let data = try encoder.encode(progression)
@@ -94,6 +98,7 @@ class BookService {
       method: "PUT",
       body: data
     )
+    logger.debug("✅ EPUB progression sent for book \(bookId)")
   }
 
   func downloadBookFile(bookId: String) async throws -> BookFileDownloadResult {
@@ -227,6 +232,9 @@ class BookService {
   }
 
   func updatePageReadProgress(bookId: String, page: Int, completed: Bool = false) async throws {
+    logger.debug(
+      "📤 Sending page progress for book \(bookId): page=\(page), completed=\(completed)"
+    )
     let body = ["page": page, "completed": completed] as [String: Any]
     let jsonData = try JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
 
@@ -235,6 +243,7 @@ class BookService {
       method: "PATCH",
       body: jsonData
     )
+    logger.debug("✅ Page progress sent for book \(bookId): page=\(page)")
   }
 
   func deleteReadProgress(bookId: String) async throws {

--- a/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
+++ b/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
@@ -1,0 +1,286 @@
+//
+//  ReaderProgressDispatchService.swift
+//  KMReader
+//
+
+import Foundation
+
+actor ReaderProgressDispatchService {
+  static let shared = ReaderProgressDispatchService()
+
+  private struct PageUpdate {
+    let bookId: String
+    let page: Int
+    let completed: Bool
+  }
+
+  private struct EpubUpdate {
+    let bookId: String
+    let globalPageNumber: Int
+    let progression: R2Progression
+    let progressionData: Data?
+  }
+
+  private let logger = AppLogger(.reader)
+
+  private var pendingPageUpdates: [String: PageUpdate] = [:]
+  private var pageDebounceTasks: [String: Task<Void, Never>] = [:]
+  private var pageSendTasks: [String: Task<Void, Never>] = [:]
+
+  private var pendingEpubUpdates: [String: EpubUpdate] = [:]
+  private var epubSendTasks: [String: Task<Void, Never>] = [:]
+
+  private init() {}
+
+  func submitPageProgress(bookId: String, page: Int, completed: Bool, debounceSeconds: Int) {
+    let update = PageUpdate(bookId: bookId, page: page, completed: completed)
+    pendingPageUpdates[bookId] = update
+    logger.debug(
+      "📝 Queued page progress dispatch for book \(bookId): page=\(page), completed=\(completed), debounce=\(debounceSeconds)s"
+    )
+
+    pageDebounceTasks[bookId]?.cancel()
+    pageDebounceTasks[bookId] = Task(priority: .utility) { [weak self] in
+      do {
+        try await Task.sleep(for: .seconds(debounceSeconds))
+      } catch {
+        return
+      }
+      await self?.triggerDebouncedPageSend(bookId: bookId)
+    }
+  }
+
+  func flushPageProgress(bookId: String, snapshotPage: Int?, snapshotCompleted: Bool?) {
+    guard !bookId.isEmpty else {
+      logger.warning("⚠️ Skip page progress flush because book ID is empty")
+      return
+    }
+
+    if pendingPageUpdates[bookId] == nil,
+      let snapshotPage,
+      let snapshotCompleted
+    {
+      let snapshot = PageUpdate(bookId: bookId, page: snapshotPage, completed: snapshotCompleted)
+      pendingPageUpdates[bookId] = snapshot
+      logger.debug(
+        "🧲 Force-captured current page progress before flush for book \(bookId): page=\(snapshotPage), completed=\(snapshotCompleted)"
+      )
+    } else if pendingPageUpdates[bookId] != nil {
+      logger.debug("♻️ Skip force-capture progress during flush because pending progress already exists")
+    } else {
+      logger.debug("⏭️ Skip force-capture progress during flush because current page snapshot is unavailable")
+    }
+
+    pageDebounceTasks[bookId]?.cancel()
+    pageDebounceTasks.removeValue(forKey: bookId)
+
+    logger.debug(
+      "🚿 Flush page progress requested for book \(bookId): hasPending=\(pendingPageUpdates[bookId] != nil), isSending=\(pageSendTasks[bookId] != nil)"
+    )
+
+    sendPendingPageProgress(for: bookId, trigger: "flush")
+  }
+
+  func submitEpubProgression(
+    bookId: String,
+    globalPageNumber: Int,
+    progression: R2Progression,
+    progressionData: Data?
+  ) {
+    let update = EpubUpdate(
+      bookId: bookId,
+      globalPageNumber: globalPageNumber,
+      progression: progression,
+      progressionData: progressionData
+    )
+    pendingEpubUpdates[bookId] = update
+
+    logger.debug(
+      "📝 Queued EPUB progression dispatch for book \(bookId): href=\(progression.locator.href), globalPage=\(globalPageNumber), offline=\(AppConfig.isOffline)"
+    )
+
+    sendPendingEpubProgression(for: bookId, trigger: "enqueue")
+  }
+
+  private func triggerDebouncedPageSend(bookId: String) {
+    pageDebounceTasks.removeValue(forKey: bookId)
+    sendPendingPageProgress(for: bookId, trigger: "debounce")
+  }
+
+  private func sendPendingPageProgress(for bookId: String, trigger: String) {
+    guard pageSendTasks[bookId] == nil else {
+      logger.debug("⏳ Page progress send already in flight for book \(bookId), trigger=\(trigger)")
+      return
+    }
+
+    guard pendingPageUpdates[bookId] != nil else {
+      logger.debug("⏭️ No pending page progress to dispatch for book \(bookId), trigger=\(trigger)")
+      return
+    }
+
+    pageSendTasks[bookId] = Task(priority: .utility) { [weak self] in
+      await self?.executePageSend(bookId: bookId, trigger: trigger)
+    }
+  }
+
+  private func sendPendingEpubProgression(for bookId: String, trigger: String) {
+    guard epubSendTasks[bookId] == nil else {
+      logger.debug("⏳ EPUB progression send already in flight for book \(bookId), trigger=\(trigger)")
+      return
+    }
+
+    guard pendingEpubUpdates[bookId] != nil else {
+      logger.debug("⏭️ No pending EPUB progression to dispatch for book \(bookId), trigger=\(trigger)")
+      return
+    }
+
+    epubSendTasks[bookId] = Task(priority: .utility) { [weak self] in
+      await self?.executeEpubSend(bookId: bookId, trigger: trigger)
+    }
+  }
+
+  private func executePageSend(bookId: String, trigger: String) async {
+    guard let update = pendingPageUpdates.removeValue(forKey: bookId) else {
+      pageSendTasks.removeValue(forKey: bookId)
+      return
+    }
+
+    logger.debug(
+      "📤 Dispatching page progress for book \(bookId): page=\(update.page), completed=\(update.completed), trigger=\(trigger)"
+    )
+
+    await ReaderProgressTracker.shared.begin(bookId: bookId)
+    await Self.performPageProgressUpdate(update)
+    await ReaderProgressTracker.shared.end(bookId: bookId)
+
+    pageSendTasks.removeValue(forKey: bookId)
+
+    if pendingPageUpdates[bookId] != nil, pageDebounceTasks[bookId] == nil {
+      logger.debug("🔁 Dispatching next queued page progress for book \(bookId)")
+      sendPendingPageProgress(for: bookId, trigger: "drain")
+    }
+  }
+
+  private func executeEpubSend(bookId: String, trigger: String) async {
+    guard let update = pendingEpubUpdates.removeValue(forKey: bookId) else {
+      epubSendTasks.removeValue(forKey: bookId)
+      return
+    }
+
+    logger.debug(
+      "📤 Dispatching EPUB progression for book \(bookId): href=\(update.progression.locator.href), globalPage=\(update.globalPageNumber), trigger=\(trigger)"
+    )
+
+    await ReaderProgressTracker.shared.begin(bookId: bookId)
+    await Self.performEpubProgressionUpdate(update)
+    await ReaderProgressTracker.shared.end(bookId: bookId)
+
+    epubSendTasks.removeValue(forKey: bookId)
+
+    if pendingEpubUpdates[bookId] != nil {
+      logger.debug("🔁 Dispatching next queued EPUB progression for book \(bookId)")
+      sendPendingEpubProgression(for: bookId, trigger: "drain")
+    }
+  }
+
+  private nonisolated static func performPageProgressUpdate(_ update: PageUpdate) async {
+    let logger = AppLogger(.reader)
+
+    logger.debug(
+      "📨 Performing page progress update for book \(update.bookId): page=\(update.page), completed=\(update.completed), offline=\(AppConfig.isOffline)"
+    )
+
+    do {
+      if AppConfig.isOffline {
+        await DatabaseOperator.shared.queuePendingProgress(
+          instanceId: AppConfig.current.instanceId,
+          bookId: update.bookId,
+          page: update.page,
+          completed: update.completed,
+          progressionData: nil
+        )
+        await DatabaseOperator.shared.updateReadingProgress(
+          bookId: update.bookId,
+          page: update.page,
+          completed: update.completed
+        )
+        await DatabaseOperator.shared.commit()
+        logger.debug(
+          "💾 Queued page progress for offline sync: book=\(update.bookId), page=\(update.page), completed=\(update.completed)"
+        )
+      } else {
+        try await BookService.shared.updatePageReadProgress(
+          bookId: update.bookId,
+          page: update.page,
+          completed: update.completed
+        )
+        await DatabaseOperator.shared.updateReadingProgress(
+          bookId: update.bookId,
+          page: update.page,
+          completed: update.completed
+        )
+        logger.debug(
+          "✅ Page progress update completed for book \(update.bookId): page=\(update.page), completed=\(update.completed)"
+        )
+      }
+    } catch {
+      logger.error(
+        "Failed to update page progress for book \(update.bookId) page \(update.page): \(error.localizedDescription)"
+      )
+    }
+  }
+
+  private nonisolated static func performEpubProgressionUpdate(_ update: EpubUpdate) async {
+    let logger = AppLogger(.reader)
+
+    do {
+      if AppConfig.isOffline {
+        logger.debug(
+          "💾 Queue EPUB progression for offline sync: book=\(update.bookId), globalPage=\(update.globalPageNumber)"
+        )
+        await DatabaseOperator.shared.queuePendingProgress(
+          instanceId: AppConfig.current.instanceId,
+          bookId: update.bookId,
+          page: update.globalPageNumber,
+          completed: false,
+          progressionData: update.progressionData
+        )
+        await DatabaseOperator.shared.commit()
+        logger.debug(
+          "✅ Queued EPUB progression for offline sync: book=\(update.bookId), globalPage=\(update.globalPageNumber)"
+        )
+      } else {
+        logger.debug(
+          "📤 Sending EPUB progression request for book=\(update.bookId), href=\(update.progression.locator.href), globalPage=\(update.globalPageNumber)"
+        )
+        try await BookService.shared.updateWebPubProgression(
+          bookId: update.bookId,
+          progression: update.progression
+        )
+        logger.debug(
+          "✅ EPUB progression request completed for book=\(update.bookId), href=\(update.progression.locator.href), globalPage=\(update.globalPageNumber)"
+        )
+      }
+    } catch let apiError as APIError {
+      if case .badRequest(let message, _, _, _) = apiError,
+        message.lowercased().contains("epub extension not found")
+      {
+        logger.error("Failed to update progression: EPUB extension not found")
+        await MainActor.run {
+          ErrorManager.shared.alert(
+            error: AppErrorType.operationFailed(
+              message: String(
+                localized: "error.epubExtensionNotFound",
+                defaultValue: "Failed to sync reading progress. This book may need to be re-analyzed on the server."
+              )
+            )
+          )
+        }
+      } else {
+        logger.error("Failed to update progression: \(apiError.localizedDescription)")
+      }
+    } catch {
+      logger.error("Failed to update progression: \(error.localizedDescription)")
+    }
+  }
+}

--- a/KMReader/Features/Reader/Services/ReaderProgressTracker.swift
+++ b/KMReader/Features/Reader/Services/ReaderProgressTracker.swift
@@ -1,0 +1,46 @@
+//
+//  ReaderProgressTracker.swift
+//  KMReader
+//
+
+import Foundation
+
+actor ReaderProgressTracker {
+  static let shared = ReaderProgressTracker()
+
+  private var inFlightUpdates: [String: Int] = [:]
+
+  func begin(bookId: String) {
+    inFlightUpdates[bookId, default: 0] += 1
+  }
+
+  func end(bookId: String) {
+    guard let count = inFlightUpdates[bookId] else { return }
+    if count <= 1 {
+      inFlightUpdates.removeValue(forKey: bookId)
+    } else {
+      inFlightUpdates[bookId] = count - 1
+    }
+  }
+
+  func waitUntilIdle(bookIds: Set<String>, timeout: Duration = .seconds(2)) async -> Bool {
+    guard !bookIds.isEmpty else { return true }
+
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+
+    while hasInFlightUpdates(for: bookIds) {
+      guard clock.now < deadline else { return false }
+      try? await Task.sleep(for: .milliseconds(50))
+    }
+
+    return true
+  }
+
+  private func hasInFlightUpdates(for bookIds: Set<String>) -> Bool {
+    for bookId in bookIds where (inFlightUpdates[bookId] ?? 0) > 0 {
+      return true
+    }
+    return false
+  }
+}

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -38,6 +38,8 @@ struct DivinaReaderView: View {
   @State private var isolateCoverPage: Bool
   @State private var splitWidePageMode: SplitWidePageMode
 
+  private let logger = AppLogger(.reader)
+
   @State private var currentBookId: String
   @State private var viewModel = ReaderViewModel()
   @State private var showingControls = false
@@ -130,7 +132,9 @@ struct DivinaReaderView: View {
   }
 
   private func closeReader() {
-    viewModel.flushProgress()
+    logger.debug(
+      "🚪 Closing DIVINA reader for book \(currentBookId), currentPage=\(viewModel.currentPage?.number ?? -1), totalPages=\(viewModel.pages.count)"
+    )
     if let onClose {
       onClose()
     } else {
@@ -342,6 +346,11 @@ struct DivinaReaderView: View {
       }
     }
     .onDisappear {
+      logger.debug(
+        "👋 DIVINA reader disappeared for book \(currentBookId), currentPage=\(viewModel.currentPage?.number ?? -1), totalPages=\(viewModel.pages.count)"
+      )
+      logger.debug("🧯 DIVINA reader disappeared, forcing progress flush")
+      viewModel.flushProgress()
       controlsTimer?.invalidate()
       tapZoneOverlayTimer?.invalidate()
       keyboardHelpTimer?.invalidate()
@@ -997,6 +1006,9 @@ struct DivinaReaderView: View {
   }
 
   private func openNextBook(nextBookId: String) {
+    logger.debug(
+      "➡️ Opening next book from \(currentBookId) to \(nextBookId), flush current progress first"
+    )
     viewModel.flushProgress()
     // Switch to next book by updating currentBookId
     // This will trigger the .task(id: currentBookId) to reload
@@ -1018,6 +1030,9 @@ struct DivinaReaderView: View {
   }
 
   private func openPreviousBook(previousBookId: String) {
+    logger.debug(
+      "⬅️ Opening previous book from \(currentBookId) to \(previousBookId), flush current progress first"
+    )
     viewModel.flushProgress()
     // Switch to previous book by updating currentBookId
     // This will trigger the .task(id: currentBookId) to reload

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -34,6 +34,8 @@
     @State private var showingQuickActions = false
     @State private var showingEndPage = false
 
+    private let logger = AppLogger(.reader)
+
     init(
       book: Book,
       incognito: Bool = false,
@@ -51,6 +53,9 @@
     }
 
     private func closeReader() {
+      logger.debug(
+        "🚪 Closing EPUB reader for book \(handoffBookId), chapter=\(viewModel.currentChapterIndex), page=\(viewModel.currentPageIndex)"
+      )
       if let onClose {
         onClose()
       } else {
@@ -122,6 +127,9 @@
           viewModel.updateDownloadProgress(notification: notification)
         }
         .onDisappear {
+          logger.debug(
+            "👋 EPUB reader disappeared for book \(handoffBookId), chapter=\(viewModel.currentChapterIndex), page=\(viewModel.currentPageIndex), hasLocation=\(viewModel.currentLocation != nil)"
+          )
           withAnimation {
             readerPresentation.hideStatusBar = false
           }


### PR DESCRIPTION
## What
- centralize DIVINA and EPUB progression delivery in `ReaderProgressDispatchService`
- keep `ReaderProgressTracker` focused on in-flight tracking and wait semantics
- move reader close flushing to `onDisappear` and route updates through the shared dispatcher
- defer reader-close dashboard refresh until progress dispatch becomes idle (with timeout fallback)
- add debug logs across capture, queue, dispatch, offline queueing, sync, and close paths

## Why
Reader close could race with refresh and sync, so the final progress update might arrive after dashboard or visited-item sync. This change makes ordering explicit and easier to diagnose.

## Validation
- `make format`
- `make build-ios-ci`
- `make build-macos-ci`
- `make build-tvos-ci`
