### PR TITLE
fix(dashboard): avoid no-op section updates

### DIFF
--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -213,10 +213,7 @@ struct DashboardSectionView: View {
     let isFirstPage = pagination.currentPage == 0
 
     if !AppConfig.isOffline {
-      await seedFromCacheIfNeeded(
-        isFirstPage: isFirstPage,
-        libraryIds: libraryIds
-      )
+      await seedFromCacheIfNeeded(isFirstPage: isFirstPage)
     }
 
     if AppConfig.isOffline {
@@ -269,12 +266,10 @@ struct DashboardSectionView: View {
       }
     }
 
-    withAnimation {
-      isLoading = false
-    }
+    isLoading = false
   }
 
-  private func seedFromCacheIfNeeded(isFirstPage: Bool, libraryIds: [String]) async {
+  private func seedFromCacheIfNeeded(isFirstPage: Bool) async {
     guard isFirstPage, !didSeedFromCache, pagination.isEmpty else { return }
     didSeedFromCache = true
 
@@ -285,9 +280,19 @@ struct DashboardSectionView: View {
 
   private func applyPage(ids: [String], moreAvailable: Bool) {
     let wrappedIds = ids.map(IdentifiedString.init)
-    withAnimation {
-      _ = pagination.applyPage(wrappedIds)
+
+    if pagination.currentPage == 0 {
+      if pagination.items != wrappedIds {
+        withAnimation {
+          pagination.items = wrappedIds
+        }
+      }
+    } else if !wrappedIds.isEmpty {
+      withAnimation {
+        pagination.items.append(contentsOf: wrappedIds)
+      }
     }
+
     pagination.advance(moreAvailable: moreAvailable)
   }
 }


### PR DESCRIPTION
## What
- skip first-page assignment animation when fetched IDs are unchanged
- keep pagination append animation only for non-empty subsequent pages
- remove loading-state animation at the end of refresh to avoid extra transaction
- drop unused cache seeding parameter

## Why
Pull-to-refresh on Dashboard could still trigger unnecessary state/animation work even when server data did not change, causing visible jank.

## Validation
- make format
- make build-macos
- make build-ios
