### PR TITLE
fix(reader): restore sub-page position on chapter reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ AuthKey_*.p8
 
 packages/
 worktrees/
+.alma-snapshots


### PR DESCRIPTION
## Summary
- Use initial progression to calculate and scroll to the correct sub-page when a chapter finishes loading, preventing the reader from resetting to the first page on chapter re-entry.
- Add `initialSubPageIndex` and `targetProgressionOnReady` parameters to `WebPubPageView` to carry the restore target through content load.
- Ignore `.alma-snapshots` directory.

## Test plan
- [ ] Open a multi-page chapter, scroll to a later sub-page, navigate away, then return — verify the reader restores to the correct position
- [ ] Verify backward navigation (jump-to-last-page) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)