### PR TITLE
fix(reader): use numberSort for offline next-book order

### DIFF
--- a/KMReader/Features/Book/Services/KomgaBookStore.swift
+++ b/KMReader/Features/Book/Services/KomgaBookStore.swift
@@ -43,7 +43,7 @@ enum KomgaBookStore {
       let isAsc = !sort.contains("desc")
       descriptor.sortBy = [SortDescriptor(\KomgaBook.downloadAt, order: isAsc ? .forward : .reverse)]
     } else {
-      descriptor.sortBy = [SortDescriptor(\KomgaBook.number, order: .forward)]
+      descriptor.sortBy = [SortDescriptor(\KomgaBook.metaNumberSort, order: .forward)]
     }
 
     do {

--- a/KMReader/Features/Series/Services/SeriesContinueReadingResolver.swift
+++ b/KMReader/Features/Series/Services/SeriesContinueReadingResolver.swift
@@ -129,7 +129,7 @@ enum SeriesContinueReadingResolver {
     let instanceId = AppConfig.current.instanceId
     let descriptor = FetchDescriptor<KomgaBook>(
       predicate: #Predicate { $0.seriesId == seriesId && $0.instanceId == instanceId },
-      sortBy: [SortDescriptor(\KomgaBook.number, order: .forward)]
+      sortBy: [SortDescriptor(\KomgaBook.metaNumberSort, order: .forward)]
     )
 
     return (try? context.fetch(descriptor)) ?? []


### PR DESCRIPTION
## Summary
- switch offline series ordering from KomgaBook.number to KomgaBook.metaNumberSort in KomgaBookStore.fetchSeriesBooks
- switch offline continue-reading ordering from KomgaBook.number to KomgaBook.metaNumberSort in SeriesContinueReadingResolver.fetchOfflineSeriesBooks

## Why
- keeps local next/previous and continue-reading navigation aligned with metadata.numberSort
- prevents misordered decimal volume sequences (e.g. 5, 5.5, 5.6) when selecting the next book offline

## Related
- https://github.com/everpcpc/KMReader/issues/456