### PR TITLE
fix(reader): persist offline progress metadata

### DIFF
--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -1083,10 +1083,14 @@ actor DatabaseOperator {
 
     if let book = try? modelContext.fetch(descriptor).first {
       let oldStatus = readingStatus(progressCompleted: book.progressCompleted, progressPage: book.progressPage)
+      let now = Date()
       book.progressPage = page
       book.progressCompleted = completed
-      book.progressReadDate = Date()
-      book.progressLastModified = Date()
+      book.progressReadDate = now
+      if book.progressCreated == nil {
+        book.progressCreated = now
+      }
+      book.progressLastModified = now
       let newStatus = readingStatus(progressCompleted: book.progressCompleted, progressPage: book.progressPage)
       if oldStatus != newStatus {
         updateSeriesReadingCounts(

--- a/KMReader/Features/Book/Models/KomgaBook.swift
+++ b/KMReader/Features/Book/Models/KomgaBook.swift
@@ -259,9 +259,9 @@ final class KomgaBook {
     guard let page = progressPage,
       let completed = progressCompleted,
       let readDate = progressReadDate,
-      let created = progressCreated,
       let lastModified = progressLastModified
     else { return nil }
+    let created = progressCreated ?? readDate
     return ReadProgress(
       page: page,
       completed: completed,


### PR DESCRIPTION
## Summary
- set `progressCreated` when persisting local reading progress updates
- keep `progressReadDate` and `progressLastModified` aligned with a single timestamp
- make `KomgaBook.readProgress` resilient for older local rows by falling back to `readDate` when `progressCreated` is missing

## Why
When reading offline and moving to the next volume, progress could appear in some UI surfaces but still resolve to unread/reset behavior because `readProgress` became nil if `progressCreated` was absent.

## Related
- https://github.com/everpcpc/KMReader/issues/457