### PR TITLE
fix(reader): persist EPUB progression in KomgaBook

### DIFF
--- a/KMReader/Features/Book/Models/KomgaBook.swift
+++ b/KMReader/Features/Book/Models/KomgaBook.swift
@@ -71,6 +71,7 @@ final class KomgaBook {
   var pagesRaw: Data?
   var tocRaw: Data?
   var webPubManifestRaw: Data?
+  var epubProgressionRaw: Data?
 
   // Track offline download status (managed locally)
   var downloadStatusRaw: String = "notDownloaded"
@@ -216,6 +217,7 @@ final class KomgaBook {
     self.readListIdsRaw = try? JSONEncoder().encode([] as [String])
     self.isolatePagesRaw = try? JSONEncoder().encode([] as [Int])
     self.epubPreferencesRaw = nil
+    self.epubProgressionRaw = nil
   }
 
   var media: Media {

--- a/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
+++ b/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
@@ -338,7 +338,6 @@ actor ReaderProgressDispatchService {
           completed: false,
           progressionData: update.progressionData
         )
-        await DatabaseOperator.shared.commit()
         logger.debug(
           "✅ Queued EPUB progression for offline sync: book=\(update.bookId), globalPage=\(update.globalPageNumber)"
         )
@@ -357,6 +356,12 @@ actor ReaderProgressDispatchService {
           "✅ EPUB progression request completed for book=\(update.bookId), href=\(update.progression.locator.href), globalPage=\(update.globalPageNumber)"
         )
       }
+
+      await DatabaseOperator.shared.updateBookEpubProgression(
+        bookId: update.bookId,
+        progression: update.progression
+      )
+      await DatabaseOperator.shared.commit()
     } catch let apiError as APIError {
       if case .badRequest(let message, _, _, _) = apiError,
         message.lowercased().contains("epub extension not found")

--- a/KMReader/Features/Sync/Services/ProgressSyncService.swift
+++ b/KMReader/Features/Sync/Services/ProgressSyncService.swift
@@ -111,6 +111,10 @@ actor ProgressSyncService {
         bookId: item.bookId,
         progression: progression
       )
+      await DatabaseOperator.shared.updateBookEpubProgression(
+        bookId: item.bookId,
+        progression: progression
+      )
       logger.debug("✅ Synced EPUB progression for book \(item.bookId)")
 
     } else {


### PR DESCRIPTION
## Summary
- add local EPUB progression storage field on KomgaBook
- add DatabaseOperator helpers to read and write EPUB progression with ISO8601 coding
- EPUB reader now syncs latest server progression to local storage when online and reads from local storage
- remove pending-progression fallback during EPUB load
- keep local EPUB progression updated in reader dispatch and pending sync flows
- make Divina reader refresh book data online on each open to pick latest server progress

## Validation
- make format
- make build-ios
- make build-macos
- make build-tvos
