### PR TITLE
fix: tighten TOC parent hit testing and build guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,11 @@ make artifacts          # Prepare IPA/DMG for GitHub Release
 make clean              # Remove archives, exports, and artifacts
 ```
 
+Build execution rule:
+- Do not run multiple `make build-*` commands in parallel. `xcodebuild` shares the same DerivedData build database and parallel runs may fail with database lock errors.
+- Prefer `make build` for full validation.
+- If platform-specific builds are required, run `make build-ios`, `make build-macos`, and `make build-tvos` sequentially.
+
 ### Run Commands
 
 Run commands support device selection with preferences stored in `devices.json`.
@@ -145,7 +150,7 @@ make localize           # Update localizations
 
 Validate changes by:
 
-1. Building all relevant targets (`make build-ios`, `make build-macos`, `make build-tvos`)
+1. Build targets sequentially (prefer `make build`; if needed, run `make build-ios`, `make build-macos`, and `make build-tvos` in order)
 2. Manual testing: login/logout, server switching, dashboard refresh, SSE auto-refresh, reader opening/closing, cache clearing
 3. Watch Xcode Console filtered by subsystem `Komga` with categories `API`, `SSE`, or `ReaderViewModel`
 

--- a/KMReader/Features/Reader/Views/Sheets/DivinaTOCSheetView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/DivinaTOCSheetView.swift
@@ -126,7 +126,6 @@ private struct TOCEntryRow: View {
           } label: {
             TOCEntryLabel(entry: entry, isCurrent: isCurrent, level: level)
           }
-          .contentShape(Rectangle())
         }
         .id(entry.pageIndex)
         .onAppear {
@@ -181,6 +180,5 @@ private struct TOCEntryLabel: View {
         .foregroundStyle(.secondary)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
-    .contentShape(Rectangle())
   }
 }

--- a/KMReader/Features/Reader/Views/Sheets/EpubTocSheetView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubTocSheetView.swift
@@ -74,7 +74,6 @@
           } label: {
             ChapterLabel(link: link, currentLink: currentLink)
           }
-          .contentShape(Rectangle())
         }
         .id(link.href)
       } else {


### PR DESCRIPTION
## Summary
- remove extra `contentShape(Rectangle())` usage from TOC parent disclosure labels in Divina and EPUB TOC sheets
- keep leaf row tap targets unchanged while reducing parent-label hit area side effects
- add AGENTS.md guidance to avoid parallel `make build-*` runs and prefer `make build` or sequential platform builds

## Testing
- [x] `make build`
