### PR TITLE
chore(network): lower default request/auth timeouts

### DIFF
--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -29,7 +29,7 @@ enum AppConfig {
       if UserDefaults.standard.object(forKey: "requestTimeout") != nil {
         return UserDefaults.standard.double(forKey: "requestTimeout")
       }
-      return 20.0
+      return 15.0
     }
     set { UserDefaults.standard.set(newValue, forKey: "requestTimeout") }
   }
@@ -49,7 +49,7 @@ enum AppConfig {
       if UserDefaults.standard.object(forKey: "authTimeout") != nil {
         return UserDefaults.standard.double(forKey: "authTimeout")
       }
-      return 10.0
+      return 5.0
     }
     set { UserDefaults.standard.set(newValue, forKey: "authTimeout") }
   }

--- a/KMReader/Features/Settings/SettingsNetworkView.swift
+++ b/KMReader/Features/Settings/SettingsNetworkView.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct SettingsNetworkView: View {
-  @AppStorage("requestTimeout") private var requestTimeout: Double = 20
+  @AppStorage("requestTimeout") private var requestTimeout: Double = 15
   @AppStorage("downloadTimeout") private var downloadTimeout: Double = 60
-  @AppStorage("authTimeout") private var authTimeout: Double = 10
+  @AppStorage("authTimeout") private var authTimeout: Double = 5
   @AppStorage("apiRetryCount") private var apiRetryCount: Int = 0
   @AppStorage("enableBrowseHandoff") private var enableBrowseHandoff: Bool = true
   @AppStorage("enableReaderHandoff") private var enableReaderHandoff: Bool = false


### PR DESCRIPTION
## Summary
- Lower default request timeout from 20s to 15s.
- Lower default auth timeout from 10s to 5s for faster startup offline fallback.
- Keep `SettingsNetworkView` AppStorage defaults aligned with `AppConfig` defaults.

## Testing
- [ ] Not run (configuration/default value change only)
