### PR TITLE
fix(reader): avoid treating online PDF pages as offline-only

### DIFF
--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -188,7 +188,7 @@ class ReaderViewModel {
         return cachedFileURL
       }
 
-      if AppConfig.isOffline, page.downloadURL == nil {
+      if AppConfig.isOffline {
         self.logger.error("❌ Missing offline page \(page.number) for book \(self.bookId)")
         return nil
       }


### PR DESCRIPTION
## What
- Remove media-type coupling from reader page loading offline gate
- After local offline file and disk cache checks fail, gate missing page by offline mode only
- Generalize log from `Missing offline PDF page` to `Missing offline page`

## Why
PDF reader could still hit an offline-only branch after the offline copy was removed, causing images not to load while online.

Closes #488
