### PR TITLE
fix: stabilize notification identity to reduce SwiftUI crash risk

### DIFF
--- a/KMReader/Core/Storage/Errors/ErrorManager.swift
+++ b/KMReader/Core/Storage/Errors/ErrorManager.swift
@@ -17,7 +17,7 @@ class ErrorManager {
 
   var hasAlert: Bool = false
   var currentError: AppError?
-  var notifications: [String] = []
+  var notifications: [AppNotification] = []
 
   private let logger = AppLogger(.notification)
 
@@ -58,10 +58,11 @@ class ErrorManager {
   /// Show a notification message (non-blocking)
   func notify(message: String, duration: TimeInterval = 2) {
     logger.info("📢 Notify: \(message)")
-    notifications.append(message)
+    let notification = AppNotification(message: message)
+    notifications.append(notification)
     DispatchQueue.main.asyncAfter(deadline: .now() + duration) { [weak self] in
-      guard let self = self, !self.notifications.isEmpty else { return }
-      self.notifications.removeFirst()
+      guard let self = self else { return }
+      self.notifications.removeAll { $0.id == notification.id }
     }
   }
 
@@ -123,6 +124,16 @@ class ErrorManager {
     }
 
     return true
+  }
+}
+
+struct AppNotification: Identifiable, Equatable {
+  let id: UUID
+  let message: String
+
+  init(id: UUID = UUID(), message: String) {
+    self.id = id
+    self.message = message
   }
 }
 

--- a/KMReader/Shared/UI/NotificationOverlay.swift
+++ b/KMReader/Shared/UI/NotificationOverlay.swift
@@ -174,8 +174,8 @@ import SwiftUI
     var body: some View {
       VStack(alignment: .center) {
         Spacer()
-        ForEach($errorManager.notifications, id: \.self) { $notification in
-          Text(notification)
+        ForEach(errorManager.notifications) { notification in
+          Text(notification.message)
             .padding(.vertical, 8)
             .padding(.horizontal, 16)
             .foregroundStyle(.white)
@@ -242,8 +242,8 @@ import SwiftUI
     var body: some View {
       VStack(alignment: .center) {
         Spacer()
-        ForEach($errorManager.notifications, id: \.self) { $notification in
-          Text(notification)
+        ForEach(errorManager.notifications) { notification in
+          Text(notification.message)
             .padding(.vertical, 8)
             .padding(.horizontal, 16)
             .foregroundStyle(.white)
@@ -282,8 +282,8 @@ import SwiftUI
     var body: some View {
       VStack(alignment: .center) {
         Spacer()
-        ForEach($errorManager.notifications, id: \.self) { $notification in
-          Text(notification)
+        ForEach(errorManager.notifications) { notification in
+          Text(notification.message)
             .padding(.vertical, 8)
             .padding(.horizontal, 16)
             .foregroundStyle(.white)


### PR DESCRIPTION
## What changed
- Replace `ErrorManager.notifications` from `[String]` to `[AppNotification]` with stable `UUID` identity.
- Update notification dismissal to remove by `id` instead of removing the first item.
- Update `NotificationOverlay` on iOS, tvOS, and macOS to render `AppNotification` entries directly.

## Why
- Crash reports show repeated `EXC_BREAKPOINT` in SwiftUICore/libswiftCore with the app frame near `MainApp`.
- A likely trigger is `ForEach(..., id: \.self)` over repeated notification strings, which can produce unstable identities during SwiftUI diffing.
- Stable per-item IDs reduce this class of runtime crashes while preserving behavior.

## Validation
- `make format`
- `make build-macos`
- `make build-ios`
- `make build-tvos`
