### PR TITLE
fix: avoid iOS 17 Browse tab crash

### DIFF
--- a/KMReader/Features/Book/Views/BooksBrowseView.swift
+++ b/KMReader/Features/Book/Views/BooksBrowseView.swift
@@ -36,10 +36,11 @@ struct BooksBrowseView: View {
       ).padding(.horizontal)
 
       BooksQueryView(
+        libraryIds: libraryIds,
+        searchText: searchText,
         browseOpts: (searchIgnoreFilters && !searchText.isEmpty) ? BookBrowseOptions() : browseOpts,
         browseLayout: browseLayout,
-        viewModel: viewModel,
-        loadMore: loadBooks
+        viewModel: viewModel
       )
       .task {
         if !hasInitialized {

--- a/KMReader/Features/Book/Views/ListViews/BooksListViewForSeries.swift
+++ b/KMReader/Features/Book/Views/ListViews/BooksListViewForSeries.swift
@@ -50,15 +50,8 @@ struct BooksListViewForSeries: View {
       SeriesBooksQueryView(
         seriesId: seriesId,
         bookViewModel: bookViewModel,
-        browseLayout: layoutMode,
-        refreshBooks: {
-          Task {
-            await refreshBooks(refresh: false)
-          }
-        },
-        loadMore: { refresh in
-          await refreshBooks(refresh: refresh)
-        }
+        browseOpts: browseOpts,
+        browseLayout: layoutMode
       )
     }
     .task(id: seriesId) {

--- a/KMReader/Features/Offline/Views/OfflineBooksBrowseView.swift
+++ b/KMReader/Features/Offline/Views/OfflineBooksBrowseView.swift
@@ -46,10 +46,13 @@ struct OfflineBooksBrowseView: View {
       .padding(.horizontal)
 
       BooksQueryView(
+        libraryIds: libraryIds,
+        searchText: searchText,
         browseOpts: (searchIgnoreFilters && !searchText.isEmpty) ? BookBrowseOptions() : browseOpts,
         browseLayout: browseLayout,
         viewModel: viewModel,
-        loadMore: loadBooks
+        useLocalOnly: true,
+        offlineOnly: true
       )
     }
     .task {

--- a/KMReader/Features/Offline/Views/OfflineSeriesBrowseView.swift
+++ b/KMReader/Features/Offline/Views/OfflineSeriesBrowseView.swift
@@ -45,11 +45,14 @@ struct OfflineSeriesBrowseView: View {
       .padding(.horizontal)
 
       SeriesQueryView(
+        libraryIds: libraryIds,
+        searchText: searchText,
         browseOpts: (searchIgnoreFilters && !searchText.isEmpty)
           ? SeriesBrowseOptions() : browseOpts,
         browseLayout: browseLayout,
         viewModel: viewModel,
-        loadMore: loadSeries
+        useLocalOnly: true,
+        offlineOnly: true
       )
     }
     .task {

--- a/KMReader/Features/Series/Views/SeriesBrowseView.swift
+++ b/KMReader/Features/Series/Views/SeriesBrowseView.swift
@@ -36,11 +36,12 @@ struct SeriesBrowseView: View {
       ).padding(.horizontal)
 
       SeriesQueryView(
+        libraryIds: libraryIds,
+        searchText: searchText,
         browseOpts: (searchIgnoreFilters && !searchText.isEmpty)
           ? SeriesBrowseOptions() : browseOpts,
         browseLayout: browseLayout,
-        viewModel: viewModel,
-        loadMore: loadSeries
+        viewModel: viewModel
       )
     }
     .task {


### PR DESCRIPTION
## Summary
- Remove stored `async` closure properties from browse query views to avoid SwiftUI/AttributeGraph metadata issues on iOS 17.
- Trigger pagination loads internally via `ModelContext` + view models; pass `libraryIds` / `searchText` as explicit inputs.
- Update online + offline Browse callers and series-detail book list.

## Testing
- `make build-ios`
- iOS 17 simulator: open Browse tab, switch content/layout, scroll to trigger pagination
- Offline Browse: switch content/layout, scroll to trigger pagination
