### PR TITLE
fix: align divina zoom and waifu2x settings behavior

### DIFF
--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -101,18 +101,20 @@ struct ReaderSettingsSheet: View {
               }
             }
             .pickerStyle(.menu)
-            VStack(alignment: .leading, spacing: 8) {
-              HStack {
-                Text("Double Tap Zoom Scale")
-                Spacer()
-                Text(String(format: "%.1fx", doubleTapZoomScale))
-                  .foregroundColor(.secondary)
+            if doubleTapZoomMode != .disabled {
+              VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                  Text("Double Tap Zoom Scale")
+                  Spacer()
+                  Text(String(format: "%.1fx", doubleTapZoomScale))
+                    .foregroundColor(.secondary)
+                }
+                Slider(
+                  value: $doubleTapZoomScale,
+                  in: 1.0...8.0,
+                  step: 0.5
+                )
               }
-              Slider(
-                value: $doubleTapZoomScale,
-                in: 1.0...8.0,
-                step: 0.5
-              )
             }
           }
         #endif
@@ -134,8 +136,6 @@ struct ReaderSettingsSheet: View {
 
             Group {
               switch imageUpscalingMode {
-              case .disabled:
-                EmptyView()
               case .auto:
                 VStack(alignment: .leading, spacing: 8) {
                   HStack {
@@ -153,7 +153,6 @@ struct ReaderSettingsSheet: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
                 }
-                .transition(.opacity)
               case .always:
                 VStack(alignment: .leading, spacing: 8) {
                   HStack {
@@ -171,10 +170,10 @@ struct ReaderSettingsSheet: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
                 }
-                .transition(.opacity)
+              case .disabled:
+                EmptyView()
               }
             }
-            .animation(.easeInOut(duration: 0.2), value: imageUpscalingMode)
           }
         #endif
 
@@ -319,6 +318,8 @@ struct ReaderSettingsSheet: View {
       }
     }
     .animation(.default, value: tapZoneMode)
+    .animation(.default, value: doubleTapZoomMode)
+    .animation(.default, value: imageUpscalingMode)
     .presentationDragIndicator(.visible)
   }
 }

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -160,8 +160,6 @@ struct DivinaPreferencesView: View {
 
           Group {
             switch imageUpscalingMode {
-            case .disabled:
-              EmptyView()
             case .auto:
               VStack(alignment: .leading, spacing: 8) {
                 HStack {
@@ -179,7 +177,6 @@ struct DivinaPreferencesView: View {
                   .font(.caption)
                   .foregroundColor(.secondary)
               }
-              .transition(.opacity)
             case .always:
               VStack(alignment: .leading, spacing: 8) {
                 HStack {
@@ -197,10 +194,10 @@ struct DivinaPreferencesView: View {
                   .font(.caption)
                   .foregroundColor(.secondary)
               }
-              .transition(.opacity)
+            case .disabled:
+              EmptyView()
             }
           }
-          .animation(.easeInOut(duration: 0.2), value: imageUpscalingMode)
         }
       #endif
 
@@ -427,6 +424,7 @@ struct DivinaPreferencesView: View {
     }
     .animation(.default, value: tapZoneMode)
     .animation(.default, value: doubleTapZoomMode)
+    .animation(.default, value: imageUpscalingMode)
     .formStyle(.grouped)
     .inlineNavigationBarTitle(SettingsSection.divinaReader.title)
   }


### PR DESCRIPTION
## Summary
- Hide `Double Tap Zoom Scale` when `Double Tap to Zoom` is set to `Disabled` in the reader settings sheet.
- Keep waifu2x settings in switch-based branches (`disabled/auto/always`) without extra outer condition wrappers.
- Remove explicit transition modifiers and rely on default state-driven form animations for both reader sheet and global Divina settings.

## Testing
- [x] `make format`
- [x] `make build-ios`
- [x] `make build-macos`
- [x] `make build-tvos`
