### PR TITLE
fix: accelerate reader progress sync and skip incognito sync

### DIFF
--- a/KMReader/Features/Book/Services/BookService.swift
+++ b/KMReader/Features/Book/Services/BookService.swift
@@ -17,7 +17,7 @@ class BookService {
   static let shared = BookService()
   private let apiClient = APIClient.shared
   private let logger = AppLogger(.api)
-  private let progressRequestTimeout: TimeInterval = 3
+  private let progressRequestTimeout: TimeInterval = 1
 
   private init() {}
 

--- a/KMReader/Features/Dashboard/Views/DashboardView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardView.swift
@@ -273,7 +273,7 @@ struct DashboardView: View {
             )
             let idle = await ReaderProgressDispatchService.shared.waitUntilCheckpointReached(
               checkpoint,
-              timeout: .seconds(6)
+              timeout: .seconds(5)
             )
             if idle {
               logger.debug(

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -69,15 +69,22 @@ class ReaderViewModel {
     self.init(
       isolateCoverPage: AppConfig.isolateCoverPage,
       pageLayout: AppConfig.pageLayout,
-      splitWidePageMode: AppConfig.splitWidePageMode
+      splitWidePageMode: AppConfig.splitWidePageMode,
+      incognitoMode: false
     )
   }
 
-  init(isolateCoverPage: Bool, pageLayout: PageLayout, splitWidePageMode: SplitWidePageMode = .none) {
+  init(
+    isolateCoverPage: Bool,
+    pageLayout: PageLayout,
+    splitWidePageMode: SplitWidePageMode = .none,
+    incognitoMode: Bool = false
+  ) {
     self.pageImageCache = ImageCache()
     self.isolateCoverPageEnabled = isolateCoverPage
     self.forceDualPagePairs = pageLayout == .dual
     self.splitWidePageMode = splitWidePageMode
+    self.incognitoMode = incognitoMode
     regenerateViewState()
   }
 

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -41,7 +41,7 @@ struct DivinaReaderView: View {
   private let logger = AppLogger(.reader)
 
   @State private var currentBookId: String
-  @State private var viewModel = ReaderViewModel()
+  @State private var viewModel: ReaderViewModel
   @State private var showingControls = false
   @State private var controlsTimer: Timer?
   @State private var currentSeries: Series?
@@ -90,6 +90,14 @@ struct DivinaReaderView: View {
     self._pageLayout = State(initialValue: AppConfig.pageLayout)
     self._isolateCoverPage = State(initialValue: AppConfig.isolateCoverPage)
     self._splitWidePageMode = State(initialValue: AppConfig.splitWidePageMode)
+    self._viewModel = State(
+      initialValue: ReaderViewModel(
+        isolateCoverPage: AppConfig.isolateCoverPage,
+        pageLayout: AppConfig.pageLayout,
+        splitWidePageMode: AppConfig.splitWidePageMode,
+        incognitoMode: incognito
+      )
+    )
   }
 
   var shouldShowControls: Bool {
@@ -1033,7 +1041,9 @@ struct DivinaReaderView: View {
     if let resolvedBook {
       currentBook = resolvedBook
       seriesId = resolvedBook.seriesId
-      readerPresentation.trackVisitedBook(bookId: resolvedBook.id, seriesId: resolvedBook.seriesId)
+      if !incognito {
+        readerPresentation.trackVisitedBook(bookId: resolvedBook.id, seriesId: resolvedBook.seriesId)
+      }
       initialPageNumber = incognito ? nil : resolvedBook.readProgress?.page
     }
 
@@ -1303,10 +1313,9 @@ struct DivinaReaderView: View {
     viewModel = ReaderViewModel(
       isolateCoverPage: isolateCoverPage,
       pageLayout: pageLayout,
-      splitWidePageMode: splitWidePageMode
+      splitWidePageMode: splitWidePageMode,
+      incognitoMode: incognito
     )
-    // Preserve incognito mode for next book
-    viewModel.incognitoMode = incognito
     // Reset isAtBottom so buttons hide until user scrolls to bottom
     isAtBottom = false
     // Reset overlay state
@@ -1327,10 +1336,9 @@ struct DivinaReaderView: View {
     viewModel = ReaderViewModel(
       isolateCoverPage: isolateCoverPage,
       pageLayout: pageLayout,
-      splitWidePageMode: splitWidePageMode
+      splitWidePageMode: splitWidePageMode,
+      incognitoMode: incognito
     )
-    // Preserve incognito mode for previous book
-    viewModel.incognitoMode = incognito
     // Reset isAtBottom so buttons hide until user scrolls to bottom
     isAtBottom = false
     // Reset overlay state


### PR DESCRIPTION
## Summary
- reduce progress API timeout to 1s for reader/book progress updates
- set dashboard wait-for-progress timeout to 5s before fallback refresh
- run progress send tasks as `TaskPriority.userInitiated` and simplify timeout race logic
- skip visited/progress sync paths when reader is in incognito mode
- pass incognito flag during reader view model construction

## Files
- KMReader/Features/Book/Services/BookService.swift
- KMReader/Features/Dashboard/Views/DashboardView.swift
- KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
- KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
- KMReader/Features/Reader/Views/DivinaReaderView.swift
- KMReader/Features/Reader/Views/ReaderPresentationManager.swift

## Validation
- not run in this step (commit + PR only)
