### PR TITLE
fix: rebalance cover preview aspect ratios

### DIFF
--- a/KMReader/ContentView.swift
+++ b/KMReader/ContentView.swift
@@ -1,6 +1,5 @@
 //
-//  ContentView.swift
-//  Komga
+// ContentView.swift
 //
 //
 

--- a/KMReader/Core/Network/APIClient.swift
+++ b/KMReader/Core/Network/APIClient.swift
@@ -1,6 +1,5 @@
 //
-//  APIClient.swift
-//  Komga
+// APIClient.swift
 //
 //
 

--- a/KMReader/Core/Network/SSEService.swift
+++ b/KMReader/Core/Network/SSEService.swift
@@ -1,6 +1,5 @@
 //
-//  SSEService.swift
-//  Komga
+// SSEService.swift
 //
 //
 

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -1,6 +1,5 @@
 //
-//  AppConfig.swift
-//  Komga
+// AppConfig.swift
 //
 //
 

--- a/KMReader/Core/Storage/AppLogger.swift
+++ b/KMReader/Core/Storage/AppLogger.swift
@@ -1,6 +1,5 @@
 //
-//  AppLogger.swift
-//  KMReader
+// AppLogger.swift
 //
 //
 

--- a/KMReader/Core/Storage/Cache/BookFileCache.swift
+++ b/KMReader/Core/Storage/Cache/BookFileCache.swift
@@ -1,6 +1,5 @@
 //
-//  BookFileCache.swift
-//  KMReader
+// BookFileCache.swift
 //
 //
 

--- a/KMReader/Core/Storage/Cache/CacheManager.swift
+++ b/KMReader/Core/Storage/Cache/CacheManager.swift
@@ -1,6 +1,5 @@
 //
-//  CacheManager.swift
-//  KMReader
+// CacheManager.swift
 //
 //
 

--- a/KMReader/Core/Storage/Cache/CacheNamespace.swift
+++ b/KMReader/Core/Storage/Cache/CacheNamespace.swift
@@ -1,6 +1,5 @@
 //
-//  CacheNamespace.swift
-//  KMReader
+// CacheNamespace.swift
 //
 //
 

--- a/KMReader/Core/Storage/Cache/CacheSizeActor.swift
+++ b/KMReader/Core/Storage/Cache/CacheSizeActor.swift
@@ -1,6 +1,5 @@
 //
-//  CacheSizeActor.swift
-//  Komga
+// CacheSizeActor.swift
 //
 //
 

--- a/KMReader/Core/Storage/Cache/ImageCache.swift
+++ b/KMReader/Core/Storage/Cache/ImageCache.swift
@@ -1,6 +1,5 @@
 //
-//  ImageCache.swift
-//  Komga
+// ImageCache.swift
 //
 //
 

--- a/KMReader/Core/Storage/Cache/ThumbnailCache.swift
+++ b/KMReader/Core/Storage/Cache/ThumbnailCache.swift
@@ -1,6 +1,5 @@
 //
-//  ThumbnailCache.swift
-//  KMReader
+// ThumbnailCache.swift
 //
 //
 

--- a/KMReader/Core/Storage/CompositeID.swift
+++ b/KMReader/Core/Storage/CompositeID.swift
@@ -1,6 +1,5 @@
 //
-//  CompositeID.swift
-//  KMReader
+// CompositeID.swift
 //
 //
 

--- a/KMReader/Core/Storage/DashboardSectionCacheStore.swift
+++ b/KMReader/Core/Storage/DashboardSectionCacheStore.swift
@@ -1,6 +1,6 @@
 //
-//  DashboardSectionCacheStore.swift
-//  KMReader
+// DashboardSectionCacheStore.swift
+//
 //
 
 import Foundation

--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -1,6 +1,5 @@
 //
-//  DatabaseOperator.swift
-//  KMReader
+// DatabaseOperator.swift
 //
 //
 

--- a/KMReader/Core/Storage/DeepLinkRouter.swift
+++ b/KMReader/Core/Storage/DeepLinkRouter.swift
@@ -1,6 +1,6 @@
 //
-//  DeepLinkRouter.swift
-//  KMReader
+// DeepLinkRouter.swift
+//
 //
 
 import Foundation

--- a/KMReader/Core/Storage/Errors/APIError.swift
+++ b/KMReader/Core/Storage/Errors/APIError.swift
@@ -1,6 +1,5 @@
 //
-//  APIError.swift
-//  Komga
+// APIError.swift
 //
 //
 

--- a/KMReader/Core/Storage/Errors/AppErrorType.swift
+++ b/KMReader/Core/Storage/Errors/AppErrorType.swift
@@ -1,6 +1,5 @@
 //
-//  AppErrorType.swift
-//  Komga
+// AppErrorType.swift
 //
 //
 

--- a/KMReader/Core/Storage/Errors/ErrorManager.swift
+++ b/KMReader/Core/Storage/Errors/ErrorManager.swift
@@ -1,6 +1,5 @@
 //
-//  ErrorManager.swift
-//  Komga
+// ErrorManager.swift
 //
 //
 

--- a/KMReader/Core/Storage/LiveTextManager.swift
+++ b/KMReader/Core/Storage/LiveTextManager.swift
@@ -1,6 +1,6 @@
 //
-//  LiveTextManager.swift
-//  KMReader
+// LiveTextManager.swift
+//
 //
 
 import Foundation

--- a/KMReader/Core/Storage/LogStore.swift
+++ b/KMReader/Core/Storage/LogStore.swift
@@ -1,6 +1,5 @@
 //
-//  LogStore.swift
-//  KMReader
+// LogStore.swift
 //
 //
 

--- a/KMReader/Core/Storage/ManagementService.swift
+++ b/KMReader/Core/Storage/ManagementService.swift
@@ -1,6 +1,5 @@
 //
-//  ManagementService.swift
-//  Komga
+// ManagementService.swift
 //
 //
 

--- a/KMReader/Core/Storage/QuickActionService.swift
+++ b/KMReader/Core/Storage/QuickActionService.swift
@@ -1,6 +1,6 @@
 //
-//  QuickActionService.swift
-//  KMReader
+// QuickActionService.swift
+//
 //
 
 import Foundation

--- a/KMReader/Core/Storage/SpotlightIndexService.swift
+++ b/KMReader/Core/Storage/SpotlightIndexService.swift
@@ -1,6 +1,6 @@
 //
-//  SpotlightIndexService.swift
-//  KMReader
+// SpotlightIndexService.swift
+//
 //
 
 @preconcurrency import CoreSpotlight

--- a/KMReader/Core/Storage/WidgetDataService.swift
+++ b/KMReader/Core/Storage/WidgetDataService.swift
@@ -1,6 +1,6 @@
 //
-//  WidgetDataService.swift
-//  KMReader
+// WidgetDataService.swift
+//
 //
 
 import Foundation

--- a/KMReader/Features/Auth/Models/ApiKey.swift
+++ b/KMReader/Features/Auth/Models/ApiKey.swift
@@ -1,6 +1,5 @@
 //
-//  ApiKey.swift
-//  Komga
+// ApiKey.swift
 //
 //
 

--- a/KMReader/Features/Auth/Models/AuthenticationActivity.swift
+++ b/KMReader/Features/Auth/Models/AuthenticationActivity.swift
@@ -1,6 +1,5 @@
 //
-//  AuthenticationActivity.swift
-//  Komga
+// AuthenticationActivity.swift
 //
 //
 

--- a/KMReader/Features/Auth/Models/AuthenticationMethod.swift
+++ b/KMReader/Features/Auth/Models/AuthenticationMethod.swift
@@ -1,6 +1,6 @@
 //
-//  AuthenticationMethod.swift
-//  KMReader
+// AuthenticationMethod.swift
+//
 //
 
 import Foundation

--- a/KMReader/Features/Auth/Models/Current.swift
+++ b/KMReader/Features/Auth/Models/Current.swift
@@ -1,6 +1,5 @@
 //
-//  Current.swift
-//  KMReader
+// Current.swift
 //
 //
 

--- a/KMReader/Features/Auth/Models/KomgaInstance.swift
+++ b/KMReader/Features/Auth/Models/KomgaInstance.swift
@@ -1,6 +1,5 @@
 //
-//  KomgaInstance.swift
-//  Komga
+// KomgaInstance.swift
 //
 //
 

--- a/KMReader/Features/Auth/Models/User.swift
+++ b/KMReader/Features/Auth/Models/User.swift
@@ -1,6 +1,5 @@
 //
-//  User.swift
-//  Komga
+// User.swift
 //
 //
 

--- a/KMReader/Features/Auth/Models/UserRole.swift
+++ b/KMReader/Features/Auth/Models/UserRole.swift
@@ -1,6 +1,5 @@
 //
-//  UserRole.swift
-//  KMReader
+// UserRole.swift
 //
 //
 

--- a/KMReader/Features/Auth/Services/AuthService.swift
+++ b/KMReader/Features/Auth/Services/AuthService.swift
@@ -1,6 +1,5 @@
 //
-//  AuthService.swift
-//  Komga
+// AuthService.swift
 //
 //
 

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -1,6 +1,5 @@
 //
-//  AuthViewModel.swift
-//  Komga
+// AuthViewModel.swift
 //
 //
 

--- a/KMReader/Features/Auth/Views/LandingView.swift
+++ b/KMReader/Features/Auth/Views/LandingView.swift
@@ -1,6 +1,5 @@
 //
-//  LandingView.swift
-//  Komga
+// LandingView.swift
 //
 //
 

--- a/KMReader/Features/Auth/Views/LoginView.swift
+++ b/KMReader/Features/Auth/Views/LoginView.swift
@@ -1,6 +1,5 @@
 //
-//  LoginView.swift
-//  Komga
+// LoginView.swift
 //
 //
 

--- a/KMReader/Features/Author/Author.swift
+++ b/KMReader/Features/Author/Author.swift
@@ -1,6 +1,5 @@
 //
-//  Author.swift
-//  Komga
+// Author.swift
 //
 //
 

--- a/KMReader/Features/Author/AuthorRole.swift
+++ b/KMReader/Features/Author/AuthorRole.swift
@@ -1,6 +1,5 @@
 //
-//  AuthorRole.swift
-//  Komga
+// AuthorRole.swift
 //
 //
 

--- a/KMReader/Features/Book/Models/Book+Download.swift
+++ b/KMReader/Features/Book/Models/Book+Download.swift
@@ -1,6 +1,5 @@
 //
-//  Book+Download.swift
-//  KMReader
+// Book+Download.swift
 //
 //
 

--- a/KMReader/Features/Book/Models/Book.swift
+++ b/KMReader/Features/Book/Models/Book.swift
@@ -1,6 +1,5 @@
 //
-//  Book.swift
-//  Komga
+// Book.swift
 //
 //
 

--- a/KMReader/Features/Book/Models/BookPage.swift
+++ b/KMReader/Features/Book/Models/BookPage.swift
@@ -1,6 +1,5 @@
 //
-//  BookPage.swift
-//  Komga
+// BookPage.swift
 //
 //
 

--- a/KMReader/Features/Book/Models/BookSearch.swift
+++ b/KMReader/Features/Book/Models/BookSearch.swift
@@ -1,6 +1,5 @@
 //
-//  BookSearch.swift
-//  Komga
+// BookSearch.swift
 //
 //
 

--- a/KMReader/Features/Book/Models/BookSortField.swift
+++ b/KMReader/Features/Book/Models/BookSortField.swift
@@ -1,6 +1,5 @@
 //
-//  BookSortField.swift
-//  Komga
+// BookSortField.swift
 //
 //
 

--- a/KMReader/Features/Book/Models/DivinaManifest.swift
+++ b/KMReader/Features/Book/Models/DivinaManifest.swift
@@ -1,6 +1,5 @@
 //
-//  DivinaManifest.swift
-//  KMReader
+// DivinaManifest.swift
 //
 //
 

--- a/KMReader/Features/Book/Models/DownloadStatus.swift
+++ b/KMReader/Features/Book/Models/DownloadStatus.swift
@@ -1,6 +1,5 @@
 //
-//  DownloadStatus.swift
-//  KMReader
+// DownloadStatus.swift
 //
 //
 

--- a/KMReader/Features/Book/Models/KomgaBook.swift
+++ b/KMReader/Features/Book/Models/KomgaBook.swift
@@ -1,6 +1,5 @@
 //
-//  KomgaBook.swift
-//  KMReader
+// KomgaBook.swift
 //
 //
 

--- a/KMReader/Features/Book/Models/Media.swift
+++ b/KMReader/Features/Book/Models/Media.swift
@@ -1,6 +1,5 @@
 //
-//  Media.swift
-//  Komga
+// Media.swift
 //
 //
 

--- a/KMReader/Features/Book/Models/Metadata/BookMetadata.swift
+++ b/KMReader/Features/Book/Models/Metadata/BookMetadata.swift
@@ -1,6 +1,5 @@
 //
-//  BookMetadata.swift
-//  Komga
+// BookMetadata.swift
 //
 //
 

--- a/KMReader/Features/Book/Models/Metadata/BookMetadataUpdate.swift
+++ b/KMReader/Features/Book/Models/Metadata/BookMetadataUpdate.swift
@@ -1,6 +1,5 @@
 //
-//  BookMetadataUpdate.swift
-//  KMReader
+// BookMetadataUpdate.swift
 //
 //
 

--- a/KMReader/Features/Book/Models/ReadProgress.swift
+++ b/KMReader/Features/Book/Models/ReadProgress.swift
@@ -1,6 +1,5 @@
 //
-//  ReadProgress.swift
-//  Komga
+// ReadProgress.swift
 //
 //
 

--- a/KMReader/Features/Book/Services/BookService.swift
+++ b/KMReader/Features/Book/Services/BookService.swift
@@ -1,6 +1,5 @@
 //
-//  BookService.swift
-//  Komga
+// BookService.swift
 //
 //
 

--- a/KMReader/Features/Book/Services/KomgaBookStore.swift
+++ b/KMReader/Features/Book/Services/KomgaBookStore.swift
@@ -1,6 +1,5 @@
 //
-//  KomgaBookStore.swift
-//  KMReader
+// KomgaBookStore.swift
 //
 //
 

--- a/KMReader/Features/Book/ViewModels/BookBrowseOptions.swift
+++ b/KMReader/Features/Book/ViewModels/BookBrowseOptions.swift
@@ -1,6 +1,5 @@
 //
-//  BookBrowseOptions.swift
-//  Komga
+// BookBrowseOptions.swift
 //
 //
 

--- a/KMReader/Features/Book/ViewModels/BookViewModel.swift
+++ b/KMReader/Features/Book/ViewModels/BookViewModel.swift
@@ -1,6 +1,5 @@
 //
-//  BookViewModel.swift
-//  Komga
+// BookViewModel.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookBrowseOptionsSheet.swift
+++ b/KMReader/Features/Book/Views/BookBrowseOptionsSheet.swift
@@ -1,6 +1,5 @@
 //
-//  BookBrowseOptionsSheet.swift
-//  Komga
+// BookBrowseOptionsSheet.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookCardView.swift
+++ b/KMReader/Features/Book/Views/BookCardView.swift
@@ -1,6 +1,5 @@
 //
-//  BookCardView.swift
-//  Komga
+// BookCardView.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookContextMenu.swift
+++ b/KMReader/Features/Book/Views/BookContextMenu.swift
@@ -1,6 +1,5 @@
 //
-//  BookContextMenu.swift
-//  Komga
+// BookContextMenu.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookDetailContentView.swift
+++ b/KMReader/Features/Book/Views/BookDetailContentView.swift
@@ -1,6 +1,5 @@
 //
-//  BookDetailContentView.swift
-//  Komga
+// BookDetailContentView.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookDetailView.swift
+++ b/KMReader/Features/Book/Views/BookDetailView.swift
@@ -1,6 +1,5 @@
 //
-//  BookDetailView.swift
-//  Komga
+// BookDetailView.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookEditSheet.swift
+++ b/KMReader/Features/Book/Views/BookEditSheet.swift
@@ -1,6 +1,5 @@
 //
-//  BookEditSheet.swift
-//  Komga
+// BookEditSheet.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookFilterView.swift
+++ b/KMReader/Features/Book/Views/BookFilterView.swift
@@ -1,6 +1,5 @@
 //
-//  BookFilterView.swift
-//  Komga
+// BookFilterView.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookItemView.swift
+++ b/KMReader/Features/Book/Views/BookItemView.swift
@@ -1,6 +1,5 @@
 //
-//  BookItemView.swift
-//  KMReader
+// BookItemView.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookQueryItemView.swift
+++ b/KMReader/Features/Book/Views/BookQueryItemView.swift
@@ -1,6 +1,5 @@
 //
-//  BookQueryItemView.swift
-//  KMReader
+// BookQueryItemView.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookReadListsSection.swift
+++ b/KMReader/Features/Book/Views/BookReadListsSection.swift
@@ -1,6 +1,5 @@
 //
-//  BookReadListsSection.swift
-//  KMReader
+// BookReadListsSection.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookReaderState.swift
+++ b/KMReader/Features/Book/Views/BookReaderState.swift
@@ -1,6 +1,5 @@
 //
-//  BookReaderState.swift
-//  Komga
+// BookReaderState.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookRowView.swift
+++ b/KMReader/Features/Book/Views/BookRowView.swift
@@ -1,6 +1,5 @@
 //
-//  BookRowView.swift
-//  Komga
+// BookRowView.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BookSelectionItemView.swift
+++ b/KMReader/Features/Book/Views/BookSelectionItemView.swift
@@ -1,6 +1,5 @@
 //
-//  BookSelectionItemView.swift
-//  KMReader
+// BookSelectionItemView.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/BooksBrowseView.swift
+++ b/KMReader/Features/Book/Views/BooksBrowseView.swift
@@ -1,6 +1,6 @@
 //
-//  BooksBrowseView.swift
-//  Komga
+// BooksBrowseView.swift
+//
 //
 
 import SwiftData

--- a/KMReader/Features/Book/Views/BooksQueryView.swift
+++ b/KMReader/Features/Book/Views/BooksQueryView.swift
@@ -1,6 +1,5 @@
 //
-//  BooksQueryView.swift
-//  KMReader
+// BooksQueryView.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/ListViews/BooksListViewForReadList.swift
+++ b/KMReader/Features/Book/Views/ListViews/BooksListViewForReadList.swift
@@ -1,6 +1,5 @@
 //
-//  BooksListViewForReadList.swift
-//  Komga
+// BooksListViewForReadList.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/ListViews/BooksListViewForSeries.swift
+++ b/KMReader/Features/Book/Views/ListViews/BooksListViewForSeries.swift
@@ -1,6 +1,6 @@
 //
-//  BooksListViewForSeries.swift
-//  Komga
+// BooksListViewForSeries.swift
+//
 //
 
 import SwiftData

--- a/KMReader/Features/Book/Views/ListViews/ReadListBooksQueryView.swift
+++ b/KMReader/Features/Book/Views/ListViews/ReadListBooksQueryView.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListBooksQueryView.swift
-//  KMReader
+// ReadListBooksQueryView.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/ListViews/SeriesBooksQueryView.swift
+++ b/KMReader/Features/Book/Views/ListViews/SeriesBooksQueryView.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesBooksQueryView.swift
-//  KMReader
+// SeriesBooksQueryView.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/Sections/BookActionsSection.swift
+++ b/KMReader/Features/Book/Views/Sections/BookActionsSection.swift
@@ -1,6 +1,5 @@
 //
-//  BookActionsSection.swift
-//  Komga
+// BookActionsSection.swift
 //
 //
 

--- a/KMReader/Features/Book/Views/Sections/BookDownloadActionsSection.swift
+++ b/KMReader/Features/Book/Views/Sections/BookDownloadActionsSection.swift
@@ -1,6 +1,6 @@
 //
-//  BookDownloadActionsSection.swift
-//  KMReader
+// BookDownloadActionsSection.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Features/Browse/Models/SavedFilter.swift
+++ b/KMReader/Features/Browse/Models/SavedFilter.swift
@@ -1,6 +1,5 @@
 //
-//  SavedFilter.swift
-//  KMReader
+// SavedFilter.swift
 //
 //
 

--- a/KMReader/Features/Browse/Views/BrowseView.swift
+++ b/KMReader/Features/Browse/Views/BrowseView.swift
@@ -1,6 +1,5 @@
 //
-//  BrowseView.swift
-//  Komga
+// BrowseView.swift
 //
 //
 

--- a/KMReader/Features/Browse/Views/SaveFilterSheet.swift
+++ b/KMReader/Features/Browse/Views/SaveFilterSheet.swift
@@ -1,6 +1,5 @@
 //
-//  SaveFilterSheet.swift
-//  KMReader
+// SaveFilterSheet.swift
 //
 //
 

--- a/KMReader/Features/Browse/Views/SavedFiltersView.swift
+++ b/KMReader/Features/Browse/Views/SavedFiltersView.swift
@@ -1,6 +1,5 @@
 //
-//  SavedFiltersView.swift
-//  KMReader
+// SavedFiltersView.swift
 //
 //
 

--- a/KMReader/Features/Browse/Views/Sheets/CollectionPickerSheet.swift
+++ b/KMReader/Features/Browse/Views/Sheets/CollectionPickerSheet.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionPickerSheet.swift
-//  Komga
+// CollectionPickerSheet.swift
 //
 //
 

--- a/KMReader/Features/Browse/Views/Sheets/LibraryPickerSheet.swift
+++ b/KMReader/Features/Browse/Views/Sheets/LibraryPickerSheet.swift
@@ -1,6 +1,5 @@
 //
-//  LibraryPickerSheet.swift
-//  Komga
+// LibraryPickerSheet.swift
 //
 //
 

--- a/KMReader/Features/Browse/Views/Sheets/ReadListPickerSheet.swift
+++ b/KMReader/Features/Browse/Views/Sheets/ReadListPickerSheet.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListPickerSheet.swift
-//  Komga
+// ReadListPickerSheet.swift
 //
 //
 

--- a/KMReader/Features/Collection/Models/Collection.swift
+++ b/KMReader/Features/Collection/Models/Collection.swift
@@ -1,6 +1,5 @@
 //
-//  Collection.swift
-//  Komga
+// Collection.swift
 //
 //
 

--- a/KMReader/Features/Collection/Models/KomgaCollection.swift
+++ b/KMReader/Features/Collection/Models/KomgaCollection.swift
@@ -1,6 +1,5 @@
 //
-//  KomgaCollection.swift
-//  KMReader
+// KomgaCollection.swift
 //
 //
 

--- a/KMReader/Features/Collection/Services/CollectionService.swift
+++ b/KMReader/Features/Collection/Services/CollectionService.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionService.swift
-//  Komga
+// CollectionService.swift
 //
 //
 

--- a/KMReader/Features/Collection/Services/KomgaCollectionStore.swift
+++ b/KMReader/Features/Collection/Services/KomgaCollectionStore.swift
@@ -1,6 +1,5 @@
 //
-//  KomgaCollectionStore.swift
-//  KMReader
+// KomgaCollectionStore.swift
 //
 //
 

--- a/KMReader/Features/Collection/ViewModels/CollectionSeriesBrowseOptions.swift
+++ b/KMReader/Features/Collection/ViewModels/CollectionSeriesBrowseOptions.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionSeriesBrowseOptions.swift
-//  Komga
+// CollectionSeriesBrowseOptions.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionCardView.swift
+++ b/KMReader/Features/Collection/Views/CollectionCardView.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionCardView.swift
-//  Komga
+// CollectionCardView.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionCompactCardView.swift
+++ b/KMReader/Features/Collection/Views/CollectionCompactCardView.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionCompactCardView.swift
-//  KMReader
+// CollectionCompactCardView.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionContextMenu.swift
+++ b/KMReader/Features/Collection/Views/CollectionContextMenu.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionContextMenu.swift
-//  Komga
+// CollectionContextMenu.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionDetailContentView.swift
+++ b/KMReader/Features/Collection/Views/CollectionDetailContentView.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionDetailContentView.swift
-//  Komga
+// CollectionDetailContentView.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionDetailView.swift
+++ b/KMReader/Features/Collection/Views/CollectionDetailView.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionDetailView.swift
-//  Komga
+// CollectionDetailView.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionEditSheet.swift
+++ b/KMReader/Features/Collection/Views/CollectionEditSheet.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionEditSheet.swift
-//  Komga
+// CollectionEditSheet.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionItemQueryView.swift
+++ b/KMReader/Features/Collection/Views/CollectionItemQueryView.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionItemQueryView.swift
-//  KMReader
+// CollectionItemQueryView.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionQueryItemView.swift
+++ b/KMReader/Features/Collection/Views/CollectionQueryItemView.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionQueryItemView.swift
-//  KMReader
+// CollectionQueryItemView.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionRowView.swift
+++ b/KMReader/Features/Collection/Views/CollectionRowView.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionRowView.swift
-//  Komga
+// CollectionRowView.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionSeriesBrowseOptionsSheet.swift
+++ b/KMReader/Features/Collection/Views/CollectionSeriesBrowseOptionsSheet.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionSeriesBrowseOptionsSheet.swift
-//  Komga
+// CollectionSeriesBrowseOptionsSheet.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionSeriesFilterView.swift
+++ b/KMReader/Features/Collection/Views/CollectionSeriesFilterView.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionSeriesFilterView.swift
-//  Komga
+// CollectionSeriesFilterView.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionSortView.swift
+++ b/KMReader/Features/Collection/Views/CollectionSortView.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionSortView.swift
-//  Komga
+// CollectionSortView.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/CollectionsBrowseView.swift
+++ b/KMReader/Features/Collection/Views/CollectionsBrowseView.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionsBrowseView.swift
-//  Komga
+// CollectionsBrowseView.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/Sections/CollectionSeriesListView.swift
+++ b/KMReader/Features/Collection/Views/Sections/CollectionSeriesListView.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionSeriesListView.swift
-//  Komga
+// CollectionSeriesListView.swift
 //
 //
 

--- a/KMReader/Features/Collection/Views/Sections/CollectionSeriesQueryView.swift
+++ b/KMReader/Features/Collection/Views/Sections/CollectionSeriesQueryView.swift
@@ -1,6 +1,5 @@
 //
-//  CollectionSeriesQueryView.swift
-//  KMReader
+// CollectionSeriesQueryView.swift
 //
 //
 

--- a/KMReader/Features/Dashboard/Models/DashboardSection.swift
+++ b/KMReader/Features/Dashboard/Models/DashboardSection.swift
@@ -1,6 +1,5 @@
 //
-//  DashboardSection.swift
-//  Komga
+// DashboardSection.swift
 //
 //
 

--- a/KMReader/Features/Dashboard/Models/DashboardSectionCache.swift
+++ b/KMReader/Features/Dashboard/Models/DashboardSectionCache.swift
@@ -1,6 +1,6 @@
 //
-//  DashboardSectionCache.swift
-//  KMReader
+// DashboardSectionCache.swift
+//
 //
 
 import Foundation

--- a/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
@@ -1,6 +1,5 @@
 //
-//  DashboardSectionDetailView.swift
-//  KMReader
+// DashboardSectionDetailView.swift
 //
 //
 

--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -1,6 +1,5 @@
 //
-//  DashboardSectionView.swift
-//  KMReader
+// DashboardSectionView.swift
 //
 //
 

--- a/KMReader/Features/Dashboard/Views/DashboardView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardView.swift
@@ -1,6 +1,5 @@
 //
-//  DashboardView.swift
-//  Komga
+// DashboardView.swift
 //
 //
 

--- a/KMReader/Features/Dashboard/Views/ServerUpdateStatusView.swift
+++ b/KMReader/Features/Dashboard/Views/ServerUpdateStatusView.swift
@@ -1,6 +1,5 @@
 //
-//  ServerUpdateStatusView.swift
-//  Komga
+// ServerUpdateStatusView.swift
 //
 //
 

--- a/KMReader/Features/Filesystem/Models/DirectoryListingResult.swift
+++ b/KMReader/Features/Filesystem/Models/DirectoryListingResult.swift
@@ -1,6 +1,5 @@
 //
-//  DirectoryListingResult.swift
-//  KMReader
+// DirectoryListingResult.swift
 //
 //
 

--- a/KMReader/Features/Filesystem/Services/FilesystemService.swift
+++ b/KMReader/Features/Filesystem/Services/FilesystemService.swift
@@ -1,6 +1,5 @@
 //
-//  FilesystemService.swift
-//  KMReader
+// FilesystemService.swift
 //
 //
 

--- a/KMReader/Features/History/Models/HistoricalEvent.swift
+++ b/KMReader/Features/History/Models/HistoricalEvent.swift
@@ -1,6 +1,5 @@
 //
-//  HistoricalEvent.swift
-//  KMReader
+// HistoricalEvent.swift
 //
 //
 

--- a/KMReader/Features/History/Models/HistoricalEventPage.swift
+++ b/KMReader/Features/History/Models/HistoricalEventPage.swift
@@ -1,6 +1,5 @@
 //
-//  HistoricalEventPage.swift
-//  KMReader
+// HistoricalEventPage.swift
 //
 //
 

--- a/KMReader/Features/History/Services/HistoryService.swift
+++ b/KMReader/Features/History/Services/HistoryService.swift
@@ -1,6 +1,5 @@
 //
-//  HistoryService.swift
-//  KMReader
+// HistoryService.swift
 //
 //
 

--- a/KMReader/Features/Library/Models/KomgaLibrary.swift
+++ b/KMReader/Features/Library/Models/KomgaLibrary.swift
@@ -1,6 +1,5 @@
 //
-//  KomgaLibrary.swift
-//  KMReader
+// KomgaLibrary.swift
 //
 //
 

--- a/KMReader/Features/Library/Models/Library.swift
+++ b/KMReader/Features/Library/Models/Library.swift
@@ -1,6 +1,5 @@
 //
-//  Library.swift
-//  Komga
+// Library.swift
 //
 //
 

--- a/KMReader/Features/Library/Models/LibraryCreation.swift
+++ b/KMReader/Features/Library/Models/LibraryCreation.swift
@@ -1,6 +1,5 @@
 //
-//  LibraryCreation.swift
-//  KMReader
+// LibraryCreation.swift
 //
 //
 

--- a/KMReader/Features/Library/Models/LibraryUpdate.swift
+++ b/KMReader/Features/Library/Models/LibraryUpdate.swift
@@ -1,6 +1,5 @@
 //
-//  LibraryUpdate.swift
-//  KMReader
+// LibraryUpdate.swift
 //
 //
 

--- a/KMReader/Features/Library/Services/LibraryManager.swift
+++ b/KMReader/Features/Library/Services/LibraryManager.swift
@@ -1,6 +1,5 @@
 //
-//  LibraryManager.swift
-//  Komga
+// LibraryManager.swift
 //
 //
 

--- a/KMReader/Features/Library/Services/LibraryMetricsLoader.swift
+++ b/KMReader/Features/Library/Services/LibraryMetricsLoader.swift
@@ -1,6 +1,5 @@
 //
-//  LibraryMetricsLoader.swift
-//  KMReader
+// LibraryMetricsLoader.swift
 //
 //
 

--- a/KMReader/Features/Library/Services/LibraryService.swift
+++ b/KMReader/Features/Library/Services/LibraryService.swift
@@ -1,6 +1,5 @@
 //
-//  LibraryService.swift
-//  Komga
+// LibraryService.swift
 //
 //
 

--- a/KMReader/Features/Offline/Services/BackgroundDownloadManager.swift
+++ b/KMReader/Features/Offline/Services/BackgroundDownloadManager.swift
@@ -1,8 +1,6 @@
 //
-//  BackgroundDownloadManager.swift
-//  KMReader
+// BackgroundDownloadManager.swift
 //
-//  Manages background downloads using URLSession background configuration.
 //
 
 import Foundation

--- a/KMReader/Features/Offline/Services/DownloadProgressTracker.swift
+++ b/KMReader/Features/Offline/Services/DownloadProgressTracker.swift
@@ -1,6 +1,5 @@
 //
-//  DownloadProgressTracker.swift
-//  KMReader
+// DownloadProgressTracker.swift
 //
 //
 

--- a/KMReader/Features/Offline/Services/LiveActivityManager.swift
+++ b/KMReader/Features/Offline/Services/LiveActivityManager.swift
@@ -1,8 +1,6 @@
 //
-//  LiveActivityManager.swift
-//  KMReader
+// LiveActivityManager.swift
 //
-//  Manages Live Activity for download progress display.
 //
 
 import Foundation

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -1,6 +1,5 @@
 //
-//  OfflineManager.swift
-//  KMReader
+// OfflineManager.swift
 //
 //
 

--- a/KMReader/Features/Offline/Views/OfflineBooksBrowseView.swift
+++ b/KMReader/Features/Offline/Views/OfflineBooksBrowseView.swift
@@ -1,6 +1,5 @@
 //
-//  OfflineBooksBrowseView.swift
-//  KMReader
+// OfflineBooksBrowseView.swift
 //
 //
 

--- a/KMReader/Features/Offline/Views/OfflineBooksCountView.swift
+++ b/KMReader/Features/Offline/Views/OfflineBooksCountView.swift
@@ -1,6 +1,5 @@
 //
-//  OfflineBooksCountView.swift
-//  KMReader
+// OfflineBooksCountView.swift
 //
 //
 

--- a/KMReader/Features/Offline/Views/OfflineBooksView.swift
+++ b/KMReader/Features/Offline/Views/OfflineBooksView.swift
@@ -1,6 +1,5 @@
 //
-//  OfflineBooksView.swift
-//  KMReader
+// OfflineBooksView.swift
 //
 //
 

--- a/KMReader/Features/Offline/Views/OfflineSection.swift
+++ b/KMReader/Features/Offline/Views/OfflineSection.swift
@@ -1,6 +1,5 @@
 //
-//  OfflineSection.swift
-//  Komga
+// OfflineSection.swift
 //
 //
 

--- a/KMReader/Features/Offline/Views/OfflineSeriesBrowseView.swift
+++ b/KMReader/Features/Offline/Views/OfflineSeriesBrowseView.swift
@@ -1,6 +1,5 @@
 //
-//  OfflineSeriesBrowseView.swift
-//  KMReader
+// OfflineSeriesBrowseView.swift
 //
 //
 

--- a/KMReader/Features/Offline/Views/OfflineShortcutRow.swift
+++ b/KMReader/Features/Offline/Views/OfflineShortcutRow.swift
@@ -1,6 +1,5 @@
 //
-//  OfflineShortcutRow.swift
-//  KMReader
+// OfflineShortcutRow.swift
 //
 //
 

--- a/KMReader/Features/Offline/Views/OfflineTasksStatusView.swift
+++ b/KMReader/Features/Offline/Views/OfflineTasksStatusView.swift
@@ -1,6 +1,5 @@
 //
-//  OfflineTasksStatusView.swift
-//  KMReader
+// OfflineTasksStatusView.swift
 //
 //
 

--- a/KMReader/Features/Offline/Views/OfflineTasksView.swift
+++ b/KMReader/Features/Offline/Views/OfflineTasksView.swift
@@ -1,6 +1,5 @@
 //
-//  OfflineTasksView.swift
-//  KMReader
+// OfflineTasksView.swift
 //
 //
 

--- a/KMReader/Features/Offline/Views/OfflineView.swift
+++ b/KMReader/Features/Offline/Views/OfflineView.swift
@@ -1,6 +1,5 @@
 //
-//  OfflineView.swift
-//  KMReader
+// OfflineView.swift
 //
 //
 

--- a/KMReader/Features/OneShot/OneShotDetailContentView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailContentView.swift
@@ -1,6 +1,5 @@
 //
-//  OneShotDetailContentView.swift
-//  Komga
+// OneShotDetailContentView.swift
 //
 //
 

--- a/KMReader/Features/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailView.swift
@@ -1,6 +1,5 @@
 //
-//  OneshotDetailView.swift
-//  Komga
+// OneShotDetailView.swift
 //
 //
 

--- a/KMReader/Features/OneShot/OneshotEditSheet.swift
+++ b/KMReader/Features/OneShot/OneshotEditSheet.swift
@@ -1,6 +1,5 @@
 //
-//  OneshotEditSheet.swift
-//  Komga
+// OneshotEditSheet.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Models/KomgaReadList.swift
+++ b/KMReader/Features/ReadList/Models/KomgaReadList.swift
@@ -1,6 +1,5 @@
 //
-//  KomgaReadList.swift
-//  KMReader
+// KomgaReadList.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Models/ReadList.swift
+++ b/KMReader/Features/ReadList/Models/ReadList.swift
@@ -1,6 +1,5 @@
 //
-//  ReadList.swift
-//  Komga
+// ReadList.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Services/KomgaReadListStore.swift
+++ b/KMReader/Features/ReadList/Services/KomgaReadListStore.swift
@@ -1,6 +1,5 @@
 //
-//  KomgaReadListStore.swift
-//  KMReader
+// KomgaReadListStore.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Services/ReadListService.swift
+++ b/KMReader/Features/ReadList/Services/ReadListService.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListService.swift
-//  Komga
+// ReadListService.swift
 //
 //
 

--- a/KMReader/Features/ReadList/ViewModels/ReadListBookBrowseOptions.swift
+++ b/KMReader/Features/ReadList/ViewModels/ReadListBookBrowseOptions.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListBookBrowseOptions.swift
-//  Komga
+// ReadListBookBrowseOptions.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListBookBrowseOptionsSheet.swift
+++ b/KMReader/Features/ReadList/Views/ReadListBookBrowseOptionsSheet.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListBookBrowseOptionsSheet.swift
-//  Komga
+// ReadListBookBrowseOptionsSheet.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListBookFilterView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListBookFilterView.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListBookFilterView.swift
-//  Komga
+// ReadListBookFilterView.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListCardView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListCardView.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListCardView.swift
-//  Komga
+// ReadListCardView.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListCompactCardView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListCompactCardView.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListCompactCardView.swift
-//  KMReader
+// ReadListCompactCardView.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListContextMenu.swift
+++ b/KMReader/Features/ReadList/Views/ReadListContextMenu.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListContextMenu.swift
-//  Komga
+// ReadListContextMenu.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListDetailContentView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListDetailContentView.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListDetailContentView.swift
-//  Komga
+// ReadListDetailContentView.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListDetailView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListDetailView.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListDetailView.swift
-//  Komga
+// ReadListDetailView.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListDownloadActionsSection.swift
+++ b/KMReader/Features/ReadList/Views/ReadListDownloadActionsSection.swift
@@ -1,6 +1,6 @@
 //
-//  ReadListDownloadActionsSection.swift
-//  KMReader
+// ReadListDownloadActionsSection.swift
+//
 //
 
 import SwiftData

--- a/KMReader/Features/ReadList/Views/ReadListEditSheet.swift
+++ b/KMReader/Features/ReadList/Views/ReadListEditSheet.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListEditSheet.swift
-//  Komga
+// ReadListEditSheet.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListItemQueryView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListItemQueryView.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListItemQueryView.swift
-//  KMReader
+// ReadListItemQueryView.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListQueryItemView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListQueryItemView.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListQueryItemView.swift
-//  KMReader
+// ReadListQueryItemView.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListRowView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListRowView.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListRowView.swift
-//  Komga
+// ReadListRowView.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListSortView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListSortView.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListSortView.swift
-//  Komga
+// ReadListSortView.swift
 //
 //
 

--- a/KMReader/Features/ReadList/Views/ReadListsBrowseView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListsBrowseView.swift
@@ -1,6 +1,5 @@
 //
-//  ReadListsBrowseView.swift
-//  Komga
+// ReadListsBrowseView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Models/CustomFont.swift
+++ b/KMReader/Features/Reader/Models/CustomFont.swift
@@ -1,6 +1,5 @@
 //
-//  CustomFont.swift
-//  KMReader
+// CustomFont.swift
 //
 //
 

--- a/KMReader/Features/Reader/Models/DoubleTapZoomMode.swift
+++ b/KMReader/Features/Reader/Models/DoubleTapZoomMode.swift
@@ -1,6 +1,5 @@
 //
-//  CustomFont.swift
-//  KMReader
+// DoubleTapZoomMode.swift
 //
 //
 

--- a/KMReader/Features/Reader/Models/EpubThemePreset.swift
+++ b/KMReader/Features/Reader/Models/EpubThemePreset.swift
@@ -1,6 +1,5 @@
 //
-//  EpubThemePreset.swift
-//  KMReader
+// EpubThemePreset.swift
 //
 //
 

--- a/KMReader/Features/Reader/Models/Page.swift
+++ b/KMReader/Features/Reader/Models/Page.swift
@@ -1,6 +1,5 @@
 //
-//  Page.swift
-//  Komga
+// Page.swift
 //
 //
 

--- a/KMReader/Features/Reader/Models/PageLayout.swift
+++ b/KMReader/Features/Reader/Models/PageLayout.swift
@@ -1,6 +1,5 @@
 //
-//  PageLayout.swift
-//  Komga
+// PageLayout.swift
 //
 //
 

--- a/KMReader/Features/Reader/Models/PageTransitionStyle.swift
+++ b/KMReader/Features/Reader/Models/PageTransitionStyle.swift
@@ -1,6 +1,6 @@
 //
-//  PageTransitionStyle.swift
-//  KMReader
+// PageTransitionStyle.swift
+//
 //
 
 import Foundation

--- a/KMReader/Features/Reader/Models/ReaderBackground.swift
+++ b/KMReader/Features/Reader/Models/ReaderBackground.swift
@@ -1,6 +1,5 @@
 //
-//  ReaderBackground.swift
-//  Komga
+// ReaderBackground.swift
 //
 //
 

--- a/KMReader/Features/Reader/Models/ReaderImageUpscalingMode.swift
+++ b/KMReader/Features/Reader/Models/ReaderImageUpscalingMode.swift
@@ -1,6 +1,6 @@
 //
-//  ReaderImageUpscalingMode.swift
-//  KMReader
+// ReaderImageUpscalingMode.swift
+//
 //
 
 import Foundation

--- a/KMReader/Features/Reader/Models/ReaderViewItem.swift
+++ b/KMReader/Features/Reader/Models/ReaderViewItem.swift
@@ -1,6 +1,5 @@
 //
-//  ReaderViewItem.swift
-//  KMReader
+// ReaderViewItem.swift
 //
 //
 

--- a/KMReader/Features/Reader/Models/ReadingDirection.swift
+++ b/KMReader/Features/Reader/Models/ReadingDirection.swift
@@ -1,6 +1,5 @@
 //
-//  ReadingDirection.swift
-//  Komga
+// ReadingDirection.swift
 //
 //
 

--- a/KMReader/Features/Reader/Models/ScrollPageTransitionStyle.swift
+++ b/KMReader/Features/Reader/Models/ScrollPageTransitionStyle.swift
@@ -1,6 +1,6 @@
 //
-//  ScrollPageTransitionStyle.swift
-//  KMReader
+// ScrollPageTransitionStyle.swift
+//
 //
 
 import Foundation

--- a/KMReader/Features/Reader/Models/SplitWidePageMode.swift
+++ b/KMReader/Features/Reader/Models/SplitWidePageMode.swift
@@ -1,6 +1,5 @@
 //
-//  SplitWidePageMode.swift
-//  KMReader
+// SplitWidePageMode.swift
 //
 //
 

--- a/KMReader/Features/Reader/Models/TapZoneHelper.swift
+++ b/KMReader/Features/Reader/Models/TapZoneHelper.swift
@@ -1,8 +1,6 @@
 //
-//  TapZoneHelper.swift
-//  KMReader
+// TapZoneHelper.swift
 //
-//  Created by Antigravity
 //
 
 import Foundation

--- a/KMReader/Features/Reader/Models/TapZoneMode.swift
+++ b/KMReader/Features/Reader/Models/TapZoneMode.swift
@@ -1,8 +1,6 @@
 //
-//  TapZoneMode.swift
-//  KMReader
+// TapZoneMode.swift
 //
-//  Created by Antigravity
 //
 
 import SwiftUI

--- a/KMReader/Features/Reader/Models/TapZoneSize.swift
+++ b/KMReader/Features/Reader/Models/TapZoneSize.swift
@@ -1,6 +1,5 @@
 //
-//  TapZoneSize.swift
-//  Komga
+// TapZoneSize.swift
 //
 //
 

--- a/KMReader/Features/Reader/Services/CustomFontStore.swift
+++ b/KMReader/Features/Reader/Services/CustomFontStore.swift
@@ -1,6 +1,5 @@
 //
-//  CustomFontStore.swift
-//  KMReader
+// CustomFontStore.swift
 //
 //
 

--- a/KMReader/Features/Reader/Services/FontFileManager.swift
+++ b/KMReader/Features/Reader/Services/FontFileManager.swift
@@ -1,6 +1,5 @@
 //
-//  FontFileManager.swift
-//  KMReader
+// FontFileManager.swift
 //
 //
 

--- a/KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift
+++ b/KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift
@@ -1,6 +1,6 @@
 //
-//  PdfOfflinePreparationService.swift
-//  KMReader
+// PdfOfflinePreparationService.swift
+//
 //
 
 import Foundation

--- a/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
+++ b/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
@@ -1,6 +1,6 @@
 //
-//  ReaderProgressDispatchService.swift
-//  KMReader
+// ReaderProgressDispatchService.swift
+//
 //
 
 import Foundation

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -1,6 +1,5 @@
 //
-//  EpubReaderViewModel.swift
-//  KMReader
+// EpubReaderViewModel.swift
 //
 //
 

--- a/KMReader/Features/Reader/ViewModels/ReaderManifestService.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderManifestService.swift
@@ -1,6 +1,5 @@
 //
-//  ReaderManifestService.swift
-//  KMReader
+// ReaderManifestService.swift
 //
 //
 

--- a/KMReader/Features/Reader/ViewModels/ReaderMediaHelper.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderMediaHelper.swift
@@ -1,6 +1,5 @@
 //
-//  ReaderMediaHelper.swift
-//  KMReader
+// ReaderMediaHelper.swift
 //
 //
 

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -1,6 +1,5 @@
 //
-//  ReaderViewModel.swift
-//  Komga
+// ReaderViewModel.swift
 //
 //
 

--- a/KMReader/Features/Reader/ViewModels/ReaderXHTMLParser.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderXHTMLParser.swift
@@ -1,6 +1,5 @@
 //
-//  ReaderXHTMLParser.swift
-//  KMReader
+// ReaderXHTMLParser.swift
 //
 //
 

--- a/KMReader/Features/Reader/ViewModels/SaveImageStatus.swift
+++ b/KMReader/Features/Reader/ViewModels/SaveImageStatus.swift
@@ -1,6 +1,5 @@
 //
-//  SaveImageStatus.swift
-//  Komga
+// SaveImageStatus.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/ArcEffectShape.swift
+++ b/KMReader/Features/Reader/Views/ArcEffectShape.swift
@@ -1,6 +1,5 @@
 //
-//  ArcEffectShape.swift
-//  Komga
+// ArcEffectShape.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/BookReaderView.swift
+++ b/KMReader/Features/Reader/Views/BookReaderView.swift
@@ -1,6 +1,5 @@
 //
-//  BookReaderView.swift
-//  KMReader
+// BookReaderView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/CurlPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlPageView.swift
@@ -1,8 +1,6 @@
 //
-//  CurlPageView.swift
-//  KMReader
+// CurlPageView.swift
 //
-//  UIPageViewController wrapper for pageCurl transition effect (iOS only)
 //
 
 #if os(iOS)

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -1,6 +1,5 @@
 //
-//  DivinaControlsOverlayView.swift
-//  Komga
+// DivinaControlsOverlayView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -1,6 +1,5 @@
 //
-//  DivinaReaderView.swift
-//  Komga
+// DivinaReaderView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/EndPageView/EndPageView.swift
+++ b/KMReader/Features/Reader/Views/EndPageView/EndPageView.swift
@@ -1,6 +1,5 @@
 //
-//  EndPageView.swift
-//  Komga
+// EndPageView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/EndPageView/NextBookInfoView.swift
+++ b/KMReader/Features/Reader/Views/EndPageView/NextBookInfoView.swift
@@ -1,6 +1,5 @@
 //
-//  NextBookInfoView.swift
-//  Komga
+// NextBookInfoView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Epub/EpubEndPageView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubEndPageView.swift
@@ -1,6 +1,5 @@
 //
-//  EpubEndPageView.swift
-//  KMReader
+// EpubEndPageView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -1,6 +1,5 @@
 //
-//  EpubReaderView.swift
-//  KMReader
+// EpubReaderView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Epub/ReadiumCSSLoader.swift
+++ b/KMReader/Features/Reader/Views/Epub/ReadiumCSSLoader.swift
@@ -1,6 +1,5 @@
 //
-//  ReadiumCSSLoader.swift
-//  KMReader
+// ReadiumCSSLoader.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Epub/WebPubPageView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPageView.swift
@@ -1,6 +1,5 @@
 //
-//  WebPubPageView.swift
-//  KMReader
+// WebPubPageView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrollView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrollView.swift
@@ -1,6 +1,5 @@
 //
-//  WebPubScrollView.swift
-//  KMReader
+// WebPubScrollView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Helpers/ReaderConstants.swift
+++ b/KMReader/Features/Reader/Views/Helpers/ReaderConstants.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonConstants.swift
-//  Komga
+// ReaderConstants.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Helpers/WebtoonConstants.swift
+++ b/KMReader/Features/Reader/Views/Helpers/WebtoonConstants.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonConstants.swift
-//  Komga
+// WebtoonConstants.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/KeyboardEventHandler.swift
+++ b/KMReader/Features/Reader/Views/KeyboardEventHandler.swift
@@ -1,6 +1,5 @@
 //
-//  KeyboardEventHandler.swift
-//  Komga
+// KeyboardEventHandler.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/KeyboardHelpOverlay.swift
+++ b/KMReader/Features/Reader/Views/KeyboardHelpOverlay.swift
@@ -1,6 +1,5 @@
 //
-//  KeyboardHelpOverlay.swift
-//  Komga
+// KeyboardHelpOverlay.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Models/EpubColumnCount.swift
+++ b/KMReader/Features/Reader/Views/Models/EpubColumnCount.swift
@@ -1,6 +1,5 @@
 //
-//  EpubColumnCount.swift
-//  KMReader
+// EpubColumnCount.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Models/EpubReaderPreferences.swift
+++ b/KMReader/Features/Reader/Views/Models/EpubReaderPreferences.swift
@@ -1,6 +1,5 @@
 //
-//  EpubReaderPreferences.swift
-//  KMReader
+// EpubReaderPreferences.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Models/NativePageData.swift
+++ b/KMReader/Features/Reader/Views/Models/NativePageData.swift
@@ -1,6 +1,6 @@
 //
-//  NativePageData.swift
-//  KMReader
+// NativePageData.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Features/Reader/Views/Models/PageDisplayMode.swift
+++ b/KMReader/Features/Reader/Views/Models/PageDisplayMode.swift
@@ -1,6 +1,5 @@
 //
-//  PageDisplayMode.swift
-//  KMReader
+// PageDisplayMode.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Models/PageViewMode.swift
+++ b/KMReader/Features/Reader/Views/Models/PageViewMode.swift
@@ -1,6 +1,5 @@
 //
-//  EpubReaderPreferences.swift
-//  KMReader
+// PageViewMode.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/NoPagesView.swift
+++ b/KMReader/Features/Reader/Views/NoPagesView.swift
@@ -1,6 +1,5 @@
 //
-//  NoPagesView.swift
-//  Komga
+// NoPagesView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/PageImage/AnimatedImagePlayButton.swift
+++ b/KMReader/Features/Reader/Views/PageImage/AnimatedImagePlayButton.swift
@@ -1,6 +1,6 @@
 //
-//  AnimatedImagePlayButton.swift
-//  KMReader
+// AnimatedImagePlayButton.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Features/Reader/Views/PageImage/AnimatedImagePlaybackOverlay.swift
+++ b/KMReader/Features/Reader/Views/PageImage/AnimatedImagePlaybackOverlay.swift
@@ -1,6 +1,6 @@
 //
-//  AnimatedImagePlaybackOverlay.swift
-//  KMReader
+// AnimatedImagePlaybackOverlay.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Features/Reader/Views/PageImage/DualPageImageView.swift
+++ b/KMReader/Features/Reader/Views/PageImage/DualPageImageView.swift
@@ -1,6 +1,5 @@
 //
-//  DualPageImageView.swift
-//  Komga
+// DualPageImageView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/PageImage/ReusableAnimatedImageWebView.swift
+++ b/KMReader/Features/Reader/Views/PageImage/ReusableAnimatedImageWebView.swift
@@ -1,6 +1,6 @@
 //
-//  ReusableAnimatedImageWebView.swift
-//  KMReader
+// ReusableAnimatedImageWebView.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Features/Reader/Views/PageImage/SinglePageImageView.swift
+++ b/KMReader/Features/Reader/Views/PageImage/SinglePageImageView.swift
@@ -1,6 +1,5 @@
 //
-//  SinglePageImageView.swift
-//  Komga
+// SinglePageImageView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/PageImage/SplitWidePageImageView.swift
+++ b/KMReader/Features/Reader/Views/PageImage/SplitWidePageImageView.swift
@@ -1,6 +1,5 @@
 //
-//  SplitWidePageImageView.swift
-//  KMReader
+// SplitWidePageImageView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/ReaderLoadingView.swift
+++ b/KMReader/Features/Reader/Views/ReaderLoadingView.swift
@@ -1,6 +1,6 @@
 //
-//  ReaderLoadingView.swift
-//  KMReader
+// ReaderLoadingView.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
+++ b/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
@@ -1,6 +1,5 @@
 //
-//  ReaderPresentationManager.swift
-//  KMReader
+// ReaderPresentationManager.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/ReaderUnavailableView.swift
+++ b/KMReader/Features/Reader/Views/ReaderUnavailableView.swift
@@ -1,6 +1,6 @@
 //
-//  ReaderUnavailableView.swift
-//  KMReader
+// ReaderUnavailableView.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Features/Reader/Views/ReaderWindowManager.swift
+++ b/KMReader/Features/Reader/Views/ReaderWindowManager.swift
@@ -1,6 +1,5 @@
 //
-//  ReaderWindowManager.swift
-//  Komga
+// ReaderWindowManager.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/ReaderWindowView.swift
+++ b/KMReader/Features/Reader/Views/ReaderWindowView.swift
@@ -1,6 +1,5 @@
 //
-//  ReaderWindowView.swift
-//  Komga
+// ReaderWindowView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/ScrollPageView.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView.swift
@@ -1,6 +1,6 @@
 //
-//  ScrollPageView.swift
-//  Komga
+// ScrollPageView.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Features/Reader/Views/Sheets/CustomFontsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/CustomFontsSheet.swift
@@ -1,6 +1,5 @@
 //
-//  CustomFontsSheet.swift
-//  KMReader
+// CustomFontsSheet.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Sheets/DivinaTOCSheetView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/DivinaTOCSheetView.swift
@@ -1,6 +1,5 @@
 //
-//  DivinaTOCSheetView.swift
-//  KMReader
+// DivinaTOCSheetView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Sheets/EpubThemePresetsView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubThemePresetsView.swift
@@ -1,6 +1,5 @@
 //
-//  EpubThemePresetsView.swift
-//  KMReader
+// EpubThemePresetsView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Sheets/EpubTocSheetView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubTocSheetView.swift
@@ -1,6 +1,5 @@
 //
-//  EpubTocSheetView.swift
-//  KMReader
+// EpubTocSheetView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Sheets/PageJumpSheetView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/PageJumpSheetView.swift
@@ -1,6 +1,5 @@
 //
-//  PageJumpSheetView.swift
-//  Komga
+// PageJumpSheetView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Sheets/ReaderDetailSheets.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderDetailSheets.swift
@@ -1,6 +1,5 @@
 //
-//  ReaderDetailSheets.swift
-//  KMReader
+// ReaderDetailSheets.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -1,6 +1,5 @@
 //
-//  ReaderSettingsSheet.swift
-//  Komga
+// ReaderSettingsSheet.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/TapZoneOverlay.swift
+++ b/KMReader/Features/Reader/Views/TapZoneOverlay.swift
@@ -1,6 +1,5 @@
 //
-//  TapZoneOverlay.swift
-//  Komga
+// TapZoneOverlay.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_iOS.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonFooterCell_iOS.swift
-//  Komga
+// WebtoonFooterCell_iOS.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_macOS.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonFooterCell_macOS.swift
-//  Komga
+// WebtoonFooterCell_macOS.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonHelpers.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonHelpers.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonHelpers.swift
-//  Komga
+// WebtoonHelpers.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonLayout_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonLayout_iOS.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonLayout_iOS.swift
-//  Komga
+// WebtoonLayout_iOS.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonLayout_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonLayout_macOS.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonLayout_macOS.swift
-//  Komga
+// WebtoonLayout_macOS.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonPageCell_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonPageCell_iOS.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonPageCell_iOS.swift
-//  Komga
+// WebtoonPageCell_iOS.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonPageCell_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonPageCell_macOS.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonPageCell_macOS.swift
-//  Komga
+// WebtoonPageCell_macOS.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonPageView.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonPageView.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonPageView.swift
-//  Komga
+// WebtoonPageView.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonReaderView_iOS.swift
-//  Komga
+// WebtoonReaderView_iOS.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonReaderView_macOS.swift
-//  Komga
+// WebtoonReaderView_macOS.swift
 //
 //
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonZoomOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonZoomOverlayView.swift
@@ -1,6 +1,5 @@
 //
-//  WebtoonZoomOverlayView.swift
-//  KMReader
+// WebtoonZoomOverlayView.swift
 //
 //
 

--- a/KMReader/Features/Referential/ReferentialService.swift
+++ b/KMReader/Features/Referential/ReferentialService.swift
@@ -1,6 +1,5 @@
 //
-//  ReferentialService.swift
-//  KMReader
+// ReferentialService.swift
 //
 //
 

--- a/KMReader/Features/SSE/SSEEvent.swift
+++ b/KMReader/Features/SSE/SSEEvent.swift
@@ -1,6 +1,5 @@
 //
-//  SSEEvent.swift
-//  Komga
+// SSEEvent.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/Filters/SeriesSortField.swift
+++ b/KMReader/Features/Series/Models/Filters/SeriesSortField.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesSortField.swift
-//  Komga
+// SeriesSortField.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/Filters/SeriesSortOption.swift
+++ b/KMReader/Features/Series/Models/Filters/SeriesSortOption.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesSortOption.swift
-//  Komga
+// SeriesSortOption.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/KomgaSeries.swift
+++ b/KMReader/Features/Series/Models/KomgaSeries.swift
@@ -1,6 +1,5 @@
 //
-//  KomgaSeries.swift
-//  KMReader
+// KomgaSeries.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/Metadata/AlternateTitle.swift
+++ b/KMReader/Features/Series/Models/Metadata/AlternateTitle.swift
@@ -1,6 +1,5 @@
 //
-//  AlternateTitle.swift
-//  Komga
+// AlternateTitle.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/Metadata/SeriesBooksMetadata.swift
+++ b/KMReader/Features/Series/Models/Metadata/SeriesBooksMetadata.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesBooksMetadata.swift
-//  Komga
+// SeriesBooksMetadata.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/Metadata/SeriesMetadata.swift
+++ b/KMReader/Features/Series/Models/Metadata/SeriesMetadata.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesMetadata.swift
-//  Komga
+// SeriesMetadata.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/Metadata/SeriesMetadataUpdate.swift
+++ b/KMReader/Features/Series/Models/Metadata/SeriesMetadataUpdate.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesMetadataUpdate.swift
-//  KMReader
+// SeriesMetadataUpdate.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/Series+Extensions.swift
+++ b/KMReader/Features/Series/Models/Series+Extensions.swift
@@ -1,6 +1,5 @@
 //
-//  Series+Extensions.swift
-//  Komga
+// Series+Extensions.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/Series.swift
+++ b/KMReader/Features/Series/Models/Series.swift
@@ -1,6 +1,5 @@
 //
-//  Series.swift
-//  Komga
+// Series.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/SeriesDownloadAction.swift
+++ b/KMReader/Features/Series/Models/SeriesDownloadAction.swift
@@ -1,6 +1,6 @@
 //
-//  SeriesDownloadAction.swift
-//  KMReader
+// SeriesDownloadAction.swift
+//
 //
 
 import Foundation

--- a/KMReader/Features/Series/Models/SeriesDownloadStatus.swift
+++ b/KMReader/Features/Series/Models/SeriesDownloadStatus.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesDownloadStatus.swift
-//  KMReader
+// SeriesDownloadStatus.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/SeriesOfflinePolicy.swift
+++ b/KMReader/Features/Series/Models/SeriesOfflinePolicy.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesOfflinePolicy.swift
-//  KMReader
+// SeriesOfflinePolicy.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/SeriesSearch.swift
+++ b/KMReader/Features/Series/Models/SeriesSearch.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesSearch.swift
-//  Komga
+// SeriesSearch.swift
 //
 //
 

--- a/KMReader/Features/Series/Models/SeriesStatus.swift
+++ b/KMReader/Features/Series/Models/SeriesStatus.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesStatus.swift
-//  Komga
+// SeriesStatus.swift
 //
 //
 

--- a/KMReader/Features/Series/Services/KomgaSeriesStore.swift
+++ b/KMReader/Features/Series/Services/KomgaSeriesStore.swift
@@ -1,6 +1,5 @@
 //
-//  KomgaSeriesStore.swift
-//  KMReader
+// KomgaSeriesStore.swift
 //
 //
 

--- a/KMReader/Features/Series/Services/SeriesContinueReadingResolver.swift
+++ b/KMReader/Features/Series/Services/SeriesContinueReadingResolver.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesContinueReadingResolver.swift
-//  KMReader
+// SeriesContinueReadingResolver.swift
 //
 //
 

--- a/KMReader/Features/Series/Services/SeriesService.swift
+++ b/KMReader/Features/Series/Services/SeriesService.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesService.swift
-//  Komga
+// SeriesService.swift
 //
 //
 

--- a/KMReader/Features/Series/ViewModels/SeriesBrowseOptions.swift
+++ b/KMReader/Features/Series/ViewModels/SeriesBrowseOptions.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesBrowseOptions.swift
-//  Komga
+// SeriesBrowseOptions.swift
 //
 //
 

--- a/KMReader/Features/Series/ViewModels/SeriesViewModel.swift
+++ b/KMReader/Features/Series/ViewModels/SeriesViewModel.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesViewModel.swift
-//  Komga
+// SeriesViewModel.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesBrowseOptionsSheet.swift
+++ b/KMReader/Features/Series/Views/SeriesBrowseOptionsSheet.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesBrowseOptionsSheet.swift
-//  Komga
+// SeriesBrowseOptionsSheet.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesBrowseView.swift
+++ b/KMReader/Features/Series/Views/SeriesBrowseView.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesBrowseView.swift
-//  Komga
+// SeriesBrowseView.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesCardView.swift
+++ b/KMReader/Features/Series/Views/SeriesCardView.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesCardView.swift
-//  Komga
+// SeriesCardView.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesCollectionsSection.swift
+++ b/KMReader/Features/Series/Views/SeriesCollectionsSection.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesCollectionsSection.swift
-//  KMReader
+// SeriesCollectionsSection.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesContextMenu.swift
+++ b/KMReader/Features/Series/Views/SeriesContextMenu.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesContextMenu.swift
-//  Komga
+// SeriesContextMenu.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesDetailContentView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailContentView.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesDetailContentView.swift
-//  Komga
+// SeriesDetailContentView.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesDetailView.swift
-//  Komga
+// SeriesDetailView.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesDownloadActionsSection.swift
+++ b/KMReader/Features/Series/Views/SeriesDownloadActionsSection.swift
@@ -1,6 +1,6 @@
 //
-//  SeriesDownloadActionsSection.swift
-//  KMReader
+// SeriesDownloadActionsSection.swift
+//
 //
 
 import SwiftData

--- a/KMReader/Features/Series/Views/SeriesEditSheet.swift
+++ b/KMReader/Features/Series/Views/SeriesEditSheet.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesEditSheet.swift
-//  Komga
+// SeriesEditSheet.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesFilterView.swift
+++ b/KMReader/Features/Series/Views/SeriesFilterView.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesFilterView.swift
-//  Komga
+// SeriesFilterView.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesItemView.swift
+++ b/KMReader/Features/Series/Views/SeriesItemView.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesItemView.swift
-//  KMReader
+// SeriesItemView.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesQueryItemView.swift
+++ b/KMReader/Features/Series/Views/SeriesQueryItemView.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesQueryItemView.swift
-//  KMReader
+// SeriesQueryItemView.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesQueryView.swift
+++ b/KMReader/Features/Series/Views/SeriesQueryView.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesQueryView.swift
-//  KMReader
+// SeriesQueryView.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesRowView.swift
+++ b/KMReader/Features/Series/Views/SeriesRowView.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesRowView.swift
-//  Komga
+// SeriesRowView.swift
 //
 //
 

--- a/KMReader/Features/Series/Views/SeriesSelectionItemView.swift
+++ b/KMReader/Features/Series/Views/SeriesSelectionItemView.swift
@@ -1,6 +1,5 @@
 //
-//  SeriesSelectionItemView.swift
-//  KMReader
+// SeriesSelectionItemView.swift
 //
 //
 

--- a/KMReader/Features/Server/AccountActivityView.swift
+++ b/KMReader/Features/Server/AccountActivityView.swift
@@ -1,6 +1,5 @@
 //
-//  AccountActivityView.swift
-//  Komga
+// AccountActivityView.swift
 //
 //
 

--- a/KMReader/Features/Server/ApiKeyAddSheet.swift
+++ b/KMReader/Features/Server/ApiKeyAddSheet.swift
@@ -1,6 +1,5 @@
 //
-//  ApiKeyAddSheet.swift
-//  Komga
+// ApiKeyAddSheet.swift
 //
 //
 

--- a/KMReader/Features/Server/ApiKeysView.swift
+++ b/KMReader/Features/Server/ApiKeysView.swift
@@ -1,6 +1,5 @@
 //
-//  ApiKeysView.swift
-//  Komga
+// ApiKeysView.swift
 //
 //
 

--- a/KMReader/Features/Server/LibraryAddSheet.swift
+++ b/KMReader/Features/Server/LibraryAddSheet.swift
@@ -1,6 +1,5 @@
 //
-//  LibraryAddSheet.swift
-//  KMReader
+// LibraryAddSheet.swift
 //
 //
 

--- a/KMReader/Features/Server/LibraryEditSheet.swift
+++ b/KMReader/Features/Server/LibraryEditSheet.swift
@@ -1,6 +1,5 @@
 //
-//  LibraryEditSheet.swift
-//  KMReader
+// LibraryEditSheet.swift
 //
 //
 

--- a/KMReader/Features/Server/RoleBadge.swift
+++ b/KMReader/Features/Server/RoleBadge.swift
@@ -1,6 +1,5 @@
 //
-//  RoleBadge.swift
-//  KMReader
+// RoleBadge.swift
 //
 //
 

--- a/KMReader/Features/Server/ServerActionRow.swift
+++ b/KMReader/Features/Server/ServerActionRow.swift
@@ -1,6 +1,5 @@
 //
-//  ServerActionRow.swift
-//  KMReader
+// ServerActionRow.swift
 //
 //
 

--- a/KMReader/Features/Server/ServerActionTile.swift
+++ b/KMReader/Features/Server/ServerActionTile.swift
@@ -1,6 +1,5 @@
 //
-//  ServerActionTile.swift
-//  KMReader
+// ServerActionTile.swift
 //
 //
 

--- a/KMReader/Features/Server/ServerEditView.swift
+++ b/KMReader/Features/Server/ServerEditView.swift
@@ -1,6 +1,5 @@
 //
-//  ServerEditView.swift
-//  Komga
+// ServerEditView.swift
 //
 //
 

--- a/KMReader/Features/Server/ServerHistoryView.swift
+++ b/KMReader/Features/Server/ServerHistoryView.swift
@@ -1,6 +1,5 @@
 //
-//  ServerHistoryView.swift
-//  KMReader
+// ServerHistoryView.swift
 //
 //
 

--- a/KMReader/Features/Server/ServerInfoView.swift
+++ b/KMReader/Features/Server/ServerInfoView.swift
@@ -1,6 +1,5 @@
 //
-//  ServerInfoView.swift
-//  Komga
+// ServerInfoView.swift
 //
 //
 

--- a/KMReader/Features/Server/ServerLibrariesView.swift
+++ b/KMReader/Features/Server/ServerLibrariesView.swift
@@ -1,6 +1,5 @@
 //
-//  ServerLibrariesView.swift
-//  Komga
+// ServerLibrariesView.swift
 //
 //
 

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -1,6 +1,5 @@
 //
-//  ServerListView.swift
-//  Komga
+// ServerListView.swift
 //
 //
 

--- a/KMReader/Features/Server/ServerRowView.swift
+++ b/KMReader/Features/Server/ServerRowView.swift
@@ -1,6 +1,6 @@
 //
-//  ServerRowView.swift
-//  KMReader
+// ServerRowView.swift
+//
 //
 
 import SwiftData

--- a/KMReader/Features/Server/ServerSection.swift
+++ b/KMReader/Features/Server/ServerSection.swift
@@ -1,6 +1,5 @@
 //
-//  ServerSection.swift
-//  Komga
+// ServerSection.swift
 //
 //
 

--- a/KMReader/Features/Server/ServerTasksView.swift
+++ b/KMReader/Features/Server/ServerTasksView.swift
@@ -1,6 +1,5 @@
 //
-//  ServerTasksView.swift
-//  Komga
+// ServerTasksView.swift
 //
 //
 

--- a/KMReader/Features/Server/ServerView.swift
+++ b/KMReader/Features/Server/ServerView.swift
@@ -1,6 +1,5 @@
 //
-//  ServerView.swift
-//  KMReader
+// ServerView.swift
 //
 //
 

--- a/KMReader/Features/Server/UpdatePasswordSheet.swift
+++ b/KMReader/Features/Server/UpdatePasswordSheet.swift
@@ -1,6 +1,5 @@
 //
-//  UpdatePasswordSheet.swift
-//  KMReader
+// UpdatePasswordSheet.swift
 //
 //
 

--- a/KMReader/Features/Settings/Components/SettingsBrowseCardPreview.swift
+++ b/KMReader/Features/Settings/Components/SettingsBrowseCardPreview.swift
@@ -1,6 +1,5 @@
 //
-//  SettingsBrowseCardPreview.swift
-//  KMReader
+// SettingsBrowseCardPreview.swift
 //
 //
 

--- a/KMReader/Features/Settings/Components/SettingsSection.swift
+++ b/KMReader/Features/Settings/Components/SettingsSection.swift
@@ -1,6 +1,5 @@
 //
-//  SettingsSection.swift
-//  Komga
+// SettingsSection.swift
 //
 //
 

--- a/KMReader/Features/Settings/Components/SettingsSectionRow.swift
+++ b/KMReader/Features/Settings/Components/SettingsSectionRow.swift
@@ -1,6 +1,5 @@
 //
-//  SettingsSectionRow.swift
-//  Komga
+// SettingsSectionRow.swift
 //
 //
 

--- a/KMReader/Features/Settings/Components/TapZonePreview.swift
+++ b/KMReader/Features/Settings/Components/TapZonePreview.swift
@@ -1,6 +1,5 @@
 //
-//  TapZonePreview.swift
-//  Komga
+// TapZonePreview.swift
 //
 //
 

--- a/KMReader/Features/Settings/DirectoryBrowserSheet.swift
+++ b/KMReader/Features/Settings/DirectoryBrowserSheet.swift
@@ -1,6 +1,5 @@
 //
-//  DirectoryBrowserSheet.swift
-//  KMReader
+// DirectoryBrowserSheet.swift
 //
 //
 

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -1,6 +1,5 @@
 //
-//  DivinaPreferencesView.swift
-//  Komga
+// DivinaPreferencesView.swift
 //
 //
 

--- a/KMReader/Features/Settings/EpubPreferencesView.swift
+++ b/KMReader/Features/Settings/EpubPreferencesView.swift
@@ -1,6 +1,5 @@
 //
-//  EpubPreferencesView.swift
-//  KMReader
+// EpubPreferencesView.swift
 //
 //
 

--- a/KMReader/Features/Settings/SettingsAppearanceView.swift
+++ b/KMReader/Features/Settings/SettingsAppearanceView.swift
@@ -1,6 +1,5 @@
 //
-//  SettingsAppearanceView.swift
-//  Komga
+// SettingsAppearanceView.swift
 //
 //
 

--- a/KMReader/Features/Settings/SettingsBrowseView.swift
+++ b/KMReader/Features/Settings/SettingsBrowseView.swift
@@ -1,6 +1,5 @@
 //
-//  SettingsBrowseView.swift
-//  Komga
+// SettingsBrowseView.swift
 //
 //
 

--- a/KMReader/Features/Settings/SettingsCacheView.swift
+++ b/KMReader/Features/Settings/SettingsCacheView.swift
@@ -1,6 +1,5 @@
 //
-//  SettingsCacheView.swift
-//  Komga
+// SettingsCacheView.swift
 //
 //
 

--- a/KMReader/Features/Settings/SettingsDashboardView.swift
+++ b/KMReader/Features/Settings/SettingsDashboardView.swift
@@ -1,6 +1,5 @@
 //
-//  SettingsDashboardView.swift
-//  Komga
+// SettingsDashboardView.swift
 //
 //
 

--- a/KMReader/Features/Settings/SettingsLogsView.swift
+++ b/KMReader/Features/Settings/SettingsLogsView.swift
@@ -1,6 +1,5 @@
 //
-//  SettingsLogsView.swift
-//  Komga
+// SettingsLogsView.swift
 //
 //
 

--- a/KMReader/Features/Settings/SettingsNetworkView.swift
+++ b/KMReader/Features/Settings/SettingsNetworkView.swift
@@ -1,6 +1,5 @@
 //
-//  SettingsNetworkView.swift
-//  Komga
+// SettingsNetworkView.swift
 //
 //
 

--- a/KMReader/Features/Settings/SettingsSSEView.swift
+++ b/KMReader/Features/Settings/SettingsSSEView.swift
@@ -1,6 +1,5 @@
 //
-//  SettingsSSEView.swift
-//  Komga
+// SettingsSSEView.swift
 //
 //
 

--- a/KMReader/Features/Settings/SettingsSpotlightView.swift
+++ b/KMReader/Features/Settings/SettingsSpotlightView.swift
@@ -1,6 +1,6 @@
 //
-//  SettingsSpotlightView.swift
-//  KMReader
+// SettingsSpotlightView.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Features/Settings/SettingsView.swift
+++ b/KMReader/Features/Settings/SettingsView.swift
@@ -1,6 +1,5 @@
 //
-//  SettingsView.swift
-//  Komga
+// SettingsView.swift
 //
 //
 

--- a/KMReader/Features/Settings/SettingsView_macOS.swift
+++ b/KMReader/Features/Settings/SettingsView_macOS.swift
@@ -1,6 +1,5 @@
 //
-//  SettingsView_macOS.swift
-//  Komga
+// SettingsView_macOS.swift
 //
 //
 

--- a/KMReader/Features/Settings/SubscriptionView.swift
+++ b/KMReader/Features/Settings/SubscriptionView.swift
@@ -1,8 +1,6 @@
 //
-//  SubscriptionView.swift
-//  KMReader
+// SubscriptionView.swift
 //
-//  Buy me a coffee ☕
 //
 
 import StoreKit

--- a/KMReader/Features/Store/StoreManager.swift
+++ b/KMReader/Features/Store/StoreManager.swift
@@ -1,8 +1,6 @@
 //
-//  StoreManager.swift
-//  KMReader
+// StoreManager.swift
 //
-//  Created for subscription management
 //
 
 import StoreKit

--- a/KMReader/Features/Sync/Models/PendingProgress.swift
+++ b/KMReader/Features/Sync/Models/PendingProgress.swift
@@ -1,6 +1,5 @@
 //
-//  PendingProgress.swift
-//  KMReader
+// PendingProgress.swift
 //
 //
 

--- a/KMReader/Features/Sync/Services/InstanceInitializer.swift
+++ b/KMReader/Features/Sync/Services/InstanceInitializer.swift
@@ -1,6 +1,5 @@
 //
-//  InstanceInitializer.swift
-//  KMReader
+// InstanceInitializer.swift
 //
 //
 

--- a/KMReader/Features/Sync/Services/ProgressSyncService.swift
+++ b/KMReader/Features/Sync/Services/ProgressSyncService.swift
@@ -1,6 +1,5 @@
 //
-//  ProgressSyncService.swift
-//  KMReader
+// ProgressSyncService.swift
 //
 //
 

--- a/KMReader/Features/Sync/Services/SyncService.swift
+++ b/KMReader/Features/Sync/Services/SyncService.swift
@@ -1,6 +1,5 @@
 //
-//  SyncService.swift
-//  KMReader
+// SyncService.swift
 //
 //
 

--- a/KMReader/Features/WebPub/R2Types.swift
+++ b/KMReader/Features/WebPub/R2Types.swift
@@ -1,6 +1,5 @@
 //
-//  R2Types.swift
-//  KMReader
+// R2Types.swift
 //
 //
 

--- a/KMReader/Features/WebPub/WebPubManifest.swift
+++ b/KMReader/Features/WebPub/WebPubManifest.swift
@@ -1,6 +1,5 @@
 //
-//  WebPubManifest.swift
-//  KMReader
+// WebPubManifest.swift
 //
 //
 

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -1,6 +1,5 @@
 //
-//  KomgaApp.swift
-//  Komga
+// MainApp.swift
 //
 //
 

--- a/KMReader/MainSplitView.swift
+++ b/KMReader/MainSplitView.swift
@@ -1,6 +1,5 @@
 //
-//  MainSplitView.swift
-//  KMReader
+// MainSplitView.swift
 //
 //
 

--- a/KMReader/OldTabView.swift
+++ b/KMReader/OldTabView.swift
@@ -1,6 +1,6 @@
 //
-//  OldTabView.swift
-//  KMReader
+// OldTabView.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/PhoneTabView.swift
+++ b/KMReader/PhoneTabView.swift
@@ -1,6 +1,6 @@
 //
-//  PhoneTabView.swift
-//  KMReader
+// PhoneTabView.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Shared/Environment/SidebarSelectionKey.swift
+++ b/KMReader/Shared/Environment/SidebarSelectionKey.swift
@@ -1,6 +1,6 @@
 //
-//  BrowseSelectionKey.swift
-//  KMReader
+// SidebarSelectionKey.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Shared/Extensions/Bundle+AppVersion.swift
+++ b/KMReader/Shared/Extensions/Bundle+AppVersion.swift
@@ -1,6 +1,5 @@
 //
-//  Bundle+AppVersion.swift
-//  Komga
+// Bundle+AppVersion.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/Color+Hex.swift
+++ b/KMReader/Shared/Extensions/Color+Hex.swift
@@ -1,6 +1,5 @@
 //
-//  Color+Hex.swift
-//  KMReader
+// Color+Hex.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/Date+Formatting.swift
+++ b/KMReader/Shared/Extensions/Date+Formatting.swift
@@ -1,6 +1,5 @@
 //
-//  Date+Formatting.swift
-//  Komga
+// Date+Formatting.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/Double+FileSize.swift
+++ b/KMReader/Shared/Extensions/Double+FileSize.swift
@@ -1,6 +1,5 @@
 //
-//  Double+FileSize.swift
-//  Komga
+// Double+FileSize.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/Font+App.swift
+++ b/KMReader/Shared/Extensions/Font+App.swift
@@ -1,6 +1,5 @@
 //
-//  Font+App.swift
-//  KMReader
+// Font+App.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+ButtonStyle.swift
+++ b/KMReader/Shared/Extensions/View+ButtonStyle.swift
@@ -1,6 +1,5 @@
 //
-//  AdaptiveButtonStyle.swift
-//  Komga
+// View+ButtonStyle.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+ControlSize.swift
+++ b/KMReader/Shared/Extensions/View+ControlSize.swift
@@ -1,6 +1,5 @@
 //
-//  View+ControlSize.swift
-//  Komga
+// View+ControlSize.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+FocusableHighlight.swift
+++ b/KMReader/Shared/Extensions/View+FocusableHighlight.swift
@@ -1,6 +1,5 @@
 //
-//  View+FocusableHighlight.swift
-//  Komga
+// View+FocusableHighlight.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+Handoff.swift
+++ b/KMReader/Shared/Extensions/View+Handoff.swift
@@ -1,6 +1,5 @@
 //
-//  View+Handoff.swift
-//  KMReader
+// View+Handoff.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+ListStyle.swift
+++ b/KMReader/Shared/Extensions/View+ListStyle.swift
@@ -1,6 +1,5 @@
 //
-//  View+ListStyle.swift
-//  Komga
+// View+ListStyle.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+MenuStyle.swift
+++ b/KMReader/Shared/Extensions/View+MenuStyle.swift
@@ -1,6 +1,5 @@
 //
-//  View+MenuStyle.swift
-//  KMReader
+// View+MenuStyle.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+Navigation.swift
+++ b/KMReader/Shared/Extensions/View+Navigation.swift
@@ -1,6 +1,5 @@
 //
-//  View+Navigation.swift
-//  Komga
+// View+Navigation.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+PickerStyle.swift
+++ b/KMReader/Shared/Extensions/View+PickerStyle.swift
@@ -1,6 +1,5 @@
 //
-//  View+PickerStyle.swift
-//  Komga
+// View+PickerStyle.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+ReaderSafeArea.swift
+++ b/KMReader/Shared/Extensions/View+ReaderSafeArea.swift
@@ -1,6 +1,5 @@
 //
-//  View+ReaderSafeArea.swift
-//  KMReader
+// View+ReaderSafeArea.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+SheetPresentation.swift
+++ b/KMReader/Shared/Extensions/View+SheetPresentation.swift
@@ -1,6 +1,5 @@
 //
-//  View+SheetPresentation.swift
-//  Komga
+// View+SheetPresentation.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+TabBar.swift
+++ b/KMReader/Shared/Extensions/View+TabBar.swift
@@ -1,6 +1,5 @@
 //
-//  Bundle+AppVersion.swift
-//  Komga
+// View+TabBar.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+TextSelection.swift
+++ b/KMReader/Shared/Extensions/View+TextSelection.swift
@@ -1,6 +1,5 @@
 //
-//  AdaptiveButtonStyle.swift
-//  Komga
+// View+TextSelection.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+ToolbarButtonStyle.swift
+++ b/KMReader/Shared/Extensions/View+ToolbarButtonStyle.swift
@@ -1,6 +1,5 @@
 //
-//  View+ToolbarButtonStyle.swift
-//  Komga
+// View+ToolbarButtonStyle.swift
 //
 //
 

--- a/KMReader/Shared/Extensions/View+ZoomTransition.swift
+++ b/KMReader/Shared/Extensions/View+ZoomTransition.swift
@@ -1,6 +1,6 @@
 //
-//  View+ZoomTransition.swift
-//  KMReader
+// View+ZoomTransition.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Shared/Foundation/Models/AppColorScheme.swift
+++ b/KMReader/Shared/Foundation/Models/AppColorScheme.swift
@@ -1,6 +1,5 @@
 //
-//  AppColorScheme.swift
-//  KMReader
+// AppColorScheme.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/BrowseContentType.swift
+++ b/KMReader/Shared/Foundation/Models/BrowseContentType.swift
@@ -1,6 +1,5 @@
 //
-//  BrowseContentType.swift
-//  Komga
+// BrowseContentType.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/BrowseLayoutMode.swift
+++ b/KMReader/Shared/Foundation/Models/BrowseLayoutMode.swift
@@ -1,6 +1,5 @@
 //
-//  BrowseLayoutMode.swift
-//  Komga
+// BrowseLayoutMode.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/Common.swift
+++ b/KMReader/Shared/Foundation/Models/Common.swift
@@ -1,6 +1,5 @@
 //
-//  Common.swift
-//  Komga
+// Common.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/FilterStrings.swift
+++ b/KMReader/Shared/Foundation/Models/FilterStrings.swift
@@ -1,6 +1,5 @@
 //
-//  FilterStrings.swift
-//  Komga
+// FilterStrings.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/JSONAny.swift
+++ b/KMReader/Shared/Foundation/Models/JSONAny.swift
@@ -1,6 +1,5 @@
 //
-//  JSONAny.swift
-//  Komga
+// JSONAny.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/LibrarySelection.swift
+++ b/KMReader/Shared/Foundation/Models/LibrarySelection.swift
@@ -1,6 +1,5 @@
 //
-//  LibrarySelection.swift
-//  KMReader
+// LibrarySelection.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/MetadataFilter.swift
+++ b/KMReader/Shared/Foundation/Models/MetadataFilter.swift
@@ -1,6 +1,5 @@
 //
-//  MetadataFilter.swift
-//  Komga
+// MetadataFilter.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/MetadataFilterConfig.swift
+++ b/KMReader/Shared/Foundation/Models/MetadataFilterConfig.swift
@@ -1,6 +1,5 @@
 //
-//  MetadataFilterConfig.swift
-//  KMReader
+// MetadataFilterConfig.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/Metrics.swift
+++ b/KMReader/Shared/Foundation/Models/Metrics.swift
@@ -1,6 +1,5 @@
 //
-//  Metrics.swift
-//  Komga
+// Metrics.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/NavDestination.swift
+++ b/KMReader/Shared/Foundation/Models/NavDestination.swift
@@ -1,6 +1,5 @@
 //
-//  NavDestination.swift
-//  Komga
+// NavDestination.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/ReadStatusSelectionHelper.swift
+++ b/KMReader/Shared/Foundation/Models/ReadStatusSelectionHelper.swift
@@ -1,6 +1,5 @@
 //
-//  ReadStatusSelectionHelper.swift
-//  Komga
+// ReadStatusSelectionHelper.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/ServerInfo.swift
+++ b/KMReader/Shared/Foundation/Models/ServerInfo.swift
@@ -1,6 +1,5 @@
 //
-//  ServerInfo.swift
-//  Komga
+// ServerInfo.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/SimpleSortField.swift
+++ b/KMReader/Shared/Foundation/Models/SimpleSortField.swift
@@ -1,6 +1,5 @@
 //
-//  SimpleSortField.swift
-//  Komga
+// SimpleSortField.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/TabItem.swift
+++ b/KMReader/Shared/Foundation/Models/TabItem.swift
@@ -1,6 +1,5 @@
 //
-//  TabItem.swift
-//  Komga
+// TabItem.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/ThemeColor.swift
+++ b/KMReader/Shared/Foundation/Models/ThemeColor.swift
@@ -1,6 +1,5 @@
 //
-//  ThemeColor.swift
-//  Komga
+// ThemeColor.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/TriStateFilter.swift
+++ b/KMReader/Shared/Foundation/Models/TriStateFilter.swift
@@ -1,6 +1,5 @@
 //
-//  TriStateFilter.swift
-//  Komga
+// TriStateFilter.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/Models/WebLink.swift
+++ b/KMReader/Shared/Foundation/Models/WebLink.swift
@@ -1,6 +1,5 @@
 //
-//  WebLink.swift
-//  Komga
+// WebLink.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/ViewModels/GridDensity.swift
+++ b/KMReader/Shared/Foundation/ViewModels/GridDensity.swift
@@ -1,6 +1,5 @@
 //
-//  GridDensity.swift
-//  KMReader
+// GridDensity.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/ViewModels/PaginatedIdViewModel.swift
+++ b/KMReader/Shared/Foundation/ViewModels/PaginatedIdViewModel.swift
@@ -1,6 +1,5 @@
 //
-//  PaginatedIdViewModel.swift
-//  Komga
+// PaginatedIdViewModel.swift
 //
 //
 

--- a/KMReader/Shared/Foundation/ViewModels/SimpleSortOptions.swift
+++ b/KMReader/Shared/Foundation/ViewModels/SimpleSortOptions.swift
@@ -1,6 +1,5 @@
 //
-//  SimpleSortOptions.swift
-//  Komga
+// SimpleSortOptions.swift
 //
 //
 

--- a/KMReader/Shared/Helpers/ContentIcons.swift
+++ b/KMReader/Shared/Helpers/ContentIcons.swift
@@ -1,6 +1,6 @@
 //
-//  ContentIcons.swift
-//  KMReader
+// ContentIcons.swift
+//
 //
 
 import Foundation

--- a/KMReader/Shared/Helpers/CoverAspectRatio.swift
+++ b/KMReader/Shared/Helpers/CoverAspectRatio.swift
@@ -1,6 +1,5 @@
 //
-//  CoverAspectRatio.swift
-//  KMReader
+// CoverAspectRatio.swift
 //
 //
 

--- a/KMReader/Shared/Helpers/FileNameHelper.swift
+++ b/KMReader/Shared/Helpers/FileNameHelper.swift
@@ -1,6 +1,5 @@
 //
-//  FileNameHelper.swift
-//  KMReader
+// FileNameHelper.swift
 //
 //
 

--- a/KMReader/Shared/Helpers/IdentifiedString.swift
+++ b/KMReader/Shared/Helpers/IdentifiedString.swift
@@ -1,6 +1,5 @@
 //
-//  IdentifiedString.swift
-//  KMReader
+// IdentifiedString.swift
 //
 //
 

--- a/KMReader/Shared/Helpers/ImageDecodeHelper.swift
+++ b/KMReader/Shared/Helpers/ImageDecodeHelper.swift
@@ -1,6 +1,5 @@
 //
-//  ImageDecodeHelper.swift
-//  Komga
+// ImageDecodeHelper.swift
 //
 //
 

--- a/KMReader/Shared/Helpers/KomgaWebLinkBuilder.swift
+++ b/KMReader/Shared/Helpers/KomgaWebLinkBuilder.swift
@@ -1,6 +1,5 @@
 //
-//  KomgaWebLinkBuilder.swift
-//  KMReader
+// KomgaWebLinkBuilder.swift
 //
 //
 

--- a/KMReader/Shared/Helpers/LanguageCodeHelper.swift
+++ b/KMReader/Shared/Helpers/LanguageCodeHelper.swift
@@ -1,6 +1,5 @@
 //
-//  LanguageCodeHelper.swift
-//  Komga
+// LanguageCodeHelper.swift
 //
 //
 

--- a/KMReader/Shared/Helpers/LayoutConfig.swift
+++ b/KMReader/Shared/Helpers/LayoutConfig.swift
@@ -1,6 +1,5 @@
 //
-//  LayoutConfig.swift
-//  KMReader
+// LayoutConfig.swift
 //
 //
 

--- a/KMReader/Shared/Helpers/PaginationState.swift
+++ b/KMReader/Shared/Helpers/PaginationState.swift
@@ -1,6 +1,5 @@
 //
-//  PaginationState.swift
-//  KMReader
+// PaginationState.swift
 //
 //
 

--- a/KMReader/Shared/Helpers/PlatformHelpers.swift
+++ b/KMReader/Shared/Helpers/PlatformHelpers.swift
@@ -1,6 +1,5 @@
 //
-//  PlatformHelpers.swift
-//  Komga
+// PlatformHelpers.swift
 //
 //
 

--- a/KMReader/Shared/UI/AdminRequiredView.swift
+++ b/KMReader/Shared/UI/AdminRequiredView.swift
@@ -1,6 +1,5 @@
 //
-//  AdminRequiredView.swift
-//  Komga
+// AdminRequiredView.swift
 //
 //
 

--- a/KMReader/Shared/UI/AgeRatingBadge.swift
+++ b/KMReader/Shared/UI/AgeRatingBadge.swift
@@ -1,8 +1,6 @@
 //
-//  AgeRatingBadge.swift
-//  KMReader
+// AgeRatingBadge.swift
 //
-//  Created by Anitgravity
 //
 
 import SwiftUI

--- a/KMReader/Shared/UI/BrowseStateView.swift
+++ b/KMReader/Shared/UI/BrowseStateView.swift
@@ -1,6 +1,5 @@
 //
-//  BrowseStateView.swift
-//  Komga
+// BrowseStateView.swift
 //
 //
 

--- a/KMReader/Shared/UI/CardOverlay.swift
+++ b/KMReader/Shared/UI/CardOverlay.swift
@@ -1,6 +1,5 @@
 //
-//  UnreadCountBadge.swift
-//  Komga
+// CardOverlay.swift
 //
 //
 

--- a/KMReader/Shared/UI/CardOverlayTextStack.swift
+++ b/KMReader/Shared/UI/CardOverlayTextStack.swift
@@ -1,6 +1,5 @@
 //
-//  CardOverlayTextStack.swift
-//  KMReader
+// CardOverlayTextStack.swift
 //
 //
 

--- a/KMReader/Shared/UI/CardOverlayTextStyle.swift
+++ b/KMReader/Shared/UI/CardOverlayTextStyle.swift
@@ -1,6 +1,5 @@
 //
-//  CardOverlayTextStyle.swift
-//  KMReader
+// CardOverlayTextStyle.swift
 //
 //
 

--- a/KMReader/Shared/UI/CardPlaceholder.swift
+++ b/KMReader/Shared/UI/CardPlaceholder.swift
@@ -1,6 +1,5 @@
 //
-//  CardPlaceholder.swift
-//  KMReader
+// CardPlaceholder.swift
 //
 //
 

--- a/KMReader/Shared/UI/CardPlaceholderKind.swift
+++ b/KMReader/Shared/UI/CardPlaceholderKind.swift
@@ -1,6 +1,5 @@
 //
-//  CardPlaceholderKind.swift
-//  KMReader
+// CardPlaceholderKind.swift
 //
 //
 

--- a/KMReader/Shared/UI/CardTextOverlay.swift
+++ b/KMReader/Shared/UI/CardTextOverlay.swift
@@ -1,6 +1,5 @@
 //
-//  CardTextOverlay.swift
-//  KMReader
+// CardTextOverlay.swift
 //
 //
 

--- a/KMReader/Shared/UI/CollapsibleChipSection.swift
+++ b/KMReader/Shared/UI/CollapsibleChipSection.swift
@@ -1,6 +1,5 @@
 //
-//  CollapsibleChipSection.swift
-//  Komga
+// CollapsibleChipSection.swift
 //
 //
 

--- a/KMReader/Shared/UI/EllipsisMenuButton.swift
+++ b/KMReader/Shared/UI/EllipsisMenuButton.swift
@@ -1,6 +1,5 @@
 //
-//  EllipsisMenuButton.swift
-//  Komga
+// EllipsisMenuButton.swift
 //
 //
 

--- a/KMReader/Shared/UI/ExpandableSummaryView.swift
+++ b/KMReader/Shared/UI/ExpandableSummaryView.swift
@@ -1,6 +1,5 @@
 //
-//  ExpandableSummaryView.swift
-//  Komga
+// ExpandableSummaryView.swift
 //
 //
 

--- a/KMReader/Shared/UI/ExternalLinkChip.swift
+++ b/KMReader/Shared/UI/ExternalLinkChip.swift
@@ -1,6 +1,6 @@
 //
-//  ExternalLinkChip.swift
-//  KMReader
+// ExternalLinkChip.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Shared/UI/FilterChip.swift
+++ b/KMReader/Shared/UI/FilterChip.swift
@@ -1,6 +1,5 @@
 //
-//  FilterChip.swift
-//  Komga
+// FilterChip.swift
 //
 //
 

--- a/KMReader/Shared/UI/HorizontalScrollButtons.swift
+++ b/KMReader/Shared/UI/HorizontalScrollButtons.swift
@@ -1,6 +1,5 @@
 //
-//  HorizontalScrollButtons.swift
-//  KMReader
+// HorizontalScrollButtons.swift
 //
 //
 

--- a/KMReader/Shared/UI/ImageSaveHelper.swift
+++ b/KMReader/Shared/UI/ImageSaveHelper.swift
@@ -1,8 +1,6 @@
 //
-//  ImageSaveHelper.swift
-//  KMReader
+// ImageSaveHelper.swift
 //
-//  Helper for saving images to Photos library
 //
 
 import Photos

--- a/KMReader/Shared/UI/ImageShareHelper.swift
+++ b/KMReader/Shared/UI/ImageShareHelper.swift
@@ -1,8 +1,6 @@
 //
-//  ImageShareHelper.swift
-//  KMReader
+// ImageShareHelper.swift
 //
-//  Helper for sharing images with proper preview support
 //
 
 import SwiftUI

--- a/KMReader/Shared/UI/InfoChip.swift
+++ b/KMReader/Shared/UI/InfoChip.swift
@@ -1,6 +1,5 @@
 //
-//  InfoChip.swift
-//  Komga
+// InfoChip.swift
 //
 //
 

--- a/KMReader/Shared/UI/InfoRow.swift
+++ b/KMReader/Shared/UI/InfoRow.swift
@@ -1,6 +1,5 @@
 //
-//  InfoRow.swift
-//  Komga
+// InfoRow.swift
 //
 //
 

--- a/KMReader/Shared/UI/LanguagePicker.swift
+++ b/KMReader/Shared/UI/LanguagePicker.swift
@@ -1,6 +1,5 @@
 //
-//  LanguagePicker.swift
-//  Komga
+// LanguagePicker.swift
 //
 //
 

--- a/KMReader/Shared/UI/LayoutModePicker.swift
+++ b/KMReader/Shared/UI/LayoutModePicker.swift
@@ -1,6 +1,5 @@
 //
-//  LayoutModePicker.swift
-//  Komga
+// LayoutModePicker.swift
 //
 //
 

--- a/KMReader/Shared/UI/LibraryAction.swift
+++ b/KMReader/Shared/UI/LibraryAction.swift
@@ -1,6 +1,6 @@
 //
-//  LibraryAction.swift
-//  KMReader
+// LibraryAction.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Shared/UI/LibraryListContent.swift
+++ b/KMReader/Shared/UI/LibraryListContent.swift
@@ -1,6 +1,5 @@
 //
-//  LibraryListContent.swift
-//  KMReader
+// LibraryListContent.swift
 //
 //
 

--- a/KMReader/Shared/UI/LibraryRowView.swift
+++ b/KMReader/Shared/UI/LibraryRowView.swift
@@ -1,6 +1,6 @@
 //
-//  LibraryRowView.swift
-//  KMReader
+// LibraryRowView.swift
+//
 //
 
 import SwiftData

--- a/KMReader/Shared/UI/LoadingIcon.swift
+++ b/KMReader/Shared/UI/LoadingIcon.swift
@@ -1,6 +1,6 @@
 //
-//  LoadingIcon.swift
-//  KMReader
+// LoadingIcon.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Shared/UI/LockToggleModifier.swift
+++ b/KMReader/Shared/UI/LockToggleModifier.swift
@@ -1,6 +1,5 @@
 //
-//  LockToggleModifier.swift
-//  Komga
+// LockToggleModifier.swift
 //
 //
 

--- a/KMReader/Shared/UI/MetadataFilterSection.swift
+++ b/KMReader/Shared/UI/MetadataFilterSection.swift
@@ -1,6 +1,5 @@
 //
-//  MetadataFilterSection.swift
-//  KMReader
+// MetadataFilterSection.swift
 //
 //
 

--- a/KMReader/Shared/UI/NotificationOverlay.swift
+++ b/KMReader/Shared/UI/NotificationOverlay.swift
@@ -1,6 +1,6 @@
 //
-//  NotificationOverlay.swift
-//  KMReader
+// NotificationOverlay.swift
+//
 //
 
 import SwiftData

--- a/KMReader/Shared/UI/ReaderDismissGestureConfigurator.swift
+++ b/KMReader/Shared/UI/ReaderDismissGestureConfigurator.swift
@@ -1,6 +1,6 @@
 //
-//  ReaderDismissGestureConfigurator.swift
-//  KMReader
+// ReaderDismissGestureConfigurator.swift
+//
 //
 
 #if os(iOS)

--- a/KMReader/Shared/UI/ReaderOverlay.swift
+++ b/KMReader/Shared/UI/ReaderOverlay.swift
@@ -1,6 +1,6 @@
 //
-//  ReaderOverlay.swift
-//  KMReader
+// ReaderOverlay.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Shared/UI/ReadingProgressBar.swift
+++ b/KMReader/Shared/UI/ReadingProgressBar.swift
@@ -1,6 +1,5 @@
 //
-//  ReadingProgressBar.swift
-//  Komga
+// ReadingProgressBar.swift
 //
 //
 

--- a/KMReader/Shared/UI/SelectionToolbar.swift
+++ b/KMReader/Shared/UI/SelectionToolbar.swift
@@ -1,6 +1,5 @@
 //
-//  SelectionToolbar.swift
-//  Komga
+// SelectionToolbar.swift
 //
 //
 

--- a/KMReader/Shared/UI/ShadowModifier.swift
+++ b/KMReader/Shared/UI/ShadowModifier.swift
@@ -1,6 +1,5 @@
 //
-//  ShadowModifier.swift
-//  Komga
+// ShadowModifier.swift
 //
 //
 

--- a/KMReader/Shared/UI/ShadowPathView.swift
+++ b/KMReader/Shared/UI/ShadowPathView.swift
@@ -1,6 +1,6 @@
 //
-//  ShadowPathView.swift
-//  KMReader
+// ShadowPathView.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Shared/UI/ShadowStyle.swift
+++ b/KMReader/Shared/UI/ShadowStyle.swift
@@ -1,6 +1,6 @@
 //
-//  ShadowStyle.swift
-//  KMReader
+// ShadowStyle.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Shared/UI/SheetView.swift
+++ b/KMReader/Shared/UI/SheetView.swift
@@ -1,6 +1,5 @@
 //
-//  SheetView.swift
-//  KMReader
+// SheetView.swift
 //
 //
 

--- a/KMReader/Shared/UI/SidebarItemLabel.swift
+++ b/KMReader/Shared/UI/SidebarItemLabel.swift
@@ -1,6 +1,6 @@
 //
-//  SidebarItemLabel.swift
-//  KMReader
+// SidebarItemLabel.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Shared/UI/SimpleSortOptionsSheet.swift
+++ b/KMReader/Shared/UI/SimpleSortOptionsSheet.swift
@@ -1,6 +1,5 @@
 //
-//  SimpleSortOptionsSheet.swift
-//  Komga
+// SimpleSortOptionsSheet.swift
 //
 //
 

--- a/KMReader/Shared/UI/SortFieldProtocol.swift
+++ b/KMReader/Shared/UI/SortFieldProtocol.swift
@@ -1,6 +1,5 @@
 //
-//  SortFieldProtocol.swift
-//  Komga
+// SortFieldProtocol.swift
 //
 //
 

--- a/KMReader/Shared/UI/SortOptionView.swift
+++ b/KMReader/Shared/UI/SortOptionView.swift
@@ -1,6 +1,5 @@
 //
-//  SortOptionView.swift
-//  Komga
+// SortOptionView.swift
 //
 //
 

--- a/KMReader/Shared/UI/SplashView.swift
+++ b/KMReader/Shared/UI/SplashView.swift
@@ -1,6 +1,5 @@
 //
-//  SplashView.swift
-//  Komga
+// SplashView.swift
 //
 //
 

--- a/KMReader/Shared/UI/SquishButtonStyle.swift
+++ b/KMReader/Shared/UI/SquishButtonStyle.swift
@@ -1,8 +1,6 @@
 //
-//  SquishButtonStyle.swift
-//  KMReader
+// SquishButtonStyle.swift
 //
-//  Created by KMReader iOS Client
 //
 
 import SwiftUI

--- a/KMReader/Shared/UI/TappableInfoChip.swift
+++ b/KMReader/Shared/UI/TappableInfoChip.swift
@@ -1,6 +1,6 @@
 //
-//  TappableInfoChip.swift
-//  KMReader
+// TappableInfoChip.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/Shared/UI/ThumbnailImage.swift
+++ b/KMReader/Shared/UI/ThumbnailImage.swift
@@ -1,6 +1,5 @@
 //
-//  ThumbnailImage.swift
-//  Komga
+// ThumbnailImage.swift
 //
 //
 

--- a/KMReader/Shared/UI/ThumbnailOverlayGradient.swift
+++ b/KMReader/Shared/UI/ThumbnailOverlayGradient.swift
@@ -1,6 +1,5 @@
 //
-//  ThumbnailOverlayGradient.swift
-//  Komga
+// ThumbnailOverlayGradient.swift
 //
 //
 

--- a/KMReader/Shared/UI/ZoomNamespaceKey.swift
+++ b/KMReader/Shared/UI/ZoomNamespaceKey.swift
@@ -1,6 +1,6 @@
 //
-//  ZoomNamespaceKey.swift
-//  KMReader
+// ZoomNamespaceKey.swift
+//
 //
 
 import SwiftUI

--- a/KMReader/SidebarView.swift
+++ b/KMReader/SidebarView.swift
@@ -1,6 +1,6 @@
 //
-//  SidebarView.swift
-//  KMReader
+// SidebarView.swift
+//
 //
 
 import SwiftData

--- a/KMReader/TVTabView.swift
+++ b/KMReader/TVTabView.swift
@@ -1,6 +1,6 @@
 //
-//  TVTabView.swift
-//  KMReader
+// TVTabView.swift
+//
 //
 
 import SwiftUI


### PR DESCRIPTION
## Summary
- Rebalance settings browse card preview random aspect ratios with symmetric sampling around the default cover ratio.
- Prevent the preview from skewing toward very short cards so narrow and short previews appear more evenly.
- Introduce a shared `CoverAspectRatio` helper and replace hard-coded `1.414` and `0.707` values in related UI components.

## Testing
- [x] `make format`
- [x] `make build-macos`
