### PR TITLE
fix: preserve read-list context in reader navigation

### DIFF
--- a/KMReader/Features/Book/Services/BookService.swift
+++ b/KMReader/Features/Book/Services/BookService.swift
@@ -283,9 +283,15 @@ class BookService {
     }
   }
 
-  func getPreviousBook(bookId: String) async throws -> Book? {
+  func getPreviousBook(bookId: String, readListId: String? = nil) async throws -> Book? {
     do {
-      return try await apiClient.request(path: "/api/v1/books/\(bookId)/previous")
+      if let readListId = readListId {
+        return try await apiClient.request(
+          path: "/api/v1/readlists/\(readListId)/books/\(bookId)/previous"
+        )
+      } else {
+        return try await apiClient.request(path: "/api/v1/books/\(bookId)/previous")
+      }
     } catch {
       return nil
     }

--- a/KMReader/Features/Book/Views/BookQueryItemView.swift
+++ b/KMReader/Features/Book/Views/BookQueryItemView.swift
@@ -12,6 +12,7 @@ struct BookQueryItemView: View {
   let layout: BrowseLayoutMode
   var showSeriesTitle: Bool = true
   var showSeriesNavigation: Bool = true
+  var readListContext: ReaderReadListContext? = nil
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @Environment(ReaderPresentationManager.self) private var readerPresentation
@@ -21,12 +22,14 @@ struct BookQueryItemView: View {
     bookId: String,
     layout: BrowseLayoutMode,
     showSeriesTitle: Bool = true,
-    showSeriesNavigation: Bool = true
+    showSeriesNavigation: Bool = true,
+    readListContext: ReaderReadListContext? = nil
   ) {
     self.bookId = bookId
     self.layout = layout
     self.showSeriesTitle = showSeriesTitle
     self.showSeriesNavigation = showSeriesNavigation
+    self.readListContext = readListContext
 
     let compositeId = CompositeID.generate(id: bookId)
     _komgaBooks = Query(filter: #Predicate<KomgaBook> { $0.id == compositeId })
@@ -43,7 +46,11 @@ struct BookQueryItemView: View {
         BookCardView(
           komgaBook: book,
           onReadBook: { incognito in
-            readerPresentation.present(book: book.toBook(), incognito: incognito)
+            readerPresentation.present(
+              book: book.toBook(),
+              incognito: incognito,
+              readListContext: readListContext
+            )
           },
           showSeriesTitle: showSeriesTitle,
           showSeriesNavigation: showSeriesNavigation
@@ -52,7 +59,11 @@ struct BookQueryItemView: View {
         BookRowView(
           komgaBook: book,
           onReadBook: { incognito in
-            readerPresentation.present(book: book.toBook(), incognito: incognito)
+            readerPresentation.present(
+              book: book.toBook(),
+              incognito: incognito,
+              readListContext: readListContext
+            )
           },
           showSeriesTitle: showSeriesTitle,
           showSeriesNavigation: showSeriesNavigation

--- a/KMReader/Features/Book/Views/BookReaderState.swift
+++ b/KMReader/Features/Book/Views/BookReaderState.swift
@@ -8,5 +8,5 @@ import Foundation
 struct BookReaderState: Equatable {
   var book: Book?
   var incognito: Bool = false
-  var readList: ReadList?
+  var readListContext: ReaderReadListContext?
 }

--- a/KMReader/Features/Book/Views/ListViews/BooksListViewForReadList.swift
+++ b/KMReader/Features/Book/Views/ListViews/BooksListViewForReadList.swift
@@ -29,6 +29,11 @@ struct BooksListViewForReadList: View {
     readLists.first
   }
 
+  private var readListContext: ReaderReadListContext? {
+    guard let readList else { return nil }
+    return ReaderReadListContext(id: readList.readListId, name: readList.name)
+  }
+
   init(
     readListId: String,
     showFilterSheet: Binding<Bool>,
@@ -123,6 +128,7 @@ struct BooksListViewForReadList: View {
       if readList?.bookIds != nil {
         ReadListBooksQueryView(
           readListId: readListId,
+          readListContext: readListContext,
           bookViewModel: bookViewModel,
           browseOpts: browseOpts,
           browseLayout: layoutMode,

--- a/KMReader/Features/Book/Views/ListViews/ReadListBooksQueryView.swift
+++ b/KMReader/Features/Book/Views/ListViews/ReadListBooksQueryView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 struct ReadListBooksQueryView: View {
   let readListId: String
+  let readListContext: ReaderReadListContext?
   @Bindable var bookViewModel: BookViewModel
   let browseOpts: ReadListBookBrowseOptions
   let browseLayout: BrowseLayoutMode
@@ -29,6 +30,7 @@ struct ReadListBooksQueryView: View {
 
   init(
     readListId: String,
+    readListContext: ReaderReadListContext?,
     bookViewModel: BookViewModel,
     browseOpts: ReadListBookBrowseOptions,
     browseLayout: BrowseLayoutMode,
@@ -38,6 +40,7 @@ struct ReadListBooksQueryView: View {
     refreshBooks: @escaping () -> Void
   ) {
     self.readListId = readListId
+    self.readListContext = readListContext
     self.bookViewModel = bookViewModel
     self.browseOpts = browseOpts
     self.browseLayout = browseLayout
@@ -71,7 +74,8 @@ struct ReadListBooksQueryView: View {
                   BookQueryItemView(
                     bookId: book.id,
                     layout: .grid,
-                    showSeriesTitle: true
+                    showSeriesTitle: true,
+                    readListContext: readListContext
                   )
                 }
               }
@@ -100,7 +104,8 @@ struct ReadListBooksQueryView: View {
                   BookQueryItemView(
                     bookId: book.id,
                     layout: .list,
-                    showSeriesTitle: true
+                    showSeriesTitle: true,
+                    readListContext: readListContext
                   )
                 }
               }

--- a/KMReader/Features/Reader/Models/ReaderReadListContext.swift
+++ b/KMReader/Features/Reader/Models/ReaderReadListContext.swift
@@ -1,0 +1,11 @@
+//
+// ReaderReadListContext.swift
+//
+//
+
+import Foundation
+
+struct ReaderReadListContext: Equatable {
+  let id: String
+  let name: String
+}

--- a/KMReader/Features/Reader/Views/BookReaderView.swift
+++ b/KMReader/Features/Reader/Views/BookReaderView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct BookReaderView: View {
   let book: Book
   let incognito: Bool
-  let readList: ReadList?
+  let readListContext: ReaderReadListContext?
   let onClose: (() -> Void)?
 
   @Environment(\.dismiss) private var dismiss
@@ -43,7 +43,7 @@ struct BookReaderView: View {
               DivinaReaderView(
                 book: book,
                 incognito: incognito,
-                readList: readList,
+                readListContext: readListContext,
                 onClose: closeReader
               )
             case .epub:
@@ -51,7 +51,7 @@ struct BookReaderView: View {
                 DivinaReaderView(
                   book: book,
                   incognito: incognito,
-                  readList: readList,
+                  readListContext: readListContext,
                   onClose: closeReader
                 )
               } else {
@@ -59,7 +59,7 @@ struct BookReaderView: View {
                   EpubReaderView(
                     book: book,
                     incognito: incognito,
-                    readList: readList,
+                    readListContext: readListContext,
                     onClose: closeReader
                   )
                 #else
@@ -97,7 +97,7 @@ struct BookReaderView: View {
                 DivinaReaderView(
                   book: book,
                   incognito: incognito,
-                  readList: readList,
+                  readListContext: readListContext,
                   onClose: closeReader
                 )
               }

--- a/KMReader/Features/Reader/Views/CurlPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlPageView.swift
@@ -14,7 +14,7 @@
     let splitWidePageMode: SplitWidePageMode
     let previousBook: Book?
     let nextBook: Book?
-    let readList: ReadList?
+    let readListContext: ReaderReadListContext?
     let onDismiss: () -> Void
     let onPreviousBook: (String) -> Void
     let onNextBook: (String) -> Void
@@ -182,7 +182,7 @@
           let endPageView = EndPageView(
             viewModel: parent.viewModel,
             nextBook: parent.nextBook,
-            readList: parent.readList,
+            readListContext: parent.readListContext,
             onDismiss: parent.onDismiss,
             onNextBook: parent.onNextBook,
             readingDirection: parent.readingDirection,

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct DivinaReaderView: View {
   let book: Book
   let incognito: Bool
-  let readList: ReadList?
+  let readListContext: ReaderReadListContext?
   let onClose: (() -> Void)?
 
   @Environment(\.dismiss) private var dismiss
@@ -75,12 +75,12 @@ struct DivinaReaderView: View {
   init(
     book: Book,
     incognito: Bool = false,
-    readList: ReadList? = nil,
+    readListContext: ReaderReadListContext? = nil,
     onClose: (() -> Void)? = nil
   ) {
     self.book = book
     self.incognito = incognito
-    self.readList = readList
+    self.readListContext = readListContext
     self.onClose = onClose
     self._currentBookId = State(initialValue: book.id)
     self._currentBook = State(initialValue: book)
@@ -638,7 +638,7 @@ struct DivinaReaderView: View {
         // Update window manager state when book changes to refresh window title
         if let book = newBook {
           ReaderWindowManager.shared.currentState = BookReaderState(
-            book: book, incognito: incognito, readList: readList)
+            book: book, incognito: incognito, readListContext: readListContext)
         }
       }
     #endif
@@ -661,7 +661,7 @@ struct DivinaReaderView: View {
                 viewModel: viewModel,
                 isAtBottom: $isAtBottom,
                 nextBook: nextBook,
-                readList: readList,
+                readListContext: readListContext,
                 onDismiss: { closeReader() },
                 onNextBook: { openNextBook(nextBookId: $0) },
                 toggleControls: { toggleControls() },
@@ -680,7 +680,7 @@ struct DivinaReaderView: View {
                 viewModel: viewModel,
                 previousBook: previousBook,
                 nextBook: nextBook,
-                readList: readList,
+                readListContext: readListContext,
                 onDismiss: { closeReader() },
                 onPreviousBook: { openPreviousBook(previousBookId: $0) },
                 onNextBook: { openNextBook(nextBookId: $0) },
@@ -710,7 +710,7 @@ struct DivinaReaderView: View {
                   splitWidePageMode: splitWidePageMode,
                   previousBook: previousBook,
                   nextBook: nextBook,
-                  readList: readList,
+                  readListContext: readListContext,
                   onDismiss: { closeReader() },
                   onPreviousBook: { openPreviousBook(previousBookId: $0) },
                   onNextBook: { openNextBook(nextBookId: $0) },
@@ -733,7 +733,7 @@ struct DivinaReaderView: View {
                   viewModel: viewModel,
                   previousBook: previousBook,
                   nextBook: nextBook,
-                  readList: readList,
+                  readListContext: readListContext,
                   onDismiss: { closeReader() },
                   onPreviousBook: { openPreviousBook(previousBookId: $0) },
                   onNextBook: { openNextBook(nextBookId: $0) },
@@ -762,7 +762,7 @@ struct DivinaReaderView: View {
                 viewModel: viewModel,
                 previousBook: previousBook,
                 nextBook: nextBook,
-                readList: readList,
+                readListContext: readListContext,
                 onDismiss: { closeReader() },
                 onPreviousBook: { openPreviousBook(previousBookId: $0) },
                 onNextBook: { openNextBook(nextBookId: $0) },
@@ -1089,20 +1089,23 @@ struct DivinaReaderView: View {
       self.nextBook = await DatabaseOperator.shared.getNextBook(
         instanceId: AppConfig.current.instanceId,
         bookId: bookId,
-        readListId: readList?.id
+        readListId: readListContext?.id
       )
       if self.nextBook == nil && !AppConfig.isOffline {
         self.nextBook = await SyncService.shared.syncNextBook(
-          bookId: bookId, readListId: readList?.id)
+          bookId: bookId, readListId: readListContext?.id)
       }
 
       self.previousBook = await DatabaseOperator.shared.getPreviousBook(
         instanceId: AppConfig.current.instanceId,
         bookId: bookId,
-        readListId: readList?.id
+        readListId: readListContext?.id
       )
       if self.previousBook == nil && !AppConfig.isOffline {
-        self.previousBook = await SyncService.shared.syncPreviousBook(bookId: bookId)
+        self.previousBook = await SyncService.shared.syncPreviousBook(
+          bookId: bookId,
+          readListId: readListContext?.id
+        )
       }
     }
 

--- a/KMReader/Features/Reader/Views/EndPageView/EndPageView.swift
+++ b/KMReader/Features/Reader/Views/EndPageView/EndPageView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct EndPageView: View {
   @Bindable var viewModel: ReaderViewModel
   let nextBook: Book?
-  let readList: ReadList?
+  let readListContext: ReaderReadListContext?
   let onDismiss: () -> Void
   let onNextBook: (String) -> Void
   let readingDirection: ReadingDirection
@@ -58,7 +58,7 @@ struct EndPageView: View {
       NextBookInfoView(
         textColor: textColor,
         nextBook: nextBook,
-        readList: readList,
+        readListContext: readListContext,
         showImage: showImage
       )
       .environment(\.layoutDirection, .leftToRight)

--- a/KMReader/Features/Reader/Views/EndPageView/NextBookInfoView.swift
+++ b/KMReader/Features/Reader/Views/EndPageView/NextBookInfoView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct NextBookInfoView: View {
   let textColor: Color
   let nextBook: Book?
-  let readList: ReadList?
+  let readListContext: ReaderReadListContext?
   let showImage: Bool
 
   private var bookNumber: String {
@@ -17,7 +17,7 @@ struct NextBookInfoView: View {
   }
 
   private var upNextLabel: String {
-    if readList != nil {
+    if readListContext != nil {
       return String.localizedStringWithFormat(
         String(localized: "UP NEXT IN READ LIST: %@"),
         bookNumber
@@ -59,11 +59,11 @@ struct NextBookInfoView: View {
               .multilineTextAlignment(.center)
               .foregroundColor(textColor)
 
-            if let readList = readList {
+            if let readListContext = readListContext {
               HStack(spacing: 4) {
                 Image(systemName: ContentIcon.readList)
                   .font(.caption)
-                Text(readList.name)
+                Text(readListContext.name)
               }
               .font(.subheadline)
               .fontDesign(.serif)

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -9,7 +9,7 @@
   struct EpubReaderView: View {
     private let book: Book
     private let incognito: Bool
-    private let readList: ReadList?
+    private let readListContext: ReaderReadListContext?
     private let onClose: (() -> Void)?
 
     @Environment(\.dismiss) private var dismiss
@@ -37,12 +37,12 @@
     init(
       book: Book,
       incognito: Bool = false,
-      readList: ReadList? = nil,
+      readListContext: ReaderReadListContext? = nil,
       onClose: (() -> Void)? = nil
     ) {
       self.book = book
       self.incognito = incognito
-      self.readList = readList
+      self.readListContext = readListContext
       self.onClose = onClose
       _viewModel = State(initialValue: EpubReaderViewModel(incognito: incognito))
       _activePreferences = State(initialValue: AppConfig.epubPreferences)

--- a/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
+++ b/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
@@ -42,7 +42,9 @@ final class ReaderPresentationManager {
   }
 
   func present(
-    book: Book, incognito: Bool, readList: ReadList? = nil
+    book: Book,
+    incognito: Bool,
+    readListContext: ReaderReadListContext? = nil
   ) {
     #if !os(macOS)
       // On iOS/tvOS we need to re-trigger the presentation cycle by dismissing first
@@ -55,7 +57,11 @@ final class ReaderPresentationManager {
     // Reset tracking sets for new session
     visitedBookIds = []
     visitedSeriesIds = []
-    let state = BookReaderState(book: book, incognito: incognito, readList: readList)
+    let state = BookReaderState(
+      book: book,
+      incognito: incognito,
+      readListContext: readListContext
+    )
     readerState = state
 
     #if os(macOS)
@@ -67,7 +73,7 @@ final class ReaderPresentationManager {
       ReaderWindowManager.shared.openReader(
         book: book,
         incognito: incognito,
-        readList: readList,
+        readListContext: readListContext,
         openWindow: openWindowHandler,
         onDismiss: { [weak self] in
           self?.handleWindowDismissal()

--- a/KMReader/Features/Reader/Views/ReaderWindowManager.swift
+++ b/KMReader/Features/Reader/Views/ReaderWindowManager.swift
@@ -32,7 +32,9 @@
     private init() {}
 
     func openReader(
-      book: Book, incognito: Bool = false, readList: ReadList? = nil,
+      book: Book,
+      incognito: Bool = false,
+      readListContext: ReaderReadListContext? = nil,
       openWindow: @escaping () -> Void,
       onDismiss: (() -> Void)? = nil
     ) {
@@ -46,10 +48,18 @@
 
       // If window is already open, just update the state (replace content)
       if isWindowOpen {
-        currentState = BookReaderState(book: book, incognito: incognito, readList: readList)
+        currentState = BookReaderState(
+          book: book,
+          incognito: incognito,
+          readListContext: readListContext
+        )
       } else {
         // Window not open, open it first
-        currentState = BookReaderState(book: book, incognito: incognito, readList: readList)
+        currentState = BookReaderState(
+          book: book,
+          incognito: incognito,
+          readListContext: readListContext
+        )
         openWindow()
         isWindowOpen = true
       }

--- a/KMReader/Features/Reader/Views/ReaderWindowView.swift
+++ b/KMReader/Features/Reader/Views/ReaderWindowView.swift
@@ -22,7 +22,7 @@
           BookReaderView(
             book: book,
             incognito: state.incognito,
-            readList: state.readList,
+            readListContext: state.readListContext,
             onClose: { ReaderWindowManager.shared.closeReader() }
           )
           .id("\(book.id)-\(state.incognito)")

--- a/KMReader/Features/Reader/Views/ScrollPageView.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView.swift
@@ -17,7 +17,7 @@ struct ScrollPageView: View {
   @Bindable var viewModel: ReaderViewModel
   let previousBook: Book?
   let nextBook: Book?
-  let readList: ReadList?
+  let readListContext: ReaderReadListContext?
   let onDismiss: () -> Void
   let onPreviousBook: (String) -> Void
   let onNextBook: (String) -> Void
@@ -61,7 +61,7 @@ struct ScrollPageView: View {
     viewModel: ReaderViewModel,
     previousBook: Book?,
     nextBook: Book?,
-    readList: ReadList?,
+    readListContext: ReaderReadListContext?,
     onDismiss: @escaping () -> Void,
     onPreviousBook: @escaping (String) -> Void,
     onNextBook: @escaping (String) -> Void,
@@ -79,7 +79,7 @@ struct ScrollPageView: View {
     self.viewModel = viewModel
     self.previousBook = previousBook
     self.nextBook = nextBook
-    self.readList = readList
+    self.readListContext = readListContext
     self.onDismiss = onDismiss
     self.onPreviousBook = onPreviousBook
     self.onNextBook = onNextBook
@@ -320,7 +320,7 @@ struct ScrollPageView: View {
           EndPageView(
             viewModel: viewModel,
             nextBook: nextBook,
-            readList: readList,
+            readListContext: readListContext,
             onDismiss: onDismiss,
             onNextBook: onNextBook,
             readingDirection: readingDirection,

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonPageView.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonPageView.swift
@@ -13,7 +13,7 @@
     let viewModel: ReaderViewModel
     @Binding var isAtBottom: Bool
     let nextBook: Book?
-    let readList: ReadList?
+    let readListContext: ReaderReadListContext?
     let onDismiss: () -> Void
     let onNextBook: (String) -> Void
     let toggleControls: () -> Void
@@ -77,7 +77,7 @@
             EndPageView(
               viewModel: viewModel,
               nextBook: nextBook,
-              readList: readList,
+              readListContext: readListContext,
               onDismiss: onDismiss,
               onNextBook: onNextBook,
               readingDirection: .webtoon,

--- a/KMReader/Features/Sync/Services/SyncService.swift
+++ b/KMReader/Features/Sync/Services/SyncService.swift
@@ -373,9 +373,12 @@ class SyncService {
     return nil
   }
 
-  func syncPreviousBook(bookId: String) async -> Book? {
+  func syncPreviousBook(bookId: String, readListId: String? = nil) async -> Book? {
     do {
-      if let book = try await BookService.shared.getPreviousBook(bookId: bookId) {
+      if let book = try await BookService.shared.getPreviousBook(
+        bookId: bookId,
+        readListId: readListId
+      ) {
         let instanceId = AppConfig.current.instanceId
         await db.upsertBook(dto: book, instanceId: instanceId)
         await db.commit()

--- a/KMReader/Shared/UI/ReaderOverlay.swift
+++ b/KMReader/Shared/UI/ReaderOverlay.swift
@@ -48,7 +48,7 @@ import SwiftUI
             BookReaderView(
               book: book,
               incognito: state.incognito,
-              readList: state.readList,
+              readListContext: state.readListContext,
               onClose: { readerPresentation.closeReader() }
             )
           } else {


### PR DESCRIPTION
## Summary
- Preserve read-list reader semantics by passing context from read-list book entries into the reader presentation flow.
- Replace `ReadList` in reader state with lightweight `ReaderReadListContext` (`id`, `name`) to reduce coupling and avoid carrying unused payload fields.
- Fix previous-book fallback to use readlist-aware endpoint when a read list context is present, matching next-book behavior.

## Related
- Related to #521

## Testing
- [x] `make format`
- [x] `make build`
