### PR TITLE
feat: add completion notifications for offline background workflows

### DIFF
--- a/KMReader/Features/Sync/Services/ProgressSyncService.swift
+++ b/KMReader/Features/Sync/Services/ProgressSyncService.swift
@@ -85,10 +85,22 @@ actor ProgressSyncService {
 
     if successCount > 0 {
       logger.info("✅ Successfully synced \(successCount) progress items")
+      if failureCount == 0 {
+        await MainActor.run {
+          ErrorManager.shared.notify(
+            message: String(localized: "notification.progressSyncCompleted")
+          )
+        }
+      }
     }
 
     if failureCount > 0 {
       logger.warning("⚠️ Failed to sync \(failureCount) progress items, will retry later")
+      await MainActor.run {
+        ErrorManager.shared.notify(
+          message: String(localized: "notification.progressSyncFailed")
+        )
+      }
     }
   }
 

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -26434,6 +26434,190 @@
         }
       }
     },
+    "notification.offline.tasksCompleted" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Hintergrundaufgaben abgeschlossen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline background tasks completed"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taches en arriere-plan hors ligne terminees"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインのバックグラウンド処理が完了しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 백그라운드 작업이 완료되었습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线后台任务已完成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離線背景任務已完成"
+          }
+        }
+      }
+    },
+    "notification.offline.syncCompleted" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Datensynchronisierung abgeschlossen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline data sync completed"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronisation des données hors ligne terminée"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインデータの同期が完了しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 데이터 동기화가 완료되었습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线数据同步完成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離線資料同步完成"
+          }
+        }
+      }
+    },
+    "notification.offline.syncCompletedWithIssues" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Synchronisierung mit Fehlern abgeschlossen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline sync completed with some errors"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronisation hors ligne terminée avec des erreurs"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフライン同期は完了しましたが、一部エラーがありました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 동기화가 완료되었지만 일부 오류가 발생했습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线同步已完成，但存在部分错误"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離線同步已完成，但存在部分錯誤"
+          }
+        }
+      }
+    },
+    "notification.progressSyncCompleted" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lesefortschritt synchronisiert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading progress synced"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progression de lecture synchronisee"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書進捗を同期しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽기 진행 상황이 동기화되었습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读进度已同步"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀進度已同步"
+          }
+        }
+      }
+    },
     "notification.progressSyncFailed" : {
       "localizations" : {
         "de" : {


### PR DESCRIPTION
## Summary
- add success/failure notifications after pending progress sync finishes
- notify once when an offline download queue batch fully completes, instead of notifying per book
- add completion notifications for offline data sync initialization with explicit "completed" vs "completed with issues" outcomes
- add localization entries for the new notification keys

## Testing
- [x] `make format`
- [x] `make build-macos`
