### PR TITLE
feat: streamline reader preference visibility

### DIFF
--- a/KMReader/Features/Settings/PdfPreferencesView.swift
+++ b/KMReader/Features/Settings/PdfPreferencesView.swift
@@ -54,19 +54,6 @@
         }
 
         if useNativePdfReader {
-          Section(header: Text("Appearance")) {
-            Picker("Reader Background", selection: $readerBackground) {
-              ForEach(ReaderBackground.allCases, id: \.self) { background in
-                Text(background.displayName).tag(background)
-              }
-            }
-            .pickerStyle(.menu)
-
-            Toggle(isOn: $readerControlsGradientBackground) {
-              Text("Controls Gradient Background")
-            }
-          }
-
           Section(header: Text("Default Reading Options")) {
             VStack(alignment: .leading, spacing: 8) {
               Picker("Preferred Direction", selection: $defaultReadingDirection) {
@@ -114,6 +101,19 @@
                     .foregroundColor(.secondary)
                 }
               }
+            }
+          }
+
+          Section(header: Text("Appearance")) {
+            Picker("Reader Background", selection: $readerBackground) {
+              ForEach(ReaderBackground.allCases, id: \.self) { background in
+                Text(background.displayName).tag(background)
+              }
+            }
+            .pickerStyle(.menu)
+
+            Toggle(isOn: $readerControlsGradientBackground) {
+              Text("Controls Gradient Background")
             }
           }
         } else {


### PR DESCRIPTION
## Summary
- Hide DIVINA reader settings that are not relevant to the current reading mode and transition style.
- Keep tap scroll duration under Tap Zone settings, but show it only when scroll transition mode is active.
- Move Default Reading Options to the top in DIVINA and PDF preferences for faster access.

## Testing
- [x] make build-macos
- [x] make build-ios
- [x] make build-tvos
