### PR TITLE
feat: show bootstrap migration progress on splash

### DIFF
--- a/KMReader/Core/Storage/AppBootstrapper.swift
+++ b/KMReader/Core/Storage/AppBootstrapper.swift
@@ -1,0 +1,62 @@
+//
+// AppBootstrapper.swift
+//
+//
+
+import Foundation
+
+@MainActor
+@Observable
+final class AppBootstrapper {
+  static let shared = AppBootstrapper()
+
+  private(set) var isBootstrapping = true
+  private(set) var progress = 0.0
+  private(set) var phaseName = String(localized: "splash.loading.preparing")
+
+  private var hasStarted = false
+  private let logger = AppLogger(.database)
+
+  private init() {}
+
+  func startIfNeeded() {
+    guard !hasStarted else { return }
+    hasStarted = true
+
+    Task.detached(priority: .userInitiated) {
+      AppSQLiteBootstrap.bootstrap { update in
+        Task { @MainActor in
+          AppBootstrapper.shared.update(update)
+        }
+      }
+
+      await MainActor.run {
+        DatabaseOperator.shared = DatabaseOperator()
+        #if os(iOS)
+          QuickActionService.handlePendingShortcutIfNeeded()
+        #endif
+        AppBootstrapper.shared.complete()
+      }
+    }
+  }
+
+  private func update(_ update: AppSQLiteBootstrap.ProgressUpdate) {
+    progress = min(max(update.fractionComplete, 0.0), 1.0)
+    phaseName =
+      switch update.phase {
+      case .preparing:
+        String(localized: "splash.loading.preparing")
+      case .importing:
+        String(localized: "splash.loading.syncing")
+      case .finalizing:
+        String(localized: "splash.loading.updating")
+      }
+  }
+
+  private func complete() {
+    progress = 1.0
+    phaseName = String(localized: "splash.loading.updating")
+    isBootstrapping = false
+    logger.info("App bootstrap completed")
+  }
+}

--- a/KMReader/Shared/UI/SplashView.swift
+++ b/KMReader/Shared/UI/SplashView.swift
@@ -12,6 +12,7 @@ struct SplashView: View {
   @State private var messageRotationTask: Task<Void, Never>?
 
   var initializer: InstanceInitializer?
+  var bootstrapper: AppBootstrapper?
 
   private let loadingMessages = [
     String(localized: "splash.loading.connecting"),
@@ -24,12 +25,36 @@ struct SplashView: View {
     initializer?.isSyncing ?? false
   }
 
+  private var isBootstrapping: Bool {
+    bootstrapper?.isBootstrapping ?? false
+  }
+
   private var initializationProgress: Double {
     initializer?.progress ?? 0.0
   }
 
+  private var bootstrapProgress: Double {
+    bootstrapper?.progress ?? 0.0
+  }
+
   private var currentPhaseName: String {
     initializer?.currentPhaseName ?? ""
+  }
+
+  private var bootstrapPhaseName: String {
+    bootstrapper?.phaseName ?? ""
+  }
+
+  private var showsDeterminateProgress: Bool {
+    isBootstrapping || isSyncing
+  }
+
+  private var determinateProgress: Double {
+    min(max(isBootstrapping ? bootstrapProgress : initializationProgress, 0.0), 1.0)
+  }
+
+  private var determinatePhaseName: String {
+    isBootstrapping ? bootstrapPhaseName : currentPhaseName
   }
 
   var body: some View {
@@ -65,20 +90,20 @@ struct SplashView: View {
       Spacer()
 
       VStack(spacing: 16) {
-        if isSyncing {
+        if showsDeterminateProgress {
           // Determinate progress bar during initialization
           VStack(spacing: 8) {
-            ProgressView(value: initializationProgress)
+            ProgressView(value: determinateProgress)
               .progressViewStyle(.linear)
               .frame(maxWidth: 280)
               .opacity(isVisible ? 1.0 : 0.0)
 
-            Text(currentPhaseName)
+            Text(determinatePhaseName)
               .font(.caption)
               .foregroundStyle(.secondary)
               .monospacedDigit()
 
-            Text("\(Int(initializationProgress * 100))%")
+            Text("\(Int(determinateProgress * 100))%")
               .font(.caption2)
               .foregroundStyle(.tertiary)
               .monospacedDigit()
@@ -140,4 +165,8 @@ struct SplashView: View {
 
 #Preview("Initializing") {
   SplashView(initializer: InstanceInitializer.shared)
+}
+
+#Preview("Bootstrapping") {
+  SplashView(bootstrapper: AppBootstrapper.shared)
 }


### PR DESCRIPTION
## Summary
- add `AppBootstrapper` to run SQLite bootstrap asynchronously and expose bootstrap progress
- add progress callback support in `AppSQLiteBootstrap`, including incremental progress while importing legacy SwiftData rows
- gate only the main app window on bootstrap completion and keep reader/settings windows unchanged
- extend `SplashView` to render determinate progress for both bootstrap and sync initialization states

## Testing
- [x] `make format`
- [x] `make build-macos`
