### PR TITLE
feat: stabilize SwiftData migration UX and recovery sync

### DIFF
--- a/KMReader/Features/Offline/Views/OfflineView.swift
+++ b/KMReader/Features/Offline/Views/OfflineView.swift
@@ -208,6 +208,11 @@ struct OfflineView: View {
           await instanceInitializer.syncData()
         }
       }
+      Button(String(localized: "offline.sync.confirm.forceAction"), role: .destructive) {
+        Task {
+          await instanceInitializer.syncData(forceFullSync: true)
+        }
+      }
       Button(String(localized: "Cancel"), role: .cancel) {}
     } message: {
       Text(String(localized: "offline.sync.confirm.message"))

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -26434,52 +26434,6 @@
         }
       }
     },
-    "notification.offline.tasksCompleted" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Offline-Hintergrundaufgaben abgeschlossen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Offline background tasks completed"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Taches en arriere-plan hors ligne terminees"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オフラインのバックグラウンド処理が完了しました"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오프라인 백그라운드 작업이 완료되었습니다"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "离线后台任务已完成"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "離線背景任務已完成"
-          }
-        }
-      }
-    },
     "notification.offline.syncCompleted" : {
       "localizations" : {
         "de" : {
@@ -26568,6 +26522,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "離線同步已完成，但存在部分錯誤"
+          }
+        }
+      }
+    },
+    "notification.offline.tasksCompleted" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Hintergrundaufgaben abgeschlossen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline background tasks completed"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Taches en arriere-plan hors ligne terminees"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインのバックグラウンド処理が完了しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 백그라운드 작업이 완료되었습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线后台任务已完成"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離線背景任務已完成"
           }
         }
       }
@@ -28316,6 +28316,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "立即同步"
+          }
+        }
+      }
+    },
+    "offline.sync.confirm.forceAction" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vollständige Synchronisierung erzwingen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Force Full Sync"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forcer la synchronisation complète"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完全同期を強制"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 동기화 강제"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "强制全量同步"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強制完整同步"
           }
         }
       }
@@ -42716,6 +42762,144 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在更新您的個人資料..."
+          }
+        }
+      }
+    },
+    "splash.migration.finalizing" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lokale Datenmigration wird abgeschlossen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizing local data migration"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalisation de la migration des données locales"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ローカルデータ移行を最終処理中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로컬 데이터 마이그레이션 마무리 중"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在完成本地数据迁移"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在完成本機資料遷移"
+          }
+        }
+      }
+    },
+    "splash.migration.migrating" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorhandene lokale Daten werden migriert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrating existing local data"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migration des données locales existantes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "既存のローカルデータを移行中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기존 로컬 데이터 마이그레이션 중"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在迁移现有本地数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在遷移現有本機資料"
+          }
+        }
+      }
+    },
+    "splash.migration.preparing" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lokale Datenbankmigration wird vorbereitet"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing local database migration"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Préparation de la migration de la base locale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ローカルデータベース移行を準備中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로컬 데이터베이스 마이그레이션 준비 중"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "准备本地数据库迁移"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "準備本機資料庫遷移"
           }
         }
       }

--- a/KMReader/Shared/UI/SplashView.swift
+++ b/KMReader/Shared/UI/SplashView.swift
@@ -12,13 +12,33 @@ struct SplashView: View {
   @State private var messageRotationTask: Task<Void, Never>?
 
   var initializer: InstanceInitializer?
+  var isMigration: Bool = false
 
-  private let loadingMessages = [
-    String(localized: "splash.loading.connecting"),
-    String(localized: "splash.loading.syncing"),
-    String(localized: "splash.loading.updating"),
-    String(localized: "splash.loading.preparing"),
-  ]
+  private var loadingMessages: [String] {
+    if isMigration {
+      [
+        String(
+          localized: "splash.migration.preparing",
+          defaultValue: "Preparing local database migration"
+        ),
+        String(
+          localized: "splash.migration.migrating",
+          defaultValue: "Migrating existing local data"
+        ),
+        String(
+          localized: "splash.migration.finalizing",
+          defaultValue: "Finalizing local data migration"
+        ),
+      ]
+    } else {
+      [
+        String(localized: "splash.loading.connecting"),
+        String(localized: "splash.loading.syncing"),
+        String(localized: "splash.loading.updating"),
+        String(localized: "splash.loading.preparing"),
+      ]
+    }
+  }
 
   private var isSyncing: Bool {
     initializer?.isSyncing ?? false
@@ -136,6 +156,10 @@ struct SplashView: View {
 
 #Preview {
   SplashView()
+}
+
+#Preview("Migrating") {
+  SplashView(isMigration: true)
 }
 
 #Preview("Initializing") {


### PR DESCRIPTION
## Summary
- Defer SwiftData `ModelContainer` creation so startup shows a splash during migration instead of a black screen.
- Add migration-specific splash messages (instead of server-connection wording) and localize them for all supported languages.
- Rework V1 -> V2 migration snapshot handling to chunk data to disk and apply in batches, reducing memory pressure on large libraries.
- Add a destructive `Force Full Sync` action in the offline sync confirmation dialog.
- Extend `InstanceInitializer` with `syncData(forceFullSync:)` so users can explicitly trigger a full series/books resync.

## Testing
- [x] `make format`
- [x] `make build`
