### PR TITLE
refactor(reader): centralize render config and harden hosting env

### DIFF
--- a/KMReader/ContentView.swift
+++ b/KMReader/ContentView.swift
@@ -19,7 +19,6 @@ struct ContentView: View {
 
   #if os(iOS) || os(tvOS)
     @Namespace private var zoomNamespace
-    @Environment(ReaderPresentationManager.self) private var readerPresentation
   #endif
 
   private var instanceInitializer: InstanceInitializer {

--- a/KMReader/Features/Book/Views/BooksBrowseView.swift
+++ b/KMReader/Features/Book/Views/BooksBrowseView.swift
@@ -14,7 +14,6 @@ struct BooksBrowseView: View {
   @Binding var showFilterSheet: Bool
   @Binding var showSavedFilters: Bool
 
-  @Environment(ReaderPresentationManager.self) private var readerPresentation
   @Environment(\.modelContext) private var modelContext
 
   @AppStorage("bookBrowseOptions") private var storedBrowseOpts: BookBrowseOptions = BookBrowseOptions()

--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -28,7 +28,6 @@ struct DashboardSectionView: View {
   @Environment(DashboardSectionCacheStore.self) private var sectionCacheStore
   @Environment(\.modelContext) private var modelContext
   @Environment(\.colorScheme) private var colorScheme
-  @Environment(ReaderPresentationManager.self) private var readerPresentation
 
   @State private var pagination = PaginationState<IdentifiedString>(pageSize: 20)
   @State private var isLoading = false

--- a/KMReader/Features/Reader/Models/ReaderRenderConfig.swift
+++ b/KMReader/Features/Reader/Models/ReaderRenderConfig.swift
@@ -1,0 +1,16 @@
+//
+// ReaderRenderConfig.swift
+//
+//
+
+import Foundation
+
+struct ReaderRenderConfig: Equatable {
+  let tapZoneSize: TapZoneSize
+  let tapZoneMode: TapZoneMode
+  let showPageNumber: Bool
+  let readerBackground: ReaderBackground
+  let enableLiveText: Bool
+  let doubleTapZoomScale: Double
+  let doubleTapZoomMode: DoubleTapZoomMode
+}

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -21,9 +21,13 @@ struct DivinaReaderView: View {
     @AppStorage("pageTransitionStyle") private var pageTransitionStyle: PageTransitionStyle = .scroll
   #endif
   @AppStorage("showTapZoneHints") private var showTapZoneHints: Bool = true
+  @AppStorage("tapZoneSize") private var tapZoneSize: TapZoneSize = .large
   @AppStorage("tapZoneMode") private var tapZoneMode: TapZoneMode = .auto
+  @AppStorage("showPageNumber") private var showPageNumber: Bool = true
   @AppStorage("showKeyboardHelpOverlay") private var showKeyboardHelpOverlay: Bool = true
   @AppStorage("enableLiveText") private var enableLiveText: Bool = false
+  @AppStorage("doubleTapZoomScale") private var doubleTapZoomScale: Double = 3.0
+  @AppStorage("doubleTapZoomMode") private var doubleTapZoomMode: DoubleTapZoomMode = .fast
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
   #if os(iOS)
     @AppStorage("autoHideControls") private var autoHideControls: Bool = false
@@ -109,6 +113,18 @@ struct DivinaReaderView: View {
         && (viewModel.pages.isEmpty || showingControls || isShowingEndPage
           || (readingDirection == .webtoon && isAtBottom))
     #endif
+  }
+
+  private var renderConfig: ReaderRenderConfig {
+    ReaderRenderConfig(
+      tapZoneSize: tapZoneSize,
+      tapZoneMode: tapZoneMode,
+      showPageNumber: showPageNumber,
+      readerBackground: readerBackground,
+      enableLiveText: enableLiveText,
+      doubleTapZoomScale: doubleTapZoomScale,
+      doubleTapZoomMode: doubleTapZoomMode
+    )
   }
 
   #if os(iOS)
@@ -666,7 +682,7 @@ struct DivinaReaderView: View {
                 onNextBook: { openNextBook(nextBookId: $0) },
                 toggleControls: { toggleControls() },
                 pageWidthPercentage: webtoonPageWidthPercentage,
-                readerBackground: readerBackground,
+                renderConfig: renderConfig,
                 onBoundaryPanUpdate: { translation in
                   boundaryDragOffset = translation
                 }
@@ -676,6 +692,7 @@ struct DivinaReaderView: View {
                 mode: .vertical,
                 readingDirection: readingDirection,
                 splitWidePageMode: splitWidePageMode,
+                renderConfig: renderConfig,
                 showingControls: showingControls,
                 viewModel: viewModel,
                 previousBook: previousBook,
@@ -708,6 +725,8 @@ struct DivinaReaderView: View {
                   mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
                   readingDirection: readingDirection,
                   splitWidePageMode: splitWidePageMode,
+                  renderConfig: renderConfig,
+                  readerPresentation: readerPresentation,
                   previousBook: previousBook,
                   nextBook: nextBook,
                   readListContext: readListContext,
@@ -729,6 +748,7 @@ struct DivinaReaderView: View {
                   mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
                   readingDirection: readingDirection,
                   splitWidePageMode: splitWidePageMode,
+                  renderConfig: renderConfig,
                   showingControls: showingControls,
                   viewModel: viewModel,
                   previousBook: previousBook,
@@ -758,6 +778,7 @@ struct DivinaReaderView: View {
                 mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
                 readingDirection: readingDirection,
                 splitWidePageMode: splitWidePageMode,
+                renderConfig: renderConfig,
                 showingControls: showingControls,
                 viewModel: viewModel,
                 previousBook: previousBook,

--- a/KMReader/Features/Reader/Views/PageImage/DualPageImageView.swift
+++ b/KMReader/Features/Reader/Views/PageImage/DualPageImageView.swift
@@ -11,6 +11,7 @@ struct DualPageImageView: View {
   let firstPageIndex: Int
   let secondPageIndex: Int
   let screenSize: CGSize
+  let renderConfig: ReaderRenderConfig
 
   let readingDirection: ReadingDirection
   let onNextPage: () -> Void
@@ -21,14 +22,6 @@ struct DualPageImageView: View {
   var resetID: String {
     "\(firstPageIndex)-\(secondPageIndex)"
   }
-
-  @AppStorage("tapZoneSize") private var tapZoneSize: TapZoneSize = .large
-  @AppStorage("tapZoneMode") private var tapZoneMode: TapZoneMode = .auto
-  @AppStorage("showPageNumber") private var showPageNumber: Bool = true
-  @AppStorage("readerBackground") private var readerBackground: ReaderBackground = .system
-  @AppStorage("enableLiveText") private var enableLiveText: Bool = false
-  @AppStorage("doubleTapZoomScale") private var doubleTapZoomScale: Double = 3.0
-  @AppStorage("doubleTapZoomMode") private var doubleTapZoomMode: DoubleTapZoomMode = .fast
 
   var body: some View {
     let page1 = firstPageIndex >= 0 && firstPageIndex < viewModel.pages.count ? viewModel.pages[firstPageIndex] : nil
@@ -41,13 +34,7 @@ struct DualPageImageView: View {
       minScale: 1.0,
       maxScale: 8.0,
       readingDirection: readingDirection,
-      doubleTapScale: CGFloat(doubleTapZoomScale),
-      doubleTapZoomMode: doubleTapZoomMode,
-      tapZoneSize: tapZoneSize,
-      tapZoneMode: tapZoneMode,
-      showPageNumber: showPageNumber,
-      readerBackground: readerBackground,
-      enableLiveText: enableLiveText,
+      renderConfig: renderConfig,
       onNextPage: onNextPage,
       onPreviousPage: onPreviousPage,
       onToggleControls: onToggleControls,

--- a/KMReader/Features/Reader/Views/PageImage/SinglePageImageView.swift
+++ b/KMReader/Features/Reader/Views/PageImage/SinglePageImageView.swift
@@ -10,20 +10,13 @@ struct SinglePageImageView: View {
   var viewModel: ReaderViewModel
   let pageIndex: Int
   let screenSize: CGSize
+  let renderConfig: ReaderRenderConfig
 
   let readingDirection: ReadingDirection
   let onNextPage: () -> Void
   let onPreviousPage: () -> Void
   let onToggleControls: () -> Void
   let onPlayAnimatedPage: ((Int) -> Void)?
-
-  @AppStorage("tapZoneSize") private var tapZoneSize: TapZoneSize = .large
-  @AppStorage("tapZoneMode") private var tapZoneMode: TapZoneMode = .auto
-  @AppStorage("showPageNumber") private var showPageNumber: Bool = true
-  @AppStorage("readerBackground") private var readerBackground: ReaderBackground = .system
-  @AppStorage("enableLiveText") private var enableLiveText: Bool = false
-  @AppStorage("doubleTapZoomScale") private var doubleTapZoomScale: Double = 3.0
-  @AppStorage("doubleTapZoomMode") private var doubleTapZoomMode: DoubleTapZoomMode = .fast
 
   var body: some View {
     let page = pageIndex >= 0 && pageIndex < viewModel.pages.count ? viewModel.pages[pageIndex] : nil
@@ -35,13 +28,7 @@ struct SinglePageImageView: View {
       minScale: 1.0,
       maxScale: 8.0,
       readingDirection: readingDirection,
-      doubleTapScale: CGFloat(doubleTapZoomScale),
-      doubleTapZoomMode: doubleTapZoomMode,
-      tapZoneSize: tapZoneSize,
-      tapZoneMode: tapZoneMode,
-      showPageNumber: showPageNumber,
-      readerBackground: readerBackground,
-      enableLiveText: enableLiveText,
+      renderConfig: renderConfig,
       onNextPage: onNextPage,
       onPreviousPage: onPreviousPage,
       onToggleControls: onToggleControls,

--- a/KMReader/Features/Reader/Views/PageImage/SplitWidePageImageView.swift
+++ b/KMReader/Features/Reader/Views/PageImage/SplitWidePageImageView.swift
@@ -11,20 +11,13 @@ struct SplitWidePageImageView: View {
   let pageIndex: Int
   let isLeftHalf: Bool  // true for left half, false for right half
   let screenSize: CGSize
+  let renderConfig: ReaderRenderConfig
 
   let readingDirection: ReadingDirection
   let onNextPage: () -> Void
   let onPreviousPage: () -> Void
   let onToggleControls: () -> Void
   let onPlayAnimatedPage: ((Int) -> Void)?
-
-  @AppStorage("tapZoneSize") private var tapZoneSize: TapZoneSize = .large
-  @AppStorage("tapZoneMode") private var tapZoneMode: TapZoneMode = .auto
-  @AppStorage("showPageNumber") private var showPageNumber: Bool = true
-  @AppStorage("readerBackground") private var readerBackground: ReaderBackground = .system
-  @AppStorage("enableLiveText") private var enableLiveText: Bool = false
-  @AppStorage("doubleTapZoomScale") private var doubleTapZoomScale: Double = 3.0
-  @AppStorage("doubleTapZoomMode") private var doubleTapZoomMode: DoubleTapZoomMode = .fast
 
   var body: some View {
     let page = pageIndex >= 0 && pageIndex < viewModel.pages.count ? viewModel.pages[pageIndex] : nil
@@ -36,13 +29,7 @@ struct SplitWidePageImageView: View {
       minScale: 1.0,
       maxScale: 8.0,
       readingDirection: readingDirection,
-      doubleTapScale: CGFloat(doubleTapZoomScale),
-      doubleTapZoomMode: doubleTapZoomMode,
-      tapZoneSize: tapZoneSize,
-      tapZoneMode: tapZoneMode,
-      showPageNumber: showPageNumber,
-      readerBackground: readerBackground,
-      enableLiveText: enableLiveText,
+      renderConfig: renderConfig,
       onNextPage: onNextPage,
       onPreviousPage: onPreviousPage,
       onToggleControls: onToggleControls,

--- a/KMReader/Features/Reader/Views/ScrollPageView.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView.swift
@@ -13,6 +13,7 @@ struct ScrollPageView: View {
   let mode: PageViewMode
   let readingDirection: ReadingDirection
   let splitWidePageMode: SplitWidePageMode
+  let renderConfig: ReaderRenderConfig
   let showingControls: Bool
   @Bindable var viewModel: ReaderViewModel
   let previousBook: Book?
@@ -27,8 +28,6 @@ struct ScrollPageView: View {
   let onPlayAnimatedPage: ((Int) -> Void)?
   let onScrollActivityChange: ((Bool) -> Void)?
   let onBoundaryPanUpdate: ((CGFloat) -> Void)?
-
-  @Environment(ReaderPresentationManager.self) private var readerPresentation
 
   private let logger = AppLogger(.reader)
 
@@ -57,6 +56,7 @@ struct ScrollPageView: View {
     mode: PageViewMode,
     readingDirection: ReadingDirection,
     splitWidePageMode: SplitWidePageMode,
+    renderConfig: ReaderRenderConfig,
     showingControls: Bool,
     viewModel: ReaderViewModel,
     previousBook: Book?,
@@ -75,6 +75,7 @@ struct ScrollPageView: View {
     self.mode = mode
     self.readingDirection = readingDirection
     self.splitWidePageMode = splitWidePageMode
+    self.renderConfig = renderConfig
     self.showingControls = showingControls
     self.viewModel = viewModel
     self.previousBook = previousBook
@@ -332,6 +333,7 @@ struct ScrollPageView: View {
             firstPageIndex: first,
             secondPageIndex: second,
             screenSize: geometry.size,
+            renderConfig: renderConfig,
             readingDirection: readingDirection,
             onNextPage: goToNextPage,
             onPreviousPage: goToPreviousPage,
@@ -343,6 +345,7 @@ struct ScrollPageView: View {
             viewModel: viewModel,
             pageIndex: index,
             screenSize: geometry.size,
+            renderConfig: renderConfig,
             readingDirection: readingDirection,
             onNextPage: goToNextPage,
             onPreviousPage: goToPreviousPage,
@@ -360,6 +363,7 @@ struct ScrollPageView: View {
             pageIndex: index,
             isLeftHalf: isLeftHalf,
             screenSize: geometry.size,
+            renderConfig: renderConfig,
             readingDirection: readingDirection,
             onNextPage: goToNextPage,
             onPreviousPage: goToPreviousPage,

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonPageView.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonPageView.swift
@@ -18,12 +18,8 @@
     let onNextBook: (String) -> Void
     let toggleControls: () -> Void
     let pageWidthPercentage: Double
-    let readerBackground: ReaderBackground
+    let renderConfig: ReaderRenderConfig
     let onBoundaryPanUpdate: ((CGFloat) -> Void)?
-
-    @AppStorage("tapZoneMode") private var tapZoneMode: TapZoneMode = .auto
-    @AppStorage("doubleTapZoomMode") private var doubleTapZoomMode: DoubleTapZoomMode = .fast
-    @AppStorage("showPageNumber") private var showPageNumber: Bool = true
 
     #if os(iOS)
       @State private var boundaryDragOffset: CGFloat = 0
@@ -45,10 +41,7 @@
             pages: viewModel.pages,
             viewModel: viewModel,
             pageWidth: pageWidth(geometry),
-            readerBackground: readerBackground,
-            tapZoneMode: tapZoneMode,
-            doubleTapZoomMode: doubleTapZoomMode,
-            showPageNumber: showPageNumber,
+            renderConfig: renderConfig,
             onPageChange: { pageIndex in
               viewModel.currentPageIndex = pageIndex
             },
@@ -96,7 +89,7 @@
               pageIndex: zoomTargetPageIndex,
               zoomAnchor: zoomAnchor,
               zoomRequestID: zoomRequestID,
-              readerBackground: readerBackground,
+              renderConfig: renderConfig,
               onClose: {
                 viewModel.isZoomed = false
                 withAnimation(.easeInOut(duration: 0.2)) {

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonZoomOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonZoomOverlayView.swift
@@ -11,20 +11,26 @@
     let pageIndex: Int
     let zoomAnchor: CGPoint?
     let zoomRequestID: UUID
-    let readerBackground: ReaderBackground
+    let renderConfig: ReaderRenderConfig
     let onClose: () -> Void
-
-    @AppStorage("doubleTapZoomScale") private var doubleTapZoomScale: Double = 3.0
-    @AppStorage("doubleTapZoomMode") private var doubleTapZoomMode: DoubleTapZoomMode = .fast
-    @AppStorage("tapZoneSize") private var tapZoneSize: TapZoneSize = .large
-    @AppStorage("showPageNumber") private var showPageNumber: Bool = true
-    @AppStorage("enableLiveText") private var enableLiveText: Bool = false
 
     @State private var hasZoomedIn = false
 
+    private var zoomRenderConfig: ReaderRenderConfig {
+      ReaderRenderConfig(
+        tapZoneSize: renderConfig.tapZoneSize,
+        tapZoneMode: .none,
+        showPageNumber: renderConfig.showPageNumber,
+        readerBackground: renderConfig.readerBackground,
+        enableLiveText: renderConfig.enableLiveText,
+        doubleTapZoomScale: renderConfig.doubleTapZoomScale,
+        doubleTapZoomMode: renderConfig.doubleTapZoomMode
+      )
+    }
+
     var body: some View {
       GeometryReader { geometry in
-        let initialScale = CGFloat(doubleTapZoomScale)
+        let initialScale = CGFloat(zoomRenderConfig.doubleTapZoomScale)
 
         PageScrollView(
           viewModel: viewModel,
@@ -34,13 +40,7 @@
           maxScale: 8.0,
           displayMode: .fillWidth,
           readingDirection: .webtoon,
-          doubleTapScale: CGFloat(doubleTapZoomScale),
-          doubleTapZoomMode: doubleTapZoomMode,
-          tapZoneSize: tapZoneSize,
-          tapZoneMode: .none,
-          showPageNumber: showPageNumber,
-          readerBackground: readerBackground,
-          enableLiveText: enableLiveText,
+          renderConfig: zoomRenderConfig,
           initialZoomScale: initialScale,
           initialZoomAnchor: zoomAnchor,
           initialZoomID: zoomRequestID,
@@ -58,7 +58,7 @@
           ]
         )
       }
-      .background(readerBackground.color.readerIgnoresSafeArea())
+      .background(renderConfig.readerBackground.color.readerIgnoresSafeArea())
       .readerIgnoresSafeArea()
       .onChange(of: viewModel.isZoomed) { _, isZoomed in
         if isZoomed {

--- a/KMReader/Shared/UI/ReaderOverlay.swift
+++ b/KMReader/Shared/UI/ReaderOverlay.swift
@@ -21,7 +21,7 @@ import SwiftUI
             set: { if !$0 { readerPresentation.closeReader() } }
           )
         ) {
-          ReaderContentView()
+          ReaderContentView(readerPresentation: readerPresentation)
             #if os(iOS)
               .readerDismissGesture(readingDirection: readerPresentation.readingDirection)
             #endif
@@ -29,6 +29,7 @@ import SwiftUI
               sourceID: readerPresentation.sourceBookId,
               in: namespace
             )
+            .environment(readerPresentation)
             #if os(iOS)
               .tint(themeColor.color)
               .accentColor(themeColor.color)
@@ -39,7 +40,7 @@ import SwiftUI
 
   /// Reader content extracted to be used in fullScreenCover
   private struct ReaderContentView: View {
-    @Environment(ReaderPresentationManager.self) private var readerPresentation
+    let readerPresentation: ReaderPresentationManager
 
     var body: some View {
       Group {


### PR DESCRIPTION
## What
- add `ReaderRenderConfig` as the single render preference payload for DIVINA/Webtoon page rendering
- thread `renderConfig` through `DivinaReaderView`, `ScrollPageView`, `CurlPageView`, page image views, and Webtoon readers
- remove duplicated leaf-level `@AppStorage` reads and use passed config values for tap zones, page numbers, background, live text, and double-tap zoom
- explicitly inject `readerPresentation` and `readerBackgroundPreference` into `UIHostingController` pages created inside curl mode
- remove a few unused environment dependencies identified during crash triage

## Why
Crash logs pointed to missing object-style environment values inside nested hosting roots. The reader stack also had split configuration sources (`@AppStorage`, `AppConfig`, params), which made behavior inconsistent and harder to reason about.

## Validation
- `make build-ios`
- `make build-macos`
- `make build-tvos`
