### PR TITLE
feat: support pinned collections and read lists in dashboard

### DIFF
--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -453,6 +453,16 @@ actor DatabaseOperator {
     }
   }
 
+  func setCollectionPinned(collectionId: String, instanceId: String, isPinned: Bool) {
+    let compositeId = CompositeID.generate(instanceId: instanceId, id: collectionId)
+    let descriptor = FetchDescriptor<KomgaCollection>(
+      predicate: #Predicate { $0.id == compositeId })
+    guard let existing = try? modelContext.fetch(descriptor).first else { return }
+    if existing.isPinned != isPinned {
+      existing.isPinned = isPinned
+    }
+  }
+
   func upsertCollections(_ collections: [SeriesCollection], instanceId: String) {
     guard !collections.isEmpty else { return }
 
@@ -516,6 +526,17 @@ actor DatabaseOperator {
     let descriptor = FetchDescriptor<KomgaReadList>(predicate: #Predicate { $0.id == compositeId })
     if let existing = try? modelContext.fetch(descriptor).first {
       modelContext.delete(existing)
+    }
+  }
+
+  func setReadListPinned(readListId: String, instanceId: String, isPinned: Bool) {
+    let compositeId = CompositeID.generate(instanceId: instanceId, id: readListId)
+    let descriptor = FetchDescriptor<KomgaReadList>(
+      predicate: #Predicate { $0.id == compositeId }
+    )
+    guard let existing = try? modelContext.fetch(descriptor).first else { return }
+    if existing.isPinned != isPinned {
+      existing.isPinned = isPinned
     }
   }
 

--- a/KMReader/Features/Collection/Models/KomgaCollection.swift
+++ b/KMReader/Features/Collection/Models/KomgaCollection.swift
@@ -18,6 +18,7 @@ final class KomgaCollection {
   var createdDate: Date
   var lastModifiedDate: Date
   var filtered: Bool
+  var isPinned: Bool = false
 
   var seriesIdsRaw: Data?
 
@@ -35,6 +36,7 @@ final class KomgaCollection {
     createdDate: Date,
     lastModifiedDate: Date,
     filtered: Bool,
+    isPinned: Bool = false,
     seriesIds: [String] = []
   ) {
     self.id = id ?? CompositeID.generate(instanceId: instanceId, id: collectionId)
@@ -45,6 +47,7 @@ final class KomgaCollection {
     self.createdDate = createdDate
     self.lastModifiedDate = lastModifiedDate
     self.filtered = filtered
+    self.isPinned = isPinned
     self.seriesIdsRaw = try? JSONEncoder().encode(seriesIds)
   }
 

--- a/KMReader/Features/Collection/Views/CollectionCardView.swift
+++ b/KMReader/Features/Collection/Views/CollectionCardView.swift
@@ -36,19 +36,28 @@ struct CollectionCardView: View {
         CollectionContextMenu(
           collectionId: komgaCollection.collectionId,
           menuTitle: komgaCollection.name,
+          isPinned: komgaCollection.isPinned,
           onDeleteRequested: {
             showDeleteConfirmation = true
           },
           onEditRequested: {
             showEditSheet = true
+          },
+          onPinToggleRequested: {
+            togglePinned()
           }
         )
       }
 
       if !cardTextOverlayMode && !coverOnlyCards {
         VStack(alignment: .leading) {
-          Text(komgaCollection.name)
-            .lineLimit(1)
+          HStack(spacing: 4) {
+            if komgaCollection.isPinned {
+              Image(systemName: "pin.fill")
+            }
+            Text(komgaCollection.name)
+              .lineLimit(1)
+          }
 
           HStack(spacing: 4) {
             Text("\(komgaCollection.seriesIds.count) series")
@@ -74,10 +83,12 @@ struct CollectionCardView: View {
 
   @ViewBuilder
   private var overlayTextContent: some View {
-    CardOverlayTextStack(title: komgaCollection.name) {
+    CardOverlayTextStack(
+      title: komgaCollection.name,
+      titleLeadingSystemImage: komgaCollection.isPinned ? "pin.fill" : nil
+    ) {
       HStack(spacing: 4) {
         Text("\(komgaCollection.seriesIds.count) series")
-        Spacer()
       }
     }
   }
@@ -91,6 +102,18 @@ struct CollectionCardView: View {
       } catch {
         ErrorManager.shared.alert(error: error)
       }
+    }
+  }
+
+  private func togglePinned() {
+    let nextPinned = !komgaCollection.isPinned
+    Task {
+      await DatabaseOperator.shared.setCollectionPinned(
+        collectionId: komgaCollection.collectionId,
+        instanceId: komgaCollection.instanceId,
+        isPinned: nextPinned
+      )
+      await DatabaseOperator.shared.commit()
     }
   }
 }

--- a/KMReader/Features/Collection/Views/CollectionCompactCardView.swift
+++ b/KMReader/Features/Collection/Views/CollectionCompactCardView.swift
@@ -7,17 +7,22 @@ import SwiftUI
 
 struct CollectionCompactCardView: View {
   @Bindable var komgaCollection: KomgaCollection
+  var coverWidth: CGFloat = 80
+  @State private var showEditSheet = false
+  @State private var showDeleteConfirmation = false
 
   var body: some View {
     NavigationLink(
       value: NavDestination.collectionDetail(collectionId: komgaCollection.collectionId)
     ) {
-      HStack {
-        ThumbnailImage(id: komgaCollection.collectionId, type: .collection, width: 60)
+      HStack(alignment: .top, spacing: 10) {
+        ThumbnailImage(id: komgaCollection.collectionId, type: .collection, width: coverWidth)
+          .frame(width: coverWidth)
+          .allowsHitTesting(false)
 
         VStack(alignment: .leading, spacing: 4) {
           Text(komgaCollection.name)
-            .font(.callout)
+            .font(.headline)
             .fontWeight(.medium)
             .lineLimit(2)
             .multilineTextAlignment(.leading)
@@ -30,15 +35,71 @@ struct CollectionCompactCardView: View {
             .font(.caption)
             .foregroundColor(.secondary)
         }
-        .frame(maxWidth: 320, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
       }
-      .padding(6)
+      .padding(8)
+      .frame(maxWidth: .infinity, alignment: .leading)
       .background {
         RoundedRectangle(cornerRadius: 12)
           .fill(.regularMaterial)
           .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
       }
+      .contentShape(Rectangle())
+      #if os(iOS)
+        .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 12))
+      #endif
     }
     .adaptiveButtonStyle(.plain)
+    .contextMenu {
+      CollectionContextMenu(
+        collectionId: komgaCollection.collectionId,
+        menuTitle: komgaCollection.name,
+        isPinned: komgaCollection.isPinned,
+        onDeleteRequested: {
+          showDeleteConfirmation = true
+        },
+        onEditRequested: {
+          showEditSheet = true
+        },
+        onPinToggleRequested: {
+          togglePinned()
+        }
+      )
+    }
+    .alert("Delete Collection", isPresented: $showDeleteConfirmation) {
+      Button("Cancel", role: .cancel) {}
+      Button("Delete", role: .destructive) {
+        deleteCollection()
+      }
+    } message: {
+      Text("Are you sure you want to delete this collection? This action cannot be undone.")
+    }
+    .sheet(isPresented: $showEditSheet) {
+      CollectionEditSheet(collection: komgaCollection.toCollection())
+    }
+  }
+
+  private func deleteCollection() {
+    Task {
+      do {
+        try await CollectionService.shared.deleteCollection(
+          collectionId: komgaCollection.collectionId)
+        ErrorManager.shared.notify(message: String(localized: "notification.collection.deleted"))
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
+  }
+
+  private func togglePinned() {
+    let nextPinned = !komgaCollection.isPinned
+    Task {
+      await DatabaseOperator.shared.setCollectionPinned(
+        collectionId: komgaCollection.collectionId,
+        instanceId: komgaCollection.instanceId,
+        isPinned: nextPinned
+      )
+      await DatabaseOperator.shared.commit()
+    }
   }
 }

--- a/KMReader/Features/Collection/Views/CollectionContextMenu.swift
+++ b/KMReader/Features/Collection/Views/CollectionContextMenu.swift
@@ -9,8 +9,10 @@ import SwiftUI
 struct CollectionContextMenu: View {
   let collectionId: String
   let menuTitle: String
+  let isPinned: Bool
   var onDeleteRequested: (() -> Void)? = nil
   var onEditRequested: (() -> Void)? = nil
+  var onPinToggleRequested: (() -> Void)? = nil
   @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("isOffline") private var isOffline: Bool = false
 
@@ -27,6 +29,16 @@ struct CollectionContextMenu: View {
 
       NavigationLink(value: NavDestination.collectionDetail(collectionId: collectionId)) {
         Label("View Details", systemImage: "info.circle")
+      }
+
+      Divider()
+      Button {
+        onPinToggleRequested?()
+      } label: {
+        Label(
+          isPinned ? String(localized: "action.unpinFromTop") : String(localized: "action.pinToTop"),
+          systemImage: isPinned ? "pin.slash" : "pin"
+        )
       }
 
       if !isOffline {

--- a/KMReader/Features/Collection/Views/CollectionDetailView.swift
+++ b/KMReader/Features/Collection/Views/CollectionDetailView.swift
@@ -42,6 +42,10 @@ struct CollectionDetailView: View {
     collection?.name ?? String(localized: "title.collection")
   }
 
+  private var isPinned: Bool {
+    komgaCollection?.isPinned ?? false
+  }
+
   var body: some View {
     ScrollView {
       VStack(alignment: .leading) {
@@ -138,6 +142,19 @@ extension CollectionDetailView {
     }
   }
 
+  private func togglePinned() {
+    guard let komgaCollection else { return }
+    let nextPinned = !komgaCollection.isPinned
+    Task {
+      await DatabaseOperator.shared.setCollectionPinned(
+        collectionId: komgaCollection.collectionId,
+        instanceId: komgaCollection.instanceId,
+        isPinned: nextPinned
+      )
+      await DatabaseOperator.shared.commit()
+    }
+  }
+
   @ViewBuilder
   private var collectionToolbarContent: some View {
     HStack {
@@ -164,7 +181,18 @@ extension CollectionDetailView {
 
       Divider()
 
+      Button {
+        togglePinned()
+      } label: {
+        Label(
+          isPinned ? String(localized: "action.unpinFromTop") : String(localized: "action.pinToTop"),
+          systemImage: isPinned ? "pin.slash" : "pin"
+        )
+      }
+
       if current.isAdmin {
+        Divider()
+
         Button {
           showEditSheet = true
         } label: {

--- a/KMReader/Features/Collection/Views/CollectionRowView.swift
+++ b/KMReader/Features/Collection/Views/CollectionRowView.swift
@@ -24,9 +24,16 @@ struct CollectionRowView: View {
         NavigationLink(
           value: NavDestination.collectionDetail(collectionId: komgaCollection.collectionId)
         ) {
-          Text(komgaCollection.name)
-            .font(.callout)
-            .lineLimit(2)
+          HStack(spacing: 6) {
+            Text(komgaCollection.name)
+              .font(.callout)
+              .lineLimit(2)
+            if komgaCollection.isPinned {
+              Image(systemName: "pin.fill")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            }
+          }
         }.adaptiveButtonStyle(.plain)
 
         HStack {
@@ -49,11 +56,15 @@ struct CollectionRowView: View {
             CollectionContextMenu(
               collectionId: komgaCollection.collectionId,
               menuTitle: komgaCollection.name,
+              isPinned: komgaCollection.isPinned,
               onDeleteRequested: {
                 showDeleteConfirmation = true
               },
               onEditRequested: {
                 showEditSheet = true
+              },
+              onPinToggleRequested: {
+                togglePinned()
               }
             )
             .id(komgaCollection.collectionId)
@@ -83,6 +94,18 @@ struct CollectionRowView: View {
       } catch {
         ErrorManager.shared.alert(error: error)
       }
+    }
+  }
+
+  private func togglePinned() {
+    let nextPinned = !komgaCollection.isPinned
+    Task {
+      await DatabaseOperator.shared.setCollectionPinned(
+        collectionId: komgaCollection.collectionId,
+        instanceId: komgaCollection.instanceId,
+        isPinned: nextPinned
+      )
+      await DatabaseOperator.shared.commit()
     }
   }
 }

--- a/KMReader/Features/Collection/Views/CollectionsBrowseView.swift
+++ b/KMReader/Features/Collection/Views/CollectionsBrowseView.swift
@@ -131,7 +131,15 @@ struct CollectionsBrowseView: View {
           sort: sortOpts.sortString,
           search: searchText.isEmpty ? nil : searchText
         )
-        return (ids: result.content.map { $0.id }, isLastPage: result.last)
+        let ids = KomgaCollectionStore.fetchCollectionIds(
+          context: modelContext,
+          libraryIds: libraryIds,
+          searchText: searchText,
+          sort: sortOpts.sortString,
+          offset: page * size,
+          limit: size
+        )
+        return (ids: ids, isLastPage: result.last || ids.count < size)
       }
     )
   }

--- a/KMReader/Features/Dashboard/Models/DashboardSection.swift
+++ b/KMReader/Features/Dashboard/Models/DashboardSection.swift
@@ -7,9 +7,18 @@ import Foundation
 import SwiftData
 import SwiftUI
 
+enum DashboardSectionContentKind {
+  case books
+  case series
+  case collections
+  case readLists
+}
+
 enum DashboardSection: String, CaseIterable, Identifiable, Codable {
   case keepReading = "keepReading"
   case onDeck = "onDeck"
+  case pinnedCollections = "pinnedCollections"
+  case pinnedReadLists = "pinnedReadLists"
   case recentlyReleasedBooks = "recentlyReleasedBooks"
   case recentlyAddedBooks = "recentlyAddedBooks"
   case recentlyAddedSeries = "recentlyAddedSeries"
@@ -24,6 +33,10 @@ enum DashboardSection: String, CaseIterable, Identifiable, Codable {
       return String(localized: "dashboard.keepReading")
     case .onDeck:
       return String(localized: "dashboard.onDeck")
+    case .pinnedCollections:
+      return String(localized: "dashboard.pinnedCollections")
+    case .pinnedReadLists:
+      return String(localized: "dashboard.pinnedReadLists")
     case .recentlyReleasedBooks:
       return String(localized: "dashboard.recentlyReleasedBooks")
     case .recentlyAddedBooks:
@@ -43,6 +56,10 @@ enum DashboardSection: String, CaseIterable, Identifiable, Codable {
       return "book.fill"
     case .onDeck:
       return "bookmark.fill"
+    case .pinnedCollections:
+      return "square.stack.3d.down.right"
+    case .pinnedReadLists:
+      return "list.bullet.rectangle"
     case .recentlyReleasedBooks:
       return "calendar.badge.clock"
     case .recentlyAddedBooks:
@@ -56,11 +73,24 @@ enum DashboardSection: String, CaseIterable, Identifiable, Codable {
     }
   }
 
-  var isBookSection: Bool {
+  var contentKind: DashboardSectionContentKind {
     switch self {
     case .keepReading, .onDeck, .recentlyReadBooks, .recentlyReleasedBooks, .recentlyAddedBooks:
-      return true
+      return .books
     case .recentlyUpdatedSeries, .recentlyAddedSeries:
+      return .series
+    case .pinnedCollections:
+      return .collections
+    case .pinnedReadLists:
+      return .readLists
+    }
+  }
+
+  var isLocalSection: Bool {
+    switch contentKind {
+    case .collections, .readLists:
+      return true
+    default:
       return false
     }
   }

--- a/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
@@ -1,0 +1,256 @@
+//
+// DashboardPinnedSectionView.swift
+//
+//
+
+import SwiftData
+import SwiftUI
+
+@MainActor
+struct DashboardPinnedSectionView: View {
+  let section: DashboardSection
+  let refreshTrigger: DashboardRefreshTrigger
+
+  @AppStorage("currentInstanceId") private var currentInstanceId: String = ""
+  @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
+  @AppStorage("dashboardShowGradient") private var dashboardShowGradient: Bool = true
+
+  @Query private var pinnedCollections: [KomgaCollection]
+  @Query private var pinnedReadLists: [KomgaReadList]
+
+  @Environment(\.colorScheme) private var colorScheme
+
+  @State private var isLoading = false
+  @State private var hasLoadedInitial = false
+  @State private var isHoveringScrollArea = false
+  @State private var hoverShowDelayTask: Task<Void, Never>?
+  @State private var hoverHideDelayTask: Task<Void, Never>?
+
+  init(section: DashboardSection, refreshTrigger: DashboardRefreshTrigger) {
+    self.section = section
+    self.refreshTrigger = refreshTrigger
+
+    let instanceId = AppConfig.current.instanceId
+    _pinnedCollections = Query(
+      filter: #Predicate<KomgaCollection> { item in
+        item.instanceId == instanceId && item.isPinned == true
+      },
+      sort: [SortDescriptor(\KomgaCollection.lastModifiedDate, order: .reverse)]
+    )
+    _pinnedReadLists = Query(
+      filter: #Predicate<KomgaReadList> { item in
+        item.instanceId == instanceId && item.isPinned == true
+      },
+      sort: [SortDescriptor(\KomgaReadList.lastModifiedDate, order: .reverse)]
+    )
+  }
+
+  private var isSupportedSection: Bool {
+    switch section.contentKind {
+    case .collections, .readLists:
+      return true
+    default:
+      return false
+    }
+  }
+
+  private var hasItems: Bool {
+    switch section.contentKind {
+    case .collections:
+      return !pinnedCollections.isEmpty
+    case .readLists:
+      return !pinnedReadLists.isEmpty
+    default:
+      return false
+    }
+  }
+
+  private var itemIds: [String] {
+    switch section.contentKind {
+    case .collections:
+      return pinnedCollections.map(\.collectionId)
+    case .readLists:
+      return pinnedReadLists.map(\.readListId)
+    default:
+      return []
+    }
+  }
+
+  private var destination: NavDestination {
+    switch section.contentKind {
+    case .collections:
+      return .browseCollections
+    case .readLists:
+      return .browseReadLists
+    default:
+      return .browseCollections
+    }
+  }
+
+  private var backgroundColors: [Color] {
+    if colorScheme == .dark {
+      return [
+        Color.secondary.opacity(0.2),
+        Color.clear,
+      ]
+    } else {
+      return [
+        Color.clear,
+        Color.secondary.opacity(0.1),
+      ]
+    }
+  }
+
+  private var compactCardWidth: CGFloat {
+    let proposed = LayoutConfig.cardWidth(for: gridDensity) * 2.0
+    #if os(tvOS)
+      return min(max(proposed, 360), 680)
+    #else
+      return min(max(proposed, 220), 480)
+    #endif
+  }
+
+  private var compactCoverWidth: CGFloat {
+    min(max(compactCardWidth * 0.24, 64), 132)
+  }
+
+  private var spacing: CGFloat {
+    LayoutConfig.spacing(for: gridDensity)
+  }
+
+  var body: some View {
+    if isSupportedSection {
+      ZStack {
+        #if os(iOS) || os(macOS)
+          if dashboardShowGradient {
+            LinearGradient(
+              colors: backgroundColors,
+              startPoint: .top,
+              endPoint: .bottom
+            ).ignoresSafeArea()
+          }
+        #endif
+
+        VStack(alignment: .leading, spacing: 0) {
+          NavigationLink(value: destination) {
+            HStack {
+              Text(section.displayName)
+                .font(.title2)
+                .bold()
+                .fontDesign(.serif)
+              Image(systemName: "chevron.right")
+                .foregroundStyle(.secondary)
+            }
+          }
+          .buttonStyle(.plain)
+          .padding()
+          #if os(macOS)
+            .padding(.leading, 16)
+          #endif
+          .disabled(!hasItems)
+
+          ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+              LazyHStack(alignment: .top, spacing: spacing) {
+                switch section.contentKind {
+                case .collections:
+                  ForEach(pinnedCollections) { collection in
+                    CollectionCompactCardView(
+                      komgaCollection: collection,
+                      coverWidth: compactCoverWidth
+                    )
+                    .id(collection.collectionId)
+                    .frame(width: compactCardWidth)
+                  }
+                case .readLists:
+                  ForEach(pinnedReadLists) { readList in
+                    ReadListCompactCardView(
+                      komgaReadList: readList,
+                      coverWidth: compactCoverWidth
+                    )
+                    .id(readList.readListId)
+                    .frame(width: compactCardWidth)
+                  }
+                default:
+                  EmptyView()
+                }
+              }
+              .padding(.vertical)
+              #if os(macOS)
+                .padding(.leading, 16)
+              #endif
+            }
+            .contentMargins(.horizontal, spacing, for: .scrollContent)
+            .scrollClipDisabled()
+            #if os(macOS)
+              .overlay {
+                HorizontalScrollButtons(
+                  scrollProxy: proxy,
+                  itemIds: itemIds,
+                  isVisible: isHoveringScrollArea
+                )
+              }
+            #endif
+          }
+        }
+      }
+      .opacity(hasItems ? 1 : 0)
+      .frame(height: hasItems ? nil : 0)
+      #if os(macOS)
+        .onContinuousHover { phase in
+          switch phase {
+          case .active:
+            hoverHideDelayTask?.cancel()
+            hoverHideDelayTask = nil
+            hoverShowDelayTask?.cancel()
+            hoverShowDelayTask = Task { @MainActor in
+              try? await Task.sleep(nanoseconds: 100_000_000)
+              guard !Task.isCancelled else { return }
+              withAnimation(.easeInOut(duration: 0.2)) {
+                isHoveringScrollArea = true
+              }
+            }
+          case .ended:
+            hoverShowDelayTask?.cancel()
+            hoverShowDelayTask = nil
+            hoverHideDelayTask?.cancel()
+            hoverHideDelayTask = Task { @MainActor in
+              try? await Task.sleep(nanoseconds: 100_000_000)
+              guard !Task.isCancelled else { return }
+              withAnimation(.easeInOut(duration: 0.2)) {
+                isHoveringScrollArea = false
+              }
+            }
+          }
+        }
+      #endif
+      .onChange(of: refreshTrigger) { _, newTrigger in
+        if let sections = newTrigger.sectionsToRefresh, !sections.contains(section) {
+          return
+        }
+        Task {
+          await refresh()
+        }
+      }
+      .task {
+        guard !hasLoadedInitial else { return }
+        hasLoadedInitial = true
+        await refresh()
+      }
+    }
+  }
+
+  private func refresh() async {
+    guard !isLoading, !AppConfig.isOffline else { return }
+    isLoading = true
+    switch section.contentKind {
+    case .collections:
+      await SyncService.shared.syncCollections(instanceId: currentInstanceId)
+    case .readLists:
+      await SyncService.shared.syncReadLists(instanceId: currentInstanceId)
+    default:
+      break
+    }
+    isLoading = false
+  }
+}

--- a/KMReader/Features/Dashboard/Views/DashboardView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardView.swift
@@ -201,10 +201,17 @@ struct DashboardView: View {
         }.padding()
 
         ForEach(dashboard.sections, id: \.id) { section in
-          DashboardSectionView(
-            section: section,
-            refreshTrigger: refreshTrigger
-          )
+          if section.isLocalSection {
+            DashboardPinnedSectionView(
+              section: section,
+              refreshTrigger: refreshTrigger
+            )
+          } else {
+            DashboardSectionView(
+              section: section,
+              refreshTrigger: refreshTrigger
+            )
+          }
         }
       }
       .padding(.vertical)

--- a/KMReader/Features/ReadList/Models/KomgaReadList.swift
+++ b/KMReader/Features/ReadList/Models/KomgaReadList.swift
@@ -19,6 +19,7 @@ final class KomgaReadList {
   var createdDate: Date
   var lastModifiedDate: Date
   var filtered: Bool
+  var isPinned: Bool = false
 
   var bookIdsRaw: Data?
 
@@ -66,6 +67,7 @@ final class KomgaReadList {
     createdDate: Date,
     lastModifiedDate: Date,
     filtered: Bool,
+    isPinned: Bool = false,
     bookIds: [String] = [],
     downloadedBooks: Int = 0,
     pendingBooks: Int = 0,
@@ -80,6 +82,7 @@ final class KomgaReadList {
     self.createdDate = createdDate
     self.lastModifiedDate = lastModifiedDate
     self.filtered = filtered
+    self.isPinned = isPinned
     self.bookIdsRaw = try? JSONEncoder().encode(bookIds)
     self.downloadedBooks = downloadedBooks
     self.pendingBooks = pendingBooks

--- a/KMReader/Features/ReadList/Views/ReadListCardView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListCardView.swift
@@ -37,19 +37,28 @@ struct ReadListCardView: View {
           readListId: komgaReadList.readListId,
           menuTitle: komgaReadList.name,
           downloadStatus: komgaReadList.downloadStatus,
+          isPinned: komgaReadList.isPinned,
           onDeleteRequested: {
             showDeleteConfirmation = true
           },
           onEditRequested: {
             showEditSheet = true
+          },
+          onPinToggleRequested: {
+            togglePinned()
           }
         )
       }
 
       if !cardTextOverlayMode && !coverOnlyCards {
         VStack(alignment: .leading) {
-          Text(komgaReadList.name)
-            .lineLimit(1)
+          HStack(spacing: 4) {
+            if komgaReadList.isPinned {
+              Image(systemName: "pin.fill")
+            }
+            Text(komgaReadList.name)
+              .lineLimit(1)
+          }
 
           HStack(spacing: 4) {
             Text("\(komgaReadList.bookIds.count) books")
@@ -75,10 +84,12 @@ struct ReadListCardView: View {
 
   @ViewBuilder
   private var overlayTextContent: some View {
-    CardOverlayTextStack(title: komgaReadList.name) {
+    CardOverlayTextStack(
+      title: komgaReadList.name,
+      titleLeadingSystemImage: komgaReadList.isPinned ? "pin.fill" : nil
+    ) {
       HStack(spacing: 4) {
         Text("\(komgaReadList.bookIds.count) books")
-        Spacer()
       }
     }
   }
@@ -91,6 +102,18 @@ struct ReadListCardView: View {
       } catch {
         ErrorManager.shared.alert(error: error)
       }
+    }
+  }
+
+  private func togglePinned() {
+    let nextPinned = !komgaReadList.isPinned
+    Task {
+      await DatabaseOperator.shared.setReadListPinned(
+        readListId: komgaReadList.readListId,
+        instanceId: komgaReadList.instanceId,
+        isPinned: nextPinned
+      )
+      await DatabaseOperator.shared.commit()
     }
   }
 }

--- a/KMReader/Features/ReadList/Views/ReadListCompactCardView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListCompactCardView.swift
@@ -7,15 +7,20 @@ import SwiftUI
 
 struct ReadListCompactCardView: View {
   @Bindable var komgaReadList: KomgaReadList
+  var coverWidth: CGFloat = 80
+  @State private var showEditSheet = false
+  @State private var showDeleteConfirmation = false
 
   var body: some View {
     NavigationLink(value: NavDestination.readListDetail(readListId: komgaReadList.readListId)) {
-      HStack {
-        ThumbnailImage(id: komgaReadList.readListId, type: .readlist, width: 60)
+      HStack(alignment: .top, spacing: 10) {
+        ThumbnailImage(id: komgaReadList.readListId, type: .readlist, width: coverWidth)
+          .frame(width: coverWidth)
+          .allowsHitTesting(false)
 
         VStack(alignment: .leading, spacing: 4) {
           Text(komgaReadList.name)
-            .font(.callout)
+            .font(.headline)
             .fontWeight(.medium)
             .lineLimit(2)
             .multilineTextAlignment(.leading)
@@ -28,15 +33,71 @@ struct ReadListCompactCardView: View {
             .font(.caption)
             .foregroundColor(.secondary)
         }
-        .frame(maxWidth: 320, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
       }
-      .padding(6)
+      .padding(8)
+      .frame(maxWidth: .infinity, alignment: .leading)
       .background {
         RoundedRectangle(cornerRadius: 12)
           .fill(.regularMaterial)
           .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
       }
+      .contentShape(Rectangle())
+      #if os(iOS)
+        .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 12))
+      #endif
     }
     .adaptiveButtonStyle(.plain)
+    .contextMenu {
+      ReadListContextMenu(
+        readListId: komgaReadList.readListId,
+        menuTitle: komgaReadList.name,
+        downloadStatus: komgaReadList.downloadStatus,
+        isPinned: komgaReadList.isPinned,
+        onDeleteRequested: {
+          showDeleteConfirmation = true
+        },
+        onEditRequested: {
+          showEditSheet = true
+        },
+        onPinToggleRequested: {
+          togglePinned()
+        }
+      )
+    }
+    .alert("Delete Read List", isPresented: $showDeleteConfirmation) {
+      Button("Cancel", role: .cancel) {}
+      Button("Delete", role: .destructive) {
+        deleteReadList()
+      }
+    } message: {
+      Text("Are you sure you want to delete this read list? This action cannot be undone.")
+    }
+    .sheet(isPresented: $showEditSheet) {
+      ReadListEditSheet(readList: komgaReadList.toReadList())
+    }
+  }
+
+  private func deleteReadList() {
+    Task {
+      do {
+        try await ReadListService.shared.deleteReadList(readListId: komgaReadList.readListId)
+        ErrorManager.shared.notify(message: String(localized: "notification.readList.deleted"))
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
+  }
+
+  private func togglePinned() {
+    let nextPinned = !komgaReadList.isPinned
+    Task {
+      await DatabaseOperator.shared.setReadListPinned(
+        readListId: komgaReadList.readListId,
+        instanceId: komgaReadList.instanceId,
+        isPinned: nextPinned
+      )
+      await DatabaseOperator.shared.commit()
+    }
   }
 }

--- a/KMReader/Features/ReadList/Views/ReadListContextMenu.swift
+++ b/KMReader/Features/ReadList/Views/ReadListContextMenu.swift
@@ -9,9 +9,11 @@ struct ReadListContextMenu: View {
   let readListId: String
   let menuTitle: String
   let downloadStatus: SeriesDownloadStatus
+  let isPinned: Bool
 
   var onDeleteRequested: (() -> Void)? = nil
   var onEditRequested: (() -> Void)? = nil
+  var onPinToggleRequested: (() -> Void)? = nil
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("isOffline") private var isOffline: Bool = false
@@ -37,6 +39,16 @@ struct ReadListContextMenu: View {
 
       NavigationLink(value: NavDestination.readListDetail(readListId: readListId)) {
         Label("View Details", systemImage: "info.circle")
+      }
+
+      Divider()
+      Button {
+        onPinToggleRequested?()
+      } label: {
+        Label(
+          isPinned ? String(localized: "action.unpinFromTop") : String(localized: "action.pinToTop"),
+          systemImage: isPinned ? "pin.slash" : "pin"
+        )
       }
 
       if !isOffline {

--- a/KMReader/Features/ReadList/Views/ReadListDetailView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListDetailView.swift
@@ -42,6 +42,10 @@ struct ReadListDetailView: View {
     readList?.name ?? String(localized: "title.readList")
   }
 
+  private var isPinned: Bool {
+    komgaReadList?.isPinned ?? false
+  }
+
   var body: some View {
     ScrollView {
       VStack(alignment: .leading) {
@@ -146,6 +150,19 @@ extension ReadListDetailView {
     }
   }
 
+  private func togglePinned() {
+    guard let komgaReadList else { return }
+    let nextPinned = !komgaReadList.isPinned
+    Task {
+      await DatabaseOperator.shared.setReadListPinned(
+        readListId: komgaReadList.readListId,
+        instanceId: komgaReadList.instanceId,
+        isPinned: nextPinned
+      )
+      await DatabaseOperator.shared.commit()
+    }
+  }
+
   @ViewBuilder
   private var readListToolbarContent: some View {
     HStack {
@@ -166,7 +183,18 @@ extension ReadListDetailView {
 
         Divider()
 
+        Button {
+          togglePinned()
+        } label: {
+          Label(
+            isPinned ? String(localized: "action.unpinFromTop") : String(localized: "action.pinToTop"),
+            systemImage: isPinned ? "pin.slash" : "pin"
+          )
+        }
+
         if current.isAdmin {
+          Divider()
+
           Button {
             showEditSheet = true
           } label: {

--- a/KMReader/Features/ReadList/Views/ReadListRowView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListRowView.swift
@@ -20,9 +20,16 @@ struct ReadListRowView: View {
 
       VStack(alignment: .leading, spacing: 6) {
         NavigationLink(value: NavDestination.readListDetail(readListId: komgaReadList.readListId)) {
-          Text(komgaReadList.name)
-            .font(.callout)
-            .lineLimit(2)
+          HStack(spacing: 6) {
+            Text(komgaReadList.name)
+              .font(.callout)
+              .lineLimit(2)
+            if komgaReadList.isPinned {
+              Image(systemName: "pin.fill")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            }
+          }
         }.adaptiveButtonStyle(.plain)
 
         HStack {
@@ -53,11 +60,15 @@ struct ReadListRowView: View {
               readListId: komgaReadList.readListId,
               menuTitle: komgaReadList.name,
               downloadStatus: komgaReadList.downloadStatus,
+              isPinned: komgaReadList.isPinned,
               onDeleteRequested: {
                 showDeleteConfirmation = true
               },
               onEditRequested: {
                 showEditSheet = true
+              },
+              onPinToggleRequested: {
+                togglePinned()
               }
             )
             .id(komgaReadList.readListId)
@@ -86,6 +97,18 @@ struct ReadListRowView: View {
       } catch {
         ErrorManager.shared.alert(error: error)
       }
+    }
+  }
+
+  private func togglePinned() {
+    let nextPinned = !komgaReadList.isPinned
+    Task {
+      await DatabaseOperator.shared.setReadListPinned(
+        readListId: komgaReadList.readListId,
+        instanceId: komgaReadList.instanceId,
+        isPinned: nextPinned
+      )
+      await DatabaseOperator.shared.commit()
     }
   }
 }

--- a/KMReader/Features/ReadList/Views/ReadListsBrowseView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListsBrowseView.swift
@@ -132,7 +132,15 @@ struct ReadListsBrowseView: View {
           sort: sortOpts.sortString,
           search: searchText.isEmpty ? nil : searchText
         )
-        return (ids: result.content.map { $0.id }, isLastPage: result.last)
+        let ids = KomgaReadListStore.fetchReadListIds(
+          context: modelContext,
+          libraryIds: libraryIds,
+          searchText: searchText,
+          sort: sortOpts.sortString,
+          offset: page * size,
+          limit: size
+        )
+        return (ids: ids, isLastPage: result.last || ids.count < size)
       }
     )
   }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -1870,6 +1870,98 @@
         }
       }
     },
+    "action.pinToTop" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oben anheften"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin to Top"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Épingler en haut"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上部にピン留め"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상단에 고정"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "置顶"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "置頂"
+          }
+        }
+      }
+    },
+    "action.unpinFromTop" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Von oben lösen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unpin from Top"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désépingler du haut"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上部のピン留めを解除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상단 고정 해제"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消置顶"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消置頂"
+          }
+        }
+      }
+    },
     "Active" : {
       "localizations" : {
         "de" : {
@@ -10192,6 +10284,98 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "待閱讀"
+          }
+        }
+      }
+    },
+    "dashboard.pinnedCollections" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Angeheftete Sammlungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pinned Collections"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Collections épinglées"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ピン留めしたコレクション"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "고정된 모음집"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "置顶收藏"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "置頂收藏"
+          }
+        }
+      }
+    },
+    "dashboard.pinnedReadLists" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Angeheftete Leselisten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pinned Read Lists"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listes de lecture épinglées"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ピン留めした読書リスト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "고정된 읽기 목록"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "置顶阅读列表"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "置頂閱讀列表"
           }
         }
       }

--- a/KMReader/Shared/UI/CardOverlayTextStack.swift
+++ b/KMReader/Shared/UI/CardOverlayTextStack.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 struct CardOverlayTextStack<Detail: View, Progress: View>: View {
   let title: String
+  let titleLeadingSystemImage: String?
   let subtitle: String?
   let titleLineLimit: Int
   let style: CardOverlayTextStyle
@@ -16,6 +17,7 @@ struct CardOverlayTextStack<Detail: View, Progress: View>: View {
 
   init(
     title: String,
+    titleLeadingSystemImage: String? = nil,
     subtitle: String? = nil,
     titleLineLimit: Int = 1,
     style: CardOverlayTextStyle = .standard,
@@ -24,6 +26,7 @@ struct CardOverlayTextStack<Detail: View, Progress: View>: View {
     @ViewBuilder progress: () -> Progress
   ) {
     self.title = title
+    self.titleLeadingSystemImage = titleLeadingSystemImage
     self.subtitle = subtitle
     self.titleLineLimit = titleLineLimit
     self.style = style
@@ -40,9 +43,18 @@ struct CardOverlayTextStack<Detail: View, Progress: View>: View {
           .lineLimit(1)
       }
 
-      Text(title)
+      if let titleLeadingSystemImage {
+        HStack(spacing: 4) {
+          Image(systemName: titleLeadingSystemImage)
+          Text(title)
+            .lineLimit(titleLineLimit)
+        }
         .cardOverlayTitle(style)
-        .lineLimit(titleLineLimit)
+      } else {
+        Text(title)
+          .cardOverlayTitle(style)
+          .lineLimit(titleLineLimit)
+      }
 
       detail
         .cardOverlayDetail(style)
@@ -55,6 +67,7 @@ struct CardOverlayTextStack<Detail: View, Progress: View>: View {
 extension CardOverlayTextStack where Progress == EmptyView {
   init(
     title: String,
+    titleLeadingSystemImage: String? = nil,
     subtitle: String? = nil,
     titleLineLimit: Int = 1,
     style: CardOverlayTextStyle = .standard,
@@ -63,6 +76,7 @@ extension CardOverlayTextStack where Progress == EmptyView {
   ) {
     self.init(
       title: title,
+      titleLeadingSystemImage: titleLeadingSystemImage,
       subtitle: subtitle,
       titleLineLimit: titleLineLimit,
       style: style,

--- a/KMReader/Shared/UI/CardPlaceholder.swift
+++ b/KMReader/Shared/UI/CardPlaceholder.swift
@@ -25,6 +25,10 @@ struct CardPlaceholder: View {
     }
   }
 
+  private var listThumbnailHeight: CGFloat {
+    listThumbnailWidth / CoverAspectRatio.widthToHeight
+  }
+
   var body: some View {
     switch layout {
     case .grid:
@@ -80,7 +84,7 @@ struct CardPlaceholder: View {
       RoundedRectangle(cornerRadius: cornerRadius)
         .fill(Color.gray.opacity(0.2))
         .frame(width: listThumbnailWidth)
-        .aspectRatio(CoverAspectRatio.widthToHeight, contentMode: .fit)
+        .frame(height: listThumbnailHeight)
 
       VStack(alignment: .leading, spacing: lineSpacing) {
         ForEach(Array(listLines.enumerated()), id: \.offset) { item in


### PR DESCRIPTION
## Summary
- add `isPinned` support for `KomgaCollection` and `KomgaReadList`, with pin/unpin actions wired through context menus and detail action menus
- add pinned dashboard sections for collections and read lists, using local SwiftData queries and compact horizontal cards
- update collection/read list browse ordering to keep pinned items first while preserving existing sort order inside pinned/unpinned groups
- add pin indicators to card/row views and adjust compact card interaction/shape behavior and sizing
- fix list placeholder thumbnail sizing to avoid stretched row placeholders

## Testing
- [x] `make build`

## Related
- Closes #521
