### PR TITLE
feat: add server reading stats dashboard

### DIFF
--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -771,6 +771,20 @@ enum AppConfig {
     }
   }
 
+  static nonisolated var readingStatsCache: ReadingStatsCache {
+    get {
+      if let stored = UserDefaults.standard.string(forKey: "readingStatsCache"),
+        let cache = ReadingStatsCache(rawValue: stored)
+      {
+        return cache
+      }
+      return ReadingStatsCache()
+    }
+    set {
+      UserDefaults.standard.set(newValue.rawValue, forKey: "readingStatsCache")
+    }
+  }
+
   private static nonisolated var recentlyReadRecordTimeByInstance: [String: TimeInterval] {
     get {
       guard

--- a/KMReader/Core/Storage/ReadingStatsCacheStore.swift
+++ b/KMReader/Core/Storage/ReadingStatsCacheStore.swift
@@ -1,0 +1,45 @@
+//
+// ReadingStatsCacheStore.swift
+//
+//
+
+import Foundation
+
+@MainActor
+@Observable
+final class ReadingStatsCacheStore {
+  static let shared = ReadingStatsCacheStore()
+
+  private(set) var cache: ReadingStatsCache
+
+  init(cache: ReadingStatsCache) {
+    self.cache = cache
+  }
+
+  convenience init() {
+    self.init(cache: AppConfig.readingStatsCache)
+  }
+
+  func snapshot(instanceId: String, libraryId: String) -> ReadingStatsSnapshot? {
+    cache.snapshot(instanceId: instanceId, libraryId: libraryId)
+  }
+
+  func upsert(snapshot: ReadingStatsSnapshot, instanceId: String, libraryId: String) {
+    var updated = cache
+    updated.upsert(snapshot: snapshot, instanceId: instanceId, libraryId: libraryId)
+    cache = updated
+    AppConfig.readingStatsCache = updated
+  }
+
+  func clear(instanceId: String) {
+    var updated = cache
+    updated.clear(instanceId: instanceId)
+    cache = updated
+    AppConfig.readingStatsCache = updated
+  }
+
+  func reset() {
+    cache = ReadingStatsCache()
+    AppConfig.readingStatsCache = cache
+  }
+}

--- a/KMReader/Features/Book/Services/BookService.swift
+++ b/KMReader/Features/Book/Services/BookService.swift
@@ -155,12 +155,17 @@ class BookService {
     search: BookSearch,
     page: Int = 0,
     size: Int = 20,
-    sort: String? = nil
+    sort: String? = nil,
+    unpaged: Bool = false
   ) async throws -> Page<Book> {
-    var queryItems = [
-      URLQueryItem(name: "page", value: "\(page)"),
-      URLQueryItem(name: "size", value: "\(size)"),
-    ]
+    var queryItems: [URLQueryItem] = []
+
+    if unpaged {
+      queryItems.append(URLQueryItem(name: "unpaged", value: "true"))
+    } else {
+      queryItems.append(URLQueryItem(name: "page", value: "\(page)"))
+      queryItems.append(URLQueryItem(name: "size", value: "\(size)"))
+    }
 
     if let sort = sort {
       queryItems.append(URLQueryItem(name: "sort", value: sort))

--- a/KMReader/Features/History/Models/ReadingStatsCache.swift
+++ b/KMReader/Features/History/Models/ReadingStatsCache.swift
@@ -1,0 +1,66 @@
+//
+// ReadingStatsCache.swift
+//
+//
+
+import Foundation
+
+nonisolated struct ReadingStatsCache: Equatable, RawRepresentable, Sendable {
+  typealias RawValue = String
+
+  var snapshotsByScope: [String: ReadingStatsSnapshot]
+
+  init(snapshotsByScope: [String: ReadingStatsSnapshot] = [:]) {
+    self.snapshotsByScope = snapshotsByScope
+  }
+
+  func snapshot(instanceId: String, libraryId: String) -> ReadingStatsSnapshot? {
+    snapshotsByScope[Self.scopeKey(instanceId: instanceId, libraryId: libraryId)]
+  }
+
+  mutating func upsert(snapshot: ReadingStatsSnapshot, instanceId: String, libraryId: String) {
+    snapshotsByScope[Self.scopeKey(instanceId: instanceId, libraryId: libraryId)] = snapshot
+  }
+
+  mutating func clear(instanceId: String) {
+    let prefix = "\(instanceId)|"
+    snapshotsByScope = snapshotsByScope.filter { !$0.key.hasPrefix(prefix) }
+  }
+
+  static func scopeKey(instanceId: String, libraryId: String) -> String {
+    let normalizedLibrary = libraryId.trimmingCharacters(in: .whitespacesAndNewlines)
+    let libraryScope = normalizedLibrary.isEmpty ? "__all__" : normalizedLibrary
+    return "\(instanceId)|\(libraryScope)"
+  }
+
+  var rawValue: String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+
+    guard
+      let data = try? encoder.encode(snapshotsByScope),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return "{}"
+    }
+
+    return json
+  }
+
+  init?(rawValue: String) {
+    guard let data = rawValue.data(using: .utf8), !data.isEmpty else {
+      self.snapshotsByScope = [:]
+      return
+    }
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    if let decoded = try? decoder.decode([String: ReadingStatsSnapshot].self, from: data) {
+      self.snapshotsByScope = decoded
+    } else {
+      self.snapshotsByScope = [:]
+    }
+  }
+}

--- a/KMReader/Features/History/Models/ReadingStatsDecodingHelpers.swift
+++ b/KMReader/Features/History/Models/ReadingStatsDecodingHelpers.swift
@@ -1,0 +1,49 @@
+//
+// ReadingStatsDecodingHelpers.swift
+//
+//
+
+import Foundation
+
+extension KeyedDecodingContainer {
+  nonisolated func decodeFirstString(forKeys keys: [Key]) throws -> String? {
+    for key in keys {
+      if let value = try decodeIfPresent(String.self, forKey: key) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+          return trimmed
+        }
+      }
+    }
+    return nil
+  }
+
+  nonisolated func decodeFirstDouble(forKeys keys: [Key]) throws -> Double? {
+    for key in keys {
+      if let value = try decodeIfPresent(Double.self, forKey: key) {
+        return value
+      }
+      if let value = try decodeIfPresent(Int.self, forKey: key) {
+        return Double(value)
+      }
+      if let value = try decodeIfPresent(Int64.self, forKey: key) {
+        return Double(value)
+      }
+      if let value = try decodeIfPresent(String.self, forKey: key),
+        let parsed = Double(value)
+      {
+        return parsed
+      }
+    }
+    return nil
+  }
+
+  nonisolated func decodeFirstArray<T: Decodable>(_ type: [T].Type, forKeys keys: [Key]) throws -> [T]? {
+    for key in keys {
+      if let value = try decodeIfPresent(type, forKey: key) {
+        return value
+      }
+    }
+    return nil
+  }
+}

--- a/KMReader/Features/History/Models/ReadingStatsItem.swift
+++ b/KMReader/Features/History/Models/ReadingStatsItem.swift
@@ -1,0 +1,44 @@
+//
+// ReadingStatsItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct ReadingStatsItem: Codable, Equatable, Sendable, Identifiable {
+  let name: String
+  let value: Double
+
+  var id: String {
+    name
+  }
+
+  init(name: String, value: Double) {
+    self.name = name
+    self.value = value
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case name
+    case label
+    case title
+    case key
+    case value
+    case count
+    case weight
+    case hours
+    case total
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    name = try container.decodeFirstString(forKeys: [.name, .label, .title, .key]) ?? "-"
+    value = try container.decodeFirstDouble(forKeys: [.value, .count, .weight, .hours, .total]) ?? 0
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(name, forKey: .name)
+    try container.encode(value, forKey: .value)
+  }
+}

--- a/KMReader/Features/History/Models/ReadingStatsPayload.swift
+++ b/KMReader/Features/History/Models/ReadingStatsPayload.swift
@@ -1,0 +1,142 @@
+//
+// ReadingStatsPayload.swift
+//
+//
+
+import Foundation
+
+nonisolated struct ReadingStatsPayload: Codable, Equatable, Sendable {
+  let summary: ReadingStatsSummary
+  let statusDistribution: [ReadingStatsItem]
+  let dailyDistribution: [ReadingStatsItem]
+  let hourlyDistribution: [ReadingStatsItem]
+  let readingTimeSeries: [ReadingStatsTimePoint]
+  let topAuthors: [ReadingStatsItem]
+  let topGenres: [ReadingStatsItem]
+  let topTags: [ReadingStatsItem]
+  let genreDistribution: [ReadingStatsItem]
+  let tagDistribution: [ReadingStatsItem]
+  let generatedAt: String?
+
+  init(
+    summary: ReadingStatsSummary = ReadingStatsSummary(),
+    statusDistribution: [ReadingStatsItem] = [],
+    dailyDistribution: [ReadingStatsItem] = [],
+    hourlyDistribution: [ReadingStatsItem] = [],
+    readingTimeSeries: [ReadingStatsTimePoint] = [],
+    topAuthors: [ReadingStatsItem] = [],
+    topGenres: [ReadingStatsItem] = [],
+    topTags: [ReadingStatsItem] = [],
+    genreDistribution: [ReadingStatsItem] = [],
+    tagDistribution: [ReadingStatsItem] = [],
+    generatedAt: String? = nil
+  ) {
+    self.summary = summary
+    self.statusDistribution = statusDistribution
+    self.dailyDistribution = dailyDistribution
+    self.hourlyDistribution = hourlyDistribution
+    self.readingTimeSeries = readingTimeSeries
+    self.topAuthors = topAuthors
+    self.topGenres = topGenres
+    self.topTags = topTags
+    self.genreDistribution = genreDistribution
+    self.tagDistribution = tagDistribution
+    self.generatedAt = generatedAt
+  }
+
+  static let empty = ReadingStatsPayload()
+
+  private enum CodingKeys: String, CodingKey {
+    case summary
+
+    case statusDistribution
+    case readingStatus
+
+    case dailyDistribution
+    case readingByDay
+
+    case hourlyDistribution
+    case readingByHour
+
+    case readingTimeSeries
+    case readingTimeChart
+    case chartData
+
+    case topAuthors
+    case authorWords
+
+    case topGenres
+    case genreWords
+
+    case topTags
+    case tagWords
+
+    case genreDistribution
+    case genresDistribution
+
+    case tagDistribution
+    case tagsDistribution
+
+    case generatedAt
+    case updatedAt
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    summary = try container.decodeIfPresent(ReadingStatsSummary.self, forKey: .summary) ?? ReadingStatsSummary()
+
+    statusDistribution =
+      try container.decodeFirstArray([ReadingStatsItem].self, forKeys: [.statusDistribution, .readingStatus])
+      ?? []
+
+    dailyDistribution =
+      try container.decodeFirstArray([ReadingStatsItem].self, forKeys: [.dailyDistribution, .readingByDay])
+      ?? []
+
+    hourlyDistribution =
+      try container.decodeFirstArray([ReadingStatsItem].self, forKeys: [.hourlyDistribution, .readingByHour])
+      ?? []
+
+    readingTimeSeries =
+      try container.decodeFirstArray(
+        [ReadingStatsTimePoint].self,
+        forKeys: [.readingTimeSeries, .readingTimeChart, .chartData]
+      ) ?? []
+
+    topAuthors =
+      try container.decodeFirstArray([ReadingStatsItem].self, forKeys: [.topAuthors, .authorWords])
+      ?? []
+
+    topGenres =
+      try container.decodeFirstArray([ReadingStatsItem].self, forKeys: [.topGenres, .genreWords])
+      ?? []
+
+    topTags = try container.decodeFirstArray([ReadingStatsItem].self, forKeys: [.topTags, .tagWords]) ?? []
+
+    genreDistribution =
+      try container.decodeFirstArray([ReadingStatsItem].self, forKeys: [.genreDistribution, .genresDistribution])
+      ?? []
+
+    tagDistribution =
+      try container.decodeFirstArray([ReadingStatsItem].self, forKeys: [.tagDistribution, .tagsDistribution])
+      ?? []
+
+    generatedAt = try container.decodeFirstString(forKeys: [.generatedAt, .updatedAt])
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(summary, forKey: .summary)
+    try container.encode(statusDistribution, forKey: .statusDistribution)
+    try container.encode(dailyDistribution, forKey: .dailyDistribution)
+    try container.encode(hourlyDistribution, forKey: .hourlyDistribution)
+    try container.encode(readingTimeSeries, forKey: .readingTimeSeries)
+    try container.encode(topAuthors, forKey: .topAuthors)
+    try container.encode(topGenres, forKey: .topGenres)
+    try container.encode(topTags, forKey: .topTags)
+    try container.encode(genreDistribution, forKey: .genreDistribution)
+    try container.encode(tagDistribution, forKey: .tagDistribution)
+    try container.encodeIfPresent(generatedAt, forKey: .generatedAt)
+  }
+}

--- a/KMReader/Features/History/Models/ReadingStatsSnapshot.swift
+++ b/KMReader/Features/History/Models/ReadingStatsSnapshot.swift
@@ -1,0 +1,18 @@
+//
+// ReadingStatsSnapshot.swift
+//
+//
+
+import Foundation
+
+nonisolated struct ReadingStatsSnapshot: Codable, Equatable, Sendable {
+  let libraryId: String
+  let cachedAt: Date
+  let payload: ReadingStatsPayload
+
+  init(libraryId: String, cachedAt: Date, payload: ReadingStatsPayload) {
+    self.libraryId = libraryId
+    self.cachedAt = cachedAt
+    self.payload = payload
+  }
+}

--- a/KMReader/Features/History/Models/ReadingStatsSummary.swift
+++ b/KMReader/Features/History/Models/ReadingStatsSummary.swift
@@ -1,0 +1,107 @@
+//
+// ReadingStatsSummary.swift
+//
+//
+
+import Foundation
+
+nonisolated struct ReadingStatsSummary: Codable, Equatable, Sendable {
+  let totalBooks: Double
+  let booksStartedReading: Double
+  let booksCompletedReading: Double
+  let totalPagesRead: Double
+  let averagePagesPerBook: Double
+  let readingDays: Double
+  let estimatedReadingHours: Double
+  let lastReadAt: String?
+
+  init(
+    totalBooks: Double = 0,
+    booksStartedReading: Double = 0,
+    booksCompletedReading: Double = 0,
+    totalPagesRead: Double = 0,
+    averagePagesPerBook: Double = 0,
+    readingDays: Double = 0,
+    estimatedReadingHours: Double = 0,
+    lastReadAt: String? = nil
+  ) {
+    self.totalBooks = totalBooks
+    self.booksStartedReading = booksStartedReading
+    self.booksCompletedReading = booksCompletedReading
+    self.totalPagesRead = totalPagesRead
+    self.averagePagesPerBook = averagePagesPerBook
+    self.readingDays = readingDays
+    self.estimatedReadingHours = estimatedReadingHours
+    self.lastReadAt = lastReadAt
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case totalBooks
+    case totalBookCount
+    case booksTotal
+
+    case booksStartedReading
+    case startedBooks
+    case booksWithProgress
+
+    case booksCompletedReading
+    case completedBooks
+
+    case totalPagesRead
+    case pagesRead
+
+    case averagePagesPerBook
+    case avgPagesPerBook
+
+    case readingDays
+    case readingStreak
+    case activeReadingDays
+
+    case estimatedReadingHours
+    case estimatedReadingTime
+    case readingHours
+
+    case lastReadAt
+    case lastReadDate
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    totalBooks = try container.decodeFirstDouble(forKeys: [.totalBooks, .totalBookCount, .booksTotal]) ?? 0
+
+    booksStartedReading =
+      try container.decodeFirstDouble(forKeys: [.booksStartedReading, .startedBooks, .booksWithProgress])
+      ?? 0
+
+    booksCompletedReading =
+      try container.decodeFirstDouble(forKeys: [.booksCompletedReading, .completedBooks]) ?? 0
+
+    totalPagesRead = try container.decodeFirstDouble(forKeys: [.totalPagesRead, .pagesRead]) ?? 0
+
+    averagePagesPerBook =
+      try container.decodeFirstDouble(forKeys: [.averagePagesPerBook, .avgPagesPerBook])
+      ?? 0
+
+    readingDays =
+      try container.decodeFirstDouble(forKeys: [.readingDays, .readingStreak, .activeReadingDays]) ?? 0
+
+    estimatedReadingHours =
+      try container.decodeFirstDouble(forKeys: [.estimatedReadingHours, .estimatedReadingTime, .readingHours])
+      ?? 0
+
+    lastReadAt = try container.decodeFirstString(forKeys: [.lastReadAt, .lastReadDate])
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(totalBooks, forKey: .totalBooks)
+    try container.encode(booksStartedReading, forKey: .booksStartedReading)
+    try container.encode(booksCompletedReading, forKey: .booksCompletedReading)
+    try container.encode(totalPagesRead, forKey: .totalPagesRead)
+    try container.encode(averagePagesPerBook, forKey: .averagePagesPerBook)
+    try container.encode(readingDays, forKey: .readingDays)
+    try container.encode(estimatedReadingHours, forKey: .estimatedReadingHours)
+    try container.encodeIfPresent(lastReadAt, forKey: .lastReadAt)
+  }
+}

--- a/KMReader/Features/History/Models/ReadingStatsTimePoint.swift
+++ b/KMReader/Features/History/Models/ReadingStatsTimePoint.swift
@@ -1,0 +1,54 @@
+//
+// ReadingStatsTimePoint.swift
+//
+//
+
+import Foundation
+
+nonisolated struct ReadingStatsTimePoint: Codable, Equatable, Sendable, Identifiable {
+  let name: String
+  let value: Double
+  let dateString: String?
+
+  var id: String {
+    if let dateString, !dateString.isEmpty {
+      return "\(dateString)-\(name)"
+    }
+    return name
+  }
+
+  init(name: String, value: Double, dateString: String? = nil) {
+    self.name = name
+    self.value = value
+    self.dateString = dateString
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case name
+    case label
+    case title
+    case key
+    case value
+    case count
+    case hours
+    case date
+    case timestamp
+    case time
+    case period
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let decodedDate = try container.decodeFirstString(forKeys: [.date, .timestamp, .time, .period])
+    dateString = decodedDate
+    name = try container.decodeFirstString(forKeys: [.name, .label, .title, .key]) ?? decodedDate ?? "-"
+    value = try container.decodeFirstDouble(forKeys: [.value, .hours, .count]) ?? 0
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(name, forKey: .name)
+    try container.encode(value, forKey: .value)
+    try container.encodeIfPresent(dateString, forKey: .date)
+  }
+}

--- a/KMReader/Features/History/Models/ReadingStatsTimeRange.swift
+++ b/KMReader/Features/History/Models/ReadingStatsTimeRange.swift
@@ -1,0 +1,55 @@
+//
+// ReadingStatsTimeRange.swift
+//
+//
+
+import Foundation
+
+nonisolated enum ReadingStatsTimeRange: String, CaseIterable, Sendable {
+  case thisWeek
+  case last7Days
+  case last30Days
+  case last90Days
+  case last6Months
+  case lastYear
+  case allTime
+
+  var title: String {
+    switch self {
+    case .thisWeek:
+      return String(localized: "This Week")
+    case .last7Days:
+      return String(localized: "Last 7 Days")
+    case .last30Days:
+      return String(localized: "Last 30 Days")
+    case .last90Days:
+      return String(localized: "Last 90 Days")
+    case .last6Months:
+      return String(localized: "Last 6 Months")
+    case .lastYear:
+      return String(localized: "Last Year")
+    case .allTime:
+      return String(localized: "All Time")
+    }
+  }
+
+  func startDate(reference: Date = Date(), calendar: Calendar = .current) -> Date? {
+    switch self {
+    case .thisWeek:
+      let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: reference)
+      return calendar.date(from: components)
+    case .last7Days:
+      return calendar.date(byAdding: .day, value: -6, to: reference)
+    case .last30Days:
+      return calendar.date(byAdding: .day, value: -29, to: reference)
+    case .last90Days:
+      return calendar.date(byAdding: .day, value: -89, to: reference)
+    case .last6Months:
+      return calendar.date(byAdding: .month, value: -6, to: reference)
+    case .lastYear:
+      return calendar.date(byAdding: .year, value: -1, to: reference)
+    case .allTime:
+      return nil
+    }
+  }
+}

--- a/KMReader/Features/History/Services/ReadingStatsService.swift
+++ b/KMReader/Features/History/Services/ReadingStatsService.swift
@@ -1,0 +1,362 @@
+//
+// ReadingStatsService.swift
+//
+//
+
+import Foundation
+
+class ReadingStatsService {
+  static let shared = ReadingStatsService()
+
+  private let bookService = BookService.shared
+  private let seriesService = SeriesService.shared
+
+  private init() {}
+
+  func fetchReadingStats(libraryId: String?) async throws -> ReadingStatsPayload {
+    let normalizedLibraryId = normalizeLibraryId(libraryId)
+
+    async let readBooksTask = fetchReadBooks()
+    async let readSeriesTask = fetchReadSeries()
+    async let totalBooksTask = fetchTotalBooks(libraryId: normalizedLibraryId)
+
+    let readBooks = try await readBooksTask
+    let readSeries = try await readSeriesTask
+    let totalBooks = try await totalBooksTask
+
+    let filteredBooks: [Book]
+    if let normalizedLibraryId {
+      filteredBooks = readBooks.filter { $0.libraryId == normalizedLibraryId }
+    } else {
+      filteredBooks = readBooks
+    }
+
+    return buildPayload(
+      filteredBooks: filteredBooks,
+      readSeries: readSeries,
+      totalBooks: totalBooks
+    )
+  }
+
+  // MARK: - Data loading (aligned with ReadingStatsView.vue)
+
+  private func fetchReadBooks() async throws -> [Book] {
+    let condition: [String: Any] = [
+      "readStatus": [
+        "operator": "isNot",
+        "value": ReadStatus.unread.rawValue,
+      ]
+    ]
+
+    let page = try await bookService.getBooksList(
+      search: BookSearch(condition: condition),
+      unpaged: true
+    )
+
+    return page.content
+  }
+
+  private func fetchReadSeries() async throws -> [Series] {
+    let condition: [String: Any] = [
+      "readStatus": [
+        "operator": "isNot",
+        "value": ReadStatus.unread.rawValue,
+      ]
+    ]
+
+    let page = try await seriesService.getSeriesList(
+      search: SeriesSearch(condition: condition),
+      unpaged: true
+    )
+
+    return page.content
+  }
+
+  private func fetchTotalBooks(libraryId: String?) async throws -> Int {
+    let search: BookSearch
+
+    if let libraryId {
+      let condition: [String: Any] = [
+        "libraryId": [
+          "operator": "is",
+          "value": libraryId,
+        ]
+      ]
+      search = BookSearch(condition: condition)
+    } else {
+      search = BookSearch()
+    }
+
+    let page = try await bookService.getBooksList(
+      search: search,
+      page: 0,
+      size: 1
+    )
+
+    return page.totalElements
+  }
+
+  // MARK: - Aggregation
+
+  private func buildPayload(filteredBooks: [Book], readSeries: [Series], totalBooks: Int) -> ReadingStatsPayload {
+    let booksWithProgress = filteredBooks.filter { $0.readProgress != nil }
+    let completedBooks = filteredBooks.filter { $0.readProgress?.completed == true }
+
+    let totalPagesRead = completedBooks.reduce(0.0) { partial, book in
+      partial + Double(book.readProgress?.page ?? 0)
+    }
+
+    let averagePagesPerBook = completedBooks.isEmpty ? 0 : (totalPagesRead / Double(completedBooks.count)).rounded()
+    let estimatedReadingHours = (totalPagesRead / 2 / 60).rounded()
+
+    let readDates = completedBooks.compactMap { $0.readProgress?.readDate }
+    let lastReadDate = readDates.max()
+    let uniqueReadingDays = Set(readDates.map { Self.dayKeyFormatter.string(from: $0) })
+
+    let summary = ReadingStatsSummary(
+      totalBooks: Double(totalBooks),
+      booksStartedReading: Double(booksWithProgress.count),
+      booksCompletedReading: Double(completedBooks.count),
+      totalPagesRead: totalPagesRead,
+      averagePagesPerBook: averagePagesPerBook,
+      readingDays: Double(uniqueReadingDays.count),
+      estimatedReadingHours: estimatedReadingHours,
+      lastReadAt: lastReadDate.map { Self.isoDateTimeFormatter.string(from: $0) }
+    )
+
+    let statusDistribution = buildStatusDistribution(
+      totalBooks: totalBooks,
+      filteredBooks: filteredBooks,
+      completedBooks: completedBooks
+    )
+
+    let dailyDistribution = buildDailyDistribution(completedBooks: completedBooks)
+    let hourlyDistribution = buildHourlyDistribution(completedBooks: completedBooks)
+    let readingTimeSeries = buildReadingTimeSeries(completedBooks: completedBooks)
+
+    let dimensions = buildDimensions(completedBooks: completedBooks, readSeries: readSeries)
+
+    return ReadingStatsPayload(
+      summary: summary,
+      statusDistribution: statusDistribution,
+      dailyDistribution: dailyDistribution,
+      hourlyDistribution: hourlyDistribution,
+      readingTimeSeries: readingTimeSeries,
+      topAuthors: dimensions.topAuthors,
+      topGenres: dimensions.topGenres,
+      topTags: dimensions.topTags,
+      genreDistribution: dimensions.genreDistribution,
+      tagDistribution: dimensions.tagDistribution,
+      generatedAt: Self.isoDateTimeFormatter.string(from: Date())
+    )
+  }
+
+  private func buildStatusDistribution(
+    totalBooks: Int,
+    filteredBooks: [Book],
+    completedBooks: [Book]
+  ) -> [ReadingStatsItem] {
+    let completedCount = completedBooks.count
+    let inProgressCount = filteredBooks.filter { book in
+      guard let progress = book.readProgress else { return false }
+      return progress.completed == false
+    }.count
+    let unreadCount = max(totalBooks - filteredBooks.count, 0)
+
+    return [
+      ReadingStatsItem(name: String(localized: "readStatus.read"), value: Double(completedCount)),
+      ReadingStatsItem(name: String(localized: "readStatus.inProgress"), value: Double(inProgressCount)),
+      ReadingStatsItem(name: String(localized: "readStatus.unread"), value: Double(unreadCount)),
+    ].filter { $0.value > 0 }
+  }
+
+  private func buildDailyDistribution(completedBooks: [Book]) -> [ReadingStatsItem] {
+    let calendar = Calendar.current
+    let weekdaySymbols = calendar.shortWeekdaySymbols
+
+    var counts = Array(repeating: 0, count: 7)
+    for book in completedBooks {
+      guard let readDate = book.readProgress?.readDate else { continue }
+      let weekday = calendar.component(.weekday, from: readDate)
+      guard weekday >= 1 && weekday <= 7 else { continue }
+      counts[weekday - 1] += 1
+    }
+
+    return weekdaySymbols.enumerated().map { index, symbol in
+      ReadingStatsItem(name: symbol, value: Double(counts[index]))
+    }
+  }
+
+  private func buildHourlyDistribution(completedBooks: [Book]) -> [ReadingStatsItem] {
+    let calendar = Calendar.current
+    var counts = Array(repeating: 0, count: 24)
+
+    for book in completedBooks {
+      guard let readDate = book.readProgress?.readDate else { continue }
+      let hour = calendar.component(.hour, from: readDate)
+      guard hour >= 0 && hour < 24 else { continue }
+      counts[hour] += 1
+    }
+
+    return counts.enumerated().map { hour, count in
+      ReadingStatsItem(name: String(format: "%d:00", hour), value: Double(count))
+    }
+  }
+
+  private func buildReadingTimeSeries(completedBooks: [Book]) -> [ReadingStatsTimePoint] {
+    guard !completedBooks.isEmpty else { return [] }
+
+    let today = Date()
+    let startDate =
+      completedBooks
+      .compactMap { $0.readProgress?.readDate }
+      .min()
+      .map { Calendar.current.startOfDay(for: $0) }
+      ?? Calendar.current.startOfDay(for: today)
+
+    var hoursByDay: [String: Double] = [:]
+    for book in completedBooks {
+      guard let progress = book.readProgress else { continue }
+      let dayKey = Self.dayKeyFormatter.string(from: progress.readDate)
+      let hours = Double(progress.page) / 2 / 60
+      hoursByDay[dayKey, default: 0] += hours
+    }
+
+    var points: [ReadingStatsTimePoint] = []
+    var cursor = startDate
+    let endDate = Calendar.current.startOfDay(for: today)
+
+    while cursor <= endDate {
+      let dayKey = Self.dayKeyFormatter.string(from: cursor)
+      points.append(
+        ReadingStatsTimePoint(
+          name: dayKey,
+          value: hoursByDay[dayKey, default: 0],
+          dateString: dayKey
+        )
+      )
+      guard let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: cursor) else { break }
+      cursor = nextDay
+    }
+
+    return points
+  }
+
+  private func buildDimensions(completedBooks: [Book], readSeries: [Series]) -> ReadingStatsDimensions {
+    let seriesById = Dictionary(uniqueKeysWithValues: readSeries.map { ($0.id, $0) })
+    let booksBySeries = Dictionary(grouping: completedBooks, by: \.seriesId)
+
+    var authorCounts: [String: Int] = [:]
+    var genreCounts: [String: Int] = [:]
+    var tagCounts: [String: Int] = [:]
+
+    for (seriesId, books) in booksBySeries {
+      let series = seriesById[seriesId]
+
+      if let genres = series?.metadata.genres {
+        for genre in genres where !genre.isEmpty {
+          genreCounts[genre, default: 0] += 1
+        }
+      }
+
+      var authors = Set<String>()
+      var tags = Set<String>()
+
+      if let seriesAuthors = series?.booksMetadata.authors {
+        for author in seriesAuthors where !author.name.isEmpty {
+          authors.insert(author.name)
+        }
+      }
+
+      if let seriesTags = series?.metadata.tags {
+        for tag in seriesTags where !tag.isEmpty {
+          tags.insert(tag)
+        }
+      }
+
+      for book in books {
+        if let bookAuthors = book.metadata.authors {
+          for author in bookAuthors where !author.name.isEmpty {
+            authors.insert(author.name)
+          }
+        }
+
+        if let bookTags = book.metadata.tags {
+          for tag in bookTags where !tag.isEmpty {
+            tags.insert(tag)
+          }
+        }
+      }
+
+      for author in authors {
+        authorCounts[author, default: 0] += 1
+      }
+
+      for tag in tags {
+        tagCounts[tag, default: 0] += 1
+      }
+    }
+
+    let topAuthors = sortedItems(from: authorCounts)
+    let topGenres = sortedItems(from: genreCounts)
+    let topTags = sortedItems(from: tagCounts)
+
+    return ReadingStatsDimensions(
+      topAuthors: topAuthors,
+      topGenres: topGenres,
+      topTags: topTags,
+      genreDistribution: makeDistribution(from: topGenres),
+      tagDistribution: makeDistribution(from: topTags)
+    )
+  }
+
+  private func sortedItems(from counts: [String: Int]) -> [ReadingStatsItem] {
+    counts
+      .map { ReadingStatsItem(name: $0.key, value: Double($0.value)) }
+      .sorted {
+        if $0.value == $1.value {
+          return $0.name.localizedCompare($1.name) == .orderedAscending
+        }
+        return $0.value > $1.value
+      }
+  }
+
+  private func makeDistribution(from items: [ReadingStatsItem], topCount: Int = 17) -> [ReadingStatsItem] {
+    guard items.count > topCount else { return items }
+
+    let fixedItems = Array(items.prefix(topCount))
+    let otherValue = items.dropFirst(topCount).reduce(0.0) { partial, item in
+      partial + item.value
+    }
+
+    return fixedItems + [ReadingStatsItem(name: String(localized: "Other"), value: otherValue)]
+  }
+
+  private func normalizeLibraryId(_ libraryId: String?) -> String? {
+    guard let libraryId else { return nil }
+    let trimmed = libraryId.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  private static let dayKeyFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter
+  }()
+
+  private static let isoDateTimeFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter
+  }()
+}
+
+private struct ReadingStatsDimensions {
+  let topAuthors: [ReadingStatsItem]
+  let topGenres: [ReadingStatsItem]
+  let topTags: [ReadingStatsItem]
+  let genreDistribution: [ReadingStatsItem]
+  let tagDistribution: [ReadingStatsItem]
+}

--- a/KMReader/Features/History/ViewModels/ReadingStatsViewModel.swift
+++ b/KMReader/Features/History/ViewModels/ReadingStatsViewModel.swift
@@ -1,0 +1,358 @@
+//
+// ReadingStatsViewModel.swift
+//
+//
+
+import Foundation
+
+@MainActor
+@Observable
+final class ReadingStatsViewModel {
+  var payload: ReadingStatsPayload?
+  var lastUpdatedAt: Date?
+  var selectedTimeRange: ReadingStatsTimeRange = .last30Days
+  var isLoading = false
+  var isRefreshing = false
+  var isUsingCachedData = false
+  var errorMessage: String?
+
+  private let cacheTTL: TimeInterval = 15 * 60
+  private let service = ReadingStatsService.shared
+  private let cacheStore = ReadingStatsCacheStore.shared
+
+  func load(instanceId: String, libraryId: String, forceRefresh: Bool = false) async {
+    guard !instanceId.isEmpty else {
+      payload = nil
+      lastUpdatedAt = nil
+      errorMessage = nil
+      isUsingCachedData = false
+      return
+    }
+
+    let cachedSnapshot = cacheStore.snapshot(instanceId: instanceId, libraryId: libraryId)
+
+    if let cachedSnapshot {
+      apply(snapshot: cachedSnapshot, usingCache: true)
+
+      let cacheAge = Date().timeIntervalSince(cachedSnapshot.cachedAt)
+      if forceRefresh == false && cacheAge <= cacheTTL {
+        return
+      }
+
+      if AppConfig.isOffline {
+        errorMessage = String(localized: "Offline mode is enabled. Showing cached reading stats.")
+        return
+      }
+    } else if AppConfig.isOffline {
+      payload = nil
+      lastUpdatedAt = nil
+      errorMessage = String(localized: "Offline mode is enabled and no cached reading stats are available.")
+      return
+    }
+
+    errorMessage = nil
+    if payload == nil {
+      isLoading = true
+    } else {
+      isRefreshing = true
+    }
+
+    do {
+      let fetched = try await service.fetchReadingStats(libraryId: normalizedLibraryId(libraryId))
+      let snapshot = ReadingStatsSnapshot(libraryId: normalizedLibraryId(libraryId), cachedAt: Date(), payload: fetched)
+      cacheStore.upsert(snapshot: snapshot, instanceId: instanceId, libraryId: libraryId)
+      apply(snapshot: snapshot, usingCache: false)
+    } catch {
+      if let cachedSnapshot {
+        apply(snapshot: cachedSnapshot, usingCache: true)
+        errorMessage = String(localized: "Failed to refresh reading stats. Showing cached data.")
+      } else {
+        payload = nil
+        lastUpdatedAt = nil
+        errorMessage = error.localizedDescription
+        ErrorManager.shared.alert(error: error)
+      }
+    }
+
+    isLoading = false
+    isRefreshing = false
+  }
+
+  func filteredTimeSeries(referenceDate: Date = Date()) -> [ReadingStatsTimePoint] {
+    guard let readingTimeSeries = payload?.readingTimeSeries, !readingTimeSeries.isEmpty else {
+      return []
+    }
+
+    let dailyPoints = readingTimeSeries.compactMap { point -> (date: Date, hours: Double)? in
+      guard let parsedDate = Self.parseDate(point.dateString ?? point.name) else {
+        return nil
+      }
+      return (Self.utcCalendar.startOfDay(for: parsedDate), point.value)
+    }
+
+    guard !dailyPoints.isEmpty else {
+      return []
+    }
+
+    let now = Self.utcCalendar.startOfDay(for: referenceDate)
+    let earliestDate = dailyPoints.map(\.date).min() ?? now
+    let window = makeTimeSeriesWindow(referenceDate: now, earliestDate: earliestDate)
+
+    var hoursByKey: [String: Double] = [:]
+    for point in dailyPoints {
+      guard point.date >= window.startDate && point.date <= window.endDate else { continue }
+      let key = Self.groupKey(for: point.date, grouping: window.grouping)
+      hoursByKey[key, default: 0] += point.hours
+    }
+
+    if window.grouping == .day {
+      let todayKey = Self.groupKey(for: window.endDate, grouping: .day)
+      if hoursByKey[todayKey] == nil {
+        hoursByKey[todayKey] = 0
+      }
+    }
+
+    if window.startDate > window.endDate {
+      let todayKey = Self.groupKey(for: window.endDate, grouping: .day)
+      let todayLabel = formatAxisLabel(key: todayKey, grouping: .day)
+      return [ReadingStatsTimePoint(name: todayLabel, value: 0, dateString: todayKey)]
+    }
+
+    var series: [ReadingStatsTimePoint] = []
+    var cursor = window.startDate
+
+    while cursor <= window.endDate {
+      let key = Self.groupKey(for: cursor, grouping: window.grouping)
+      let value = hoursByKey[key, default: 0]
+
+      series.append(
+        ReadingStatsTimePoint(
+          name: formatAxisLabel(key: key, grouping: window.grouping),
+          value: (value * 100).rounded() / 100,
+          dateString: key
+        )
+      )
+
+      guard let nextCursor = Self.nextDate(from: cursor, grouping: window.grouping) else {
+        break
+      }
+      cursor = nextCursor
+    }
+
+    if window.grouping == .day {
+      let todayKey = Self.groupKey(for: window.endDate, grouping: .day)
+      let hasToday = series.contains { $0.dateString == todayKey }
+      if !hasToday {
+        series.append(
+          ReadingStatsTimePoint(
+            name: formatAxisLabel(key: todayKey, grouping: .day),
+            value: 0,
+            dateString: todayKey
+          )
+        )
+      }
+    }
+
+    return series
+  }
+
+  private func makeTimeSeriesWindow(referenceDate: Date, earliestDate: Date) -> ReadingTimeWindow {
+    let now = Self.utcCalendar.startOfDay(for: referenceDate)
+    let year = Self.utcCalendar.component(.year, from: now)
+    let month = Self.utcCalendar.component(.month, from: now)
+    let day = Self.utcCalendar.component(.day, from: now)
+    let weekday = Self.utcCalendar.component(.weekday, from: now)
+
+    let startDate: Date
+    let grouping: ReadingTimeGrouping
+
+    switch selectedTimeRange {
+    case .thisWeek:
+      let offset = weekday - 1
+      startDate = Self.utcCalendar.date(byAdding: .day, value: -offset, to: now) ?? now
+      grouping = .day
+    case .last7Days:
+      startDate = Self.utcCalendar.date(byAdding: .day, value: -6, to: now) ?? now
+      grouping = .day
+    case .last30Days:
+      startDate = Self.utcCalendar.date(byAdding: .day, value: -29, to: now) ?? now
+      grouping = .day
+    case .last90Days:
+      startDate = Self.utcCalendar.date(from: DateComponents(year: year, month: month - 2, day: 1)) ?? now
+      grouping = .month
+    case .last6Months:
+      startDate = Self.utcCalendar.date(from: DateComponents(year: year, month: month - 5, day: 1)) ?? now
+      grouping = .month
+    case .lastYear:
+      startDate = Self.utcCalendar.date(from: DateComponents(year: year - 1, month: month + 1, day: 1)) ?? now
+      grouping = .month
+    case .allTime:
+      startDate = Self.utcCalendar.date(from: DateComponents(year: year, month: month, day: day)) ?? earliestDate
+      grouping = .year
+    }
+
+    if selectedTimeRange == .allTime {
+      return ReadingTimeWindow(startDate: earliestDate, endDate: now, grouping: grouping)
+    }
+
+    return ReadingTimeWindow(
+      startDate: Self.utcCalendar.startOfDay(for: startDate),
+      endDate: now,
+      grouping: grouping
+    )
+  }
+
+  private func formatAxisLabel(key: String, grouping: ReadingTimeGrouping) -> String {
+    switch grouping {
+    case .day:
+      guard let date = Self.dayKeyFormatter.date(from: key) else { return key }
+      return Self.dayAxisLabelFormatter.string(from: date)
+    case .month:
+      guard let date = Self.monthKeyFormatter.date(from: key) else { return key }
+      return Self.monthAxisLabelFormatter.string(from: date)
+    case .year:
+      return key
+    }
+  }
+
+  private static func groupKey(for date: Date, grouping: ReadingTimeGrouping) -> String {
+    switch grouping {
+    case .day:
+      return dayKeyFormatter.string(from: date)
+    case .month:
+      return monthKeyFormatter.string(from: date)
+    case .year:
+      return yearKeyFormatter.string(from: date)
+    }
+  }
+
+  private static func nextDate(from date: Date, grouping: ReadingTimeGrouping) -> Date? {
+    switch grouping {
+    case .day:
+      return utcCalendar.date(byAdding: .day, value: 1, to: date)
+    case .month:
+      return utcCalendar.date(byAdding: .month, value: 1, to: date)
+    case .year:
+      return utcCalendar.date(byAdding: .year, value: 1, to: date)
+    }
+  }
+
+  private enum ReadingTimeGrouping {
+    case day
+    case month
+    case year
+  }
+
+  private struct ReadingTimeWindow {
+    let startDate: Date
+    let endDate: Date
+    let grouping: ReadingTimeGrouping
+  }
+
+  static func parseDate(_ rawValue: String?) -> Date? {
+    guard let rawValue else { return nil }
+
+    let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    if let date = iso8601WithFractional.date(from: trimmed) {
+      return date
+    }
+    if let date = iso8601.date(from: trimmed) {
+      return date
+    }
+
+    for formatter in additionalDateFormatters {
+      if let date = formatter.date(from: trimmed) {
+        return date
+      }
+    }
+
+    return nil
+  }
+
+  private func apply(snapshot: ReadingStatsSnapshot, usingCache: Bool) {
+    payload = snapshot.payload
+    lastUpdatedAt = snapshot.cachedAt
+    isUsingCachedData = usingCache
+  }
+
+  private func normalizedLibraryId(_ libraryId: String) -> String {
+    libraryId.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private static let iso8601WithFractional: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter
+  }()
+
+  private static let iso8601: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter
+  }()
+
+  private static let additionalDateFormatters: [DateFormatter] = {
+    let formats = [
+      "yyyy-MM-dd",
+      "yyyy-MM",
+      "yyyy",
+      "yyyy-MM-dd HH:mm:ss",
+      "yyyy-MM-dd'T'HH:mm:ss",
+      "yyyy-MM-dd'T'HH:mm:ss.SSS",
+    ]
+
+    return formats.map { format in
+      let formatter = DateFormatter()
+      formatter.locale = Locale(identifier: "en_US_POSIX")
+      formatter.timeZone = .current
+      formatter.dateFormat = format
+      return formatter
+    }
+  }()
+
+  private static let utcCalendar: Calendar = {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+    return calendar
+  }()
+
+  private static let dayKeyFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter
+  }()
+
+  private static let monthKeyFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM"
+    return formatter
+  }()
+
+  private static let yearKeyFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy"
+    return formatter
+  }()
+
+  private static let dayAxisLabelFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = .current
+    formatter.setLocalizedDateFormatFromTemplate("MMMd")
+    return formatter
+  }()
+
+  private static let monthAxisLabelFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = .current
+    formatter.setLocalizedDateFormatFromTemplate("yMMM")
+    return formatter
+  }()
+}

--- a/KMReader/Features/History/Views/ServerReadingStatsView.swift
+++ b/KMReader/Features/History/Views/ServerReadingStatsView.swift
@@ -1,0 +1,593 @@
+//
+// ServerReadingStatsView.swift
+//
+//
+
+import Charts
+import SwiftData
+import SwiftUI
+
+struct ServerReadingStatsView: View {
+  @AppStorage("currentAccount") private var current: Current = .init()
+  @AppStorage("isOffline") private var isOffline: Bool = false
+  @Query(sort: [SortDescriptor(\KomgaLibrary.name, order: .forward)]) private var allLibraries: [KomgaLibrary]
+
+  @State private var selectedLibraryId: String = ""
+  @State private var viewModel = ReadingStatsViewModel()
+  @State private var selectedTimePointIndex: Int?
+
+  private var libraries: [KomgaLibrary] {
+    guard !current.instanceId.isEmpty else { return [] }
+    return allLibraries.filter {
+      $0.instanceId == current.instanceId && $0.libraryId != KomgaLibrary.allLibrariesId
+    }
+  }
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 16) {
+        controlsSection
+
+        if let errorMessage = viewModel.errorMessage {
+          Text(errorMessage)
+            .font(.footnote)
+            .foregroundStyle(.orange)
+        }
+
+        if viewModel.isLoading && viewModel.payload == nil {
+          HStack {
+            Spacer()
+            ProgressView()
+            Spacer()
+          }
+          .padding(.top, 24)
+        } else if let payload = viewModel.payload {
+          statsContent(payload: payload)
+        } else {
+          emptyState
+        }
+      }
+      .padding(.horizontal)
+      .padding(.vertical, 12)
+    }
+    .inlineNavigationBarTitle(ServerSection.readingStats.title)
+    .task(id: current.instanceId) {
+      selectedLibraryId = ""
+      await reload(forceRefresh: false)
+    }
+    .onChange(of: selectedLibraryId) { _, _ in
+      Task {
+        await reload(forceRefresh: false)
+      }
+    }
+    .onChange(of: viewModel.selectedTimeRange) { _, _ in
+      selectedTimePointIndex = nil
+    }
+    .onChange(of: isOffline) { oldValue, newValue in
+      if oldValue && !newValue {
+        Task {
+          await reload(forceRefresh: false)
+        }
+      }
+    }
+    #if os(iOS) || os(macOS)
+      .refreshable {
+        await reload(forceRefresh: true)
+      }
+    #endif
+    .toolbar {
+      ToolbarItem(placement: .primaryAction) {
+        Button {
+          Task {
+            await reload(forceRefresh: true)
+          }
+        } label: {
+          if viewModel.isRefreshing {
+            ProgressView()
+          } else {
+            Image(systemName: "arrow.clockwise")
+          }
+        }
+        .disabled(viewModel.isLoading || viewModel.isRefreshing)
+      }
+    }
+  }
+
+  private var controlsSection: some View {
+    HStack(spacing: 8) {
+      Picker(String(localized: "Library"), selection: $selectedLibraryId) {
+        Text(String(localized: "All Libraries"))
+          .lineLimit(1)
+          .truncationMode(.tail)
+          .tag("")
+        ForEach(libraries) { library in
+          Text(library.name)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .tag(library.libraryId)
+        }
+      }
+      .pickerStyle(.menu)
+      .frame(maxWidth: 220, alignment: .leading)
+      .lineLimit(1)
+      .truncationMode(.tail)
+
+      Spacer()
+
+      if let lastUpdatedAt = viewModel.lastUpdatedAt {
+        Text(lastUpdatedAt.formatted(date: .numeric, time: .shortened))
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.tail)
+      }
+
+      if viewModel.isUsingCachedData {
+        Text(String(localized: "Cached"))
+          .font(.caption)
+          .fontWeight(.semibold)
+          .padding(.horizontal, 8)
+          .padding(.vertical, 4)
+          .background(Color.orange.opacity(0.2), in: Capsule())
+          .foregroundStyle(.orange)
+      }
+    }
+    .padding(12)
+    .background(.thinMaterial)
+    .clipShape(RoundedRectangle(cornerRadius: 14))
+  }
+
+  private var emptyState: some View {
+    VStack(spacing: 12) {
+      Image(systemName: "chart.bar.doc.horizontal")
+        .font(.system(size: 36))
+        .foregroundStyle(.secondary)
+      Text(String(localized: "No reading stats available"))
+        .font(.headline)
+      Text(String(localized: "Pull to refresh or tap refresh after your server finishes aggregation."))
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+      Button {
+        Task {
+          await reload(forceRefresh: true)
+        }
+      } label: {
+        Label(String(localized: "Refresh"), systemImage: "arrow.clockwise")
+      }
+      .adaptiveButtonStyle(.borderedProminent)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 28)
+  }
+
+  @ViewBuilder
+  private func statsContent(payload: ReadingStatsPayload) -> some View {
+    let summary = payload.summary
+    let filteredTimeSeries = viewModel.filteredTimeSeries()
+    let indexedTimeSeries = Array(filteredTimeSeries.enumerated())
+
+    summarySection(summary)
+
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(spacing: 12) {
+        Text(String(localized: "Reading Time"))
+          .font(.headline)
+
+        Spacer()
+
+        Picker(String(localized: "Range"), selection: $viewModel.selectedTimeRange) {
+          ForEach(ReadingStatsTimeRange.allCases, id: \.self) { range in
+            Text(range.title)
+              .tag(range)
+          }
+        }
+        .pickerStyle(.menu)
+      }
+
+      if filteredTimeSeries.isEmpty {
+        sectionEmptyState(systemImage: "chart.xyaxis.line", message: String(localized: "No data"))
+      } else {
+        Chart(indexedTimeSeries, id: \.offset) { item in
+          let index = item.offset
+          let point = item.element
+
+          LineMark(
+            x: .value("Index", index),
+            y: .value("Hours", point.value)
+          )
+          .foregroundStyle(Color.accentColor)
+
+          AreaMark(
+            x: .value("Index", index),
+            y: .value("Hours", point.value)
+          )
+          .interpolationMethod(.catmullRom)
+          .foregroundStyle(
+            LinearGradient(
+              colors: [Color.accentColor.opacity(0.35), Color.accentColor.opacity(0.05)],
+              startPoint: .top,
+              endPoint: .bottom
+            )
+          )
+
+          if selectedTimePointIndex == index {
+            PointMark(
+              x: .value("Index", index),
+              y: .value("Hours", point.value)
+            )
+            .symbolSize(60)
+            .foregroundStyle(Color.accentColor)
+          }
+        }
+        .chartXAxis {
+          AxisMarks(values: axisMarkIndices(count: filteredTimeSeries.count)) { value in
+            if let index = value.as(Int.self), index < filteredTimeSeries.count {
+              AxisValueLabel(axisLabel(for: filteredTimeSeries[index]))
+            }
+          }
+        }
+        #if !os(tvOS)
+          .chartOverlay { proxy in
+            GeometryReader { geometry in
+              Color.clear
+              .contentShape(Rectangle())
+              .gesture(
+                DragGesture(minimumDistance: 0)
+                  .onChanged { drag in
+                    guard let plotFrame = proxy.plotFrame else { return }
+                    let plotOrigin = geometry[plotFrame].origin
+                    let plotX = drag.location.x - plotOrigin.x
+
+                    guard plotX >= 0, plotX <= proxy.plotSize.width else { return }
+
+                    if let index = proxy.value(atX: plotX, as: Int.self) {
+                      selectedTimePointIndex = max(0, min(index, filteredTimeSeries.count - 1))
+                    } else if let index = proxy.value(atX: plotX, as: Double.self) {
+                      let rounded = Int(index.rounded())
+                      selectedTimePointIndex = max(0, min(rounded, filteredTimeSeries.count - 1))
+                    }
+                  }
+              )
+            }
+          }
+        #endif
+        .chartBackground { _ in
+          if let selectedTimePointIndex,
+            selectedTimePointIndex >= 0,
+            selectedTimePointIndex < filteredTimeSeries.count
+          {
+            let point = filteredTimeSeries[selectedTimePointIndex]
+            VStack(alignment: .leading, spacing: 4) {
+              Text(displayDate(for: point))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+              Text(String(localized: "Reading Time: \(formatHoursAndMinutes(point.value))"))
+                .font(.caption)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+            }
+            .padding(8)
+            .background(.ultraThinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+            .padding(.top, 8)
+            .padding(.trailing, 8)
+          }
+        }
+        .frame(height: 220)
+
+        Text(String(localized: "X-axis: Date, Y-axis: Estimated reading hours."))
+          .font(.caption)
+          .foregroundStyle(.secondary)
+
+        #if !os(tvOS)
+          Text(String(localized: "Tip: Tap or drag a point to view details."))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        #endif
+      }
+    }
+    .padding(12)
+    .background(.thinMaterial)
+    .clipShape(RoundedRectangle(cornerRadius: 14))
+
+    sectionCard(title: String(localized: "Reading Status")) {
+      if payload.statusDistribution.isEmpty {
+        sectionEmptyState(systemImage: "chart.bar", message: String(localized: "No data"))
+      } else {
+        pieChart(payload.statusDistribution)
+      }
+    }
+
+    sectionCard(title: String(localized: "Reading by Weekday")) {
+      if payload.dailyDistribution.isEmpty {
+        sectionEmptyState(systemImage: "calendar", message: String(localized: "No data"))
+      } else {
+        distributionChart(payload.dailyDistribution, keepOrder: true)
+      }
+    }
+
+    sectionCard(title: String(localized: "Reading by Hour")) {
+      if payload.hourlyDistribution.isEmpty {
+        sectionEmptyState(systemImage: "clock", message: String(localized: "No data"))
+      } else {
+        distributionChart(payload.hourlyDistribution, keepOrder: true, sparseAxisLabels: true)
+      }
+    }
+
+    topItemsSection(title: String(localized: "Top Authors"), items: payload.topAuthors)
+    topItemsSection(title: String(localized: "Top Genres"), items: payload.topGenres)
+    topItemsSection(title: String(localized: "Top Tags"), items: payload.topTags)
+
+    sectionCard(title: String(localized: "Genres Distribution")) {
+      if payload.genreDistribution.isEmpty {
+        sectionEmptyState(systemImage: "chart.pie", message: String(localized: "No data"))
+      } else {
+        pieChart(payload.genreDistribution)
+      }
+    }
+
+    sectionCard(title: String(localized: "Tags Distribution")) {
+      if payload.tagDistribution.isEmpty {
+        sectionEmptyState(systemImage: "chart.pie", message: String(localized: "No data"))
+      } else {
+        pieChart(payload.tagDistribution)
+      }
+    }
+  }
+
+  private func summarySection(_ summary: ReadingStatsSummary) -> some View {
+    let cards = [
+      (String(localized: "Books Started"), formatCount(summary.booksStartedReading), "book"),
+      (String(localized: "Books Completed"), formatCount(summary.booksCompletedReading), "checkmark.circle"),
+      (String(localized: "Pages Read"), formatCount(summary.totalPagesRead), "doc.text"),
+      (String(localized: "Reading Days"), formatCount(summary.readingDays), "calendar"),
+      (String(localized: "Estimated Hours"), formatDecimal(summary.estimatedReadingHours), "hourglass"),
+      (String(localized: "Avg Pages / Book"), formatDecimal(summary.averagePagesPerBook), "chart.bar.xaxis"),
+      (String(localized: "Total Books"), formatCount(summary.totalBooks), "books.vertical"),
+      (String(localized: "Last Read"), formatLastRead(summary.lastReadAt), "clock.arrow.circlepath"),
+    ]
+
+    return LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 12)], spacing: 12) {
+      ForEach(cards.indices, id: \.self) { index in
+        let card = cards[index]
+        VStack(alignment: .leading, spacing: 8) {
+          Label(card.0, systemImage: card.2)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+          Text(card.1)
+            .font(.title3)
+            .fontWeight(.semibold)
+            .lineLimit(1)
+            .minimumScaleFactor(0.75)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(.thinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+      }
+    }
+  }
+
+  private func distributionChart(
+    _ items: [ReadingStatsItem],
+    keepOrder: Bool = false,
+    sparseAxisLabels: Bool = false
+  ) -> some View {
+    let chartItems: [ReadingStatsItem]
+    if keepOrder {
+      chartItems = items
+    } else {
+      chartItems = Array(items.sorted { $0.value > $1.value }.prefix(16))
+    }
+
+    if sparseAxisLabels {
+      let indexedItems = Array(chartItems.enumerated())
+      return AnyView(
+        Chart(indexedItems, id: \.offset) { item in
+          BarMark(
+            x: .value("Index", item.offset),
+            y: .value("Value", item.element.value)
+          )
+          .foregroundStyle(Color.accentColor.gradient)
+        }
+        .chartXAxis {
+          AxisMarks(values: distributionAxisIndices(count: chartItems.count, keepOrder: keepOrder)) { value in
+            if let index = value.as(Int.self), index >= 0, index < chartItems.count {
+              AxisValueLabel(chartItems[index].name)
+            }
+          }
+        }
+        .frame(height: 220)
+      )
+    }
+
+    return AnyView(
+      Chart(chartItems) { item in
+        BarMark(
+          x: .value("Label", item.name),
+          y: .value("Value", item.value)
+        )
+        .foregroundStyle(Color.accentColor.gradient)
+      }
+      .frame(height: 220)
+    )
+  }
+
+  private func pieChart(_ items: [ReadingStatsItem]) -> some View {
+    let topItems = Array(items.sorted { $0.value > $1.value }.prefix(12))
+
+    return Chart(topItems, id: \.id) { item in
+      SectorMark(
+        angle: .value("Value", item.value),
+        innerRadius: .ratio(0.58),
+        angularInset: 1.5
+      )
+      .foregroundStyle(by: .value("Label", item.name))
+    }
+    .frame(height: 240)
+  }
+
+  private func topItemsSection(title: String, items: [ReadingStatsItem]) -> some View {
+    sectionCard(title: title) {
+      let sortedItems = items.sorted { $0.value > $1.value }
+      if sortedItems.isEmpty {
+        sectionEmptyState(systemImage: "list.bullet", message: String(localized: "No data"))
+      } else {
+        VStack(spacing: 8) {
+          ForEach(sortedItems.prefix(10).indices, id: \.self) { index in
+            let item = sortedItems[index]
+            HStack(spacing: 8) {
+              Text("\(index + 1).")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .frame(width: 20, alignment: .trailing)
+
+              Text(item.name)
+                .lineLimit(1)
+
+              Spacer()
+
+              Text(formatDecimal(item.value))
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func sectionCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text(title)
+        .font(.headline)
+      content()
+    }
+    .padding(12)
+    .background(.thinMaterial)
+    .clipShape(RoundedRectangle(cornerRadius: 14))
+  }
+
+  private func sectionEmptyState(systemImage: String, message: String) -> some View {
+    VStack(spacing: 8) {
+      Image(systemName: systemImage)
+        .foregroundStyle(.secondary)
+      Text(message)
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 16)
+  }
+
+  private func formatCount(_ value: Double) -> String {
+    Int(max(value.rounded(), 0)).formatted()
+  }
+
+  private func formatDecimal(_ value: Double) -> String {
+    if abs(value.rounded() - value) < 0.01 {
+      return Int(value.rounded()).formatted()
+    }
+
+    return String(format: "%.1f", value)
+  }
+
+  private func formatLastRead(_ rawValue: String?) -> String {
+    guard let rawValue else {
+      return String(localized: "No record")
+    }
+
+    guard let date = ReadingStatsViewModel.parseDate(rawValue) else {
+      return rawValue
+    }
+
+    return date.formattedMediumDate
+  }
+
+  private func axisMarkIndices(count: Int) -> [Int] {
+    guard count > 0 else { return [] }
+    let desiredMarks = 6
+    let step = max(1, Int(ceil(Double(count) / Double(desiredMarks))))
+    var indices = Array(stride(from: 0, to: count, by: step))
+    if indices.last != count - 1 {
+      indices.append(count - 1)
+    }
+    return indices
+  }
+
+  private func distributionAxisIndices(count: Int, keepOrder: Bool) -> [Int] {
+    guard count > 0 else { return [] }
+    if keepOrder == false {
+      return Array(0..<count)
+    }
+    let desiredMarks = 8
+    let step = max(1, Int(ceil(Double(count) / Double(desiredMarks))))
+    var indices = Array(stride(from: 0, to: count, by: step))
+    if indices.last != count - 1 {
+      indices.append(count - 1)
+    }
+    return indices
+  }
+
+  private func axisLabel(for point: ReadingStatsTimePoint) -> String {
+    point.name
+  }
+
+  private func displayDate(for point: ReadingStatsTimePoint) -> String {
+    if let dateString = point.dateString {
+      if dateString.count == 4 {
+        return dateString
+      }
+
+      if dateString.count == 7, let date = Self.monthKeyFormatter.date(from: dateString) {
+        return Self.monthDisplayFormatter.string(from: date)
+      }
+    }
+
+    guard let date = ReadingStatsViewModel.parseDate(point.dateString) else {
+      return point.name
+    }
+    return date.formattedMediumDate
+  }
+
+  private func formatHoursAndMinutes(_ hours: Double) -> String {
+    let totalMinutes = Int((hours * 60).rounded())
+    let hourPart = totalMinutes / 60
+    let minutePart = totalMinutes % 60
+
+    if hourPart == 0 {
+      return "\(minutePart)m"
+    }
+    if minutePart == 0 {
+      return "\(hourPart)h"
+    }
+    return "\(hourPart)h \(minutePart)m"
+  }
+
+  private static let monthKeyFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM"
+    return formatter
+  }()
+
+  private static let monthDisplayFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = .current
+    formatter.setLocalizedDateFormatFromTemplate("yMMM")
+    return formatter
+  }()
+
+  private func reload(forceRefresh: Bool) async {
+    await viewModel.load(
+      instanceId: current.instanceId,
+      libraryId: selectedLibraryId,
+      forceRefresh: forceRefresh
+    )
+  }
+}

--- a/KMReader/Features/Series/Services/SeriesService.swift
+++ b/KMReader/Features/Series/Services/SeriesService.swift
@@ -65,12 +65,17 @@ class SeriesService {
     search: SeriesSearch,
     page: Int = 0,
     size: Int = 20,
-    sort: String? = nil
+    sort: String? = nil,
+    unpaged: Bool = false
   ) async throws -> Page<Series> {
-    var queryItems = [
-      URLQueryItem(name: "page", value: "\(page)"),
-      URLQueryItem(name: "size", value: "\(size)"),
-    ]
+    var queryItems: [URLQueryItem] = []
+
+    if unpaged {
+      queryItems.append(URLQueryItem(name: "unpaged", value: "true"))
+    } else {
+      queryItems.append(URLQueryItem(name: "page", value: "\(page)"))
+      queryItems.append(URLQueryItem(name: "size", value: "\(size)"))
+    }
 
     if let sort = sort {
       queryItems.append(URLQueryItem(name: "sort", value: sort))

--- a/KMReader/Features/Server/ServerSection.swift
+++ b/KMReader/Features/Server/ServerSection.swift
@@ -8,6 +8,7 @@ import Foundation
 enum ServerSection: String, CaseIterable {
 
   case libraries
+  case readingStats
   case serverInfo
   case tasks
   case history
@@ -21,6 +22,8 @@ enum ServerSection: String, CaseIterable {
     switch self {
     case .libraries:
       return ContentIcon.library
+    case .readingStats:
+      return "chart.bar.doc.horizontal"
     case .serverInfo:
       return "server.rack"
     case .tasks:
@@ -44,6 +47,8 @@ enum ServerSection: String, CaseIterable {
     switch self {
     case .libraries:
       return String(localized: "Libraries")
+    case .readingStats:
+      return String(localized: "Reading Stats")
     case .serverInfo:
       return String(localized: "Server Info")
     case .tasks:

--- a/KMReader/Features/Server/ServerView.swift
+++ b/KMReader/Features/Server/ServerView.swift
@@ -94,6 +94,14 @@ struct ServerView: View {
         }
         .adaptiveButtonStyle(.plain)
 
+        NavigationLink(value: NavDestination.settingsReadingStats) {
+          ServerActionTile(
+            title: ServerSection.readingStats.title,
+            systemImage: ServerSection.readingStats.icon
+          )
+        }
+        .adaptiveButtonStyle(.plain)
+
         if current.isAdmin {
           NavigationLink(value: NavDestination.settingsServerInfo) {
             ServerActionTile(

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -1080,6 +1080,52 @@
         }
       }
     },
+    "%lld." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld."
+          }
+        }
+      }
+    },
     "%lld%%" : {
       "localizations" : {
         "de" : {
@@ -2970,6 +3016,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部已讀"
+          }
+        }
+      }
+    },
+    "All Time" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesamte Zeit"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All Time"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toute la période"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全期間"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 기간"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部時間"
           }
         }
       }
@@ -5228,6 +5320,52 @@
         }
       }
     },
+    "Avg Pages / Book" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durchschn. Seiten/Buch"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avg Pages / Book"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pages moyennes / livre"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1冊あたり平均ページ数"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "권당 평균 페이지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平均页数/书"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平均頁數/書"
+          }
+        }
+      }
+    },
     "Basic Information" : {
       "localizations" : {
         "de" : {
@@ -5914,6 +6052,98 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書籍"
+          }
+        }
+      }
+    },
+    "Books Completed" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abgeschlossene Bücher"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Books Completed"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Livres terminés"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読了した本"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완독한 책"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已读完书籍"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已讀完書籍"
+          }
+        }
+      }
+    },
+    "Books Started" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Begonnene Bücher"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Books Started"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Livres commencés"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読み始めた本"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽기 시작한 책"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开始阅读书籍"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始閱讀書籍"
           }
         }
       }
@@ -7018,6 +7248,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "快取"
+          }
+        }
+      }
+    },
+    "Cached" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zwischengespeichert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cached"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En cache"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャッシュ済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐시됨"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已缓存"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已快取"
           }
         }
       }
@@ -15992,6 +16268,52 @@
         }
       }
     },
+    "Estimated Hours" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geschätzte Stunden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estimated Hours"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heures estimées"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推定時間"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예상 시간"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预计小时数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預計小時數"
+          }
+        }
+      }
+    },
     "Every 6 hours" : {
       "localizations" : {
         "de" : {
@@ -16218,6 +16540,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "載入媒體失敗"
+          }
+        }
+      }
+    },
+    "Failed to refresh reading stats. Showing cached data." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktualisierung der Lesestatistiken fehlgeschlagen. Zwischengespeicherte Daten werden angezeigt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to refresh reading stats. Showing cached data."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de l’actualisation des statistiques de lecture. Affichage des données en cache."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書統計の更新に失敗しました。キャッシュされたデータを表示しています。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "독서 통계를 새로 고치는 데 실패했습니다. 캐시된 데이터를 표시합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新阅读统计失败，正在显示缓存数据。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新整理閱讀統計失敗，正在顯示快取資料。"
           }
         }
       }
@@ -17050,6 +17418,52 @@
         }
       }
     },
+    "Genres Distribution" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genre-Verteilung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genres Distribution"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Répartition des genres"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ジャンル分布"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "장르 분포"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "类型分布"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "類型分布"
+          }
+        }
+      }
+    },
     "Get Started" : {
       "localizations" : {
         "de" : {
@@ -17414,6 +17828,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "每小時"
+          }
+        }
+      }
+    },
+    "Hours" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stunden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hours"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heures"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時間"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시간"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小時"
           }
         }
       }
@@ -17920,6 +18380,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在單頁模式下，根據閱讀方向將橫向頁面分割為兩個獨立頁面"
+          }
+        }
+      }
+    },
+    "Index" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Index"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Index"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indice"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インデックス"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인덱스"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "索引"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "索引"
           }
         }
       }
@@ -19166,6 +19672,190 @@
         }
       }
     },
+    "Last 6 Months" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte 6 Monate"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last 6 Months"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6 derniers mois"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去6か月"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 6개월"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近6个月"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近6個月"
+          }
+        }
+      }
+    },
+    "Last 7 Days" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte 7 Tage"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last 7 Days"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7 derniers jours"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去7日"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 7일"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近7天"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近7天"
+          }
+        }
+      }
+    },
+    "Last 30 Days" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte 30 Tage"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last 30 Days"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 derniers jours"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去30日"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 30일"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近30天"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近30天"
+          }
+        }
+      }
+    },
+    "Last 90 Days" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte 90 Tage"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last 90 Days"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "90 derniers jours"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "過去90日"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최근 90일"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近90天"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近90天"
+          }
+        }
+      }
+    },
     "Last page" : {
       "localizations" : {
         "de" : {
@@ -19208,6 +19898,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "末頁"
+          }
+        }
+      }
+    },
+    "Last Read" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zuletzt gelesen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last Read"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dernière lecture"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最終読書"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마지막 읽기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最后阅读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最後閱讀"
           }
         }
       }
@@ -19346,6 +20082,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次使用 %@"
+          }
+        }
+      }
+    },
+    "Last Year" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letztes Jahr"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last Year"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’année dernière"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "昨年"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작년"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去年"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "去年"
           }
         }
       }
@@ -19570,6 +20352,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "库"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書庫"
+          }
+        }
+      }
+    },
+    "Library" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bibliothek"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Library"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bibliothèque"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライブラリ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "라이브러리"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "书库"
           }
         },
         "zh-Hant" : {
@@ -24410,6 +25238,52 @@
         }
       }
     },
+    "No data" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Daten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No data"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune donnée"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "データなし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "데이터 없음"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無資料"
+          }
+        }
+      }
+    },
     "No details available" : {
       "localizations" : {
         "de" : {
@@ -24916,6 +25790,52 @@
         }
       }
     },
+    "No reading stats available" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Lesestatistiken verfügbar"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No reading stats available"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune statistique de lecture disponible"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用可能な読書統計がありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용 가능한 독서 통계가 없습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无阅读统计数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暫無閱讀統計資料"
+          }
+        }
+      }
+    },
     "No recent activity" : {
       "localizations" : {
         "de" : {
@@ -24958,6 +25878,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "近期無活動"
+          }
+        }
+      }
+    },
+    "No record" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Eintrag"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No record"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun enregistrement"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "記録なし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기록 없음"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无记录"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無記錄"
           }
         }
       }
@@ -28688,6 +29654,98 @@
         }
       }
     },
+    "Offline mode is enabled and no cached reading stats are available." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Modus ist aktiviert und es sind keine zwischengespeicherten Lesestatistiken verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline mode is enabled and no cached reading stats are available."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le mode hors ligne est activé et aucune statistique de lecture en cache n’est disponible."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインモードが有効で、キャッシュされた読書統計がありません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 모드가 활성화되어 있으며 캐시된 독서 통계가 없습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线模式已启用，且没有可用的阅读统计缓存。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離線模式已啟用，且沒有可用的閱讀統計快取。"
+          }
+        }
+      }
+    },
+    "Offline mode is enabled. Showing cached reading stats." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Modus ist aktiviert. Zwischengespeicherte Lesestatistiken werden angezeigt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline mode is enabled. Showing cached reading stats."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le mode hors ligne est activé. Affichage des statistiques de lecture en cache."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインモードが有効です。キャッシュされた読書統計を表示しています。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 모드가 활성화되어 있습니다. 캐시된 독서 통계를 표시합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线模式已启用，正在显示缓存的阅读统计。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離線模式已啟用，正在顯示快取的閱讀統計。"
+          }
+        }
+      }
+    },
     "Offline PDF file is missing. Please try downloading again." : {
       "localizations" : {
         "de" : {
@@ -29011,18 +30069,17 @@
       }
     },
     "offline.sync.confirm.progressOnlyAction" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sync Reading History"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Leseverlauf synchronisieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync Reading History"
           }
         },
         "fr" : {
@@ -29104,18 +30161,17 @@
       }
     },
     "offline.sync.readHistory.lastRead" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last read"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zuletzt gelesen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last read"
           }
         },
         "fr" : {
@@ -29702,6 +30758,52 @@
         }
       }
     },
+    "Other" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sonstige"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Other"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autres"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기타"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他"
+          }
+        }
+      }
+    },
     "Outdated" : {
       "localizations" : {
         "de" : {
@@ -30160,6 +31262,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "翻頁"
+          }
+        }
+      }
+    },
+    "Pages Read" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gelesene Seiten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pages Read"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pages lues"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読んだページ数"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽은 페이지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已读页数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已讀頁數"
           }
         }
       }
@@ -31682,6 +32830,52 @@
         }
       }
     },
+    "Pull to refresh or tap refresh after your server finishes aggregation." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zum Aktualisieren nach unten ziehen oder auf Aktualisieren tippen, nachdem der Server die Aggregation abgeschlossen hat."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pull to refresh or tap refresh after your server finishes aggregation."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tirez pour actualiser ou appuyez sur actualiser après la fin de l’agrégation côté serveur."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サーバーの集計完了後に、下に引いて更新するか更新ボタンを押してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "서버 집계가 완료된 후 당겨서 새로고침하거나 새로고침 버튼을 누르세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下拉刷新，或在服务器完成聚合后点击刷新。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下拉重新整理，或在伺服器完成彙總後點擊重新整理。"
+          }
+        }
+      }
+    },
     "Purchase request timed out. Please try again." : {
       "localizations" : {
         "de" : {
@@ -31724,6 +32918,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "購買請求超時。請稍後再試。"
+          }
+        }
+      }
+    },
+    "Range" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitraum"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Range"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Période"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "範囲"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "범위"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "范围"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "範圍"
           }
         }
       }
@@ -33568,6 +34808,144 @@
         }
       }
     },
+    "Reading by Hour" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lesen nach Stunde"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading by Hour"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture par heure"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時間帯別読書"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시간대별 읽기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按小时阅读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按小時閱讀"
+          }
+        }
+      }
+    },
+    "Reading by Weekday" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lesen nach Wochentag"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading by Weekday"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture par jour de semaine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "曜日別読書"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요일별 읽기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按星期阅读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按星期閱讀"
+          }
+        }
+      }
+    },
+    "Reading Days" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lesetage"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading Days"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jours de lecture"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書日数"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽은 날 수"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读天数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀天數"
+          }
+        }
+      }
+    },
     "Reading Direction" : {
       "localizations" : {
         "de" : {
@@ -33702,6 +35080,190 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀應該是舒適和愉快的。請花時間自定義這些設定，直到找到完美的組合。"
+          }
+        }
+      }
+    },
+    "Reading Stats" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lesestatistiken"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading Stats"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statistiques de lecture"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書統計"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "독서 통계"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读统计"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀統計"
+          }
+        }
+      }
+    },
+    "Reading Status" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lesestatus"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading Status"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statut de lecture"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書ステータス"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽기 상태"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读状态"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀狀態"
+          }
+        }
+      }
+    },
+    "Reading Time" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lesezeit"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading Time"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temps de lecture"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書時間"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽기 시간"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读时长"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀時長"
+          }
+        }
+      }
+    },
+    "Reading Time: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lesezeit: %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading Time: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temps de lecture : %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書時間: %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽기 시간: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读时长：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀時長：%@"
           }
         }
       }
@@ -44884,6 +46446,52 @@
         }
       }
     },
+    "Tags Distribution" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tag-Verteilung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tags Distribution"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Répartition des tags"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タグ分布"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "태그 분포"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标签分布"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標籤分布"
+          }
+        }
+      }
+    },
     "Tap Page Scroll Duration" : {
       "localizations" : {
         "de" : {
@@ -45666,6 +47274,52 @@
         }
       }
     },
+    "This Week" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Woche"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This Week"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette semaine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今週"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 주"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本周"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本週"
+          }
+        }
+      }
+    },
     "This will permanently delete %@ from Komga." : {
       "localizations" : {
         "de" : {
@@ -46172,6 +47826,52 @@
         }
       }
     },
+    "Tip: Tap or drag a point to view details." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipp: Tippen oder ziehen Sie auf einen Punkt, um Details anzuzeigen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tip: Tap or drag a point to view details."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Astuce : touchez ou faites glisser un point pour voir les détails."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヒント: ポイントをタップまたはドラッグして詳細を表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "팁: 포인트를 탭하거나 드래그해 상세 정보를 확인하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示：点击或拖动数据点可查看详情。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提示：點擊或拖動資料點可查看詳情。"
+          }
+        }
+      }
+    },
     "Title" : {
       "localizations" : {
         "de" : {
@@ -46632,6 +48332,144 @@
         }
       }
     },
+    "Top Authors" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top-Autoren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top Authors"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auteurs principaux"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上位著者"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상위 저자"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "热门作者"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "熱門作者"
+          }
+        }
+      }
+    },
+    "Top Genres" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top-Genres"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top Genres"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genres principaux"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上位ジャンル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상위 장르"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "热门类型"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "熱門類型"
+          }
+        }
+      }
+    },
+    "Top Tags" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top-Tags"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top Tags"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tags principaux"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上位タグ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상위 태그"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "热门标签"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "熱門標籤"
+          }
+        }
+      }
+    },
     "Total Book Count" : {
       "localizations" : {
         "de" : {
@@ -46674,6 +48512,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書籍總數"
+          }
+        }
+      }
+    },
+    "Total Books" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesamtzahl Bücher"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total Books"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Livres au total"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "総書籍数"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 도서"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "图书总数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圖書總數"
           }
         }
       }
@@ -48150,6 +50034,52 @@
         }
       }
     },
+    "Value" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Value"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valeur"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "値"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "값"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "數值"
+          }
+        }
+      }
+    },
     "Vendor" : {
       "localizations" : {
         "de" : {
@@ -48836,6 +50766,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "詞間距: %@"
+          }
+        }
+      }
+    },
+    "X-axis: Date, Y-axis: Estimated reading hours." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X-Achse: Datum, Y-Achse: Geschätzte Lesestunden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X-axis: Date, Y-axis: Estimated reading hours."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Axe X : date, axe Y : heures de lecture estimées."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X軸: 日付、Y軸: 推定読書時間。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X축: 날짜, Y축: 예상 독서 시간."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X轴：日期，Y轴：预计阅读小时。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "X軸：日期，Y軸：預計閱讀小時。"
           }
         }
       }

--- a/KMReader/Shared/Foundation/Models/NavDestination.swift
+++ b/KMReader/Shared/Foundation/Models/NavDestination.swift
@@ -55,6 +55,7 @@ enum NavDestination: Hashable {
   case settingsOfflineBooks
 
   case settingsLibraries
+  case settingsReadingStats
   case settingsServerInfo
   case settingsTasks
   case settingsHistory
@@ -149,6 +150,8 @@ enum NavDestination: Hashable {
 
     case .settingsLibraries:
       ServerLibrariesView()
+    case .settingsReadingStats:
+      ServerReadingStatsView()
     case .settingsServerInfo:
       ServerInfoView()
     case .settingsTasks:


### PR DESCRIPTION
## Summary
- add a new server reading stats page and navigation entry
- align stats data fetching with komga-webui ReadingStatsView semantics using BookSearch and SeriesSearch unpaged queries
- add cached reading stats storage, view model time-series regrouping, and chart UX refinements (range selector on chart, inspect tooltip, sparse hour axis labels)
- complete localization entries for all supported languages via misc/translate.py

## Testing
- [x] make format
- [x] make build

## Issue
- Related to #546
