### PR TITLE
docs: update changelog and product marketing copy

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,24 +1,28 @@
-KMReader - What's New (from v3.4 to current)
+KMReader - What's New (from v3.5 to current)
 
-NEW
-- Added optional waifu2x super resolution for reader pages with three modes: Off, Auto, and Always.
-- Added smarter offline preparation for downloaded PDF books, so PDF reading starts faster and feels more reliable.
-- Added a setting to choose Native PDF Reader or DIVINA for PDF books.
+Reading Insights
+- Added a new Reading Stats page so you can quickly see your reading activity trends.
+- Added pinned Collections and Read Lists, including dedicated pinned sections on the Dashboard.
 
-IMPROVED
-- Reading progress now saves more reliably, especially when closing the reader or moving between books.
-- Offline EPUB progress recovery is more consistent, making it easier to continue where you left off.
-- PDF reading controls are more consistent across reading directions and layouts.
-- The large Keep Reading widget now shows up to six books.
-- Spotlight search results now open the correct book or series more reliably.
-- waifu2x super resolution settings and descriptions are clearer and easier to understand.
-- Connection fallback behavior is faster when a server is temporarily unavailable.
+Reader Experience
+- Added inline autoplay for animated pages, so motion content plays without interrupting navigation.
+- Added a new EPUB scrolled reading mode with adjustable tap-scroll distance.
+- Improved EPUB progress handling when switching chapters or closing the reader.
+- Finished books now reopen from the beginning, making re-reads easier.
+- Improved navigation flow when opening books from Read Lists.
+- Simplified reader settings so options are shown only when relevant to your current reading mode.
 
-FIXED
-- Fixed an important iOS 17 crash that could happen when switching main tabs, including Browse.
-- Resolved a broad set of crash issues across startup, reading, page turning, notifications, quick actions, widgets, logs, and Live Text interactions.
-- Fixed multiple page-turn and edge-swipe issues at the beginning or end of books.
-- Fixed cases where PDF pages could fail to appear after offline files were removed.
-- Improved Live Text stability on iOS and macOS.
-- Fixed occasional EPUB typeface selection not being remembered correctly.
-- Improved touch behavior in table of contents for more accurate selection.
+Offline and Sync
+- Improved offline reading history sync and made recent reading updates clearer.
+- Added clearer completion notifications for offline sync and download tasks.
+- Added a full re-sync action to help recover quickly if local data gets out of sync.
+- Added metadata-based filters in Offline mode, so finding downloaded books is faster and easier.
+- Improved sync behavior for deleted or changed items to keep your library cleaner and more accurate.
+
+Performance and Polish
+- Improved progress update speed and overall refresh responsiveness.
+- Improved cache cleanup behavior for smoother performance, especially with larger libraries.
+- Fixed a rare page-curl reader crash for more stable reading sessions.
+- Fixed stale thumbnail and preview issues when switching content.
+- Improved book grid alignment and several visual polish details across cards and badges.
+- Improved update and loading messaging so long migrations are clearer and less confusing.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -1,37 +1,37 @@
-KMReader - Full-Featured Native Komga Client for iPhone, iPad, Mac, and Apple TV
+KMReader - Native Komga Client for iPhone, iPad, Mac, and Apple TV
 
-KMReader is a full-featured native SwiftUI client for Komga. Read, browse, download, and manage your library with platform-optimized workflows across iOS, macOS, and tvOS.
+KMReader helps you read and manage your Komga library with a fast, native experience across Apple platforms.
 
 IMPORTANT FEATURES
 
-• Powerful Readers
-DIVINA reader on iOS, macOS, and tvOS with LTR/RTL/vertical/Webtoon modes, spreads, zoom, and tap-zone navigation.
-EPUB reader on iOS with custom font import (.ttf/.otf), theme presets, and per-book EPUB preferences.
-Native PDF reader on iOS and macOS with table of contents, page jump, and search.
+• Powerful Reading Experience
+DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, spreads, zoom, and page curl transitions.
+Webtoon mode on iOS and macOS.
+EPUB reader on iOS and macOS with paged and scrolled flow, custom fonts, and per-book preferences.
+PDF reading on iOS and macOS with native PDF mode, search, table of contents, and page jump.
 Incognito mode lets you read without syncing progress.
+
+• Smart Dashboard and Insights
+Keep Reading and On Deck make it easy to continue where you left off.
+Pin collections and read lists so favorites always stay on top.
+Reading Stats helps you understand your reading habits over time.
 
 • Offline Library
 Download books for full offline reading.
 iOS supports background downloads with Live Activities.
-Per-series offline policies: Manual, Unread only, Unread + cleanup read, or All books.
-Download queues and pending progress sync resume automatically when reconnected.
+Use per-series download policies: Manual, Unread only, Unread + cleanup, or All books.
+Offline mode includes metadata filters so downloaded books are easier to find.
 
-• Smart Browse and Dashboard
-Dashboard sections include Keep Reading, On Deck, Recently Released, Recently Added, Recently Updated, and Recently Read.
-Real-time dashboard refresh through server-sent events (SSE).
+• Browse and Organize
 Browse Series, Books, Collections, and Read Lists.
-Metadata filters support all/any logic for publishers, authors, genres, tags, and languages.
+Use metadata filters for publishers, authors, genres, tags, and languages.
+Switch between multiple Komga servers instantly.
+Sign in with username/password or API key.
 
-• Multi-Server and Account
-Save multiple Komga servers and switch instantly.
-Authenticate with username/password or API key.
-Manage API keys and review authentication activity.
-
-• Admin and Diagnostics
+• Admin Tools
 Edit metadata for series, books, collections, and read lists.
-Create/edit libraries with scanner options and directory browser.
-Monitor task queues and cancel all tasks.
-Use the built-in log viewer with filtering and export.
+Create and manage libraries.
+Monitor server tasks and logs in the app.
 
 KMReader targets Komga 1.19.0+ and supports API v1/v2.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="icon.svg" alt="KMReader Icon" width="128" height="128">
 </div>
 
-**Full-featured native SwiftUI Komga client for iOS, macOS, and tvOS.**
+**Native SwiftUI Komga client for iOS, macOS, and tvOS.**
 
 [![iOS](https://img.shields.io/badge/iOS-17.0+-blue.svg)](https://www.apple.com/ios/)
 [![macOS](https://img.shields.io/badge/macOS-14.0+-blue.svg)](https://www.apple.com/macos/)
@@ -20,46 +20,40 @@
 
 ## Important Features
 
-### Readers
+### Reading Experience
 
-- DIVINA reader on iOS/macOS/tvOS with LTR/RTL/vertical/Webtoon modes, spreads, zoom, and tap zones.
-- EPUB reader on iOS with custom font import (`.ttf`/`.otf`), theme presets, layout controls, and per-book EPUB preferences.
-- Native PDF reader on iOS/macOS with TOC, page jump, search, and reading direction/layout controls.
-- Incognito mode to read without sending progress updates.
+- DIVINA reader on iOS/macOS/tvOS with LTR, RTL, vertical, spreads, zoom, and page curl transitions.
+- Webtoon reading mode on iOS/macOS.
+- EPUB reader on iOS/macOS with paged and scrolled flow, custom fonts (`.ttf`/`.otf`), and per-book preferences.
+- PDF reading on iOS/macOS with native PDF mode, search, table of contents, and page jump.
+- Per-book reading preferences and Incognito mode.
 
-### Offline & Sync
+### Dashboard and Discovery
+
+- Dashboard sections for Keep Reading, On Deck, recently added/updated content, and pinned sections.
+- Pin collections and read lists to keep favorites at the top.
+- Reading Stats page for daily, weekly, and monthly reading insights.
+- Browse Series, Books, Collections, and Read Lists with metadata filters (publisher, author, genre, tag, language).
+
+### Offline and Sync
 
 - Download books for full offline reading.
-- iOS background download queue with Live Activities.
-- Per-series offline policies: `Manual`, `Unread only`, `Unread + cleanup read`, `All`.
-- Auto-resume downloads and pending progress sync when back online.
+- iOS background downloads with Live Activities.
+- Per-series download policies: Manual, Unread only, Unread + cleanup, and All books.
+- Offline mode supports metadata-based filtering to quickly find downloaded books.
+- Progress and offline data sync automatically when reconnecting.
 
-### Browse & Real-Time
-
-- Dashboard sections: Keep Reading, On Deck, Recently Released/Added/Read books, Recently Added/Updated series.
-- SSE-based dashboard auto refresh with debounce and reader-aware timing.
-- Browse Series, Books, Collections, and Read Lists.
-- Metadata filters (publisher, author, genre, tag, language) with all/any logic.
-
-### Multi-Server & Account
+### Multi-Server and Management
 
 - Save multiple Komga servers and switch instantly.
-- Login with username/password or API key.
-- Manage API keys and view authentication activity.
-
-### Admin & Diagnostics
-
-- Edit metadata for series, books, collections, and read lists.
-- Create/edit/delete libraries with scanner options and directory browser.
-- Monitor server task queues and cancel all tasks.
-- Built-in logs viewer with filters and export.
+- Sign in with username/password or API key.
+- Admin tools for metadata editing, library management, task management, and logs.
 
 ### Platform Highlights
 
 - iOS/iPadOS: widgets, quick actions, background downloads, Live Activities.
-- macOS: dedicated reader window and keyboard-first workflows.
-- tvOS: remote-first DIVINA reading experience.
-- iOS/macOS: optional Spotlight indexing for downloaded books and series.
+- macOS: dedicated reader windows and keyboard-first controls.
+- tvOS: remote-first DIVINA reading.
 
 ## Getting Started
 
@@ -67,7 +61,7 @@
 
 - Komga 1.19.0+
 - Xcode 15.0+
-- iOS 17.0+, macOS 14.0+, or tvOS 17.0+
+- iOS 17.0+, macOS 14.0+, tvOS 17.0+
 
 ### Build and run
 
@@ -90,7 +84,6 @@ make run-tvos-sim
 ## Compatibility
 
 - Komga API v1 and v2
-- SSE-based real-time updates
 
 ## Community
 

--- a/static/index.html
+++ b/static/index.html
@@ -3,12 +3,10 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>
-            KMReader · Full-Featured Native Komga Client for iOS, macOS & tvOS
-        </title>
+        <title>KMReader · Native Komga Client for iOS, macOS & tvOS</title>
         <meta
             name="description"
-            content="KMReader is a full-featured native SwiftUI Komga client with DIVINA/EPUB/PDF readers, offline downloads, SSE dashboards, multi-server switching, and admin tools."
+            content="KMReader is a native SwiftUI Komga client with DIVINA, EPUB, and PDF reading, offline downloads, reading stats, multi-server switching, and admin tools."
         />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -25,12 +23,11 @@
         <div class="container">
             <header class="hero">
                 <img src="assets/icon.svg" alt="KMReader logo" class="logo" />
-                <p class="eyebrow">Full-Featured Native SwiftUI Komga Client</p>
+                <p class="eyebrow">Native SwiftUI Komga Client</p>
                 <h1>KMReader</h1>
                 <p class="tagline">
-                    A full-featured native SwiftUI client to read, download,
-                    browse, and manage your Komga library on iPhone, iPad,
-                    Mac, and Apple TV.
+                    Read, download, browse, and manage your Komga library with
+                    a native experience on iPhone, iPad, Mac, and Apple TV.
                 </p>
                 <div class="cta">
                     <a
@@ -59,14 +56,12 @@
                         <strong>iOS 17.0+ · macOS 14.0+ · tvOS 17.0+</strong>
                     </div>
                     <div class="meta-card">
-                        <span>Reader Support</span>
-                        <strong>
-                            DIVINA (all) · EPUB (iOS) · PDF (iOS/macOS)
-                        </strong>
+                        <span>Readers</span>
+                        <strong>DIVINA (all) · EPUB/PDF (iOS/macOS)</strong>
                     </div>
                     <div class="meta-card">
                         <span>Offline</span>
-                        <strong>Download queue + iOS background tasks</strong>
+                        <strong>Downloads + iOS background queue</strong>
                     </div>
                 </div>
             </header>
@@ -74,66 +69,63 @@
             <section id="features">
                 <h2 class="section-title">Important features</h2>
                 <p class="section-subtitle">
-                    A full-featured experience focused on reliable reading,
-                    offline-first behavior, real-time updates, and practical
-                    server management.
+                    Focused on reliable reading, practical offline workflows,
+                    and smooth day-to-day library management.
                 </p>
                 <div class="feature-grid">
                     <article class="card">
                         <span class="pill">Readers</span>
                         <h3>DIVINA, EPUB, and PDF</h3>
                         <p>
-                            DIVINA on iOS/macOS/tvOS with LTR/RTL/vertical/
-                            Webtoon modes, spreads, zoom, and tap zones. EPUB
-                            on iOS with custom fonts and theme presets. Native
-                            PDF on iOS/macOS with TOC, page jump, and search.
-                            Incognito mode is supported.
+                            DIVINA on iOS/macOS/tvOS with LTR, RTL, vertical,
+                            spreads, zoom, and page curl. EPUB on iOS/macOS
+                            with paged/scrolled flow and custom fonts. PDF on
+                            iOS/macOS with native mode, search, TOC, and page
+                            jump.
+                        </p>
+                    </article>
+                    <article class="card">
+                        <span class="pill">Insights</span>
+                        <h3>Reading stats and pinned sections</h3>
+                        <p>
+                            Track reading habits with reading stats. Pin
+                            collections and read lists so favorites stay easy to
+                            access from the dashboard.
                         </p>
                     </article>
                     <article class="card">
                         <span class="pill">Offline</span>
-                        <h3>Download and continue anywhere</h3>
+                        <h3>Download and keep reading anywhere</h3>
                         <p>
-                            Download books for full offline reading. Series
-                            policies support Manual, Unread only, Unread +
-                            cleanup read, and All. iOS supports background
-                            downloads with Live Activities.
-                        </p>
-                    </article>
-                    <article class="card">
-                        <span class="pill">Dashboards</span>
-                        <h3>Live library updates</h3>
-                        <p>
-                            Keep Reading, On Deck, Recently Released, Recently
-                            Added, Recently Updated, and Recently Read sections
-                            with SSE-driven refresh and debounce.
+                            Download books for offline reading, run background
+                            downloads on iOS, and use per-series policies to
+                            automate what stays on device.
                         </p>
                     </article>
                     <article class="card">
                         <span class="pill">Browse</span>
-                        <h3>Metadata filtering</h3>
+                        <h3>Flexible filtering</h3>
                         <p>
                             Browse series, books, collections, and read lists.
                             Filter by publisher, author, genre, tag, and
-                            language with all/any logic.
+                            language, including metadata filters in Offline
+                            mode.
                         </p>
                     </article>
                     <article class="card">
                         <span class="pill">Multi-Server</span>
                         <h3>Switch servers instantly</h3>
                         <p>
-                            Save multiple Komga instances, sign in with
-                            username/password or API key, and manage API keys
-                            plus authentication activity in-app.
+                            Save multiple Komga servers and switch quickly.
+                            Sign in with username/password or API key.
                         </p>
                     </article>
                     <article class="card">
                         <span class="pill">Admin</span>
-                        <h3>Server operations and logs</h3>
+                        <h3>Manage your server in-app</h3>
                         <p>
-                            Edit metadata, manage libraries with scanner
-                            settings and directory browser, monitor/cancel task
-                            queues, and inspect/export logs.
+                            Edit metadata, manage libraries, monitor tasks, and
+                            view logs directly in KMReader.
                         </p>
                     </article>
                 </div>
@@ -142,7 +134,7 @@
             <section id="platforms">
                 <h2 class="section-title">Built for Apple platforms</h2>
                 <p class="section-subtitle">
-                    Shared core behavior with focused platform integrations.
+                    Shared core features with platform-specific strengths.
                 </p>
                 <div class="feature-grid">
                     <article class="card">
@@ -155,16 +147,15 @@
                     <article class="card">
                         <h3>macOS</h3>
                         <p>
-                            Dedicated reader window workflow, keyboard-first
-                            controls, and optional Spotlight indexing for
-                            downloaded items.
+                            DIVINA, EPUB, and PDF with dedicated reader windows
+                            and keyboard-first controls.
                         </p>
                     </article>
                     <article class="card">
                         <h3>tvOS</h3>
                         <p>
-                            Remote-first DIVINA reading experience with a
-                            focused TV interface.
+                            Remote-first DIVINA reading with a focused TV
+                            browsing experience.
                         </p>
                     </article>
                 </div>
@@ -177,38 +168,36 @@
                         <h4>Is KMReader an official Komga app?</h4>
                         <p>
                             No. KMReader is an independent open-source client
-                            built on Komga public APIs.
+                            built for Komga users.
                         </p>
                     </article>
                     <article class="faq-item">
-                        <h4>Which formats are supported?</h4>
+                        <h4>Which readers are available?</h4>
                         <p>
                             DIVINA is available on iOS, macOS, and tvOS. EPUB
-                            is available on iOS. Native PDF is available on iOS
-                            and macOS.
+                            and PDF are available on iOS and macOS.
                         </p>
                     </article>
                     <article class="faq-item">
-                        <h4>Can I connect multiple servers?</h4>
+                        <h4>Can I use multiple Komga servers?</h4>
                         <p>
-                            Yes. You can save and switch between multiple Komga
-                            instances, and use either username/password or API
-                            key authentication.
+                            Yes. You can save and switch between multiple
+                            servers and authenticate with password or API key.
                         </p>
                     </article>
                     <article class="faq-item">
                         <h4>How does offline mode work?</h4>
                         <p>
-                            Downloaded books remain readable without network,
-                            series policies automate queue behavior, and sync
-                            resumes when the app reconnects.
+                            Downloaded books stay readable offline, filtering is
+                            available for offline items, and sync resumes when
+                            you reconnect.
                         </p>
                     </article>
                     <article class="faq-item">
-                        <h4>Can admins manage the server in-app?</h4>
+                        <h4>Can admins manage library data in-app?</h4>
                         <p>
-                            Yes. Admin tools include metadata editing, library
-                            management, task controls, and server history.
+                            Yes. KMReader includes metadata editing, library
+                            management, task monitoring, and logs.
                         </p>
                     </article>
                     <article class="faq-item">


### PR DESCRIPTION
## Summary
- regenerate App Store changelog content from `v3.5..HEAD` with end-user friendly wording
- update `APP_STORE_CHANGELOG.txt` to include offline metadata filtering and page-curl reader stability fixes
- rewrite `README.md`, `APP_STORE_DESCRIPTION.txt`, and `static/index.html` to reflect current important product features and platform support

## Testing
- [ ] Not run (copy/content-only changes)
