### PR TITLE
fix: stabilize page curl backside transitions

### DIFF
--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -221,7 +221,7 @@ struct DivinaControlsOverlayView: View {
             }
           }
           .padding(.vertical, 2)
-          .padding(.horizontal, 4)
+          .padding(.horizontal)
         }
         .optimizedControlSize()
         .contentShape(Capsule())

--- a/KMReader/Features/Reader/Views/PageCurlBacksideViewController.swift
+++ b/KMReader/Features/Reader/Views/PageCurlBacksideViewController.swift
@@ -1,0 +1,84 @@
+//
+// PageCurlBacksideViewController.swift
+//
+
+#if os(iOS)
+  import UIKit
+
+  final class PageCurlBacksideViewController: UIViewController {
+    struct Style {
+      let baseColor: UIColor
+      let fillOpacity: CGFloat
+      let dimOpacity: CGFloat
+
+      init(
+        baseColor: UIColor,
+        fillOpacity: CGFloat = 0.55,
+        dimOpacity: CGFloat = 0.12
+      ) {
+        self.baseColor = baseColor
+        self.fillOpacity = Self.clamp(fillOpacity)
+        self.dimOpacity = Self.clamp(dimOpacity)
+      }
+
+      var renderedColor: UIColor {
+        baseColor.withAlphaComponent(fillOpacity)
+      }
+
+      private static func clamp(_ value: CGFloat) -> CGFloat {
+        max(0, min(1, value))
+      }
+    }
+
+    let destinationToken: String
+    private var style: Style
+    private let dimView = UIView()
+
+    init(destinationToken: String, style: Style) {
+      self.destinationToken = destinationToken
+      self.style = style
+      super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+      let baseView = UIView()
+      baseView.backgroundColor = .clear
+      dimView.translatesAutoresizingMaskIntoConstraints = false
+      dimView.isUserInteractionEnabled = false
+      baseView.addSubview(dimView)
+      NSLayoutConstraint.activate([
+        dimView.topAnchor.constraint(equalTo: baseView.topAnchor),
+        dimView.leadingAnchor.constraint(equalTo: baseView.leadingAnchor),
+        dimView.trailingAnchor.constraint(equalTo: baseView.trailingAnchor),
+        dimView.bottomAnchor.constraint(equalTo: baseView.bottomAnchor),
+      ])
+      view = baseView
+      applyStyle()
+    }
+
+    func updateStyle(_ style: Style) {
+      self.style = style
+      if isViewLoaded {
+        applyStyle()
+      }
+    }
+
+    private func applyStyle() {
+      view.backgroundColor = style.renderedColor
+      dimView.backgroundColor = UIColor.black.withAlphaComponent(style.dimOpacity)
+    }
+
+    static func applyStyle(_ style: Style, to pageViewController: UIPageViewController) {
+      let color = style.renderedColor
+      pageViewController.view.backgroundColor = color
+      for subview in pageViewController.view.subviews {
+        subview.backgroundColor = color
+      }
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Views/PageCurlControllerPlanner.swift
+++ b/KMReader/Features/Reader/Views/PageCurlControllerPlanner.swift
@@ -1,0 +1,87 @@
+//
+// PageCurlControllerPlanner.swift
+//
+
+#if os(iOS)
+  import UIKit
+
+  enum PageCurlControllerPlanner {
+    static func configure(
+      pageViewController: UIPageViewController,
+      semanticContentAttribute: UISemanticContentAttribute? = nil
+    ) {
+      pageViewController.isDoubleSided = true
+      if let semanticContentAttribute {
+        pageViewController.view.semanticContentAttribute = semanticContentAttribute
+      }
+    }
+
+    static func controllers(
+      primary: UIViewController,
+      animated: Bool,
+      in pageViewController: UIPageViewController,
+      makeBackside: () -> UIViewController
+    ) -> [UIViewController] {
+      if requiredControllerCount(in: pageViewController, animated: animated) <= 1 {
+        return [primary]
+      }
+      return [primary, makeBackside()]
+    }
+
+    static func safeSetViewControllers(
+      _ requestedControllers: [UIViewController],
+      on pageViewController: UIPageViewController,
+      direction: UIPageViewController.NavigationDirection,
+      animated: Bool,
+      completion: ((Bool) -> Void)? = nil
+    ) {
+      assert(Thread.isMainThread)
+      let controllers = normalizedControllers(
+        requestedControllers,
+        in: pageViewController,
+        animated: animated
+      )
+      guard !controllers.isEmpty else {
+        completion?(false)
+        return
+      }
+      pageViewController.setViewControllers(
+        controllers,
+        direction: direction,
+        animated: animated,
+        completion: completion
+      )
+    }
+
+    private static func requiredControllerCount(
+      in pageViewController: UIPageViewController,
+      animated: Bool
+    ) -> Int {
+      if animated && pageViewController.isDoubleSided {
+        return 2
+      }
+      return pageViewController.spineLocation == .mid ? 2 : 1
+    }
+
+    private static func normalizedControllers(
+      _ requestedControllers: [UIViewController],
+      in pageViewController: UIPageViewController,
+      animated: Bool
+    ) -> [UIViewController] {
+      guard let primary = requestedControllers.first else { return [] }
+      if requiredControllerCount(in: pageViewController, animated: animated) <= 1 {
+        return [primary]
+      }
+      if requestedControllers.count >= 2 {
+        return Array(requestedControllers.prefix(2))
+      }
+      return [primary, fallbackCompanionController(matching: primary)]
+    }
+
+    private static func fallbackCompanionController(matching primary: UIViewController) -> UIViewController {
+      let fallback = UIViewController()
+      fallback.view.backgroundColor = primary.isViewLoaded ? primary.view.backgroundColor : .clear
+      return fallback
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
@@ -116,7 +116,7 @@
               }
             }
             .padding(.vertical, 2)
-            .padding(.horizontal, 4)
+            .padding(.horizontal)
           }
           .optimizedControlSize()
           .contentShape(Capsule())


### PR DESCRIPTION
## Summary
- add `PageCurlBacksideViewController` to render a custom backside color (with configurable fill/dim opacity) for page-curl transitions
- add `PageCurlControllerPlanner` to centralize page-curl runtime setup, controller-count planning, and safe `setViewControllers` normalization
- update DIVINA and EPUB curl flows to use unified backside routing and commit target controllers after transition, including non-animated initial programmatic jumps
- keep compact reader control chip horizontal padding consistent in DIVINA/PDF overlays

## Testing
- [x] `make format`
- [x] `make build`
