### PR TITLE
refactor: simplify divina tap zone input handling

### DIFF
--- a/KMReader/Features/Reader/Views/CurlPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlPageView.swift
@@ -14,9 +14,6 @@
     let renderConfig: ReaderRenderConfig
     let readListContext: ReaderReadListContext?
     let onDismiss: () -> Void
-    let goToNextPage: () -> Void
-    let goToPreviousPage: () -> Void
-    let toggleControls: () -> Void
     let onPlayAnimatedPage: ((Int) -> Void)?
 
     func makeCoordinator() -> Coordinator {
@@ -264,9 +261,6 @@
           splitMode: splitMode,
           readingDirection: parent.readingDirection,
           renderConfig: parent.renderConfig,
-          onNextPage: parent.goToNextPage,
-          onPreviousPage: parent.goToPreviousPage,
-          onToggleControls: parent.toggleControls,
           onPlayAnimatedPage: parent.onPlayAnimatedPage
         )
       }
@@ -281,9 +275,6 @@
           readListContext: parent.readListContext,
           readingDirection: parent.readingDirection,
           renderConfig: parent.renderConfig,
-          onNextPage: parent.goToNextPage,
-          onPreviousPage: parent.goToPreviousPage,
-          onToggleControls: parent.toggleControls,
           onDismiss: parent.onDismiss
         )
       }

--- a/KMReader/Features/Reader/Views/EndPageView/EndPageView.swift
+++ b/KMReader/Features/Reader/Views/EndPageView/EndPageView.swift
@@ -11,10 +11,6 @@ struct EndPageView: View {
   let readListContext: ReaderReadListContext?
   let onDismiss: () -> Void
   let readingDirection: ReadingDirection
-  let renderConfig: ReaderRenderConfig?
-  let onNextPage: (() -> Void)?
-  let onPreviousPage: (() -> Void)?
-  let onToggleControls: (() -> Void)?
 
   @Environment(\.readerBackgroundPreference) private var readerBackground
 
@@ -23,21 +19,13 @@ struct EndPageView: View {
     nextBook: Book?,
     readListContext: ReaderReadListContext?,
     onDismiss: @escaping () -> Void,
-    readingDirection: ReadingDirection,
-    renderConfig: ReaderRenderConfig? = nil,
-    onNextPage: (() -> Void)? = nil,
-    onPreviousPage: (() -> Void)? = nil,
-    onToggleControls: (() -> Void)? = nil
+    readingDirection: ReadingDirection
   ) {
     self.previousBook = previousBook
     self.nextBook = nextBook
     self.readListContext = readListContext
     self.onDismiss = onDismiss
     self.readingDirection = readingDirection
-    self.renderConfig = renderConfig
-    self.onNextPage = onNextPage
-    self.onPreviousPage = onPreviousPage
-    self.onToggleControls = onToggleControls
   }
 
   private var textColor: Color {
@@ -94,38 +82,6 @@ struct EndPageView: View {
       .padding(40)
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .contentShape(Rectangle())
-      #if !os(tvOS)
-        .simultaneousGesture(
-          SpatialTapGesture().onEnded { value in
-            handleTap(at: value.location, size: geometry.size)
-          },
-          including: .gesture
-        )
-      #endif
-    }
-  }
-
-  private func handleTap(at location: CGPoint, size: CGSize) {
-    guard let renderConfig else { return }
-    guard size.width > 0, size.height > 0 else { return }
-
-    let normalizedX = location.x / size.width
-    let normalizedY = location.y / size.height
-    let action = TapZoneHelper.action(
-      normalizedX: normalizedX,
-      normalizedY: normalizedY,
-      tapZoneMode: renderConfig.tapZoneMode,
-      readingDirection: readingDirection,
-      zoneThreshold: renderConfig.tapZoneSize.value
-    )
-
-    switch action {
-    case .previous:
-      onPreviousPage?()
-    case .next:
-      onNextPage?()
-    case .toggleControls:
-      onToggleControls?()
     }
   }
 

--- a/KMReader/Features/Reader/Views/NativeEndPageViewController.swift
+++ b/KMReader/Features/Reader/Views/NativeEndPageViewController.swift
@@ -7,7 +7,7 @@
   import UIKit
 
   @MainActor
-  final class NativeEndPageViewController: UIViewController, UIGestureRecognizerDelegate {
+  final class NativeEndPageViewController: UIViewController {
     private var previousBook: Book?
     private var nextBook: Book?
     private var readListContext: ReaderReadListContext?
@@ -23,9 +23,6 @@
       doubleTapZoomMode: .fast
     )
     private var onDismiss: (() -> Void)?
-    private var onNextPage: (() -> Void)?
-    private var onPreviousPage: (() -> Void)?
-    private var onToggleControls: (() -> Void)?
     private var lastIsPortrait: Bool?
 
     private let contentStack = UIStackView()
@@ -66,9 +63,6 @@
       readListContext: ReaderReadListContext?,
       readingDirection: ReadingDirection,
       renderConfig: ReaderRenderConfig,
-      onNextPage: (() -> Void)? = nil,
-      onPreviousPage: (() -> Void)? = nil,
-      onToggleControls: (() -> Void)? = nil,
       onDismiss: @escaping () -> Void
     ) {
       self.previousBook = previousBook
@@ -76,9 +70,6 @@
       self.readListContext = readListContext
       self.readingDirection = readingDirection
       self.renderConfig = renderConfig
-      self.onNextPage = onNextPage
-      self.onPreviousPage = onPreviousPage
-      self.onToggleControls = onToggleControls
       self.onDismiss = onDismiss
 
       if isViewLoaded {
@@ -99,11 +90,6 @@
 
     private func setupUI() {
       view.backgroundColor = UIColor(renderConfig.readerBackground.color)
-
-      let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleSingleTap(_:)))
-      singleTap.cancelsTouchesInView = false
-      singleTap.delegate = self
-      view.addGestureRecognizer(singleTap)
 
       contentStack.translatesAutoresizingMaskIntoConstraints = false
       contentStack.axis = .vertical
@@ -474,37 +460,6 @@
 
     @objc private func handleClose() {
       onDismiss?()
-    }
-
-    @objc private func handleSingleTap(_ gesture: UITapGestureRecognizer) {
-      let location = gesture.location(in: view)
-      guard view.bounds.width > 0, view.bounds.height > 0 else { return }
-
-      let normalizedX = location.x / view.bounds.width
-      let normalizedY = location.y / view.bounds.height
-      let action = TapZoneHelper.action(
-        normalizedX: normalizedX,
-        normalizedY: normalizedY,
-        tapZoneMode: renderConfig.tapZoneMode,
-        readingDirection: readingDirection,
-        zoneThreshold: renderConfig.tapZoneSize.value
-      )
-
-      switch action {
-      case .previous:
-        onPreviousPage?()
-      case .next:
-        onNextPage?()
-      case .toggleControls:
-        onToggleControls?()
-      }
-    }
-
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-      if let touchedView = touch.view, touchedView is UIControl {
-        return false
-      }
-      return true
     }
 
   }

--- a/KMReader/Features/Reader/Views/PageImage/DualPageImageView.swift
+++ b/KMReader/Features/Reader/Views/PageImage/DualPageImageView.swift
@@ -15,9 +15,6 @@ struct DualPageImageView: View {
   let renderConfig: ReaderRenderConfig
 
   let readingDirection: ReadingDirection
-  let onNextPage: () -> Void
-  let onPreviousPage: () -> Void
-  let onToggleControls: () -> Void
   let onPlayAnimatedPage: ((Int) -> Void)?
 
   var resetID: String {
@@ -36,9 +33,6 @@ struct DualPageImageView: View {
       maxScale: 8.0,
       readingDirection: readingDirection,
       renderConfig: renderConfig,
-      onNextPage: onNextPage,
-      onPreviousPage: onPreviousPage,
-      onToggleControls: onToggleControls,
       pages: [
         NativePageData(
           bookId: viewModel.resolvedBookId(forPageIndex: firstPageIndex),

--- a/KMReader/Features/Reader/Views/PageImage/PageScrollView_macOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/PageScrollView_macOS.swift
@@ -31,10 +31,6 @@
     let initialZoomAnchor: CGPoint?
     let initialZoomID: AnyHashable?
 
-    let onNextPage: () -> Void
-    let onPreviousPage: () -> Void
-    let onToggleControls: () -> Void
-
     let pages: [NativePageData]
 
     init(
@@ -49,9 +45,6 @@
       initialZoomScale: CGFloat? = nil,
       initialZoomAnchor: CGPoint? = nil,
       initialZoomID: AnyHashable? = nil,
-      onNextPage: @escaping () -> Void,
-      onPreviousPage: @escaping () -> Void,
-      onToggleControls: @escaping () -> Void,
       pages: [NativePageData]
     ) {
       self.viewModel = viewModel
@@ -65,9 +58,6 @@
       self.initialZoomScale = initialZoomScale
       self.initialZoomAnchor = initialZoomAnchor
       self.initialZoomID = initialZoomID
-      self.onNextPage = onNextPage
-      self.onPreviousPage = onPreviousPage
-      self.onToggleControls = onToggleControls
       self.pages = pages
     }
 
@@ -144,12 +134,6 @@
 
       nsView.backgroundColor = NSColor(renderConfig.readerBackground.color)
 
-      if let focusScroll = nsView as? FocusScrollView {
-        focusScroll.readingDirection = readingDirection
-        focusScroll.onNextPage = onNextPage
-        focusScroll.onPreviousPage = onPreviousPage
-      }
-
       if context.coordinator.lastResetID != resetID {
         context.coordinator.lastResetID = resetID
         context.coordinator.lastInitialZoomID = nil
@@ -166,16 +150,11 @@
     }
 
     @MainActor
-    class Coordinator: NSObject, NSGestureRecognizerDelegate {
+    class Coordinator: NSObject {
       var lastResetID: AnyHashable?
       var lastInitialZoomID: AnyHashable?
       var lastDisplayMode: PageDisplayMode?
       var isUpdatingFromSwiftUI = false
-      var isLongPressing = false
-      var isMenuVisible = false
-      var lastZoomOutTime: Date = .distantPast
-      var lastLongPressEndTime: Date = .distantPast
-      private let logger = AppLogger(.reader)
 
       var parent: PageScrollView!
       weak var scrollView: NSScrollView?
@@ -228,17 +207,6 @@
       }
 
       func setupNativeInteractions(on scrollView: NSScrollView) {
-        guard let view = scrollView.documentView else { return }
-        let click = NSClickGestureRecognizer(target: self, action: #selector(handleClick(_:)))
-        click.numberOfClicksRequired = 1
-        click.delegate = self
-        view.addGestureRecognizer(click)
-
-        let press = NSPressGestureRecognizer(target: self, action: #selector(handlePress(_:)))
-        press.minimumPressDuration = 0.5
-        press.delegate = self
-        view.addGestureRecognizer(press)
-
         NotificationCenter.default.addObserver(
           self,
           selector: #selector(handleScrollEnded(_:)),
@@ -340,123 +308,6 @@
         }
       }
 
-      @objc func handlePress(_ gesture: NSPressGestureRecognizer) {
-        if gesture.state == .began {
-          isLongPressing = true
-        } else if gesture.state == .ended || gesture.state == .cancelled {
-          lastLongPressEndTime = Date()
-          DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            self?.isLongPressing = false
-          }
-        }
-      }
-
-      @objc func handleClick(_ gesture: NSClickGestureRecognizer) {
-        let now = Date()
-        let longPressDiff = now.timeIntervalSince(lastLongPressEndTime)
-        let zoomOutDiff = now.timeIntervalSince(lastZoomOutTime)
-
-        guard !isLongPressing && !isMenuVisible else { return }
-        if longPressDiff < 0.5 { return }
-
-        guard let scrollView = scrollView else { return }
-        if scrollView.magnification > parent.minScale + 0.01 { return }
-        if zoomOutDiff < 0.4 { return }
-
-        let location = gesture.location(in: gesture.view)
-        let normalizedX = location.x / parent.screenSize.width
-        // macOS uses flipped Y coordinate (0 at bottom)
-        let normalizedY = 1.0 - (location.y / parent.screenSize.height)
-
-        let action = TapZoneHelper.action(
-          normalizedX: normalizedX,
-          normalizedY: normalizedY,
-          tapZoneMode: parent.renderConfig.tapZoneMode,
-          readingDirection: parent.readingDirection,
-          zoneThreshold: parent.renderConfig.tapZoneSize.value
-        )
-
-        switch action {
-        case .previous:
-          parent.onPreviousPage()
-        case .next:
-          parent.onNextPage()
-        case .toggleControls:
-          parent.onToggleControls()
-        }
-
-        // Recover focus
-        restoreKeyboardFocus()
-      }
-
-      private func restoreKeyboardFocus() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-          if let window = self?.scrollView?.window {
-            let keyboardHandler = window.contentView?.findViewOfType(KeyboardHandlerView.self)
-            if let target = keyboardHandler, window.firstResponder !== target {
-              window.makeFirstResponder(target)
-            }
-          }
-        }
-      }
-
-      func gestureRecognizer(_ gestureRecognizer: NSGestureRecognizer, shouldAttemptToRecognizeWith event: NSEvent)
-        -> Bool
-      {
-        guard let view = gestureRecognizer.view else { return true }
-        let location = view.convert(event.locationInWindow, from: nil)
-
-        if let hitView = view.hitTest(location) {
-          let className = hitView.className
-
-          // Rule 1: NSImageView should ALWAYS allow paging
-          if hitView is NSImageView || className == "NSImageView" {
-            return true
-          }
-
-          // Rule 2: Precision check for interactive buttons/controls in VisionKit
-          var current: NSView? = hitView
-          while let c = current {
-            let cn = c.className
-            if c is NSButton || c is NSControl || cn.contains("Button") || cn.contains("Control")
-              || cn.contains("Action") || cn.contains("Toggle") || cn.contains("Popup")
-            {
-              // DO NOT block if it's just a general overlay or background layer
-              if !cn.contains("Overlay") && !cn.contains("Background") && !cn.contains("View") {
-                return false  // Block paging only for real buttons
-              }
-              if cn.contains("Button") {
-                return false  // Specific block for anything named Button
-              }
-            }
-            if c is NativePageItem { break }
-            current = c.superview
-          }
-
-          // Rule 3: If Live Text is active, and we hit the overlay area (VKCActionInfoView etc.):
-          // We only allow the paging gesture if the click is in the LEFT/RIGHT paging zones.
-          // This allows the center to be used for Live Text interaction (like clicking to deselect).
-          if parent.renderConfig.enableLiveText && className.contains("VK") {
-            let normalizedX = location.x / parent.screenSize.width
-            let threshold = parent.renderConfig.tapZoneSize.value
-            let isEdge = normalizedX < threshold || normalizedX > (1.0 - threshold)
-
-            if !isEdge {
-              // Clicked in the center of a Live Text overlay: block paging to allow interaction
-              return false
-            }
-          }
-        }
-        return true
-      }
-
-      func gestureRecognizer(
-        _ gestureRecognizer: NSGestureRecognizer,
-        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: NSGestureRecognizer
-      ) -> Bool {
-        return true
-      }
-
       func applyInitialZoomIfNeeded(in scrollView: NSScrollView) {
         guard let initialZoomID = parent.initialZoomID else { return }
         guard initialZoomID != lastInitialZoomID else { return }
@@ -522,56 +373,10 @@
   }
 
   private class FocusScrollView: NSScrollView {
-    var onNextPage: (() -> Void)?
-    var onPreviousPage: (() -> Void)?
-    var readingDirection: ReadingDirection = .ltr
-
-    private var scrollAccumulator: CGFloat = 0
-    private let scrollThreshold: CGFloat = 100.0
-    private var hasPageTurnedInCurrentGesture = false
-
     override var acceptsFirstResponder: Bool { true }
-
-    override func mouseDown(with event: NSEvent) {
-      super.mouseDown(with: event)
-    }
 
     override func keyDown(with event: NSEvent) {
       self.nextResponder?.keyDown(with: event)
-    }
-
-    override func scrollWheel(with event: NSEvent) {
-      guard magnification <= minMagnification + 0.01 else {
-        super.scrollWheel(with: event)
-        return
-      }
-
-      if abs(event.scrollingDeltaX) > abs(event.scrollingDeltaY) {
-        if event.phase == .began {
-          scrollAccumulator = 0
-          hasPageTurnedInCurrentGesture = false
-        }
-
-        if !hasPageTurnedInCurrentGesture {
-          scrollAccumulator += event.scrollingDeltaX
-          if abs(scrollAccumulator) >= scrollThreshold {
-            if scrollAccumulator > 0 {
-              readingDirection == .rtl ? onPreviousPage?() : onNextPage?()
-            } else {
-              readingDirection == .rtl ? onNextPage?() : onPreviousPage?()
-            }
-            hasPageTurnedInCurrentGesture = true
-            scrollAccumulator = 0
-          }
-        }
-
-        if event.phase == .ended || event.phase == .cancelled {
-          scrollAccumulator = 0
-          hasPageTurnedInCurrentGesture = false
-        }
-      } else {
-        super.scrollWheel(with: event)
-      }
     }
   }
 

--- a/KMReader/Features/Reader/Views/PageImage/SinglePageImageView.swift
+++ b/KMReader/Features/Reader/Views/PageImage/SinglePageImageView.swift
@@ -14,9 +14,6 @@ struct SinglePageImageView: View {
   let renderConfig: ReaderRenderConfig
 
   let readingDirection: ReadingDirection
-  let onNextPage: () -> Void
-  let onPreviousPage: () -> Void
-  let onToggleControls: () -> Void
   let onPlayAnimatedPage: ((Int) -> Void)?
 
   var body: some View {
@@ -30,9 +27,6 @@ struct SinglePageImageView: View {
       maxScale: 8.0,
       readingDirection: readingDirection,
       renderConfig: renderConfig,
-      onNextPage: onNextPage,
-      onPreviousPage: onPreviousPage,
-      onToggleControls: onToggleControls,
       pages: [
         NativePageData(
           bookId: viewModel.resolvedBookId(forPageIndex: pageIndex),

--- a/KMReader/Features/Reader/Views/PageImage/SplitWidePageImageView.swift
+++ b/KMReader/Features/Reader/Views/PageImage/SplitWidePageImageView.swift
@@ -15,9 +15,6 @@ struct SplitWidePageImageView: View {
   let renderConfig: ReaderRenderConfig
 
   let readingDirection: ReadingDirection
-  let onNextPage: () -> Void
-  let onPreviousPage: () -> Void
-  let onToggleControls: () -> Void
   let onPlayAnimatedPage: ((Int) -> Void)?
 
   var body: some View {
@@ -31,9 +28,6 @@ struct SplitWidePageImageView: View {
       maxScale: 8.0,
       readingDirection: readingDirection,
       renderConfig: renderConfig,
-      onNextPage: onNextPage,
-      onPreviousPage: onPreviousPage,
-      onToggleControls: onToggleControls,
       pages: [
         NativePageData(
           bookId: viewModel.resolvedBookId(forPageIndex: pageIndex),

--- a/KMReader/Features/Reader/Views/ScrollPageView.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView.swift
@@ -14,8 +14,6 @@ struct ScrollPageView: View {
   @Bindable var viewModel: ReaderViewModel
   let readListContext: ReaderReadListContext?
   let onDismiss: () -> Void
-  let goToNextPage: () -> Void
-  let goToPreviousPage: () -> Void
   let toggleControls: () -> Void
   let onPlayAnimatedPage: ((Int) -> Void)?
   let onScrollActivityChange: ((Bool) -> Void)?
@@ -47,8 +45,6 @@ struct ScrollPageView: View {
     viewModel: ReaderViewModel,
     readListContext: ReaderReadListContext?,
     onDismiss: @escaping () -> Void,
-    goToNextPage: @escaping () -> Void,
-    goToPreviousPage: @escaping () -> Void,
     toggleControls: @escaping () -> Void,
     onPlayAnimatedPage: ((Int) -> Void)? = nil,
     onScrollActivityChange: ((Bool) -> Void)? = nil
@@ -61,8 +57,6 @@ struct ScrollPageView: View {
     self.viewModel = viewModel
     self.readListContext = readListContext
     self.onDismiss = onDismiss
-    self.goToNextPage = goToNextPage
-    self.goToPreviousPage = goToPreviousPage
     self.toggleControls = toggleControls
     self.onPlayAnimatedPage = onPlayAnimatedPage
     self.onScrollActivityChange = onScrollActivityChange
@@ -201,11 +195,7 @@ struct ScrollPageView: View {
             nextBook: viewModel.nextBook(forSegmentBookId: bookId),
             readListContext: readListContext,
             onDismiss: onDismiss,
-            readingDirection: readingDirection,
-            renderConfig: renderConfig,
-            onNextPage: goToNextPage,
-            onPreviousPage: goToPreviousPage,
-            onToggleControls: toggleControls
+            readingDirection: readingDirection
           )
         case .dual(let first, let second):
           if let firstPageIndex = viewModel.pageIndex(for: first),
@@ -219,9 +209,6 @@ struct ScrollPageView: View {
               screenSize: geometry.size,
               renderConfig: renderConfig,
               readingDirection: readingDirection,
-              onNextPage: goToNextPage,
-              onPreviousPage: goToPreviousPage,
-              onToggleControls: toggleControls,
               onPlayAnimatedPage: onPlayAnimatedPage
             )
           }
@@ -234,9 +221,6 @@ struct ScrollPageView: View {
               screenSize: geometry.size,
               renderConfig: renderConfig,
               readingDirection: readingDirection,
-              onNextPage: goToNextPage,
-              onPreviousPage: goToPreviousPage,
-              onToggleControls: toggleControls,
               onPlayAnimatedPage: onPlayAnimatedPage
             )
           }
@@ -255,9 +239,6 @@ struct ScrollPageView: View {
               screenSize: geometry.size,
               renderConfig: renderConfig,
               readingDirection: readingDirection,
-              onNextPage: goToNextPage,
-              onPreviousPage: goToPreviousPage,
-              onToggleControls: toggleControls,
               onPlayAnimatedPage: onPlayAnimatedPage
             )
           }

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonZoomOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonZoomOverlayView.swift
@@ -45,9 +45,6 @@
           initialZoomScale: initialScale,
           initialZoomAnchor: zoomAnchor,
           initialZoomID: zoomRequestID,
-          onNextPage: {},
-          onPreviousPage: {},
-          onToggleControls: {},
           pages: [
             NativePageData(
               bookId: viewModel.resolvedBookId(forPageIndex: pageIndex),


### PR DESCRIPTION
## Summary
- centralize DIVINA tap-zone handling at the SwiftUI layer with simultaneous gestures instead of per-renderer UIKit/AppKit handlers
- remove duplicated tap-zone callbacks and dead parameter plumbing from `PageScrollView`, page image views, end-page controllers, and curl wiring
- keep tap-zone actions disabled while zoomed and remove non-webtoon mouse-wheel paging on macOS

## Testing
- [x] `make build`
