### PR TITLE
fix: polish server onboarding empty state and login feedback

### DIFF
--- a/KMReader/Features/Auth/Views/LandingView.swift
+++ b/KMReader/Features/Auth/Views/LandingView.swift
@@ -37,17 +37,18 @@ struct LandingView: View {
       Button(action: {
         showGetStarted = true
       }) {
-        HStack {
+        HStack(spacing: 8) {
           Text("Get Started")
             .fontWeight(.semibold)
           Image(systemName: "arrow.right")
         }
         .frame(maxWidth: .infinity)
-        .frame(height: 56)
+        .frame(height: 48)
       }
       .adaptiveButtonStyle(.borderedProminent)
-      .padding(.horizontal, 40)
-      .padding(.bottom, 60)
+      .padding(.horizontal, 24)
+      .frame(maxWidth: 360)
+      .padding(.bottom, 40)
     }
     #if os(iOS)
       .fullScreenCover(isPresented: $showGetStarted) {

--- a/KMReader/Features/Auth/Views/LoginView.swift
+++ b/KMReader/Features/Auth/Views/LoginView.swift
@@ -50,7 +50,7 @@ struct LoginView: View {
 
   private func login() {
     Task {
-      loginErrorMessage = nil
+      setLoginErrorMessage(nil)
       let trimmedName = instanceName.trimmingCharacters(in: .whitespacesAndNewlines)
       let displayName = trimmedName.isEmpty ? nil : trimmedName
 
@@ -72,7 +72,7 @@ struct LoginView: View {
         }
         dismiss()
       } catch {
-        loginErrorMessage = formattedErrorMessage(from: error)
+        setLoginErrorMessage(formattedErrorMessage(from: error))
       }
     }
   }
@@ -111,7 +111,7 @@ struct LoginView: View {
           #endif
           .autocorrectionDisabled()
           .onChange(of: serverURLText) { _, _ in
-            loginErrorMessage = nil
+            setLoginErrorMessage(nil)
           }
       }
 
@@ -131,7 +131,7 @@ struct LoginView: View {
       }
       .pickerStyle(.segmented)
       .onChange(of: authMethod) { _, _ in
-        loginErrorMessage = nil
+        setLoginErrorMessage(nil)
       }
 
       // Conditional fields based on auth method
@@ -149,7 +149,7 @@ struct LoginView: View {
             #endif
             .autocorrectionDisabled()
             .onChange(of: usernameText) { _, _ in
-              loginErrorMessage = nil
+              setLoginErrorMessage(nil)
             }
         }
 
@@ -161,7 +161,7 @@ struct LoginView: View {
           SecureField(String(localized: "Enter your password"), text: $password)
             .textContentType(.password)
             .onChange(of: password) { _, _ in
-              loginErrorMessage = nil
+              setLoginErrorMessage(nil)
             }
         }
 
@@ -178,27 +178,10 @@ struct LoginView: View {
             #endif
             .autocorrectionDisabled()
             .onChange(of: apiKey) { _, _ in
-              loginErrorMessage = nil
+              setLoginErrorMessage(nil)
             }
         }
       }
-
-      Button(action: login) {
-        HStack(spacing: 8) {
-          Spacer()
-          if authViewModel.isLoading {
-            LoadingIcon()
-          } else {
-            Text(String(localized: "Login"))
-            Image(systemName: "arrow.right.circle.fill")
-          }
-          Spacer()
-        }
-        .padding(.vertical, 12)
-      }
-      .adaptiveButtonStyle(.borderedProminent)
-      .disabled(!isFormValid || authViewModel.isLoading)
-      .padding(.top, 8)
 
       if let loginErrorMessage {
         HStack(alignment: .top, spacing: 8) {
@@ -211,9 +194,38 @@ struct LoginView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.top, 4)
+        .transition(.opacity.combined(with: .move(edge: .top)))
       }
+
+      Button(action: login) {
+        HStack(spacing: 8) {
+          if authViewModel.isLoading {
+            LoadingIcon()
+          } else {
+            Text(String(localized: "Login"))
+            Image(systemName: "arrow.right.circle.fill")
+          }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 10)
+      }
+      #if !os(tvOS)
+        .frame(maxWidth: 360)
+      #endif
+      .frame(maxWidth: .infinity, alignment: .center)
+      .adaptiveButtonStyle(.borderedProminent)
+      .disabled(!isFormValid || authViewModel.isLoading)
+      .padding(.top, 8)
     }
     .animation(.default, value: authMethod)
+    .animation(.easeInOut(duration: 0.2), value: loginErrorMessage)
+  }
+
+  private func setLoginErrorMessage(_ message: String?) {
+    guard loginErrorMessage != message else { return }
+    withAnimation(.easeInOut(duration: 0.2)) {
+      loginErrorMessage = message
+    }
   }
 
   private var fieldBackgroundColor: Color {

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -45,15 +45,19 @@ struct ServerListView: View {
             Image(systemName: "list.bullet.rectangle")
               .font(.largeTitle)
               .foregroundStyle(.secondary)
-            Text(String(localized: "No servers found"))
+            Text(String(localized: "No servers added yet"))
               .font(.headline)
-            Text(String(localized: "Login to a Komga server to see it listed here."))
+            Text(String(localized: "Add or connect to a Komga server to get started."))
               .font(.caption)
               .foregroundStyle(.secondary)
               .multilineTextAlignment(.center)
-            Button(String(localized: "Retry")) {
+            Button {
               showLogin = true
+            } label: {
+              Label(String(localized: "Connect to a Server"), systemImage: "plus.circle")
+                .labelStyle(.titleAndIcon)
             }
+            .adaptiveButtonStyle(.borderedProminent)
           }
           .frame(maxWidth: .infinity)
           .padding(.vertical)
@@ -82,14 +86,17 @@ struct ServerListView: View {
       }
       .listRowBackground(Color.clear)
 
-      Section {
-        Button {
-          showLogin = true
-        } label: {
-          HStack {
-            Spacer()
-            Label(addButtonTitle, systemImage: "plus.circle")
-            Spacer()
+      if !instances.isEmpty {
+        Section {
+          Button {
+            showLogin = true
+          } label: {
+            HStack {
+              Spacer()
+              Label(addButtonTitle, systemImage: "plus.circle")
+                .labelStyle(.titleAndIcon)
+              Spacer()
+            }
           }
         }
       }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -2468,6 +2468,52 @@
         }
       }
     },
+    "Add or connect to a Komga server to get started." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fügen Sie einen Komga-Server hinzu oder verbinden Sie sich, um zu beginnen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add or connect to a Komga server to get started."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajoutez ou connectez-vous à un serveur Komga pour commencer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始するには、Komga サーバーを追加または接続してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시작하려면 Komga 서버를 추가하거나 연결하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加或连接到 Komga 服务器以开始使用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新增或連線到 Komga 伺服器以開始使用。"
+          }
+        }
+      }
+    },
     "Add to Collection" : {
       "localizations" : {
         "de" : {
@@ -23720,52 +23766,6 @@
         }
       }
     },
-    "Login to a Komga server to see it listed here." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Melden Sie sich an einem Komga-Server an, um ihn hier zu sehen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Login to a Komga server to see it listed here."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connectez-vous à un serveur Komga pour le voir apparaître ici."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Komga サーバーにログインするとここに表示されます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Komga 서버에 로그인하면 여기에 표시됩니다."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "登录 Komga 服务器即可在此列出。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "登入 Komga 伺服器即可在此列出。"
-          }
-        }
-      }
-    },
     "Logout" : {
       "localizations" : {
         "de" : {
@@ -26066,48 +26066,48 @@
         }
       }
     },
-    "No servers found" : {
+    "No servers added yet" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Keine Server gefunden"
+            "value" : "Noch keine Server hinzugefügt"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No servers found"
+            "value" : "No servers added yet"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aucune série trouvée"
+            "value" : "Aucun serveur ajouté pour le moment"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "シリーズが見つかりません"
+            "value" : "追加されたサーバーはまだありません"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "서버를 찾을 수 없음"
+            "value" : "추가된 서버가 아직 없습니다"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未找到服务器"
+            "value" : "还没有添加服务器"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未找到伺服器"
+            "value" : "還沒有新增伺服器"
           }
         }
       }


### PR DESCRIPTION
## Summary
- replace the server list empty-state retry action with a connect-focused CTA and improved copy
- keep plus icons visible on server list action labels in Form contexts
- reduce oversized onboarding/login primary buttons for better balance
- show login errors above the login button with animated show/hide transitions
- update localized strings for the new server empty-state messaging

## Validation
- make format
- make build-macos
