### PR TITLE
fix: improve reader end page styling and responsiveness

### DIFF
--- a/KMReader/Features/Reader/Views/EndPageView/EndPageView.swift
+++ b/KMReader/Features/Reader/Views/EndPageView/EndPageView.swift
@@ -13,6 +13,7 @@ struct EndPageView: View {
   let readingDirection: ReadingDirection
 
   @Environment(\.readerBackgroundPreference) private var readerBackground
+  @Environment(\.colorScheme) private var colorScheme
 
   init(
     previousBook: Book?,
@@ -52,13 +53,37 @@ struct EndPageView: View {
   var body: some View {
     GeometryReader { geometry in
       let isPortrait = geometry.size.height >= geometry.size.width
+      let minDimension = min(geometry.size.width, geometry.size.height)
+      let contentPadding = clamped(minDimension * 0.08, lower: 20, upper: 56)
+      let contentSpacing = clamped(minDimension * 0.04, lower: 14, upper: 28)
+      let sectionSpacing = clamped(minDimension * 0.032, lower: 10, upper: 20)
+      let portraitExtraDividerPadding = clamped(sectionSpacing * 0.5, lower: 6, upper: 12)
+      let coverWidth = clamped(
+        minDimension * (isPortrait ? 0.3 : 0.23),
+        lower: 96,
+        upper: 190
+      )
+      let coverHeight = coverWidth / CoverAspectRatio.widthToHeight
+      let dividerHeight = clamped(geometry.size.height * 0.32, lower: 140, upper: 320)
+      let dividerMaxWidth = clamped(geometry.size.width * 0.78, lower: 260, upper: 680)
 
-      VStack(spacing: 20) {
+      VStack(spacing: contentSpacing) {
         Group {
           if isPortrait {
-            portraitContent
+            portraitContent(
+              sectionSpacing: sectionSpacing,
+              coverWidth: coverWidth,
+              coverHeight: coverHeight,
+              dividerMaxWidth: dividerMaxWidth,
+              dividerVerticalPadding: portraitExtraDividerPadding
+            )
           } else {
-            landscapeContent
+            landscapeContent(
+              sectionSpacing: sectionSpacing,
+              coverWidth: coverWidth,
+              coverHeight: coverHeight,
+              dividerHeight: dividerHeight
+            )
           }
         }
         .allowsHitTesting(false)
@@ -69,7 +94,9 @@ struct EndPageView: View {
           } label: {
             HStack(spacing: 8) {
               Image(systemName: "xmark")
+                .font(.subheadline)
               Text("Close")
+                .font(.body)
             }
             .padding(.horizontal, 4)
             .contentShape(.capsule)
@@ -79,36 +106,56 @@ struct EndPageView: View {
           .tint(.primary)
         }
       }
-      .padding(40)
+      .padding(contentPadding)
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .contentShape(Rectangle())
     }
   }
 
-  private var portraitContent: some View {
-    VStack(spacing: 20) {
+  private func portraitContent(
+    sectionSpacing: CGFloat,
+    coverWidth: CGFloat,
+    coverHeight: CGFloat,
+    dividerMaxWidth: CGFloat,
+    dividerVerticalPadding: CGFloat
+  ) -> some View {
+    VStack(spacing: sectionSpacing) {
       chapterSection(
         label: String(localized: "reader.previousBook"),
         book: previousBook,
         showCover: false,
         isNextSection: false,
-        alignment: .center
+        alignment: .center,
+        showLabel: true,
+        sectionSpacing: sectionSpacing,
+        coverWidth: coverWidth,
+        coverHeight: coverHeight
       )
 
-      relationDividerHorizontal
+      relationDividerHorizontal(maxWidth: dividerMaxWidth)
+        .padding(.vertical, dividerVerticalPadding)
 
       chapterSection(
         label: String(localized: "reader.nextBook"),
         book: nextBook,
         showCover: true,
         isNextSection: true,
-        alignment: .center
+        alignment: .center,
+        showLabel: nextBook != nil,
+        sectionSpacing: sectionSpacing,
+        coverWidth: coverWidth,
+        coverHeight: coverHeight
       )
     }
   }
 
-  private var landscapeContent: some View {
-    VStack(spacing: 18) {
+  private func landscapeContent(
+    sectionSpacing: CGFloat,
+    coverWidth: CGFloat,
+    coverHeight: CGFloat,
+    dividerHeight: CGFloat
+  ) -> some View {
+    VStack(spacing: sectionSpacing) {
       if !relationTitle.isEmpty {
         Text(relationTitle)
           .font(.headline)
@@ -118,22 +165,30 @@ struct EndPageView: View {
           .lineLimit(1)
       }
 
-      HStack(spacing: 20) {
+      HStack(spacing: sectionSpacing) {
         if isForwardOnLeadingSide {
           chapterSection(
             label: String(localized: "reader.nextBook"),
             book: nextBook,
             showCover: true,
             isNextSection: true,
-            alignment: .center
+            alignment: .center,
+            showLabel: nextBook != nil,
+            sectionSpacing: sectionSpacing,
+            coverWidth: coverWidth,
+            coverHeight: coverHeight
           )
-          relationDividerVertical
+          relationDividerVertical(height: dividerHeight)
           chapterSection(
             label: String(localized: "reader.previousBook"),
             book: previousBook,
             showCover: true,
             isNextSection: false,
-            alignment: .center
+            alignment: .center,
+            showLabel: true,
+            sectionSpacing: sectionSpacing,
+            coverWidth: coverWidth,
+            coverHeight: coverHeight
           )
         } else {
           chapterSection(
@@ -141,22 +196,30 @@ struct EndPageView: View {
             book: previousBook,
             showCover: true,
             isNextSection: false,
-            alignment: .center
+            alignment: .center,
+            showLabel: true,
+            sectionSpacing: sectionSpacing,
+            coverWidth: coverWidth,
+            coverHeight: coverHeight
           )
-          relationDividerVertical
+          relationDividerVertical(height: dividerHeight)
           chapterSection(
             label: String(localized: "reader.nextBook"),
             book: nextBook,
             showCover: true,
             isNextSection: true,
-            alignment: .center
+            alignment: .center,
+            showLabel: nextBook != nil,
+            sectionSpacing: sectionSpacing,
+            coverWidth: coverWidth,
+            coverHeight: coverHeight
           )
         }
       }
     }
   }
 
-  private var relationDividerHorizontal: some View {
+  private func relationDividerHorizontal(maxWidth: CGFloat) -> some View {
     HStack(spacing: 10) {
       Rectangle()
         .fill(textColor.opacity(0.3))
@@ -171,13 +234,13 @@ struct EndPageView: View {
         .fill(textColor.opacity(0.3))
         .frame(height: 1)
     }
-    .frame(maxWidth: 520)
+    .frame(maxWidth: maxWidth)
   }
 
-  private var relationDividerVertical: some View {
+  private func relationDividerVertical(height: CGFloat) -> some View {
     Rectangle()
       .fill(textColor.opacity(0.3))
-      .frame(width: 1, height: 220)
+      .frame(width: 1, height: height)
   }
 
   @ViewBuilder
@@ -186,30 +249,42 @@ struct EndPageView: View {
     book: Book?,
     showCover: Bool,
     isNextSection: Bool,
-    alignment: HorizontalAlignment
+    alignment: HorizontalAlignment,
+    showLabel: Bool,
+    sectionSpacing: CGFloat,
+    coverWidth: CGFloat,
+    coverHeight: CGFloat
   ) -> some View {
-    VStack(alignment: alignment, spacing: 8) {
-      Text(label.uppercased())
-        .font(.caption)
-        .fontWeight(.semibold)
-        .foregroundColor(textColor.opacity(0.55))
-        .frame(maxWidth: .infinity, alignment: frameAlignment(alignment))
+    VStack(alignment: alignment, spacing: sectionSpacing) {
+      if showLabel {
+        Text(label.uppercased())
+          .font(.caption)
+          .fontWeight(.semibold)
+          .foregroundColor(textColor.opacity(0.55))
+          .frame(maxWidth: .infinity, alignment: frameAlignment(alignment))
+      }
 
       if let book {
         if showCover {
           ThumbnailImage(
             id: book.id,
             type: .book,
-            shadowStyle: .basic,
-            width: 120,
-            cornerRadius: 12
+            shadowStyle: .none,
+            width: coverWidth,
+            cornerRadius: coverCornerRadius(for: coverWidth)
           )
-          .frame(maxHeight: 160)
+          .frame(width: coverWidth, height: coverHeight)
+          .shadow(
+            color: coverShadowColor,
+            radius: clamped(coverWidth * 0.08, lower: 4, upper: 10),
+            x: 0,
+            y: clamped(coverWidth * 0.04, lower: 2, upper: 6)
+          )
           .frame(maxWidth: .infinity, alignment: frameAlignment(alignment))
         }
 
         Text(chapterTitle(for: book))
-          .font(.title3)
+          .font(coverWidth >= 150 ? .title2 : .title3)
           .fontDesign(.serif)
           .fontWeight(.bold)
           .foregroundColor(textColor)
@@ -258,6 +333,25 @@ struct EndPageView: View {
     default:
       return .center
     }
+  }
+
+  private var coverShadowColor: Color {
+    switch readerBackground {
+    case .black, .gray:
+      return .white.opacity(0.16)
+    case .white:
+      return .black.opacity(0.18)
+    case .system:
+      return colorScheme == .dark ? .white.opacity(0.14) : .black.opacity(0.18)
+    }
+  }
+
+  private func coverCornerRadius(for width: CGFloat) -> CGFloat {
+    clamped(width * 0.1, lower: 10, upper: 16)
+  }
+
+  private func clamped(_ value: CGFloat, lower: CGFloat, upper: CGFloat) -> CGFloat {
+    Swift.min(Swift.max(value, lower), upper)
   }
 
 }

--- a/KMReader/Features/Reader/Views/NativeBookCoverViewController.swift
+++ b/KMReader/Features/Reader/Views/NativeBookCoverViewController.swift
@@ -14,6 +14,12 @@
     private var coverImageBookID: String?
     private var failedCoverImageBookID: String?
 
+    var useLightShadow: Bool = false {
+      didSet {
+        updateShadowAppearance()
+      }
+    }
+
     var cornerRadius: CGFloat = 12 {
       didSet {
         updateCoverImageDecoration()
@@ -43,7 +49,6 @@
 
       coverContainerView.translatesAutoresizingMaskIntoConstraints = false
       coverContainerView.backgroundColor = .clear
-      coverContainerView.layer.shadowColor = UIColor.black.cgColor
       coverContainerView.layer.shadowOpacity = 0
       coverContainerView.layer.shadowOffset = CGSize(width: 0, height: 3)
       coverContainerView.layer.shadowRadius = 6
@@ -65,6 +70,8 @@
         coverImageView.topAnchor.constraint(equalTo: coverContainerView.topAnchor),
         coverImageView.bottomAnchor.constraint(equalTo: coverContainerView.bottomAnchor),
       ])
+
+      updateShadowAppearance()
     }
 
     private func updateCoverImage(for bookID: String?) {
@@ -147,6 +154,17 @@
       let x = (viewSize.width - width) / 2
       let y = (viewSize.height - height) / 2
       return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    private func updateShadowAppearance() {
+      coverContainerView.layer.shadowColor = effectiveShadowColor.cgColor
+    }
+
+    private var effectiveShadowColor: UIColor {
+      if useLightShadow {
+        return UIColor.white.withAlphaComponent(0.4)
+      }
+      return UIColor.black.withAlphaComponent(0.35)
     }
 
     nonisolated private static func loadCoverImage(for bookID: String) async -> UIImage? {


### PR DESCRIPTION
## Summary
- move end-page cover corner radius handling to the image itself and add subtle cover shadow treatment
- make end-page layout and spacing responsive to screen size, including extra divider spacing in portrait mode
- tune close button icon size relative to text and hide next-book label when there is no next book
- align native iOS end-page behavior with SwiftUI end-page updates

## Testing
- [x] make build
