### PR TITLE
fix: complete sepia multiply rendering for webtoon

### DIFF
--- a/KMReader/Features/Reader/Views/NativeBookCoverViewController.swift
+++ b/KMReader/Features/Reader/Views/NativeBookCoverViewController.swift
@@ -137,31 +137,13 @@
       }
 
       if let tintColor = imageBlendTintColor,
-        let blendedImage = multiplyBlend(image: sourceCoverImage, tintColor: tintColor)
+        let blendedImage = ReaderImageBlendHelper.multiply(image: sourceCoverImage, tintColor: tintColor)
       {
         coverImageView.image = blendedImage
       } else {
         coverImageView.image = sourceCoverImage
       }
       updateCoverImageDecoration()
-    }
-
-    private func multiplyBlend(image: UIImage, tintColor: UIColor) -> UIImage? {
-      let size = image.size
-      guard size.width > 0, size.height > 0 else { return image }
-
-      let format = UIGraphicsImageRendererFormat.preferred()
-      format.scale = image.scale
-      format.opaque = false
-      let renderer = UIGraphicsImageRenderer(size: size, format: format)
-
-      return renderer.image { context in
-        let rect = CGRect(origin: .zero, size: size)
-        image.draw(in: rect)
-        context.cgContext.setBlendMode(.multiply)
-        context.cgContext.setFillColor(tintColor.cgColor)
-        context.cgContext.fill(rect)
-      }
     }
 
     private func updateCoverImageDecoration() {

--- a/KMReader/Shared/Helpers/ReaderImageBlendHelper.swift
+++ b/KMReader/Shared/Helpers/ReaderImageBlendHelper.swift
@@ -1,0 +1,73 @@
+//
+// ReaderImageBlendHelper.swift
+//
+//
+
+import Foundation
+
+#if os(iOS) || os(tvOS)
+  import UIKit
+
+  enum ReaderImageBlendHelper {
+    static func multiply(image: UIImage, tintColor: UIColor) -> UIImage? {
+      let size = image.size
+      guard size.width > 0, size.height > 0 else { return image }
+
+      let format = UIGraphicsImageRendererFormat.preferred()
+      format.scale = image.scale
+      format.opaque = false
+      let renderer = UIGraphicsImageRenderer(size: size, format: format)
+
+      return renderer.image { context in
+        let rect = CGRect(origin: .zero, size: size)
+        image.draw(in: rect)
+        context.cgContext.setBlendMode(.multiply)
+        context.cgContext.setFillColor(tintColor.cgColor)
+        context.cgContext.fill(rect)
+      }
+    }
+  }
+#elseif os(macOS)
+  import AppKit
+
+  enum ReaderImageBlendHelper {
+    static func multiply(image: NSImage, tintColor: NSColor) -> NSImage? {
+      guard
+        let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
+      else {
+        return image
+      }
+
+      let width = cgImage.width
+      let height = cgImage.height
+      guard width > 0, height > 0 else { return image }
+
+      let colorSpace = CGColorSpaceCreateDeviceRGB()
+      guard
+        let context = CGContext(
+          data: nil,
+          width: width,
+          height: height,
+          bitsPerComponent: 8,
+          bytesPerRow: 0,
+          space: colorSpace,
+          bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+      else {
+        return image
+      }
+
+      let rect = CGRect(x: 0, y: 0, width: width, height: height)
+      context.draw(cgImage, in: rect)
+      context.setBlendMode(.multiply)
+      context.setFillColor(tintColor.cgColor)
+      context.fill(rect)
+
+      guard let blendedCGImage = context.makeImage() else {
+        return image
+      }
+
+      return NSImage(cgImage: blendedCGImage, size: image.size)
+    }
+  }
+#endif


### PR DESCRIPTION
## Summary
- fix missing sepia multiply rendering for webtoon page cells on iOS and macOS
- extract shared multiply logic into `ReaderImageBlendHelper` and reuse it across reader image rendering paths
- simplify render cache state from separate rendered-source tracking to `sourceImage + renderedBackground + renderedImage`

## Testing
- [x] `make format`
- [x] `make build-ios`
- [x] `make build-macos`
- [x] `make build-tvos`
