### PR TITLE
fix: stabilize page curl mirrored backside behavior

### DIFF
--- a/KMReader/Features/Reader/Views/PageCurlBacksideViewController.swift
+++ b/KMReader/Features/Reader/Views/PageCurlBacksideViewController.swift
@@ -30,13 +30,40 @@
       }
     }
 
+    enum MirrorAxis {
+      case horizontal
+      case vertical
+
+      var transform: CGAffineTransform {
+        switch self {
+        case .horizontal:
+          return CGAffineTransform(scaleX: -1, y: 1)
+        case .vertical:
+          return CGAffineTransform(scaleX: 1, y: -1)
+        }
+      }
+    }
+
+    struct MirroredSnapshot {
+      let view: UIView
+      let axis: MirrorAxis
+    }
+
     let destinationToken: String
     private var style: Style
+    private var mirroredSnapshot: MirroredSnapshot?
+    private let snapshotContainerView = UIView()
+    private var activeSnapshotView: UIView?
     private let dimView = UIView()
 
-    init(destinationToken: String, style: Style) {
+    init(
+      destinationToken: String,
+      style: Style,
+      mirroredSnapshot: MirroredSnapshot? = nil
+    ) {
       self.destinationToken = destinationToken
       self.style = style
+      self.mirroredSnapshot = mirroredSnapshot
       super.init(nibName: nil, bundle: nil)
     }
 
@@ -48,10 +75,20 @@
     override func loadView() {
       let baseView = UIView()
       baseView.backgroundColor = .clear
+
+      snapshotContainerView.translatesAutoresizingMaskIntoConstraints = false
+      snapshotContainerView.isUserInteractionEnabled = false
+      snapshotContainerView.clipsToBounds = true
+      baseView.addSubview(snapshotContainerView)
+
       dimView.translatesAutoresizingMaskIntoConstraints = false
       dimView.isUserInteractionEnabled = false
       baseView.addSubview(dimView)
       NSLayoutConstraint.activate([
+        snapshotContainerView.topAnchor.constraint(equalTo: baseView.topAnchor),
+        snapshotContainerView.leadingAnchor.constraint(equalTo: baseView.leadingAnchor),
+        snapshotContainerView.trailingAnchor.constraint(equalTo: baseView.trailingAnchor),
+        snapshotContainerView.bottomAnchor.constraint(equalTo: baseView.bottomAnchor),
         dimView.topAnchor.constraint(equalTo: baseView.topAnchor),
         dimView.leadingAnchor.constraint(equalTo: baseView.leadingAnchor),
         dimView.trailingAnchor.constraint(equalTo: baseView.trailingAnchor),
@@ -59,6 +96,7 @@
       ])
       view = baseView
       applyStyle()
+      applyMirroredSnapshot()
     }
 
     func updateStyle(_ style: Style) {
@@ -71,6 +109,69 @@
     private func applyStyle() {
       view.backgroundColor = style.renderedColor
       dimView.backgroundColor = UIColor.black.withAlphaComponent(style.dimOpacity)
+    }
+
+    private func applyMirroredSnapshot() {
+      activeSnapshotView?.removeFromSuperview()
+      activeSnapshotView = nil
+
+      guard let mirroredSnapshot else {
+        snapshotContainerView.isHidden = true
+        return
+      }
+
+      let snapshotView = mirroredSnapshot.view
+      snapshotView.translatesAutoresizingMaskIntoConstraints = false
+      snapshotView.isUserInteractionEnabled = false
+      snapshotContainerView.addSubview(snapshotView)
+      NSLayoutConstraint.activate([
+        snapshotView.topAnchor.constraint(equalTo: snapshotContainerView.topAnchor),
+        snapshotView.leadingAnchor.constraint(equalTo: snapshotContainerView.leadingAnchor),
+        snapshotView.trailingAnchor.constraint(equalTo: snapshotContainerView.trailingAnchor),
+        snapshotView.bottomAnchor.constraint(equalTo: snapshotContainerView.bottomAnchor),
+      ])
+      snapshotView.transform = mirroredSnapshot.axis.transform
+      snapshotContainerView.isHidden = false
+      activeSnapshotView = snapshotView
+    }
+
+    static func makeMirroredSnapshot(
+      from sourceController: UIViewController,
+      axis: MirrorAxis
+    ) -> MirroredSnapshot? {
+      guard sourceController.isViewLoaded else { return nil }
+      guard let sourceView = sourceController.view else { return nil }
+      sourceView.layoutIfNeeded()
+      let bounds = sourceView.bounds
+      guard bounds.width > 1, bounds.height > 1 else { return nil }
+
+      // For onscreen views, a direct snapshot is fast and avoids extra rendering work.
+      if sourceView.window != nil,
+        let snapshotView = sourceView.snapshotView(afterScreenUpdates: false)
+      {
+        return MirroredSnapshot(view: snapshotView, axis: axis)
+      }
+
+      // For offscreen/unrendered views, render the layer directly to avoid
+      // triggering SwiftUI/AttributeGraph updates during tap-driven transitions.
+      let format = UIGraphicsImageRendererFormat.preferred()
+      format.opaque = false
+      format.scale = sourceView.window?.screen.scale ?? UIScreen.main.scale
+      let renderer = UIGraphicsImageRenderer(bounds: bounds, format: format)
+      let image = renderer.image { context in
+        sourceView.layer.render(in: context.cgContext)
+      }
+      let imageView = UIImageView(image: image)
+      imageView.contentMode = .scaleToFill
+      imageView.clipsToBounds = true
+      return MirroredSnapshot(view: imageView, axis: axis)
+    }
+
+    static func makeMirroredSnapshot(from image: UIImage, axis: MirrorAxis) -> MirroredSnapshot {
+      let imageView = UIImageView(image: image)
+      imageView.contentMode = .scaleToFill
+      imageView.clipsToBounds = true
+      return MirroredSnapshot(view: imageView, axis: axis)
     }
 
     static func applyStyle(_ style: Style, to pageViewController: UIPageViewController) {


### PR DESCRIPTION
## Summary
- Replace page-curl backside pure-color rendering with mirrored snapshots while keeping color fallback.
- Fix direction-aware backside source selection so LTR/RTL forward and backward curls use the expected source page.
- Stabilize EPUB backward curls by adding cached rendered-page snapshots and using them preferentially for target-page backside rendering.
- Adjust snapshot capture fallback to reduce AttributeGraph cycle noise during tap-zone page turns.

## Testing
- [x] `make format`
- [x] `make build-ios`
