### PR TITLE
feat(reader): support waifu2x on macOS

### DIFF
--- a/KMReader/Features/Reader/Services/Upscaling/ReaderImageModel.swift
+++ b/KMReader/Features/Reader/Services/Upscaling/ReaderImageModel.swift
@@ -1,36 +1,34 @@
-#if os(iOS) || os(tvOS)
-  import CoreImage
-  import CoreML
-  import Foundation
-  @preconcurrency import Vision
+import CoreImage
+import CoreML
+import Foundation
+@preconcurrency import Vision
 
-  nonisolated final class ReaderImageModel: ReaderImageProcessingModel {
-    private let vnModel: VNCoreMLModel
+nonisolated final class ReaderImageModel: ReaderImageProcessingModel {
+  private let vnModel: VNCoreMLModel
 
-    nonisolated required init?(model: MLModel, descriptor _: ReaderUpscaleModelDescriptor) {
-      guard let vnModel = try? VNCoreMLModel(for: model) else {
-        return nil
-      }
-      self.vnModel = vnModel
+  nonisolated required init?(model: MLModel, descriptor _: ReaderUpscaleModelDescriptor) {
+    guard let vnModel = try? VNCoreMLModel(for: model) else {
+      return nil
     }
+    self.vnModel = vnModel
+  }
 
-    nonisolated func process(_ image: CGImage) async -> CGImage? {
-      await withCheckedContinuation { continuation in
-        DispatchQueue.global(qos: .userInitiated).async { [vnModel] in
-          let request = VNCoreMLRequest(model: vnModel)
-          request.imageCropAndScaleOption = .scaleFill
-          let handler = VNImageRequestHandler(cgImage: image, options: [:])
-          try? handler.perform([request])
+  nonisolated func process(_ image: CGImage) async -> CGImage? {
+    await withCheckedContinuation { continuation in
+      DispatchQueue.global(qos: .userInitiated).async { [vnModel] in
+        let request = VNCoreMLRequest(model: vnModel)
+        request.imageCropAndScaleOption = .scaleFill
+        let handler = VNImageRequestHandler(cgImage: image, options: [:])
+        try? handler.perform([request])
 
-          guard let result = request.results?.first as? VNPixelBufferObservation else {
-            continuation.resume(returning: nil)
-            return
-          }
-
-          let output = CIImage(cvImageBuffer: result.pixelBuffer).cgImage
-          continuation.resume(returning: output)
+        guard let result = request.results?.first as? VNPixelBufferObservation else {
+          continuation.resume(returning: nil)
+          return
         }
+
+        let output = CIImage(cvImageBuffer: result.pixelBuffer).cgImage
+        continuation.resume(returning: output)
       }
     }
   }
-#endif
+}

--- a/KMReader/Features/Reader/Services/Upscaling/ReaderImageProcessingModel.swift
+++ b/KMReader/Features/Reader/Services/Upscaling/ReaderImageProcessingModel.swift
@@ -1,9 +1,7 @@
-#if os(iOS) || os(tvOS)
-  import CoreGraphics
-  import CoreML
+import CoreGraphics
+import CoreML
 
-  protocol ReaderImageProcessingModel {
-    nonisolated init?(model: MLModel, descriptor: ReaderUpscaleModelDescriptor)
-    nonisolated func process(_ image: CGImage) async -> CGImage?
-  }
-#endif
+protocol ReaderImageProcessingModel {
+  nonisolated init?(model: MLModel, descriptor: ReaderUpscaleModelDescriptor)
+  nonisolated func process(_ image: CGImage) async -> CGImage?
+}

--- a/KMReader/Features/Reader/Services/Upscaling/ReaderMultiArrayModel.swift
+++ b/KMReader/Features/Reader/Services/Upscaling/ReaderMultiArrayModel.swift
@@ -1,4 +1,3 @@
-#if os(iOS) || os(tvOS)
   import Accelerate
   import CoreGraphics
   @preconcurrency import CoreML
@@ -413,4 +412,3 @@
       return arr
     }
   }
-#endif

--- a/KMReader/Features/Reader/Services/Upscaling/ReaderUpscaleDecision.swift
+++ b/KMReader/Features/Reader/Services/Upscaling/ReaderUpscaleDecision.swift
@@ -1,6 +1,9 @@
-#if os(iOS) || os(tvOS)
   import CoreGraphics
-  import UIKit
+  #if os(iOS) || os(tvOS)
+    import UIKit
+  #elseif os(macOS)
+    import AppKit
+  #endif
 
   nonisolated struct ReaderUpscaleDecision {
     nonisolated enum SkipReason {
@@ -79,14 +82,25 @@
       )
     }
 
-    @MainActor
-    static func screenPixelSize(for screen: UIScreen) -> CGSize {
-      let size = screen.bounds.size
-      let scale = screen.scale
-      return CGSize(
-        width: max(size.width * scale, 1),
-        height: max(size.height * scale, 1)
-      )
-    }
+    #if os(iOS) || os(tvOS)
+      @MainActor
+      static func screenPixelSize(for screen: UIScreen) -> CGSize {
+        let size = screen.bounds.size
+        let scale = screen.scale
+        return CGSize(
+          width: max(size.width * scale, 1),
+          height: max(size.height * scale, 1)
+        )
+      }
+    #elseif os(macOS)
+      @MainActor
+      static func screenPixelSize(for screen: NSScreen) -> CGSize {
+        let frame = screen.frame
+        let scale = screen.backingScaleFactor
+        return CGSize(
+          width: max(frame.width * scale, 1),
+          height: max(frame.height * scale, 1)
+        )
+      }
+    #endif
   }
-#endif

--- a/KMReader/Features/Reader/Services/Upscaling/ReaderUpscaleModelDescriptor.swift
+++ b/KMReader/Features/Reader/Services/Upscaling/ReaderUpscaleModelDescriptor.swift
@@ -1,49 +1,47 @@
-#if os(iOS) || os(tvOS)
-  import Foundation
+import Foundation
 
-  nonisolated enum ReaderUpscaleModelType: String, Decodable {
-    case multiarray
-    case image
+nonisolated enum ReaderUpscaleModelType: String, Decodable {
+  case multiarray
+  case image
+}
+
+nonisolated struct ReaderUpscaleModelConfig: Decodable {
+  let inputName: String?
+  let outputName: String?
+  let blockSize: Int?
+  let shrinkSize: Int?
+  let scale: Int?
+  let shape: [Int]?
+}
+
+nonisolated struct ReaderUpscaleModelDescriptor: Decodable {
+  let name: String?
+  let type: String?
+  let file: String
+  let config: ReaderUpscaleModelConfig?
+
+  var fileName: String {
+    (file as NSString).lastPathComponent
   }
 
-  nonisolated struct ReaderUpscaleModelConfig: Decodable {
-    let inputName: String?
-    let outputName: String?
-    let blockSize: Int?
-    let shrinkSize: Int?
-    let scale: Int?
-    let shape: [Int]?
+  var modelType: ReaderUpscaleModelType {
+    if let type, let parsed = ReaderUpscaleModelType(rawValue: type.lowercased()) {
+      return parsed
+    }
+    return .multiarray
   }
 
-  nonisolated struct ReaderUpscaleModelDescriptor: Decodable {
-    let name: String?
-    let type: String?
-    let file: String
-    let config: ReaderUpscaleModelConfig?
-
-    var fileName: String {
-      (file as NSString).lastPathComponent
-    }
-
-    var modelType: ReaderUpscaleModelType {
-      if let type, let parsed = ReaderUpscaleModelType(rawValue: type.lowercased()) {
-        return parsed
-      }
-      return .multiarray
-    }
-
-    static let defaultWaifu2x = ReaderUpscaleModelDescriptor(
-      name: "waifu2x (photo, 2x, noise0)",
-      type: ReaderUpscaleModelType.multiarray.rawValue,
-      file: "waifu2x_photo_noise0_scale2x.mlmodel",
-      config: ReaderUpscaleModelConfig(
-        inputName: "input",
-        outputName: "output",
-        blockSize: 156,
-        shrinkSize: 7,
-        scale: 2,
-        shape: nil
-      )
+  static let defaultWaifu2x = ReaderUpscaleModelDescriptor(
+    name: "waifu2x (photo, 2x, noise0)",
+    type: ReaderUpscaleModelType.multiarray.rawValue,
+    file: "waifu2x_photo_noise0_scale2x.mlmodel",
+    config: ReaderUpscaleModelConfig(
+      inputName: "input",
+      outputName: "output",
+      blockSize: 156,
+      shrinkSize: 7,
+      scale: 2,
+      shape: nil
     )
-  }
-#endif
+  )
+}

--- a/KMReader/Features/Reader/Services/Upscaling/ReaderUpscaleModelManager.swift
+++ b/KMReader/Features/Reader/Services/Upscaling/ReaderUpscaleModelManager.swift
@@ -1,152 +1,150 @@
-#if os(iOS) || os(tvOS)
-  import CoreML
-  import Foundation
+import CoreML
+import Foundation
 
-  actor ReaderUpscaleModelManager {
-    static let shared = ReaderUpscaleModelManager()
+actor ReaderUpscaleModelManager {
+  static let shared = ReaderUpscaleModelManager()
 
-    private let logger = AppLogger(.reader)
-    private let descriptor = ReaderUpscaleModelDescriptor.defaultWaifu2x
-    private let maxConcurrentTasks = 2
+  private let logger = AppLogger(.reader)
+  private let descriptor = ReaderUpscaleModelDescriptor.defaultWaifu2x
+  private let maxConcurrentTasks = 2
 
-    private var modelCache: [String: any ReaderImageProcessingModel] = [:]
-    private var runningTasks = 0
-    private var waitQueue: [CheckedContinuation<Void, Never>] = []
-    private var hasLoggedMissingDescriptor = false
+  private var modelCache: [String: any ReaderImageProcessingModel] = [:]
+  private var runningTasks = 0
+  private var waitQueue: [CheckedContinuation<Void, Never>] = []
+  private var hasLoggedMissingDescriptor = false
 
-    func activeDescriptor() -> ReaderUpscaleModelDescriptor? {
-      resolveModelURL(descriptor: descriptor) == nil ? nil : descriptor
-    }
-
-    func modelAvailability() -> (isReady: Bool, isDownloading: Bool, errorMessage: String?) {
-      let isReady = resolveModelURL(descriptor: descriptor) != nil
-      let message = isReady ? nil : "Built-in waifu2x model is unavailable"
-      return (isReady, false, message)
-    }
-
-    func ensureModelReady() async -> Bool {
-      resolveModelURL(descriptor: descriptor) != nil
-    }
-
-    func process(_ image: CGImage) async -> CGImage? {
-      guard !Task.isCancelled else { return nil }
-      guard let activeDescriptor = activeDescriptor() else {
-        if !hasLoggedMissingDescriptor {
-          logger.error("[Upscale] Built-in waifu2x model is unavailable")
-          hasLoggedMissingDescriptor = true
-        }
-        return nil
-      }
-      hasLoggedMissingDescriptor = false
-
-      let model: (any ReaderImageProcessingModel)
-      do {
-        guard let loadedModel = try await loadModel(descriptor: activeDescriptor) else {
-          logger.debug("⏭️ [Upscale] Skip processing because model file is unavailable: \(activeDescriptor.file)")
-          return nil
-        }
-        model = loadedModel
-      } catch {
-        logger.error("[Upscale] Failed to load model \(activeDescriptor.file): \(error.localizedDescription)")
-        return nil
-      }
-
-      guard !Task.isCancelled else { return nil }
-      await acquireSlot()
-      defer { releaseSlot() }
-
-      guard !Task.isCancelled else { return nil }
-      let output = await model.process(image)
-      if output == nil {
-        logger.debug("⏭️ [Upscale] Model returned nil output: \(activeDescriptor.file)")
-      }
-      return output
-    }
-
-    private func acquireSlot() async {
-      if runningTasks < maxConcurrentTasks {
-        runningTasks += 1
-        return
-      }
-
-      await withCheckedContinuation { continuation in
-        waitQueue.append(continuation)
-      }
-      runningTasks += 1
-    }
-
-    private func releaseSlot() {
-      runningTasks = max(0, runningTasks - 1)
-      guard !waitQueue.isEmpty else { return }
-      let continuation = waitQueue.removeFirst()
-      continuation.resume()
-    }
-
-    private func loadModel(descriptor: ReaderUpscaleModelDescriptor) async throws -> (any ReaderImageProcessingModel)? {
-      guard let modelURL = resolveModelURL(descriptor: descriptor) else {
-        return nil
-      }
-
-      let cacheKey = modelURL.path
-      if let cached = modelCache[cacheKey] {
-        return cached
-      }
-
-      let model: MLModel
-      if modelURL.pathExtension.lowercased() == "mlmodelc" {
-        model = try MLModel(contentsOf: modelURL)
-      } else {
-        let compiledURL = try await MLModel.compileModel(at: modelURL)
-        model = try MLModel(contentsOf: compiledURL)
-      }
-
-      let processingModel: (any ReaderImageProcessingModel)?
-      switch descriptor.modelType {
-      case .multiarray:
-        processingModel = ReaderMultiArrayModel(model: model, descriptor: descriptor)
-      case .image:
-        processingModel = ReaderImageModel(model: model, descriptor: descriptor)
-      }
-
-      guard let processingModel else { return nil }
-      modelCache[cacheKey] = processingModel
-      return processingModel
-    }
-
-    private func resolveModelURL(descriptor: ReaderUpscaleModelDescriptor) -> URL? {
-      let fileName = descriptor.fileName
-      let baseName = (fileName as NSString).deletingPathExtension
-      let ext = (fileName as NSString).pathExtension
-
-      if !baseName.isEmpty {
-        if !ext.isEmpty {
-          if let bundled = bundledResourceURL(resource: baseName, ext: ext) {
-            return bundled
-          }
-        }
-
-        if let compiled = bundledResourceURL(resource: baseName, ext: "mlmodelc") {
-          return compiled
-        }
-      }
-
-      guard let resourceRoot = Bundle.main.resourceURL else { return nil }
-      let direct = resourceRoot.appendingPathComponent(fileName)
-      if FileManager.default.fileExists(atPath: direct.path) {
-        return direct
-      }
-
-      return nil
-    }
-
-    private func bundledResourceURL(resource: String, ext: String) -> URL? {
-      let subdirectories = ["Resources/Upscaling", "Upscaling", "Resources/Models", "Models", nil]
-      for subdirectory in subdirectories {
-        if let url = Bundle.main.url(forResource: resource, withExtension: ext, subdirectory: subdirectory) {
-          return url
-        }
-      }
-      return nil
-    }
+  func activeDescriptor() -> ReaderUpscaleModelDescriptor? {
+    resolveModelURL(descriptor: descriptor) == nil ? nil : descriptor
   }
-#endif
+
+  func modelAvailability() -> (isReady: Bool, isDownloading: Bool, errorMessage: String?) {
+    let isReady = resolveModelURL(descriptor: descriptor) != nil
+    let message = isReady ? nil : "Built-in waifu2x model is unavailable"
+    return (isReady, false, message)
+  }
+
+  func ensureModelReady() async -> Bool {
+    resolveModelURL(descriptor: descriptor) != nil
+  }
+
+  func process(_ image: CGImage) async -> CGImage? {
+    guard !Task.isCancelled else { return nil }
+    guard let activeDescriptor = activeDescriptor() else {
+      if !hasLoggedMissingDescriptor {
+        logger.error("[Upscale] Built-in waifu2x model is unavailable")
+        hasLoggedMissingDescriptor = true
+      }
+      return nil
+    }
+    hasLoggedMissingDescriptor = false
+
+    let model: (any ReaderImageProcessingModel)
+    do {
+      guard let loadedModel = try await loadModel(descriptor: activeDescriptor) else {
+        logger.debug("⏭️ [Upscale] Skip processing because model file is unavailable: \(activeDescriptor.file)")
+        return nil
+      }
+      model = loadedModel
+    } catch {
+      logger.error("[Upscale] Failed to load model \(activeDescriptor.file): \(error.localizedDescription)")
+      return nil
+    }
+
+    guard !Task.isCancelled else { return nil }
+    await acquireSlot()
+    defer { releaseSlot() }
+
+    guard !Task.isCancelled else { return nil }
+    let output = await model.process(image)
+    if output == nil {
+      logger.debug("⏭️ [Upscale] Model returned nil output: \(activeDescriptor.file)")
+    }
+    return output
+  }
+
+  private func acquireSlot() async {
+    if runningTasks < maxConcurrentTasks {
+      runningTasks += 1
+      return
+    }
+
+    await withCheckedContinuation { continuation in
+      waitQueue.append(continuation)
+    }
+    runningTasks += 1
+  }
+
+  private func releaseSlot() {
+    runningTasks = max(0, runningTasks - 1)
+    guard !waitQueue.isEmpty else { return }
+    let continuation = waitQueue.removeFirst()
+    continuation.resume()
+  }
+
+  private func loadModel(descriptor: ReaderUpscaleModelDescriptor) async throws -> (any ReaderImageProcessingModel)? {
+    guard let modelURL = resolveModelURL(descriptor: descriptor) else {
+      return nil
+    }
+
+    let cacheKey = modelURL.path
+    if let cached = modelCache[cacheKey] {
+      return cached
+    }
+
+    let model: MLModel
+    if modelURL.pathExtension.lowercased() == "mlmodelc" {
+      model = try MLModel(contentsOf: modelURL)
+    } else {
+      let compiledURL = try await MLModel.compileModel(at: modelURL)
+      model = try MLModel(contentsOf: compiledURL)
+    }
+
+    let processingModel: (any ReaderImageProcessingModel)?
+    switch descriptor.modelType {
+    case .multiarray:
+      processingModel = ReaderMultiArrayModel(model: model, descriptor: descriptor)
+    case .image:
+      processingModel = ReaderImageModel(model: model, descriptor: descriptor)
+    }
+
+    guard let processingModel else { return nil }
+    modelCache[cacheKey] = processingModel
+    return processingModel
+  }
+
+  private func resolveModelURL(descriptor: ReaderUpscaleModelDescriptor) -> URL? {
+    let fileName = descriptor.fileName
+    let baseName = (fileName as NSString).deletingPathExtension
+    let ext = (fileName as NSString).pathExtension
+
+    if !baseName.isEmpty {
+      if !ext.isEmpty {
+        if let bundled = bundledResourceURL(resource: baseName, ext: ext) {
+          return bundled
+        }
+      }
+
+      if let compiled = bundledResourceURL(resource: baseName, ext: "mlmodelc") {
+        return compiled
+      }
+    }
+
+    guard let resourceRoot = Bundle.main.resourceURL else { return nil }
+    let direct = resourceRoot.appendingPathComponent(fileName)
+    if FileManager.default.fileExists(atPath: direct.path) {
+      return direct
+    }
+
+    return nil
+  }
+
+  private func bundledResourceURL(resource: String, ext: String) -> URL? {
+    let subdirectories = ["Resources/Upscaling", "Upscaling", "Resources/Models", "Models", nil]
+    for subdirectory in subdirectories {
+      if let url = Bundle.main.url(forResource: resource, withExtension: ext, subdirectory: subdirectory) {
+        return url
+      }
+    }
+    return nil
+  }
+}

--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -133,7 +133,7 @@ struct ReaderSettingsSheet: View {
           }
         #endif
 
-        #if os(iOS)
+        #if os(iOS) || os(macOS)
           Section(header: Text("Image Upscaling")) {
             VStack(alignment: .leading, spacing: 8) {
               Picker("Waifu2x Mode", selection: $imageUpscalingMode) {

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -241,7 +241,7 @@ struct DivinaPreferencesView: View {
         }
       #endif
 
-      #if os(iOS)
+      #if os(iOS) || os(macOS)
         Section(header: Text("Image Upscaling")) {
           VStack(alignment: .leading, spacing: 8) {
             Picker("Waifu2x Mode", selection: $imageUpscalingMode) {


### PR DESCRIPTION
## Summary
- enable built-in waifu2x upscaling for Divina Reader on macOS
- extend upscaling pipeline files to compile on macOS and keep platform-specific screen-size logic (`UIScreen` / `NSScreen`)
- expose `Image Upscaling` settings on macOS in both global Divina preferences and in-reader settings sheet
- remove redundant outer three-platform compile guards in the updated upscaling path

## Testing
- [x] `make build`
