### PR TITLE
feat: switch reading stats to local data and add project skills

### DIFF
--- a/.agents/skills/changelog/SKILL.md
+++ b/.agents/skills/changelog/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: changelog
+description: Generate App Store changelog text from commits between the latest tag and HEAD. Use full commit details, keep user-facing language, sectioned plain text, and exclude technical implementation details.
+---
+
+# Changelog
+
+Generate App Store changelog content for end users.
+
+## When To Use
+
+- The user asks for a release changelog.
+- The user asks to summarize recent changes for App Store update notes.
+- The task is to convert git commits into user-facing release notes.
+
+## Source Range
+
+Use commits from the latest tag to `HEAD`.
+
+```bash
+latest_tag=$(git describe --tags --abbrev=0)
+git log "${latest_tag}..HEAD" --pretty=format:'%H%n%s%n%b%n---'
+```
+
+If no tag exists, use full history and state that assumption.
+
+```bash
+git log --pretty=format:'%H%n%s%n%b%n---'
+```
+
+## Content Rules
+
+- Read detailed commit bodies, not only commit titles.
+- Write for end users in friendly, clear product language.
+- Organize output into sections.
+- Output plain text only, optimized for copy.
+- Do not include emoji.
+- Do not include technical implementation details.
+
+## Writing Style
+
+- Focus on user-visible improvements and behavior changes.
+- Merge related commits into one coherent item.
+- Remove internal terms, file names, class names, and refactor-only details.
+- Keep each bullet concise and meaningful.
+
+## Output
+
+Default output is changelog text only.
+
+If the user asks to update a file, write the final content to `APP_STORE_CHANGELOG.txt`.

--- a/.agents/skills/changelog/agents/openai.yaml
+++ b/.agents/skills/changelog/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "KMReader Changelog"
+  short_description: "Generate App Store changelog from commits"
+  default_prompt: "Generate a user-facing App Store changelog from latest-tag-to-HEAD commits using commit details, plain text sections, and no technical details."

--- a/.agents/skills/docs/SKILL.md
+++ b/.agents/skills/docs/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: docs
+description: Regenerate README.md, APP_STORE_DESCRIPTION.txt, and static/index.html based on current important product features in the codebase.
+---
+
+# Docs
+
+Regenerate key project docs from current product capabilities.
+
+## When To Use
+
+- The user asks to refresh project docs after feature changes.
+- README and App Store description are outdated.
+- Marketing landing content in `static/index.html` needs alignment with current app features.
+
+## Target Files
+
+- `README.md`
+- `APP_STORE_DESCRIPTION.txt`
+- `static/index.html`
+
+## Scope Rules
+
+- Reflect current important features only.
+- Keep product-facing language clear and concise.
+- Avoid low-level technical implementation details.
+- Keep messaging consistent across all three files.
+
+## Inputs To Read First
+
+- `AGENTS.md` (project capabilities and architecture summary)
+- Current target files (to preserve structure where appropriate)
+- Relevant feature modules under `KMReader/Features/` when needed
+
+## Update Workflow
+
+1. Collect current user-visible features from codebase and project docs.
+2. Decide the most important feature set to present.
+3. Update all target files so wording and feature emphasis stay aligned.
+4. Keep `README.md` as the most complete overview.
+5. Keep `APP_STORE_DESCRIPTION.txt` concise and store-appropriate.
+6. Keep `static/index.html` aligned with the same feature priorities.
+
+## Validation
+
+- Ensure all three files mention the same core features.
+- Remove stale or no-longer-available claims.
+- Keep formatting clean and ready to publish.

--- a/.agents/skills/docs/agents/openai.yaml
+++ b/.agents/skills/docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "KMReader Docs"
+  short_description: "Regenerate README, App Store description, and landing page docs"
+  default_prompt: "Regenerate README.md, APP_STORE_DESCRIPTION.txt, and static/index.html from current important product features in the codebase."

--- a/.agents/skills/localization/SKILL.md
+++ b/.agents/skills/localization/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: localization
+description: Use when updating KMReader translations in Localizable.xcstrings after code changes. Covers build/localize refresh, missing key discovery, context lookup, and deterministic updates through misc/translate.py.
+---
+
+# KMReader Localization
+
+Maintain and complete KMReader translations in `KMReader/Localizable.xcstrings`.
+
+## When To Use
+
+- The user asks to fill missing translations.
+- New localized strings were introduced and need all supported languages.
+- The user mentions `misc/translate.py`, `make localize`, or missing localization entries.
+
+## Standard Workflow
+
+Default order:
+
+1. Build once to refresh extracted strings data.
+2. Sync extracted strings data into `Localizable.xcstrings`.
+3. Fill missing translations.
+
+If the user explicitly says build is already done, do not build again. Run `make localize` directly, then continue from the missing-check step.
+
+```bash
+make build
+make localize
+```
+
+## Missing Translation Check
+
+```bash
+./misc/translate.py list
+```
+
+- This lists keys with missing languages.
+- If output is `No missing translations found.`, no translation update is needed.
+
+## Per-Key Process
+
+1. Understand key meaning and UI context.
+2. Locate usage in code when needed to avoid semantic drift.
+3. Prepare all target languages first, then write once.
+
+```bash
+rg -n "String\\(localized: \"<KEY>\"\\)|\"<KEY>\"" KMReader Shared KMReaderWidgets
+```
+
+Optional terminology alignment source (if present):
+
+- `../komga/komga-webui/src/locales/`
+
+## Deterministic Update Command
+
+Always write all target languages in one command to avoid partial updates.
+
+```bash
+./misc/translate.py update "<KEY>" \
+  --de "<German>" \
+  --en "<English>" \
+  --fr "<French>" \
+  --ja "<Japanese>" \
+  --ko "<Korean>" \
+  --zh-hans "<Simplified Chinese>" \
+  --zh-hant "<Traditional Chinese>"
+```
+
+## Quality Rules
+
+- Preserve placeholders and format markers exactly: `%@`, `%d`, `%lld`, `%f`, `%1$@`, `\\n`.
+- Keep tone consistent with product domains (Reader, Series, Read List, Offline Sync).
+- Do not modify entries where `shouldTranslate == false`.
+- Do not rewrite unrelated keys; only update requested or missing ones.
+
+## Final Verification
+
+```bash
+./misc/translate.py list
+```
+
+If missing items remain, continue until the list is empty.

--- a/.agents/skills/localization/agents/openai.yaml
+++ b/.agents/skills/localization/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Localization"
+  short_description: "Handle Localizable.xcstrings translation workflow"
+  default_prompt: "Complete KMReader localization updates by refreshing extracted strings and filling missing translate.py entries safely."

--- a/KMReader/Features/History/ViewModels/ReadingStatsViewModel.swift
+++ b/KMReader/Features/History/ViewModels/ReadingStatsViewModel.swift
@@ -16,7 +16,8 @@ final class ReadingStatsViewModel {
   var isUsingCachedData = false
   var errorMessage: String?
 
-  private let cacheTTL: TimeInterval = 15 * 60
+  // Cached stats are immediately displayed; if last refresh is older than this interval, refresh in background.
+  private let autoRefreshInterval: TimeInterval = 24 * 60 * 60
   private let service = ReadingStatsService.shared
   private let cacheStore = ReadingStatsCacheStore.shared
 
@@ -35,19 +36,9 @@ final class ReadingStatsViewModel {
       apply(snapshot: cachedSnapshot, usingCache: true)
 
       let cacheAge = Date().timeIntervalSince(cachedSnapshot.cachedAt)
-      if forceRefresh == false && cacheAge <= cacheTTL {
+      if forceRefresh == false && cacheAge <= autoRefreshInterval {
         return
       }
-
-      if AppConfig.isOffline {
-        errorMessage = String(localized: "Offline mode is enabled. Showing cached reading stats.")
-        return
-      }
-    } else if AppConfig.isOffline {
-      payload = nil
-      lastUpdatedAt = nil
-      errorMessage = String(localized: "Offline mode is enabled and no cached reading stats are available.")
-      return
     }
 
     errorMessage = nil

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -23674,6 +23674,52 @@
         }
       }
     },
+    "Local data has not been synced yet. Run offline sync first to generate reading stats." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lokale Daten wurden noch nicht synchronisiert. Führen Sie zuerst eine Offline-Synchronisierung aus, um Lesestatistiken zu erstellen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local data has not been synced yet. Run offline sync first to generate reading stats."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les données locales n'ont pas encore été synchronisées. Exécutez d'abord une synchronisation hors ligne pour générer les statistiques de lecture."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ローカルデータはまだ同期されていません。読書統計を生成するには、先にオフライン同期を実行してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로컬 데이터가 아직 동기화되지 않았습니다. 독서 통계를 생성하려면 먼저 오프라인 동기화를 실행하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地数据尚未同步。请先执行离线同步以生成阅读统计。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本地資料尚未同步。請先執行離線同步以產生閱讀統計。"
+          }
+        }
+      }
+    },
     "Logged in successfully" : {
       "localizations" : {
         "de" : {
@@ -29747,6 +29793,7 @@
       }
     },
     "Offline mode is enabled and no cached reading stats are available." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -29793,6 +29840,7 @@
       }
     },
     "Offline mode is enabled. Showing cached reading stats." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -32923,6 +32971,7 @@
       }
     },
     "Pull to refresh or tap refresh after your server finishes aggregation." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -32964,6 +33013,52 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下拉重新整理，或在伺服器完成彙總後點擊重新整理。"
+          }
+        }
+      }
+    },
+    "Pull to refresh to recalculate reading stats from local data." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zum Aktualisieren nach unten ziehen, um Lesestatistiken aus lokalen Daten neu zu berechnen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pull to refresh to recalculate reading stats from local data."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tirez pour actualiser afin de recalculer les statistiques de lecture à partir des données locales."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下に引いて更新すると、ローカルデータから読書統計を再計算します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아래로 당겨 새로 고치면 로컬 데이터에서 독서 통계를 다시 계산합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下拉刷新以根据本地数据重新计算阅读统计。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下拉重新整理以根據本地資料重新計算閱讀統計。"
           }
         }
       }


### PR DESCRIPTION
## Summary
- switch reading stats generation to local SwiftData-backed data instead of remote list aggregation
- add initial-sync hint in reading stats view and keep cached stats visible with 24h auto-refresh behavior
- add translations for new reading-stats strings
- stabilize `make localize` output by re-sorting `Localizable.xcstrings` keys after `xcstringstool sync`
- add project skills under `.agents/skills` for `changelog`, `docs`, and `localization`

## Testing
- [x] `make build`
- [x] `make localize`
- [x] `./misc/translate.py list`
