### PR TITLE
docs: refresh product messaging

### DIFF
--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -1,37 +1,30 @@
 KMReader - Native Komga Client for iPhone, iPad, Mac, and Apple TV
 
-KMReader helps you read and manage your Komga library with a fast, native experience across Apple platforms.
+KMReader helps you read, browse, download, and manage your Komga library with a fast native experience across Apple platforms.
 
 IMPORTANT FEATURES
 
-• Powerful Reading Experience
-DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, spreads, zoom, and page curl transitions.
-Webtoon mode on iOS and macOS.
-EPUB reader on iOS and macOS with paged and scrolled flow, custom fonts, and per-book preferences.
-PDF reading on iOS and macOS with native PDF mode, search, table of contents, and page jump.
-Incognito mode lets you read without syncing progress.
+- Native readers for every format
+DIVINA on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, and page curl transitions.
+EPUB on iOS and macOS with paged or scrolled flow, custom fonts, themes, and per-book preferences.
+PDF on iOS and macOS with a native PDF reader or DIVINA mode, plus search, table of contents, and page jump.
+Incognito mode and iOS Live Text support let you read your way.
 
-• Smart Dashboard and Insights
-Keep Reading and On Deck make it easy to continue where you left off.
-Pin collections and read lists so favorites always stay on top.
-Reading Stats helps you understand your reading habits over time.
+- Dashboard, discovery, and shortcuts
+Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists keep important items close.
+Browse Series, Books, Collections, and Read Lists with advanced metadata filters and saved filters.
+Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions, help you jump back into reading faster.
 
-• Offline Library
-Download books for full offline reading.
-iOS supports background downloads with Live Activities.
-Use per-series download policies: Manual, Unread only, Unread + cleanup, or All books.
-Offline mode includes metadata filters so downloaded books are easier to find.
+- Offline that actually works
+Download books for offline reading.
+Use iOS background downloads with Live Activities.
+Set per-series policies: Manual, Unread only, Unread + cleanup, or All books.
+Sync progress and offline changes when you reconnect.
 
-• Browse and Organize
-Browse Series, Books, Collections, and Read Lists.
-Use metadata filters for publishers, authors, genres, tags, and languages.
-Switch between multiple Komga servers instantly.
-Sign in with username/password or API key.
-
-• Admin Tools
-Edit metadata for series, books, collections, and read lists.
-Create and manage libraries.
-Monitor server tasks and logs in the app.
+- Multi-server and admin tools
+Save multiple Komga servers and switch instantly.
+Sign in with password or API key, and manage API keys in the app.
+Edit metadata, manage libraries, monitor tasks, and view logs.
 
 KMReader targets Komga 1.19.0+ and supports API v1/v2.
 

--- a/README.md
+++ b/README.md
@@ -20,40 +20,42 @@
 
 ## Important Features
 
-### Reading Experience
+### Native Reading Experience
 
-- DIVINA reader on iOS/macOS/tvOS with LTR, RTL, vertical, spreads, zoom, and page curl transitions.
-- Webtoon reading mode on iOS/macOS.
-- EPUB reader on iOS/macOS with paged and scrolled flow, custom fonts (`.ttf`/`.otf`), and per-book preferences.
-- PDF reading on iOS/macOS with native PDF mode, search, table of contents, and page jump.
-- Per-book reading preferences and Incognito mode.
+- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, customizable tap zones, and page curl transitions.
+- EPUB reader on iOS/macOS with paged, scrolled, and curl layouts, custom font importing (`.ttf`/`.otf`), theme presets, multi-column reading, and nested table of contents.
+- PDF reading on iOS/macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, and offline preparation controls.
+- Per-book preferences save reading direction, page layout, and theme settings.
+- Incognito mode and iOS Live Text support, including optional shake-to-toggle.
 
 ### Dashboard and Discovery
 
-- Dashboard sections for Keep Reading, On Deck, recently added/updated content, and pinned sections.
-- Pin collections and read lists to keep favorites at the top.
-- Reading Stats page for daily, weekly, and monthly reading insights.
-- Browse Series, Books, Collections, and Read Lists with metadata filters (publisher, author, genre, tag, language).
+- Dashboard sections for Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists.
+- Browse Series, Books, Collections, and Read Lists with metadata filters for publishers, authors, genres, tags, and languages using all/any logic.
+- Save and reuse filters across browse surfaces.
+- Reading history and stats help surface recent activity from synced local data.
+- Spotlight integration for downloaded content on iOS/macOS, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
 
 ### Offline and Sync
 
-- Download books for full offline reading.
+- Download books for full offline reading across DIVINA, EPUB, and PDF workflows.
 - iOS background downloads with Live Activities.
 - Per-series download policies: Manual, Unread only, Unread + cleanup, and All books.
-- Offline mode supports metadata-based filtering to quickly find downloaded books.
+- Offline mode includes dedicated downloaded-library browsing and metadata filters.
 - Progress and offline data sync automatically when reconnecting.
+- Cache controls cover pages, book files, and thumbnails.
 
 ### Multi-Server and Management
 
 - Save multiple Komga servers and switch instantly.
-- Sign in with username/password or API key.
-- Admin tools for metadata editing, library management, task management, and logs.
+- Sign in with username/password or API key, and manage Komga API keys inside the app.
+- Admin tools for metadata editing, library management, task monitoring, and log viewing/export.
 
 ### Platform Highlights
 
-- iOS/iPadOS: widgets, quick actions, background downloads, Live Activities.
-- macOS: dedicated reader windows and keyboard-first controls.
-- tvOS: remote-first DIVINA reading.
+- iOS/iPadOS: widgets, quick actions, Spotlight search, Live Activities, background downloads, Live Text, and page curl transitions.
+- macOS: dedicated reader windows, Spotlight search for downloaded content, keyboard shortcuts, and keyboard help overlay.
+- tvOS: remote-first DIVINA reading with a TV-optimized browsing experience.
 
 ## Getting Started
 

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
         <title>KMReader · Native Komga Client for iOS, macOS & tvOS</title>
         <meta
             name="description"
-            content="KMReader is a native SwiftUI Komga client with DIVINA, EPUB, and PDF reading, offline downloads, reading stats, multi-server switching, and admin tools."
+            content="KMReader is a native SwiftUI Komga client with DIVINA, EPUB, and PDF readers, offline downloads, widgets, quick actions, multi-server switching, and admin tools."
         />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -27,7 +27,8 @@
                 <h1>KMReader</h1>
                 <p class="tagline">
                     Read, download, browse, and manage your Komga library with
-                    a native experience on iPhone, iPad, Mac, and Apple TV.
+                    native readers, offline sync, and practical Apple-platform
+                    extras on iPhone, iPad, Mac, and Apple TV.
                 </p>
                 <div class="cta">
                     <a
@@ -60,8 +61,8 @@
                         <strong>DIVINA (all) · EPUB/PDF (iOS/macOS)</strong>
                     </div>
                     <div class="meta-card">
-                        <span>Offline</span>
-                        <strong>Downloads + iOS background queue</strong>
+                        <span>Productivity</span>
+                        <strong>Widgets + Spotlight + Quick Actions</strong>
                     </div>
                 </div>
             </header>
@@ -78,19 +79,19 @@
                         <h3>DIVINA, EPUB, and PDF</h3>
                         <p>
                             DIVINA on iOS/macOS/tvOS with LTR, RTL, vertical,
-                            spreads, zoom, and page curl. EPUB on iOS/macOS
-                            with paged/scrolled flow and custom fonts. PDF on
-                            iOS/macOS with native mode, search, TOC, and page
-                            jump.
+                            Webtoon, spreads, zoom, tap zones, and page curl.
+                            EPUB on iOS/macOS with custom fonts and flexible
+                            layouts. PDF on iOS/macOS with a native reader or
+                            DIVINA mode, plus search and TOC.
                         </p>
                     </article>
                     <article class="card">
-                        <span class="pill">Insights</span>
-                        <h3>Reading stats and pinned sections</h3>
+                        <span class="pill">Dashboard</span>
+                        <h3>Keep reading, recent updates, and favorites</h3>
                         <p>
-                            Track reading habits with reading stats. Pin
-                            collections and read lists so favorites stay easy to
-                            access from the dashboard.
+                            Keep Reading, On Deck, Recently Added, Recently
+                            Updated, and pinned collections/read lists keep the
+                            most useful parts of your library close.
                         </p>
                     </article>
                     <article class="card">
@@ -104,20 +105,21 @@
                     </article>
                     <article class="card">
                         <span class="pill">Browse</span>
-                        <h3>Flexible filtering</h3>
+                        <h3>Advanced filtering and saved views</h3>
                         <p>
                             Browse series, books, collections, and read lists.
                             Filter by publisher, author, genre, tag, and
-                            language, including metadata filters in Offline
-                            mode.
+                            language, use all/any logic, and save filters for
+                            later, including in Offline mode.
                         </p>
                     </article>
                     <article class="card">
                         <span class="pill">Multi-Server</span>
-                        <h3>Switch servers instantly</h3>
+                        <h3>Switch servers and credentials quickly</h3>
                         <p>
                             Save multiple Komga servers and switch quickly.
-                            Sign in with username/password or API key.
+                            Sign in with username/password or API key, and
+                            manage API keys directly in KMReader.
                         </p>
                     </article>
                     <article class="card">
@@ -141,14 +143,16 @@
                         <h3>iOS & iPadOS</h3>
                         <p>
                             DIVINA, EPUB, and PDF readers with widgets, quick
-                            actions, background downloads, and Live Activities.
+                            actions, Spotlight search, background downloads,
+                            Live Activities, and Live Text.
                         </p>
                     </article>
                     <article class="card">
                         <h3>macOS</h3>
                         <p>
-                            DIVINA, EPUB, and PDF with dedicated reader windows
-                            and keyboard-first controls.
+                            DIVINA, EPUB, and PDF with dedicated reader windows,
+                            Spotlight search for downloaded content,
+                            keyboard-first controls, and keyboard help.
                         </p>
                     </article>
                     <article class="card">
@@ -175,14 +179,16 @@
                         <h4>Which readers are available?</h4>
                         <p>
                             DIVINA is available on iOS, macOS, and tvOS. EPUB
-                            and PDF are available on iOS and macOS.
+                            and PDF are available on iOS and macOS, with PDF
+                            support offering a native reader or DIVINA mode.
                         </p>
                     </article>
                     <article class="faq-item">
                         <h4>Can I use multiple Komga servers?</h4>
                         <p>
                             Yes. You can save and switch between multiple
-                            servers and authenticate with password or API key.
+                            servers, authenticate with password or API key, and
+                            manage API keys in the app.
                         </p>
                     </article>
                     <article class="faq-item">
@@ -191,6 +197,15 @@
                             Downloaded books stay readable offline, filtering is
                             available for offline items, and sync resumes when
                             you reconnect.
+                        </p>
+                    </article>
+                    <article class="faq-item">
+                        <h4>Does KMReader support widgets and quick actions?</h4>
+                        <p>
+                            Yes. On iOS and iPadOS, KMReader includes widgets
+                            plus Home Screen quick actions for Keep Reading,
+                            Search, and Downloads, and it supports Spotlight
+                            search for downloaded content on iOS and macOS.
                         </p>
                     </article>
                     <article class="faq-item">


### PR DESCRIPTION
## Summary
- refresh the README, App Store description, and landing page copy to match current KMReader capabilities
- clarify reader modes, offline workflows, saved filters, Spotlight integration, and platform-specific highlights
- keep the three public-facing docs aligned around the same product messaging

## Testing
- not run (docs-only changes)
