### PR TITLE
fix: defer pending quick action handling from app init

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -414,9 +414,9 @@
 		192E6F8B2EC4B4E30040D165 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES[sdk=iphoneos*]" = "AppIconClassic AppIconReverse AppIconGlass";
 				"ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES[sdk=iphonesimulator*]" = "AppIconClassic AppIconReverse AppIconGlass";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = KMReader/KMReader.entitlements;
@@ -472,9 +472,9 @@
 		192E6F8C2EC4B4E30040D165 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES[sdk=iphoneos*]" = "AppIconClassic AppIconReverse AppIconGlass";
 				"ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES[sdk=iphonesimulator*]" = "AppIconClassic AppIconReverse AppIconGlass";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = KMReader/KMReader.entitlements;

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -70,11 +70,6 @@ struct MainApp: App {
   @State private var deepLinkRouter = DeepLinkRouter.shared
 
   init() {
-    #if os(iOS)
-      Task { @MainActor in
-        QuickActionService.handlePendingShortcutIfNeeded()
-      }
-    #endif
     PlatformHelper.setup()
     _authViewModel = State(initialValue: AuthViewModel())
   }
@@ -104,6 +99,9 @@ struct MainApp: App {
       DatabaseOperator.shared = DatabaseOperator(modelContainer: container)
       _ = OfflineManager.shared
       modelContainer = container
+      #if os(iOS)
+        QuickActionService.handlePendingShortcutIfNeeded()
+      #endif
       modelContainerFailureDetails = nil
     } catch {
       let errorMessage = String(describing: error)


### PR DESCRIPTION
## Summary
- Move pending quick action handling out of `MainApp.init` to avoid startup main-thread I/O warning.
- Process pending shortcuts only after `ModelContainer` and `DatabaseOperator` are initialized.
- Keep quick action behavior unchanged while removing work from the earliest launch path.

## Testing
- [x] make build-ios
- [x] make build
