### PR TITLE
fix: animate browse thumbnail appearance

### DIFF
--- a/KMReader/Shared/UI/ThumbnailImage.swift
+++ b/KMReader/Shared/UI/ThumbnailImage.swift
@@ -66,7 +66,7 @@ struct ThumbnailImage<Overlay: View, Menu: View>: View {
           menu()
         }
       }
-      .transition(.opacity)
+      .transition(.opacity.combined(with: .scale(scale: 0.98)))
   }
 
   init(
@@ -149,7 +149,8 @@ struct ThumbnailImage<Overlay: View, Menu: View>: View {
         }
       }
     }
-    .animation(.easeInOut(duration: 0.18), value: refreshTrigger)
+    .animation(.easeInOut(duration: 0.18), value: image != nil)
+    .animation(.easeInOut(duration: 0.18), value: shouldShowPlaceholder)
     .aspectRatio(CoverAspectRatio.widthToHeight, contentMode: .fit)
     .frame(width: width)
     .overlay {


### PR DESCRIPTION
## Summary
- Animate browse thumbnail insertion by binding animation to `image != nil` and placeholder visibility state changes.
- Replace plain opacity transition with a subtle opacity + scale transition for thumbnail content appearance.

## Testing
- [x] make build-macos
