### PR TITLE
feat: add es/it/ru localization coverage and docs

### DIFF
--- a/.agents/skills/docs/SKILL.md
+++ b/.agents/skills/docs/SKILL.md
@@ -25,6 +25,7 @@ Regenerate key project docs from current product capabilities.
 - Keep product-facing language clear and concise.
 - Avoid low-level technical implementation details.
 - Keep messaging consistent across all three files.
+- Keep any supported-language claims aligned with the current app localization set.
 
 ## Inputs To Read First
 

--- a/.agents/skills/localization/SKILL.md
+++ b/.agents/skills/localization/SKILL.md
@@ -56,6 +56,10 @@ Optional terminology alignment source (if present):
 
 - `../komga/komga-webui/src/locales/`
 
+Current supported target languages:
+
+- `de`, `en`, `es`, `fr`, `it`, `ja`, `ko`, `ru`, `zh-Hans`, `zh-Hant`
+
 ## Deterministic Update Command
 
 Always write all target languages in one command to avoid partial updates.
@@ -64,9 +68,12 @@ Always write all target languages in one command to avoid partial updates.
 ./misc/translate.py update "<KEY>" \
   --de "<German>" \
   --en "<English>" \
+  --es "<Spanish>" \
   --fr "<French>" \
+  --it "<Italian>" \
   --ja "<Japanese>" \
   --ko "<Korean>" \
+  --ru "<Russian>" \
   --zh-hans "<Simplified Chinese>" \
   --zh-hant "<Traditional Chinese>"
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ make localize           # Update localizations
 ./misc/translate.py list
 
 # Update translations for a key
-./misc/translate.py update <key>  --zh-hans <zh-hans> --zh-hant <zh-hant> --de <de> --en <en> --fr <fr> --ja <ja> --ko <ko>
+./misc/translate.py update <key>  --zh-hans <zh-hans> --zh-hant <zh-hant> --de <de> --en <en> --es <es> --fr <fr> --it <it> --ja <ja> --ko <ko> --ru <ru>
 ```
 
 ## Testing & Validation

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -14,6 +14,7 @@ Incognito mode and iOS Live Text support let you read your way.
 Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists keep important items close.
 Browse Series, Books, Collections, and Read Lists with advanced metadata filters and saved filters.
 Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions, help you jump back into reading faster.
+KMReader UI is localized in English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
 
 - Offline that actually works
 Download books for offline reading.

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -224,6 +224,9 @@
 				ja,
 				ko,
 				de,
+				ru,
+				it,
+				es,
 			);
 			mainGroup = 192E6F742EC4B4E20040D165;
 			minimizedProjectReferenceProxies = 1;

--- a/KMReader/InfoPlist.xcstrings
+++ b/KMReader/InfoPlist.xcstrings
@@ -10,6 +10,24 @@
             "state" : "new",
             "value" : "KMReader"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
         }
       },
       "shouldTranslate" : false
@@ -21,6 +39,24 @@
         "en" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "KMReader"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "KMReader"
           }
         }
@@ -72,6 +108,24 @@
             "state" : "translated",
             "value" : "將書中的圖片儲存到相簿"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guarda imágenes de libros en tu fototeca"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salva immagini dei libri nella libreria foto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохраняйте изображения из книг в Фотопленку"
+          }
         }
       }
     },
@@ -117,6 +171,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "繼續閱讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar leyendo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continua a leggere"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить чтение"
           }
         }
       }
@@ -164,6 +236,24 @@
             "state" : "translated",
             "value" : "下載"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузки"
+          }
         }
       }
     },
@@ -209,6 +299,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜尋"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск"
           }
         }
       }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -362,6 +362,24 @@
             "state" : "translated",
             "value" : "剩餘 %@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ restante"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ rimanenti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Осталось %@"
+          }
         }
       }
     },
@@ -490,6 +508,24 @@
             "state" : "translated",
             "value" : "%lld / %lld"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld / %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld / %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld / %lld"
+          }
         }
       }
     },
@@ -535,6 +571,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$lld / %2$lld 本書"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld / %2$lld libros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld / %2$lld libri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld / %2$lld книг"
           }
         }
       }
@@ -582,6 +636,24 @@
             "state" : "translated",
             "value" : "%lld 本書"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld libros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld libri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld книг"
+          }
         }
       }
     },
@@ -627,6 +699,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已新增 %lld 個自訂字體"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se añadieron %lld fuentes personalizadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiunti %lld font personalizzati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавлено пользовательских шрифтов: %lld"
           }
         }
       }
@@ -674,6 +764,24 @@
             "state" : "translated",
             "value" : "%lld 個失敗"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld fallidos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld non riusciti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ошибок: %lld"
+          }
         }
       }
     },
@@ -720,6 +828,24 @@
             "state" : "translated",
             "value" : "%lld GB"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld GB"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld GB"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld ГБ"
+          }
         }
       }
     },
@@ -765,6 +891,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 正在閱讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld en progreso"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld in corso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В процессе: %lld"
           }
         }
       }
@@ -847,6 +991,24 @@
             "state" : "translated",
             "value" : "%lld 頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld páginas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld pagine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld страниц"
+          }
         }
       }
     },
@@ -892,6 +1054,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "剩 %lld 頁"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quedan %lld páginas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld pagine rimanenti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Осталось страниц: %lld"
           }
         }
       }
@@ -939,6 +1119,24 @@
             "state" : "translated",
             "value" : "%lld 個待處理"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld pendientes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld in attesa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В ожидании: %lld"
+          }
         }
       }
     },
@@ -984,6 +1182,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 筆結果"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld resultados"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld risultati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Результатов: %lld"
           }
         }
       }
@@ -1031,6 +1247,24 @@
             "state" : "translated",
             "value" : "%lld 個系列"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld series"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld серий"
+          }
         }
       }
     },
@@ -1077,6 +1311,24 @@
             "state" : "translated",
             "value" : "%lld 未讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld sin leer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld non letti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Непрочитанные: %lld"
+          }
         }
       }
     },
@@ -1119,6 +1371,24 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld."
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld."
@@ -1169,6 +1439,24 @@
             "state" : "translated",
             "value" : "%lld%%"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%%"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%%"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%%"
+          }
         }
       }
     },
@@ -1211,6 +1499,24 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld+"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld+"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld+"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld+"
@@ -1260,6 +1566,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld秒"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld s"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld s"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld с"
           }
         }
       }
@@ -1453,6 +1777,24 @@
             "state" : "translated",
             "value" : "1"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1"
+          }
         }
       }
     },
@@ -1498,6 +1840,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "這個 API 金鑰有甚麼用途？"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un comentario te ayuda a identificar esta clave de API más tarde."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un commento ti aiuta a identificare questa chiave API in seguito."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Комментарий поможет позже распознать этот API-ключ."
           }
         }
       }
@@ -1545,6 +1905,24 @@
             "state" : "translated",
             "value" : "一杯 / 月"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Una taza / mes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Una tazza / mese"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Одна чашка / месяц"
+          }
         }
       }
     },
@@ -1590,6 +1968,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "一壺 / 年"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Una tetera / año"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Una caffettiera / anno"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Один чайник / год"
           }
         }
       }
@@ -1637,6 +2033,24 @@
             "state" : "translated",
             "value" : "已放棄"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abandonado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbandonato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Заброшено"
+          }
         }
       }
     },
@@ -1682,6 +2096,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "關於"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acerca de"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informazioni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "О приложении"
           }
         }
       }
@@ -1729,6 +2161,24 @@
             "state" : "translated",
             "value" : "帳戶"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuenta"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аккаунт"
+          }
         }
       }
     },
@@ -1774,6 +2224,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "修改密碼"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar contraseña"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambia password"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изменить пароль"
           }
         }
       }
@@ -1821,6 +2289,24 @@
             "state" : "translated",
             "value" : "確認密碼"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar contraseña"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conferma password"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подтвердите пароль"
+          }
         }
       }
     },
@@ -1866,6 +2352,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新密碼"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nueva contraseña"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nuova password"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Новый пароль"
           }
         }
       }
@@ -1913,6 +2417,24 @@
             "state" : "translated",
             "value" : "密碼已成功更新"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La contraseña se actualizó correctamente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Password aggiornata con successo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пароль успешно обновлен"
+          }
         }
       }
     },
@@ -1958,6 +2480,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新密碼"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar contraseña"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiorna password"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновить пароль"
           }
         }
       }
@@ -2005,6 +2545,24 @@
             "state" : "translated",
             "value" : "置頂"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fijar arriba"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fissa in alto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрепить сверху"
+          }
         }
       }
     },
@@ -2050,6 +2608,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消置頂"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quitar de arriba"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuovi dall'alto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открепить сверху"
           }
         }
       }
@@ -2097,6 +2673,24 @@
             "state" : "translated",
             "value" : "使用中"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attivo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Активно"
+          }
         }
       }
     },
@@ -2142,6 +2736,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新增"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить"
           }
         }
       }
@@ -2189,6 +2801,24 @@
             "state" : "translated",
             "value" : "請在 Komga 網頁端新增圖書館以便在此管理。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anade una biblioteca desde la interfaz web de Komga para gestionarla aqui."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi una libreria dall'interfaccia web di Komga per gestirla qui."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавьте библиотеку из веб-интерфейса Komga, чтобы управлять ею здесь."
+          }
         }
       }
     },
@@ -2234,6 +2864,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新增別名"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar título alternativo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi titolo alternativo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить альтернативное название"
           }
         }
       }
@@ -2281,6 +2929,24 @@
             "state" : "translated",
             "value" : "添加新的伺服器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar otro servidor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi un altro server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить другой сервер"
+          }
         }
       }
     },
@@ -2326,6 +2992,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "產生 API 金鑰"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generar clave API"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genera chiave API"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать API-ключ"
           }
         }
       }
@@ -2373,6 +3057,24 @@
             "state" : "translated",
             "value" : "新增作者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar autor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi autore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить автора"
+          }
         }
       }
     },
@@ -2418,6 +3120,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新增漸變背景以提高按鈕可見度"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anadir fondo degradado para mejorar la visibilidad del boton"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi uno sfondo sfumato per migliorare la visibilita del pulsante"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить градиентный фон для улучшения видимости кнопки"
           }
         }
       }
@@ -2465,6 +3185,24 @@
             "state" : "translated",
             "value" : "新增連結"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar enlace"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi link"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить ссылку"
+          }
         }
       }
     },
@@ -2510,6 +3248,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新增或連線到 Komga 伺服器以開始使用。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anade o conectate a un servidor Komga para empezar."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi o connettiti a un server Komga per iniziare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавьте или подключитесь к серверу Komga, чтобы начать."
           }
         }
       }
@@ -2557,6 +3313,24 @@
             "state" : "translated",
             "value" : "加入收藏"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar a la colección"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi alla raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить в коллекцию"
+          }
         }
       }
     },
@@ -2602,6 +3376,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "加入閱讀清單"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar a la lista de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi alla lista di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить в список чтения"
           }
         }
       }
@@ -2649,6 +3441,24 @@
             "state" : "translated",
             "value" : "調節封面快取上限，超出將自動清理。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajusta el tamano maximo de la cache de portadas. Se limpiara automaticamente al superarlo."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regola la dimensione massima della cache delle copertine. La cache verra pulita automaticamente quando superata."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройте максимальный размер кэша обложек. При превышении кэш будет очищен автоматически."
+          }
         }
       }
     },
@@ -2694,6 +3504,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "調節頁面快取上限，超出將自動清理。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajusta el tamano maximo de la cache de paginas. Se limpiara automaticamente al superarlo."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regola la dimensione massima della cache delle pagine. La cache verra pulita automaticamente quando superata."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройте максимальный размер кэша страниц. При превышении кэш будет очищен автоматически."
           }
         }
       }
@@ -2741,6 +3569,24 @@
             "state" : "translated",
             "value" : "調整 Webtoon 頁寬占螢幕比例"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajusta el ancho de las paginas webtoon como porcentaje del ancho de pantalla"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regola la larghezza delle pagine webtoon come percentuale della larghezza dello schermo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройте ширину страниц webtoon как процент от ширины экрана"
+          }
         }
       }
     },
@@ -2786,6 +3632,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "管理員"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acceso de administrador"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accesso amministratore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Доступ администратора"
           }
         }
       }
@@ -2833,6 +3697,24 @@
             "state" : "translated",
             "value" : "需要管理員權限"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se requiere acceso de administrador"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accesso amministratore richiesto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Требуется доступ администратора"
+          }
         }
       }
     },
@@ -2878,6 +3760,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "高級佈局"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diseño avanzado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Layout avanzato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Расширенный макет"
           }
         }
       }
@@ -2925,6 +3825,24 @@
             "state" : "translated",
             "value" : "年齡限制"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clasificación por edad"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classificazione per età"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Возрастной рейтинг"
+          }
         }
       }
     },
@@ -2970,6 +3888,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все"
           }
         }
       }
@@ -3017,6 +3953,24 @@
             "state" : "translated",
             "value" : "所有書庫"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todas las bibliotecas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutte le librerie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все библиотеки"
+          }
         }
       }
     },
@@ -3062,6 +4016,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部已讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo leído"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutto letto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все прочитано"
           }
         }
       }
@@ -3109,6 +4081,24 @@
             "state" : "translated",
             "value" : "全部時間"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todo el tiempo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sempre"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "За все время"
+          }
         }
       }
     },
@@ -3154,6 +4144,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "副標題"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Títulos alternativos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titoli alternativi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Альтернативные названия"
           }
         }
       }
@@ -3201,6 +4209,24 @@
             "state" : "translated",
             "value" : "始終"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siempre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sempre"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Всегда"
+          }
         }
       }
     },
@@ -3246,6 +4272,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "始終模式來源圖片尺寸閾值"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umbral de tamano de origen para modo Siempre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soglia dimensione sorgente per modalita Sempre"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Порог размера источника для режима «Всегда»"
           }
         }
       }
@@ -3293,6 +4337,24 @@
             "state" : "translated",
             "value" : "始終顯示頁碼"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar siempre el número de página"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra sempre il numero di pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Всегда показывать номер страницы"
+          }
         }
       }
     },
@@ -3338,6 +4400,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分析"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analizar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analizza"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Анализ"
           }
         }
       }
@@ -3385,6 +4465,24 @@
             "state" : "translated",
             "value" : "點擊翻頁的動畫時長"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duracion de animacion al tocar para pasar pagina"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durata dell'animazione al tocco per voltare pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Длительность анимации при касании для перелистывания"
+          }
         }
       }
     },
@@ -3430,6 +4528,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "任意"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cualquiera"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qualsiasi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Любой"
           }
         }
       }
@@ -3477,6 +4593,24 @@
             "state" : "translated",
             "value" : "任何使用此 API 金鑰的應用程式或腳本將無法再存取 Komga API。此操作無法復原。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cualquier aplicacion o script que use esta clave API ya no podra acceder a la API de Komga. No puedes deshacer esta accion."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qualsiasi applicazione o script che usa questa chiave API non potra piu accedere all'API di Komga. Questa azione non puo essere annullata."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Любые приложения или скрипты, использующие этот API-ключ, больше не смогут обращаться к API Komga. Это действие нельзя отменить."
+          }
         }
       }
     },
@@ -3522,6 +4656,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "API 金鑰"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave API"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiave API"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-ключ"
           }
         }
       }
@@ -3569,6 +4721,24 @@
             "state" : "translated",
             "value" : "API 金鑰已複製到剪貼簿"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave API copiada al portapapeles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiave API copiata negli appunti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-ключ скопирован в буфер обмена"
+          }
         }
       }
     },
@@ -3614,6 +4784,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "API 金鑰已建立"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave API creada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiave API creata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-ключ создан"
           }
         }
       }
@@ -3661,6 +4849,24 @@
             "state" : "translated",
             "value" : "API 金鑰"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Claves API"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiavi API"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-ключи"
+          }
         }
       }
     },
@@ -3706,6 +4912,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "App 圖示"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Icono de la app"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Icona app"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Иконка приложения"
           }
         }
       }
@@ -3753,6 +4977,24 @@
             "state" : "translated",
             "value" : "外觀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apariencia"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aspetto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Внешний вид"
+          }
         }
       }
     },
@@ -3798,6 +5040,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "套用篩選器"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicar filtro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Applica filtro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Применить фильтр"
           }
         }
       }
@@ -3845,6 +5105,24 @@
             "state" : "translated",
             "value" : "套用預設"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicar preajuste"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Applica preset"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Применить пресет"
+          }
         }
       }
     },
@@ -3890,6 +5168,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "架構"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arquitectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Architettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Архитектура"
           }
         }
       }
@@ -3937,6 +5233,24 @@
             "state" : "translated",
             "value" : "你確定要取消所有失敗的下載嗎？"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguro que quieres cancelar todas las descargas fallidas?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei sicuro di voler annullare tutti i download non riusciti?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы уверены, что хотите отменить все неудавшиеся загрузки?"
+          }
         }
       }
     },
@@ -3982,6 +5296,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "確定要取消所有任務？此操作無法復原。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguro que quieres cancelar todas las tareas? Esta accion no se puede deshacer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei sicuro di voler annullare tutte le attivita? Questa azione non puo essere annullata."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы уверены, что хотите отменить все задачи? Это действие нельзя отменить."
           }
         }
       }
@@ -4029,6 +5361,24 @@
             "state" : "translated",
             "value" : "確定要刪除這本書？此操作無法復原。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguro que quieres eliminar este libro? Esta accion no se puede deshacer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei sicuro di voler eliminare questo libro? Questa azione non puo essere annullata."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы уверены, что хотите удалить эту книгу? Это действие нельзя отменить."
+          }
         }
       }
     },
@@ -4074,6 +5424,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "確定要刪除此收藏？此操作無法復原。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguro que quieres eliminar esta coleccion? Esta accion no se puede deshacer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei sicuro di voler eliminare questa raccolta? Questa azione non puo essere annullata."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы уверены, что хотите удалить эту коллекцию? Это действие нельзя отменить."
           }
         }
       }
@@ -4121,6 +5489,24 @@
             "state" : "translated",
             "value" : "確定要刪除此閱讀清單？此操作無法復原。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguro que quieres eliminar esta lista de lectura? Esta accion no se puede deshacer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei sicuro di voler eliminare questa lista di lettura? Questa azione non puo essere annullata."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы уверены, что хотите удалить этот список чтения? Это действие нельзя отменить."
+          }
         }
       }
     },
@@ -4166,6 +5552,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "確定要刪除此系列？此操作無法復原。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguro que quieres eliminar esta serie? Esta accion no se puede deshacer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei sicuro di voler eliminare questa serie? Questa azione non puo essere annullata."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы уверены, что хотите удалить эту серию? Это действие нельзя отменить."
           }
         }
       }
@@ -4213,6 +5617,24 @@
             "state" : "translated",
             "value" : "確定要登出？"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguro que quieres cerrar sesion?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei sicuro di voler disconnetterti?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы уверены, что хотите выйти из системы?"
+          }
         }
       }
     },
@@ -4258,6 +5680,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你確定要重試所有失敗的下載嗎？"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguro que quieres reintentar todas las descargas fallidas?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei sicuro di voler riprovare tutti i download non riusciti?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы уверены, что хотите повторить все неудавшиеся загрузки?"
           }
         }
       }
@@ -4305,6 +5745,24 @@
             "state" : "translated",
             "value" : "構建產物"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artefacto"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artefatto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Артефакт"
+          }
         }
       }
     },
@@ -4350,6 +5808,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "身份驗證活動"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actividad de autenticación"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attività di autenticazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Активность аутентификации"
           }
         }
       }
@@ -4397,6 +5873,24 @@
             "state" : "translated",
             "value" : "認證方式"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Método de autenticación"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metodo di autenticazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метод аутентификации"
+          }
         }
       }
     },
@@ -4442,6 +5936,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "著色師"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colorista"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colorista"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Колорист"
           }
         }
       }
@@ -4489,6 +6001,24 @@
             "state" : "translated",
             "value" : "封面"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Portada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copertina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обложка"
+          }
         }
       }
     },
@@ -4534,6 +6064,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "編輯"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Редактор"
           }
         }
       }
@@ -4581,6 +6129,24 @@
             "state" : "translated",
             "value" : "繪圖者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entintador"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inchiostratore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Инкер"
+          }
         }
       }
     },
@@ -4626,6 +6192,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "嵌字者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotulista"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letterista"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Леттерер"
           }
         }
       }
@@ -4673,6 +6257,24 @@
             "state" : "translated",
             "value" : "構圖者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dibujante"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disegnatore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Карандашист"
+          }
         }
       }
     },
@@ -4718,6 +6320,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "翻譯者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traductor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Traduttore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переводчик"
           }
         }
       }
@@ -4765,6 +6385,24 @@
             "state" : "translated",
             "value" : "作者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guionista"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sceneggiatore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сценарист"
+          }
         }
       }
     },
@@ -4810,6 +6448,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "作者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autores"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autori"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Авторы"
           }
         }
       }
@@ -4857,6 +6513,24 @@
             "state" : "translated",
             "value" : "自動"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automático"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatico"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Авто"
+          }
         }
       }
     },
@@ -4902,6 +6576,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "開啟時自動全螢幕"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pantalla completa automatica al abrir"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schermo intero automatico all'apertura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматический полноэкранный режим при открытии"
           }
         }
       }
@@ -4949,6 +6641,24 @@
             "state" : "translated",
             "value" : "僅當頁面適配螢幕所需的縮放倍率大於此值時才自動放大。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aplicar autoescalado solo cuando la escala necesaria para ajustar la pagina a la pantalla supere este valor."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Applica la scalatura automatica solo quando la scala necessaria per adattare la pagina allo schermo supera questo valore."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Применять автомасштабирование только если требуемый масштаб для подгонки страницы под экран больше этого значения."
+          }
         }
       }
     },
@@ -4994,6 +6704,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自動觸發縮放閾值"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Umbral de activacion de autoescalado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soglia di attivazione della scalatura automatica"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Порог срабатывания автоскейла"
           }
         }
       }
@@ -5041,6 +6769,24 @@
             "state" : "translated",
             "value" : "自動刷新"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualización automática"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiornamento automatico"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автообновление"
+          }
         }
       }
     },
@@ -5086,6 +6832,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自動刷新主頁"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar panel automaticamente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiornamento automatico dashboard"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автообновление панели"
           }
         }
       }
@@ -5133,6 +6897,24 @@
             "state" : "translated",
             "value" : "為所有圖片自動開啟實況文本。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar automaticamente Live Text para todas las imagenes."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abilita automaticamente Live Text per tutte le immagini."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически включать Live Text для всех изображений."
+          }
         }
       }
     },
@@ -5178,6 +6960,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "開啟閱讀器時自動進入全螢幕模式"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrar automaticamente en pantalla completa al abrir el lector"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entra automaticamente a schermo intero all'apertura del lettore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически входить в полноэкранный режим при открытии ридера"
           }
         }
       }
@@ -5225,6 +7025,24 @@
             "state" : "translated",
             "value" : "內容變更時自動刷新主頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar automaticamente el panel cuando cambie el contenido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiorna automaticamente la dashboard quando i contenuti cambiano"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически обновлять панель при изменении контента"
+          }
         }
       }
     },
@@ -5270,6 +7088,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "平均頁數/書"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paginas medias / libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagine medie / libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Среднее страниц / книга"
           }
         }
       }
@@ -5317,6 +7153,24 @@
             "state" : "translated",
             "value" : "均衡（3072 px）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Equilibrado (3072 px)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bilanciato (3072 px)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбалансированный (3072 px)"
+          }
         }
       }
     },
@@ -5362,6 +7216,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "基本資訊"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informacion basica"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informazioni di base"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Основная информация"
           }
         }
       }
@@ -5409,6 +7281,24 @@
             "state" : "translated",
             "value" : "行為"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comportamiento"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comportamento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поведение"
+          }
         }
       }
     },
@@ -5454,6 +7344,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "圖書"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книга"
           }
         }
       }
@@ -5501,6 +7409,24 @@
             "state" : "translated",
             "value" : "已讀完"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libro terminado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libro completato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книга завершена"
+          }
         }
       }
     },
@@ -5546,6 +7472,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書籍已刪除"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El libro ha sido eliminado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il libro e stato eliminato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книга удалена"
           }
         }
       }
@@ -5593,6 +7537,24 @@
             "state" : "translated",
             "value" : "書籍 ID"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID de libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID книги"
+          }
         }
       }
     },
@@ -5638,6 +7600,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書籍詳情"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informacion del libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Info libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Информация о книге"
           }
         }
       }
@@ -5685,6 +7665,24 @@
             "state" : "translated",
             "value" : "書籍導航"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navegacion del libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navigazione libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Навигация по книге"
+          }
         }
       }
     },
@@ -5730,6 +7728,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "本書進度 %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avanzamento %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прогресс %@"
           }
         }
       }
@@ -5777,6 +7793,24 @@
             "state" : "translated",
             "value" : "编作者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autores"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autori"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Авторы"
+          }
         }
       }
     },
@@ -5822,6 +7856,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "常规"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Общее"
           }
         }
       }
@@ -5869,6 +7921,24 @@
             "state" : "translated",
             "value" : "链接"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enlaces"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Links"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ссылки"
+          }
         }
       }
     },
@@ -5914,6 +7984,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标签"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etiquetas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etichette"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Теги"
           }
         }
       }
@@ -5961,6 +8049,24 @@
             "state" : "translated",
             "value" : "書籍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книги"
+          }
         }
       }
     },
@@ -6006,6 +8112,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已讀完書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libros completados"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libri completati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книг завершено"
           }
         }
       }
@@ -6053,6 +8177,24 @@
             "state" : "translated",
             "value" : "開始閱讀書籍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libros iniciados"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libri iniziati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книг начато"
+          }
         }
       }
     },
@@ -6098,6 +8240,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新增日期"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de adicion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di aggiunta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата добавления"
           }
         }
       }
@@ -6145,6 +8305,24 @@
             "state" : "translated",
             "value" : "閱讀日期"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата чтения"
+          }
         }
       }
     },
@@ -6190,6 +8368,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新日期"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de actualizacion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di aggiornamento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата обновления"
           }
         }
       }
@@ -6237,6 +8433,24 @@
             "state" : "translated",
             "value" : "下載時間"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hora de descarga"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ora download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время загрузки"
+          }
         }
       }
     },
@@ -6282,6 +8496,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檔名"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre de archivo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome file"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Имя файла"
           }
         }
       }
@@ -6329,6 +8561,24 @@
             "state" : "translated",
             "value" : "檔案大小"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamano de archivo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dimensione file"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размер файла"
+          }
         }
       }
     },
@@ -6374,6 +8624,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "名稱"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название"
           }
         }
       }
@@ -6421,6 +8689,24 @@
             "state" : "translated",
             "value" : "頁數"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cantidad de paginas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numero pagine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Количество страниц"
+          }
         }
       }
     },
@@ -6466,6 +8752,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "發行日期"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de publicación"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di uscita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата выхода"
           }
         }
       }
@@ -6513,6 +8817,24 @@
             "state" : "translated",
             "value" : "系列"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серия"
+          }
         }
       }
     },
@@ -6558,6 +8880,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分支"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rama"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Branch"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ветка"
           }
         }
       }
@@ -6605,6 +8945,24 @@
             "state" : "translated",
             "value" : "調製中..."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In preparazione..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завариваем..."
+          }
         }
       }
     },
@@ -6650,6 +9008,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "開啟閱讀器時短暫顯示鍵盤快捷鍵"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar brevemente los atajos de teclado al abrir el lector"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra brevemente le scorciatoie da tastiera all'apertura del lettore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кратко показывать сочетания клавиш при открытии ридера"
           }
         }
       }
@@ -6697,6 +9073,24 @@
             "state" : "translated",
             "value" : "瀏覽"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Explorar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esplora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обзор"
+          }
         }
       }
     },
@@ -6742,6 +9136,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книги"
           }
         }
       }
@@ -6789,6 +9201,24 @@
             "state" : "translated",
             "value" : "收藏"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colecciones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raccolte"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коллекции"
+          }
         }
       }
     },
@@ -6834,6 +9264,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀列表"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listas de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liste di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Списки чтения"
           }
         }
       }
@@ -6881,6 +9329,24 @@
             "state" : "translated",
             "value" : "系列"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Series"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серии"
+          }
         }
       }
     },
@@ -6926,6 +9392,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "網格"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuadricula"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Griglia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сетка"
           }
         }
       }
@@ -6973,6 +9457,24 @@
             "state" : "translated",
             "value" : "列表"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lista"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elenco"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Список"
+          }
         }
       }
     },
@@ -7018,6 +9520,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "構建資訊"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informacion de compilacion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informazioni build"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Информация о сборке"
           }
         }
       }
@@ -7065,6 +9585,24 @@
             "state" : "translated",
             "value" : "構建時間"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hora de compilacion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ora build"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время сборки"
+          }
         }
       }
     },
@@ -7110,6 +9648,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "請我喝杯咖啡"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invitame a un cafe"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offrimi un caffe"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Угостите меня кофе"
           }
         }
       }
@@ -7157,6 +9713,24 @@
             "state" : "translated",
             "value" : "快取"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кэш"
+          }
         }
       }
     },
@@ -7202,6 +9776,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已快取"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En cache"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In cache"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В кэше"
           }
         }
       }
@@ -7249,6 +9841,24 @@
             "state" : "translated",
             "value" : "已快取封面"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Portadas en cache"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copertine in cache"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обложки в кэше"
+          }
         }
       }
     },
@@ -7294,6 +9904,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已快取圖片"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imagenes en cache"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Immagini in cache"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изображения в кэше"
           }
         }
       }
@@ -7341,6 +9969,24 @@
             "state" : "translated",
             "value" : "快取大小"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamano en cache"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dimensione cache"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размер кэша"
+          }
         }
       }
     },
@@ -7386,6 +10032,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在計算章節頁數"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calculando paginas del capitulo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calcolo pagine capitolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вычисление страниц главы"
           }
         }
       }
@@ -7433,6 +10097,24 @@
             "state" : "translated",
             "value" : "取消"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annulla"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмена"
+          }
         }
       }
     },
@@ -7478,6 +10160,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部取消"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar todo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annulla tutto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отменить все"
           }
         }
       }
@@ -7525,6 +10225,24 @@
             "state" : "translated",
             "value" : "取消所有任務"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar todas las tareas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annulla tutte le attivita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отменить все задачи"
+          }
         }
       }
     },
@@ -7570,6 +10288,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "取消下載"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar descarga"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annulla download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отменить загрузку"
           }
         }
       }
@@ -7617,6 +10353,24 @@
             "state" : "translated",
             "value" : "取消單獨顯示"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar aislamiento"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annulla isolamento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отменить изоляцию"
+          }
         }
       }
     },
@@ -7659,6 +10413,24 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CBX"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CBX"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CBX"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "CBX"
@@ -7709,6 +10481,24 @@
             "state" : "translated",
             "value" : "章節進度 %@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso del capitulo %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avanzamento capitolo %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прогресс главы %@"
+          }
         }
       }
     },
@@ -7754,6 +10544,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "章節進度 %lld / %lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso del capitulo %lld / %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avanzamento capitolo %lld / %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прогресс главы %lld / %lld"
           }
         }
       }
@@ -7801,6 +10609,24 @@
             "state" : "translated",
             "value" : "字元與單字"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caracter y palabra"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carattere e parola"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Символ и слово"
+          }
         }
       }
     },
@@ -7846,6 +10672,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇已有的 Komga 伺服器或者添加新的"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige un servidor Komga existente o anade uno nuevo para empezar."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scegli un server Komga esistente o aggiungine uno nuovo per iniziare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите существующий сервер Komga или добавьте новый, чтобы начать."
           }
         }
       }
@@ -7893,6 +10737,24 @@
             "state" : "translated",
             "value" : "選擇點擊區域的工作方式：「自動」模式匹配閱讀方向，或者手動選擇固定佈局"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige como funcionan las zonas tactiles: \"auto\" coincide con la direccion de lectura, o selecciona un diseno fijo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scegli come funzionano le zone di tocco: \"auto\" segue la direzione di lettura oppure seleziona un layout fisso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите, как работают зоны касания: \"auto\" соответствует направлению чтения, либо выберите фиксированную схему"
+          }
         }
       }
     },
@@ -7938,6 +10800,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇要在 Spotlight 結果中顯示的內容類型。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige que elementos deben aparecer en los resultados de Spotlight."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scegli quali elementi devono apparire nei risultati Spotlight."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите, какие сущности должны отображаться в результатах Spotlight."
           }
         }
       }
@@ -7985,6 +10865,24 @@
             "state" : "translated",
             "value" : "經典"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clasico"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classico"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Классический"
+          }
         }
       }
     },
@@ -8030,6 +10928,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить"
           }
         }
       }
@@ -8077,6 +10993,24 @@
             "state" : "translated",
             "value" : "全部清除"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar todo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella tutto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить все"
+          }
         }
       }
     },
@@ -8122,6 +11056,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除快取"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar cache"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella cache"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить кэш"
           }
         }
       }
@@ -8169,6 +11121,24 @@
             "state" : "translated",
             "value" : "清除封面（所有伺服器）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar portadas (todos los servidores)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella copertine (tutti i server)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить обложки (все серверы)"
+          }
         }
       }
     },
@@ -8214,6 +11184,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除封面（目前伺服器）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar portadas (servidor actual)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella copertine (server corrente)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить обложки (текущий сервер)"
           }
         }
       }
@@ -8261,6 +11249,24 @@
             "state" : "translated",
             "value" : "清除當前"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar actual"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella corrente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить текущее"
+          }
         }
       }
     },
@@ -8306,6 +11312,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清理本地項目"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar entradas locales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella elementi locali"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить локальные записи"
           }
         }
       }
@@ -8353,6 +11377,24 @@
             "state" : "translated",
             "value" : "清除頁面（所有服務器）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar paginas (todos los servidores)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella pagine (tutti i server)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить страницы (все серверы)"
+          }
         }
       }
     },
@@ -8398,6 +11440,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清除頁面（當前服務器）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar paginas (servidor actual)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella pagine (server corrente)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить страницы (текущий сервер)"
           }
         }
       }
@@ -8445,6 +11505,24 @@
             "state" : "translated",
             "value" : "清除選取"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar seleccion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella selezione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить выбор"
+          }
         }
       }
     },
@@ -8490,6 +11568,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "關閉"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiudi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрыть"
           }
         }
       }
@@ -8537,6 +11633,24 @@
             "state" : "translated",
             "value" : "咖啡機壞了..."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La cafetera esta averiada..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La macchina del caffe e rotta..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кофемашина сломалась..."
+          }
         }
       }
     },
@@ -8582,6 +11696,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "收藏名稱"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre de coleccion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название коллекции"
           }
         }
       }
@@ -8629,6 +11761,24 @@
             "state" : "translated",
             "value" : "收藏"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colecciones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raccolte"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коллекции"
+          }
         }
       }
     },
@@ -8674,6 +11824,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "註釋"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comentario"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Комментарий"
           }
         }
       }
@@ -8721,6 +11889,24 @@
             "state" : "translated",
             "value" : "提交 ID"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID de commit"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID commit"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID коммита"
+          }
         }
       }
     },
@@ -8766,6 +11952,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "提交 ID（短）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID de commit (corto)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID commit (breve)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID коммита (короткий)"
           }
         }
       }
@@ -8813,6 +12017,24 @@
             "state" : "translated",
             "value" : "提交時間"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hora del commit"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ora commit"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время коммита"
+          }
         }
       }
     },
@@ -8858,6 +12080,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "緊湊（2048 px）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compacto (2048 px)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compatto (2048 px)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Компактный (2048 px)"
           }
         }
       }
@@ -8905,6 +12145,24 @@
             "state" : "translated",
             "value" : "完結"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завершенные"
+          }
         }
       }
     },
@@ -8950,6 +12208,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已讀完"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завершено"
           }
         }
       }
@@ -8997,6 +12273,24 @@
             "state" : "translated",
             "value" : "確認"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conferma"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подтвердить"
+          }
         }
       }
     },
@@ -9042,6 +12336,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "確認操作"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmar accion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conferma azione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подтвердить действие"
           }
         }
       }
@@ -9089,6 +12401,24 @@
             "state" : "translated",
             "value" : "確定要下載所有書籍嗎？"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguro que quieres descargar todos los libros?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei sicuro di voler scaricare tutti i libri?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы уверены, что хотите скачать все книги?"
+          }
         }
       }
     },
@@ -9134,6 +12464,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "確定要下載未讀書籍嗎？"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguro que quieres descargar los libros no leidos?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei sicuro di voler scaricare i libri non letti?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы уверены, что хотите скачать непрочитанные книги?"
           }
         }
       }
@@ -9181,6 +12529,24 @@
             "state" : "translated",
             "value" : "確定要移除所有離線書籍嗎？"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguro que quieres eliminar todos los libros sin conexion?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei sicuro di voler rimuovere tutti i libri offline?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы уверены, что хотите удалить все офлайн-книги?"
+          }
         }
       }
     },
@@ -9226,6 +12592,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "確定要移除已讀的離線書籍嗎？"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguro que quieres eliminar los libros sin conexion leidos?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei sicuro di voler rimuovere i libri offline gia letti?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы уверены, что хотите удалить прочитанные офлайн-книги?"
           }
         }
       }
@@ -9273,6 +12657,24 @@
             "state" : "translated",
             "value" : "連線伺服器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectarse a un servidor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connetti a un server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подключиться к серверу"
+          }
         }
       }
     },
@@ -9318,6 +12720,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "連線"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conexion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connessione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подключение"
           }
         }
       }
@@ -9365,6 +12785,24 @@
             "state" : "translated",
             "value" : "連線驗證成功"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conexion validada correctamente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connessione verificata con successo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подключение успешно проверено"
+          }
         }
       }
     },
@@ -9410,6 +12848,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "內容類型"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipos de contenido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipi di contenuto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Типы контента"
           }
         }
       }
@@ -9457,6 +12913,24 @@
             "state" : "translated",
             "value" : "目錄 · %.1f%%"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contenido · %.1f%%"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contenuti · %.1f%%"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Содержание · %.1f%%"
+          }
         }
       }
     },
@@ -9502,6 +12976,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "控制列漸變背景"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fondo degradado de controles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sfondo sfumato dei controlli"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Градиентный фон элементов управления"
           }
         }
       }
@@ -9549,6 +13041,24 @@
             "state" : "translated",
             "value" : "複製"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Копировать"
+          }
         }
       }
     },
@@ -9594,6 +13104,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "複製到剪貼簿"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiar al portapapeles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copia negli appunti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Копировать в буфер обмена"
           }
         }
       }
@@ -9641,6 +13169,24 @@
             "state" : "translated",
             "value" : "封面"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Portada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copertina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обложка"
+          }
         }
       }
     },
@@ -9686,6 +13232,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "創建"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crea"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать"
           }
         }
       }
@@ -9733,6 +13297,24 @@
             "state" : "translated",
             "value" : "建立收藏"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear coleccion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crea raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать коллекцию"
+          }
         }
       }
     },
@@ -9778,6 +13360,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新建"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear nuevo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crea nuovo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать новый"
           }
         }
       }
@@ -9825,6 +13425,24 @@
             "state" : "translated",
             "value" : "建立閱讀列表"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear lista de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crea lista di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать список чтения"
+          }
         }
       }
     },
@@ -9870,6 +13488,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "建立"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создано"
           }
         }
       }
@@ -9917,6 +13553,24 @@
             "state" : "translated",
             "value" : "創建: %@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creado: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creato: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создано: %@"
+          }
         }
       }
     },
@@ -9962,6 +13616,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "憑證"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credenciales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credenziali"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Учетные данные"
           }
         }
       }
@@ -10009,6 +13681,24 @@
             "state" : "translated",
             "value" : "憑證本地儲存，切換伺服器無須重輸。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las credenciales se guardan localmente para que puedas cambiar de servidor sin volver a introducirlas."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le credenziali vengono salvate localmente cosi puoi cambiare server senza reinserirle."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Учетные данные хранятся локально, поэтому вы можете переключать серверы без повторного ввода."
+          }
         }
       }
     },
@@ -10054,6 +13744,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "當前書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libro actual"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libro corrente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Текущая книга"
           }
         }
       }
@@ -10101,6 +13809,24 @@
             "state" : "translated",
             "value" : "當前頁：%lld"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina actual: %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina corrente: %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Текущая страница: %lld"
+          }
         }
       }
     },
@@ -10146,6 +13872,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "目前閱讀設定"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opciones de lectura actuales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opzioni di lettura correnti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Текущие параметры чтения"
           }
         }
       }
@@ -10193,6 +13937,24 @@
             "state" : "translated",
             "value" : "自訂"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personalizado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Personalizzato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пользовательский"
+          }
         }
       }
     },
@@ -10238,6 +14000,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自訂字體"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuentes personalizadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Font personalizzati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пользовательские шрифты"
           }
         }
       }
@@ -10285,6 +14065,24 @@
             "state" : "translated",
             "value" : "自訂角色"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rol personalizado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruolo personalizzato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пользовательская роль"
+          }
         }
       }
     },
@@ -10330,6 +14128,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "每天"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diario"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giornaliero"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ежедневно"
           }
         }
       }
@@ -10377,6 +14193,24 @@
             "state" : "translated",
             "value" : "主頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Panel"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dashboard"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Панель"
+          }
         }
       }
     },
@@ -10422,6 +14256,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在主頁區塊上顯示漸層背景"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar fondo degradado en las secciones del panel"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra uno sfondo sfumato nelle sezioni della dashboard"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать градиентный фон в разделах панели"
           }
         }
       }
@@ -10469,6 +14321,24 @@
             "state" : "translated",
             "value" : "顯示漸層背景"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar fondo degradado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra sfondo sfumato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать градиентный фон"
+          }
         }
       }
     },
@@ -10514,6 +14384,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "隱藏區塊"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secciones ocultas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sezioni nascoste"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скрытые разделы"
           }
         }
       }
@@ -10561,6 +14449,24 @@
             "state" : "translated",
             "value" : "繼續閱讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguir leyendo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continua a leggere"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить Чтение"
+          }
         }
       }
     },
@@ -10606,6 +14512,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "待閱讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En curso"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primo Piano"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Текущее"
           }
         }
       }
@@ -10653,6 +14577,24 @@
             "state" : "translated",
             "value" : "置頂收藏"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colecciones fijadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raccolte fissate"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрепленные коллекции"
+          }
         }
       }
     },
@@ -10698,6 +14640,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "置頂閱讀列表"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listas de lectura fijadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liste di lettura fissate"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрепленные списки чтения"
           }
         }
       }
@@ -10745,6 +14705,24 @@
             "state" : "translated",
             "value" : "最近新增的書籍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libros añadidos recientemente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fumetti aggiunti di recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавно добавленные книги"
+          }
         }
       }
     },
@@ -10790,6 +14768,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近新增的系列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Series añadidas recientemente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie aggiunte di recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавно добавленные серии"
           }
         }
       }
@@ -10837,6 +14833,24 @@
             "state" : "translated",
             "value" : "最近閱讀的書籍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libros leídos recientemente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libri letti di recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавно прочитанные книги"
+          }
         }
       }
     },
@@ -10882,6 +14896,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近發布的書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libros publicados recientemente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libri aggiunti di recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавно выпущенные книги"
           }
         }
       }
@@ -10929,6 +14961,24 @@
             "state" : "translated",
             "value" : "最近更新的系列"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Series actualizadas recientemente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie aggiornate di recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавно Обновленные Серии"
+          }
         }
       }
     },
@@ -10974,6 +15024,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重設為預設"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer por defecto"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ripristina predefiniti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить к значениям по умолчанию"
           }
         }
       }
@@ -11021,6 +15089,24 @@
             "state" : "translated",
             "value" : "主頁區塊"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secciones del panel"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sezioni dashboard"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разделы панели"
+          }
         }
       }
     },
@@ -11066,6 +15152,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "拖曳以重新排序區塊。切換以顯示或隱藏。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrastra para reordenar secciones. Activa o desactiva para mostrar u ocultar."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trascina per riordinare le sezioni. Attiva o disattiva per mostrare o nascondere."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перетаскивайте для изменения порядка разделов. Переключайте, чтобы показывать или скрывать."
           }
         }
       }
@@ -11113,6 +15217,24 @@
             "state" : "translated",
             "value" : "選擇移動按鈕並使用遙控器重新排序區塊。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona el boton de mover y usa el mando para reordenar las secciones."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona il pulsante di spostamento e usa il telecomando per riordinare le sezioni."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите кнопку перемещения и используйте пульт, чтобы изменить порядок разделов."
+          }
         }
       }
     },
@@ -11158,6 +15280,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "預設"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Predeterminado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Predefinito"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "По умолчанию"
           }
         }
       }
@@ -11205,6 +15345,24 @@
             "state" : "translated",
             "value" : "預設閱讀選項"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opciones de lectura predeterminadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opzioni di lettura predefinite"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Параметры чтения по умолчанию"
+          }
         }
       }
     },
@@ -11250,6 +15408,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить"
           }
         }
       }
@@ -11297,6 +15473,24 @@
             "state" : "translated",
             "value" : "刪除 (%lld)"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar (%lld)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina (%lld)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить (%lld)"
+          }
         }
       }
     },
@@ -11342,6 +15536,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部刪除"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar todo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina tutto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить все"
           }
         }
       }
@@ -11389,6 +15601,24 @@
             "state" : "translated",
             "value" : "删除 API 金鑰"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar clave API"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina chiave API"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить API-ключ"
+          }
         }
       }
     },
@@ -11434,6 +15664,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina Libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить книгу"
           }
         }
       }
@@ -11481,6 +15729,24 @@
             "state" : "translated",
             "value" : "刪除書籍？"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar libro?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminare il libro?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить книгу?"
+          }
         }
       }
     },
@@ -11526,6 +15792,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除收藏"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar colección"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina Raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить коллекцию"
           }
         }
       }
@@ -11573,6 +15857,24 @@
             "state" : "translated",
             "value" : "刪除收藏？"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar coleccion?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminare la raccolta?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить коллекцию?"
+          }
         }
       }
     },
@@ -11618,6 +15920,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除圖書館"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar biblioteca"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina Libreria"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить Библиотеку"
           }
         }
       }
@@ -11665,6 +15985,24 @@
             "state" : "translated",
             "value" : "刪除單行本"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar one-shot"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina one-shot"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить one-shot"
+          }
         }
       }
     },
@@ -11710,6 +16048,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除單行本？"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar one-shot?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminare one-shot?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить one-shot?"
           }
         }
       }
@@ -11757,6 +16113,24 @@
             "state" : "translated",
             "value" : "刪除閱讀列表"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar lista de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina Elenco Lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить список чтения"
+          }
         }
       }
     },
@@ -11802,6 +16176,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除閱讀列表？"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar lista de lectura?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminare la lista di lettura?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить список чтения?"
           }
         }
       }
@@ -11849,6 +16241,24 @@
             "state" : "translated",
             "value" : "刪除系列"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Borrar serie(s)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina le serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить серии"
+          }
         }
       }
     },
@@ -11894,6 +16304,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除系列？"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar serie?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminare la serie?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить серию?"
           }
         }
       }
@@ -11941,6 +16369,24 @@
             "state" : "translated",
             "value" : "刪除伺服器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar servidor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить сервер"
+          }
         }
       }
     },
@@ -11986,6 +16432,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不可用"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалено"
           }
         }
       }
@@ -12033,6 +16497,24 @@
             "state" : "translated",
             "value" : "全部取消"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deseleccionar todo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deseleziona tutto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Снять выделение со всего"
+          }
         }
       }
     },
@@ -12078,6 +16560,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "詳情"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dettagli"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подробности"
           }
         }
       }
@@ -12125,6 +16625,24 @@
             "state" : "translated",
             "value" : "方向"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direccion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direzione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Направление"
+          }
         }
       }
     },
@@ -12170,6 +16688,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "禁用"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactivado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disabilitato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отключено"
           }
         }
       }
@@ -12217,6 +16753,24 @@
             "state" : "translated",
             "value" : "顯示"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visualización"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visualizzazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отображение"
+          }
         }
       }
     },
@@ -12262,6 +16816,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀時顯示頁碼"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar superposicion del numero de pagina en las imagenes durante la lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra sovrimpressione numero pagina sulle immagini durante la lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать наложение номера страницы на изображениях во время чтения"
           }
         }
       }
@@ -12309,6 +16881,24 @@
             "state" : "translated",
             "value" : "打開閱讀器時顯示點擊區域提示"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar sugerencias de zonas tactiles al abrir el lector"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra i suggerimenti delle zone di tocco all'apertura del lettore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать подсказки зон касания при открытии ридера"
+          }
         }
       }
     },
@@ -12354,6 +16944,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "單獨顯示封面頁，不與下一頁配對"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar la portada por separado, sin emparejarla con la pagina siguiente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra la pagina di copertina separatamente, non abbinata alla pagina successiva"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать обложку отдельно, не объединяя со следующей страницей"
           }
         }
       }
@@ -12401,6 +17009,24 @@
             "state" : "translated",
             "value" : "DIVINA 閱讀器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lector DIVINA"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettore DIVINA"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ридер DIVINA"
+          }
         }
       }
     },
@@ -12446,6 +17072,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "完成"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "hecho"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "fatto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "готово"
           }
         }
       }
@@ -12493,6 +17137,24 @@
             "state" : "translated",
             "value" : "完成"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hecho"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fatto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готово"
+          }
         }
       }
     },
@@ -12538,6 +17200,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "雙擊縮放"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doble toque para ampliar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doppio tocco per zoom"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Двойное касание для увеличения"
           }
         }
       }
@@ -12585,6 +17265,24 @@
             "state" : "translated",
             "value" : "雙擊縮放比例"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escala de zoom con doble toque"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scala zoom doppio tocco"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Масштаб увеличения по двойному касанию"
+          }
         }
       }
     },
@@ -12630,6 +17328,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下載"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scarica"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скачать"
           }
         }
       }
@@ -12677,6 +17393,24 @@
             "state" : "translated",
             "value" : "下載全部"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargar todo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scarica tutto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скачать все"
+          }
         }
       }
     },
@@ -12722,6 +17456,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下載完成，但有失敗項"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La descarga termino con errores"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download terminato con errori"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка завершилась с ошибками"
           }
         }
       }
@@ -12769,6 +17521,24 @@
             "state" : "translated",
             "value" : "下載任務"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tareas de descarga"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attivita di download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задачи загрузки"
+          }
         }
       }
     },
@@ -12814,6 +17584,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下載未讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargar no leidos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scarica non letti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скачать непрочитанное"
           }
         }
       }
@@ -12861,6 +17649,24 @@
             "state" : "translated",
             "value" : "已下載書籍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libros descargados"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libri scaricati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скачанные книги"
+          }
         }
       }
     },
@@ -12906,6 +17712,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下載中"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargando"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download in corso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка"
           }
         }
       }
@@ -12953,6 +17777,24 @@
             "state" : "translated",
             "value" : "下載中 %lld%%"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargando %lld%%"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download %lld%%"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка %lld%%"
+          }
         }
       }
     },
@@ -12998,6 +17840,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在下載書籍內容"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargando contenido del libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download contenuto libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка содержимого книги"
           }
         }
       }
@@ -13045,6 +17905,24 @@
             "state" : "translated",
             "value" : "正在下載圖書..."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargando libro..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download libro..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка книги..."
+          }
         }
       }
     },
@@ -13090,6 +17968,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在下載：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargando: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка: %@"
           }
         }
       }
@@ -13137,6 +18033,24 @@
             "state" : "translated",
             "value" : "例如「Home」或「Work」"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "p. ej. \"Casa\" o \"Trabajo\""
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "es. \"Casa\" o \"Lavoro\""
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "например, \"Дом\" или \"Работа\""
+          }
         }
       }
     },
@@ -13182,6 +18096,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "編輯"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Редактировать"
           }
         }
       }
@@ -13229,6 +18161,24 @@
             "state" : "translated",
             "value" : "編輯"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Редактировать"
+          }
         }
       }
     },
@@ -13274,6 +18224,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "編輯書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Редактировать книгу"
           }
         }
       }
@@ -13321,6 +18289,24 @@
             "state" : "translated",
             "value" : "編輯收藏"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar coleccion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Редактировать коллекцию"
+          }
         }
       }
     },
@@ -13366,6 +18352,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "編輯單行本"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar one-shot"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica one-shot"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Редактировать one-shot"
           }
         }
       }
@@ -13413,6 +18417,24 @@
             "state" : "translated",
             "value" : "編輯閱讀列表"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar lista de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica lista di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Редактировать список чтения"
+          }
         }
       }
     },
@@ -13458,6 +18480,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "編輯系列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar serie"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Редактировать серию"
           }
         }
       }
@@ -13505,6 +18545,24 @@
             "state" : "translated",
             "value" : "編輯伺服器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar servidor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Редактировать сервер"
+          }
         }
       }
     },
@@ -13550,6 +18608,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清空資源回收桶"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vaciar papelera"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Svuota cestino"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить корзину"
           }
         }
       }
@@ -13597,6 +18673,24 @@
             "state" : "translated",
             "value" : "清空所有圖書館的回收桶"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vaciar papelera de todas las bibliotecas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Svuota cestino per tutte le librerie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить корзину для всех библиотек"
+          }
         }
       }
     },
@@ -13642,6 +18736,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "開啟實況文本"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar Live Text"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abilita Live Text"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включить Live Text"
           }
         }
       }
@@ -13689,6 +18801,24 @@
             "state" : "translated",
             "value" : "啟用即時更新後可使用此功能。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activa las actualizaciones en tiempo real arriba para usar esta funcion."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abilita gli aggiornamenti in tempo reale sopra per usare questa funzione."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включите обновления в реальном времени выше, чтобы использовать эту функцию."
+          }
         }
       }
     },
@@ -13734,6 +18864,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "啟用 SSE 以獲取即時更新"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar Server-Sent Events para actualizaciones en tiempo real"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abilita Server-Sent Events per aggiornamenti in tempo reale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включить Server-Sent Events для обновлений в реальном времени"
           }
         }
       }
@@ -13781,6 +18929,24 @@
             "state" : "translated",
             "value" : "啟用 Spotlight 索引"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar indexacion de Spotlight"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abilita indicizzazione Spotlight"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включить индексацию Spotlight"
+          }
         }
       }
     },
@@ -13826,6 +18992,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已完結"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Concluso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закончена"
           }
         }
       }
@@ -13873,6 +19057,24 @@
             "state" : "translated",
             "value" : "輸入此主題預設的名稱"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduce un nombre para este preset de tema"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inserisci un nome per questo preset tema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите имя для этого пресета темы"
+          }
         }
       }
     },
@@ -13918,6 +19120,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "輸入用於存取 Komga 的憑證。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduce las credenciales que usas para acceder a tu servidor Komga."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inserisci le credenziali che usi per accedere al tuo server Komga."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите учетные данные, которые вы используете для доступа к серверу Komga."
           }
         }
       }
@@ -13965,6 +19185,24 @@
             "state" : "translated",
             "value" : "輸入 API 金鑰"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduce tu clave API"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inserisci la tua chiave API"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите ваш API-ключ"
+          }
         }
       }
     },
@@ -14010,6 +19248,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "輸入密碼"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduce tu contrasena"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inserisci la tua password"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите пароль"
           }
         }
       }
@@ -14057,6 +19313,24 @@
             "state" : "translated",
             "value" : "輸入伺服器 URL"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduce la URL de tu servidor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inserisci l'URL del tuo server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите URL вашего сервера"
+          }
         }
       }
     },
@@ -14103,6 +19377,24 @@
             "state" : "translated",
             "value" : "輸入使用者名稱"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduce tu nombre de usuario"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inserisci il tuo nome utente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите имя пользователя"
+          }
         }
       }
     },
@@ -14145,6 +19437,24 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "EPUB"
@@ -14195,6 +19505,24 @@
             "state" : "translated",
             "value" : "EPUB 閱讀器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lector EPUB"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettore EPUB"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ридер EPUB"
+          }
         }
       }
     },
@@ -14240,6 +19568,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "EPUB 閱讀器不可用"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lector EPUB no disponible"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettore EPUB non disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ридер EPUB недоступен"
           }
         }
       }
@@ -14287,6 +19633,24 @@
             "state" : "translated",
             "value" : "EPUB 閱讀僅在 iOS 上支援。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La lectura EPUB solo es compatible con iOS."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La lettura EPUB e supportata solo su iOS."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чтение EPUB поддерживается только на iOS."
+          }
         }
       }
     },
@@ -14332,6 +19696,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自動"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatico"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatico"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Авто"
           }
         }
       }
@@ -14379,6 +19761,24 @@
             "state" : "translated",
             "value" : "單欄"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 columna"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 colonna"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 колонка"
+          }
         }
       }
     },
@@ -14424,6 +19824,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "雙欄"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 columnas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 colonne"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 колонки"
           }
         }
       }
@@ -14471,6 +19889,24 @@
             "state" : "translated",
             "value" : "分頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paginado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paginato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Постранично"
+          }
         }
       }
     },
@@ -14516,6 +19952,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "連續捲動"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desplazado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scorrimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прокрутка"
           }
         }
       }
@@ -14563,6 +20017,24 @@
             "state" : "translated",
             "value" : "閱讀流程"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flujo de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flusso di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Режим чтения"
+          }
         }
       }
     },
@@ -14608,6 +20080,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "點擊捲動高度"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altura de desplazamiento al tocar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altezza scorrimento al tocco"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Высота прокрутки по касанию"
           }
         }
       }
@@ -14655,6 +20145,24 @@
             "state" : "translated",
             "value" : "在捲動模式下，點擊翻頁時捲動的距離"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distancia de desplazamiento al tocar para navegar en modo desplazado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distanza di scorrimento al tocco per navigare in modalita scorrimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дистанция прокрутки при касании для навигации в режиме прокрутки"
+          }
         }
       }
     },
@@ -14700,6 +20208,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "錯誤"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Errore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ошибка"
           }
         }
       }
@@ -14747,6 +20273,24 @@
             "state" : "translated",
             "value" : "書籍 ID 為空"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El ID del libro esta vacio"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'ID libro e vuoto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID книги пуст"
+          }
         }
       }
     },
@@ -14792,6 +20336,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定錯誤：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error de configuracion: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Errore di configurazione: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ошибка конфигурации: %@"
           }
         }
       }
@@ -14839,6 +20401,24 @@
             "state" : "translated",
             "value" : "資料毀損：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datos corruptos: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dati corrotti: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Данные повреждены: %@"
+          }
         }
       }
     },
@@ -14884,6 +20464,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "同步閱讀進度失敗。這本書可能需要在伺服器上重新分析。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo sincronizar el progreso de lectura. Puede que este libro deba volver a analizarse en el servidor."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile sincronizzare il progresso di lettura. Questo libro potrebbe dover essere analizzato di nuovo sul server."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось синхронизировать прогресс чтения. Возможно, эту книгу нужно заново проанализировать на сервере."
           }
         }
       }
@@ -14931,6 +20529,24 @@
             "state" : "translated",
             "value" : "無法載入影像資料"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron cargar los datos de imagen"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile caricare i dati immagine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить данные изображения"
+          }
         }
       }
     },
@@ -14976,6 +20592,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "找不到檔案：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archivo no encontrado: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "File non trovato: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Файл не найден: %@"
           }
         }
       }
@@ -15023,6 +20657,24 @@
             "state" : "translated",
             "value" : "讀取檔案 %1$@ 失敗：%2$@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al leer el archivo %1$@: %2$@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile leggere il file %1$@: %2$@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось прочитать файл %1$@: %2$@"
+          }
         }
       }
     },
@@ -15068,6 +20720,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "寫入檔案 %1$@ 失敗：%2$@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error al escribir el archivo %1$@: %2$@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile scrivere il file %1$@: %2$@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось записать файл %1$@: %2$@"
           }
         }
       }
@@ -15115,6 +20785,24 @@
             "state" : "translated",
             "value" : "圖像尚未快取"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imagen aun no cacheada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Immagine non ancora in cache"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изображение еще не закэшировано"
+          }
         }
       }
     },
@@ -15160,6 +20848,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定無效：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuracion invalida: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurazione non valida: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Некорректная конфигурация: %@"
           }
         }
       }
@@ -15207,6 +20913,24 @@
             "state" : "translated",
             "value" : "檔案 URL 無效：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL de archivo invalida: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL file non valido: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Некорректный URL файла: %@"
+          }
         }
       }
     },
@@ -15252,6 +20976,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "輸入無效：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrada invalida: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Input non valido: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Некорректный ввод: %@"
           }
         }
       }
@@ -15299,6 +21041,24 @@
             "state" : "translated",
             "value" : "在 XHTML 文件中找不到圖片標籤：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontro ninguna etiqueta de imagen en el documento XHTML: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun tag immagine trovato nel documento XHTML: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В документе XHTML не найден тег изображения: %@"
+          }
         }
       }
     },
@@ -15344,6 +21104,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無效的清單 href：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Href de manifiesto invalido: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Href del manifesto non valido: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Некорректный href манифеста: %@"
           }
         }
       }
@@ -15391,6 +21169,24 @@
             "state" : "translated",
             "value" : "無法解碼 XHTML 文件：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo decodificar el documento XHTML: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile decodificare il documento XHTML: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось декодировать документ XHTML: %@"
+          }
         }
       }
     },
@@ -15436,6 +21232,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不支援的清單資源類型：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo de recurso de manifiesto no compatible: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo di risorsa del manifesto non supportato: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Неподдерживаемый тип ресурса манифеста: %@"
           }
         }
       }
@@ -15483,6 +21297,24 @@
             "state" : "translated",
             "value" : "缺少必要資料：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faltan datos obligatorios: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dati obbligatori mancanti: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отсутствуют обязательные данные: %@"
+          }
         }
       }
     },
@@ -15528,6 +21360,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "請求已取消"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitud cancelada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Richiesta annullata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запрос отменен"
           }
         }
       }
@@ -15575,6 +21425,24 @@
             "state" : "translated",
             "value" : "網路錯誤：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error de red: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Errore di rete: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ошибка сети: %@"
+          }
         }
       }
     },
@@ -15620,6 +21488,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "請求逾時，請稍後再試。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La solicitud excedio el tiempo de espera. Intentalo de nuevo mas tarde."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tempo di attesa della richiesta scaduto. Riprova piu tardi."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время ожидания запроса истекло. Повторите попытку позже."
           }
         }
       }
@@ -15667,6 +21553,24 @@
             "state" : "translated",
             "value" : "沒有網路連線，請檢查網路設定。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin conexion a internet. Revisa la configuracion de red."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna connessione internet. Controlla le impostazioni di rete."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет подключения к интернету. Проверьте настройки сети."
+          }
         }
       }
     },
@@ -15712,6 +21616,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "沒有可呈現的頁面"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay paginas renderizables"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna pagina renderizzabile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет страниц для отображения"
           }
         }
       }
@@ -15759,6 +21681,24 @@
             "state" : "translated",
             "value" : "操作失敗：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Operacion fallida: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Operazione non riuscita: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Операция не выполнена: %@"
+          }
         }
       }
     },
@@ -15804,6 +21744,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不允許的操作：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Operacion no permitida: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Operazione non consentita: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Операция не разрешена: %@"
           }
         }
       }
@@ -15851,6 +21809,24 @@
             "state" : "translated",
             "value" : "相簿存取被拒"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acceso a la fototeca denegado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accesso alla libreria foto negato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Доступ к фотобиблиотеке запрещен"
+          }
         }
       }
     },
@@ -15896,6 +21872,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "找不到資源：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recurso no encontrado: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Risorsa non trovata: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ресурс не найден: %@"
           }
         }
       }
@@ -15943,6 +21937,24 @@
             "state" : "translated",
             "value" : "儲存未設定：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Almacenamiento no configurado: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archiviazione non configurata: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Хранилище не настроено: %@"
+          }
         }
       }
     },
@@ -15988,6 +22000,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "儲存操作失敗：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Operacion de almacenamiento fallida: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Operazione di archiviazione non riuscita: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ошибка операции хранилища: %@"
           }
         }
       }
@@ -16035,6 +22065,24 @@
             "state" : "translated",
             "value" : "錯誤"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Errore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ошибка"
+          }
         }
       }
     },
@@ -16080,6 +22128,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未知錯誤"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error desconocido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Errore sconosciuto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Неизвестная ошибка"
           }
         }
       }
@@ -16127,6 +22193,24 @@
             "state" : "translated",
             "value" : "驗證失敗：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validacion fallida: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validazione non riuscita: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ошибка валидации: %@"
+          }
         }
       }
     },
@@ -16172,6 +22256,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "預計小時數"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Horas estimadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ore stimate"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оценочные часы"
           }
         }
       }
@@ -16219,6 +22321,24 @@
             "state" : "translated",
             "value" : "每6小時"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cada 6 horas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ogni 6 ore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Каждые 6 часов"
+          }
         }
       }
     },
@@ -16264,6 +22384,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "每12小時"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cada 12 horas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ogni 12 ore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Каждые 12 часов"
           }
         }
       }
@@ -16311,6 +22449,24 @@
             "state" : "translated",
             "value" : "失敗"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fallido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non riuscito"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбой"
+          }
         }
       }
     },
@@ -16356,6 +22512,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "載入書籍詳情失敗"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron cargar los detalles del libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile caricare i dettagli del libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить сведения о книге"
           }
         }
       }
@@ -16403,6 +22577,24 @@
             "state" : "translated",
             "value" : "載入媒體失敗"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo cargar el medio"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile caricare il contenuto multimediale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить медиа"
+          }
         }
       }
     },
@@ -16448,6 +22640,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新整理閱讀統計失敗，正在顯示快取資料。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron actualizar las estadisticas de lectura. Mostrando datos en cache."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile aggiornare le statistiche di lettura. Mostro i dati in cache."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось обновить статистику чтения. Показаны кэшированные данные."
           }
         }
       }
@@ -16495,6 +22705,24 @@
             "state" : "translated",
             "value" : "快速"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rapido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veloce"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Быстрый"
+          }
         }
       }
     },
@@ -16540,6 +22768,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "回饋"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comentarios"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feedback"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обратная связь"
           }
         }
       }
@@ -16587,6 +22833,24 @@
             "state" : "translated",
             "value" : "正在獲取圖書信息..."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obteniendo informacion del libro..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recupero informazioni libro..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Получение информации о книге..."
+          }
         }
       }
     },
@@ -16632,6 +22896,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在獲取書籍元數據"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obteniendo metadatos del libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recupero metadati libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Получение метаданных книги"
           }
         }
       }
@@ -16679,6 +22961,24 @@
             "state" : "translated",
             "value" : "篩選"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtrar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фильтр"
+          }
         }
       }
     },
@@ -16724,6 +23024,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "篩選與排序"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtrar y ordenar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtra e ordina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фильтр и сортировка"
           }
         }
       }
@@ -16771,6 +23089,24 @@
             "state" : "translated",
             "value" : "篩選器名稱"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre del filtro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome filtro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название фильтра"
+          }
         }
       }
     },
@@ -16816,6 +23152,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "首本"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El primero"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Первая"
           }
         }
       }
@@ -16863,6 +23217,24 @@
             "state" : "translated",
             "value" : "首本未讀或首本"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primero no leido o primero"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primo non letto o primo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Первый непрочитанный или первый"
+          }
         }
       }
     },
@@ -16908,6 +23280,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "首本未讀或末本"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primero no leido o ultimo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Primo non letto o ultimo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Первый непрочитанный или последний"
           }
         }
       }
@@ -16955,6 +23345,24 @@
             "state" : "translated",
             "value" : "標記"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicadores"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flag"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Флаги"
+          }
         }
       }
     },
@@ -17000,6 +23408,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字體"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Font"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Шрифт"
           }
         }
       }
@@ -17047,6 +23473,24 @@
             "state" : "translated",
             "value" : "字體名稱"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre de fuente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome font"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название шрифта"
+          }
         }
       }
     },
@@ -17092,6 +23536,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字體大小: %@x"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamano de fuente: %@x"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dimensione font: %@x"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размер шрифта: %@x"
           }
         }
       }
@@ -17139,6 +23601,24 @@
             "state" : "translated",
             "value" : "強制默認閱讀方向"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forzar direccion de lectura predeterminada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forza direzione di lettura predefinita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Принудительно использовать направление чтения по умолчанию"
+          }
         }
       }
     },
@@ -17184,6 +23664,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "GB"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GB"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GB"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ГБ"
           }
         }
       }
@@ -17231,6 +23729,24 @@
             "state" : "translated",
             "value" : "類型"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Género"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genere"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жанр"
+          }
         }
       }
     },
@@ -17276,6 +23792,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "風格"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Géneros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Жанры"
           }
         }
       }
@@ -17323,6 +23857,24 @@
             "state" : "translated",
             "value" : "類型分布"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distribucion por generos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distribuzione generi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Распределение по жанрам"
+          }
         }
       }
     },
@@ -17368,6 +23920,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "開始使用"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comenzar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inizia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Начать"
           }
         }
       }
@@ -17415,6 +23985,24 @@
             "state" : "translated",
             "value" : "Git 資訊"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informacion de Git"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informazioni Git"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Информация Git"
+          }
         }
       }
     },
@@ -17460,6 +24048,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "玻璃"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cristal"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vetro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Стекло"
           }
         }
       }
@@ -17507,6 +24113,24 @@
             "state" : "translated",
             "value" : "跳轉到頁面"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ir a pagina"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vai alla pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перейти к странице"
+          }
         }
       }
     },
@@ -17552,6 +24176,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分組"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grupo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gruppo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Группа"
           }
         }
       }
@@ -17599,6 +24241,24 @@
             "state" : "translated",
             "value" : "有生之年"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interrumpido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hiatus"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Заморожена"
+          }
         }
       }
     },
@@ -17644,6 +24304,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "高（4096 px）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alto (4096 px)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alto (4096 px)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Высокое (4096 px)"
           }
         }
       }
@@ -17691,6 +24369,24 @@
             "state" : "translated",
             "value" : "歷史"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Historial"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Storia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "История"
+          }
         }
       }
     },
@@ -17736,6 +24432,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "歷史詳情"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalles del historial"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dettagli cronologia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подробности истории"
           }
         }
       }
@@ -17783,6 +24497,24 @@
             "state" : "translated",
             "value" : "每小時"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cada hora"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ogni ora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ежечасно"
+          }
         }
       }
     },
@@ -17828,6 +24560,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "小時"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Horas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Часы"
           }
         }
       }
@@ -17875,6 +24625,24 @@
             "state" : "translated",
             "value" : "閒置"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inactivo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inattivo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Неактивно"
+          }
         }
       }
     },
@@ -17920,6 +24688,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "如果你喜歡這個應用，請考慮請我喝杯咖啡！"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si disfrutas esta app, considera invitarme a un cafe!"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se ti piace questa app, considera di offrirmi un caffe!"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Если вам нравится это приложение, угостите меня кофе!"
           }
         }
       }
@@ -17967,6 +24753,24 @@
             "state" : "translated",
             "value" : "忽略書籍和系列元數據，始終使用首选方向"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignora los metadatos de libro y serie y usa siempre la direccion preferida"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignora i metadati di libro e serie e usa sempre la direzione preferita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Игнорировать метаданные книги и серии и всегда использовать предпочтительное направление"
+          }
         }
       }
     },
@@ -18012,6 +24816,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "圖像"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imagen"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Immagine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изображение"
           }
         }
       }
@@ -18059,6 +24881,24 @@
             "state" : "translated",
             "value" : "影像超解析度"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escalado de imagen"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upscaling immagine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Масштабирование изображения"
+          }
         }
       }
     },
@@ -18104,6 +24944,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "從檔案 App 匯入 .ttf 或 .otf 字型檔案"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa fuentes .ttf u .otf desde la app Archivos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa file font .ttf o .otf dall'app File"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импортируйте файлы шрифтов .ttf или .otf из приложения «Файлы»"
           }
         }
       }
@@ -18151,6 +25009,24 @@
             "state" : "translated",
             "value" : "匯入自訂字型"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar fuente personalizada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa font personalizzato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импортировать пользовательский шрифт"
+          }
         }
       }
     },
@@ -18196,6 +25072,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "從檔案匯入字型"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar fuente desde Archivos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa font da File"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импортировать шрифт из «Файлов»"
           }
         }
       }
@@ -18243,6 +25137,24 @@
             "state" : "translated",
             "value" : "使用內建 waifu2x（2x）提升低解析度頁面的清晰度。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mejora la nitidez de paginas de baja resolucion con waifu2x integrado (2x)."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migliora la nitidezza delle pagine a bassa risoluzione con waifu2x integrato (2x)."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повышайте четкость страниц низкого разрешения с помощью встроенного waifu2x (2x)."
+          }
         }
       }
     },
@@ -18288,6 +25200,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在始終模式下，除非來源圖片寬度或高度超過螢幕尺寸的此倍數，否則都會放大。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En modo Siempre, ampliar salvo que el ancho o alto de origen supere este multiple de la pantalla."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In modalita Sempre, esegue l'upscale salvo quando larghezza o altezza sorgente superano questo multiplo dello schermo."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В режиме «Всегда» увеличивать, если ширина или высота исходника не превышает этот множитель экрана."
           }
         }
       }
@@ -18335,6 +25265,24 @@
             "state" : "translated",
             "value" : "在單頁模式下，根據閱讀方向將橫向頁面分割為兩個獨立頁面"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En modo de pagina unica, divide las paginas horizontales en dos paginas segun la direccion de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In modalita pagina singola, dividi le pagine orizzontali in due pagine separate in base alla direzione di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В режиме одной страницы разделять горизонтальные страницы на две отдельные по направлению чтения"
+          }
         }
       }
     },
@@ -18380,6 +25328,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "索引"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Índice"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indice"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Индекс"
           }
         }
       }
@@ -18427,6 +25393,24 @@
             "state" : "translated",
             "value" : "索引所有資料庫"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indexar todas las bibliotecas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicizza tutte le librerie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Индексировать все библиотеки"
+          }
         }
       }
     },
@@ -18472,6 +25456,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "索引書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indexar libros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicizza libri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Индексировать книги"
           }
         }
       }
@@ -18519,6 +25521,24 @@
             "state" : "translated",
             "value" : "索引範圍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ambito de indexacion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ambito indicizzazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Область индексации"
+          }
         }
       }
     },
@@ -18564,6 +25584,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "索引系列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indexar series"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indicizza serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Индексировать серии"
           }
         }
       }
@@ -18611,6 +25649,24 @@
             "state" : "translated",
             "value" : "已索引資料庫"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bibliotecas indexadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Librerie indicizzate"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Индексированные библиотеки"
+          }
         }
       }
     },
@@ -18656,6 +25712,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在同步書籍..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizando libros..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzazione libri..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация книг..."
           }
         }
       }
@@ -18703,6 +25777,24 @@
             "state" : "translated",
             "value" : "正在同步收藏集..."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizando colecciones..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzazione raccolte..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация коллекций..."
+          }
         }
       }
     },
@@ -18748,6 +25840,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在載入媒體庫..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando bibliotecas..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caricamento librerie..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка библиотек..."
           }
         }
       }
@@ -18795,6 +25905,24 @@
             "state" : "translated",
             "value" : "正在同步閱讀列表..."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizando listas de lectura..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzazione liste di lettura..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация списков чтения..."
+          }
         }
       }
     },
@@ -18840,6 +25968,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在同步系列..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizando series..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzazione serie..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация серий..."
           }
         }
       }
@@ -18887,6 +26033,24 @@
             "state" : "translated",
             "value" : "實例名稱（可選）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre de instancia (opcional)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome istanza (opzionale)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Имя инстанса (необязательно)"
+          }
         }
       }
     },
@@ -18933,6 +26097,24 @@
             "state" : "translated",
             "value" : "憑證無效"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credenciales invalidas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Credenziali non valide"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Неверные учетные данные"
+          }
         }
       }
     },
@@ -18975,6 +26157,24 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ISBN"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ISBN"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ISBN"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ISBN"
@@ -19025,6 +26225,24 @@
             "state" : "translated",
             "value" : "單獨顯示封面"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aislar portada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Isola pagina di copertina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изолировать обложку"
+          }
         }
       }
     },
@@ -19070,6 +26288,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "單獨顯示第 %d 頁"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aislar pagina %d"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Isola pagina %d"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изолировать страницу %d"
           }
         }
       }
@@ -19117,6 +26353,24 @@
             "state" : "translated",
             "value" : "Java 資訊"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informacion de Java"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informazioni Java"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Информация Java"
+          }
         }
       }
     },
@@ -19162,6 +26416,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "跳轉"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saltar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перейти"
           }
         }
       }
@@ -19209,6 +26481,24 @@
             "state" : "translated",
             "value" : "跳轉到頁面"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saltar a pagina"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vai alla pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перейти к странице"
+          }
         }
       }
     },
@@ -19254,6 +26544,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "JVM 環境"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JVM"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JVM"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JVM"
           }
         }
       }
@@ -19301,6 +26609,24 @@
             "state" : "translated",
             "value" : "JVM 供應商"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proveedor de JVM"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fornitore JVM"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поставщик JVM"
+          }
         }
       }
     },
@@ -19346,6 +26672,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "JVM 版本"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version de JVM"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versione JVM"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Версия JVM"
           }
         }
       }
@@ -19393,6 +26737,24 @@
             "state" : "translated",
             "value" : "鍵盤快捷鍵"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atajos de teclado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scorciatoie da tastiera"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сочетания клавиш"
+          }
         }
       }
     },
@@ -19435,6 +26797,24 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "KMReader"
@@ -19485,6 +26865,24 @@
             "state" : "translated",
             "value" : "標籤"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rótulo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etichetta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метка"
+          }
         }
       }
     },
@@ -19530,6 +26928,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "語言"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idioma"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lingua"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Язык"
           }
         }
       }
@@ -19577,6 +26993,24 @@
             "state" : "translated",
             "value" : "語言"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idiomas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lingue"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Языки"
+          }
         }
       }
     },
@@ -19622,6 +27056,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "離線檔案最大，最適合大幅縮放和大螢幕裝置。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archivos offline mas grandes. Ideal para mucho zoom y pantallas grandes."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "File offline piu grandi. Ideale per zoom intenso e schermi grandi."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Самые большие офлайн-файлы. Лучше всего для сильного увеличения и больших экранов."
           }
         }
       }
@@ -19669,6 +27121,24 @@
             "state" : "translated",
             "value" : "末本"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El último"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последняя"
+          }
         }
       }
     },
@@ -19714,6 +27184,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近6個月"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimos 6 meses"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimi 6 mesi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние 6 месяцев"
           }
         }
       }
@@ -19761,6 +27249,24 @@
             "state" : "translated",
             "value" : "最近7天"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimos 7 dias"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimi 7 giorni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние 7 дней"
+          }
         }
       }
     },
@@ -19806,6 +27312,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近30天"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimos 30 dias"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimi 30 giorni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние 30 дней"
           }
         }
       }
@@ -19853,6 +27377,24 @@
             "state" : "translated",
             "value" : "最近90天"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimos 90 dias"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimi 90 giorni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последние 90 дней"
+          }
         }
       }
     },
@@ -19898,6 +27440,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "末頁"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima pagina"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последняя страница"
           }
         }
       }
@@ -19945,6 +27505,24 @@
             "state" : "translated",
             "value" : "最後閱讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последнее чтение"
+          }
         }
       }
     },
@@ -19990,6 +27568,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次閱讀：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima lectura: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima lettura: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последнее чтение: %@"
           }
         }
       }
@@ -20037,6 +27633,24 @@
             "state" : "translated",
             "value" : "最近更新：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima actualizacion: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimo aggiornamento: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последнее обновление: %@"
+          }
         }
       }
     },
@@ -20082,6 +27696,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上次使用 %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimo uso %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimo utilizzo %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последнее использование %@"
           }
         }
       }
@@ -20129,6 +27761,24 @@
             "state" : "translated",
             "value" : "去年"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimo ano"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultimo anno"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прошлый год"
+          }
         }
       }
     },
@@ -20174,6 +27824,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "佈局"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diseño"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Layout"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вид"
           }
         }
       }
@@ -20221,6 +27889,24 @@
             "state" : "translated",
             "value" : "密碼留空以保留現有憑證。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deja la contrasena vacia para mantener las credenciales actuales."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lascia vuota la password per mantenere le credenziali esistenti."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оставьте пароль пустым, чтобы сохранить текущие учетные данные."
+          }
         }
       }
     },
@@ -20266,6 +27952,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字元間距: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espaciado entre letras: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spaziatura lettere: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Межбуквенный интервал: %@"
           }
         }
       }
@@ -20313,6 +28017,24 @@
             "state" : "translated",
             "value" : "級別"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nivel"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Livello"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Уровень"
+          }
         }
       }
     },
@@ -20358,6 +28080,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書庫"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bibliotecas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Librerie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Библиотеки"
           }
         }
       }
@@ -20405,6 +28145,24 @@
             "state" : "translated",
             "value" : "書庫"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biblioteca"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libreria"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Библиотека"
+          }
         }
       }
     },
@@ -20450,6 +28208,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "編輯"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Редактировать"
           }
         }
       }
@@ -20497,6 +28273,24 @@
             "state" : "translated",
             "value" : "上級目錄"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directorio padre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory padre"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Родительский каталог"
+          }
         }
       }
     },
@@ -20542,6 +28336,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "瀏覽目錄"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Explorar directorio"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sfoglia directory"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обзор каталога"
           }
         }
       }
@@ -20589,6 +28401,24 @@
             "state" : "translated",
             "value" : "分析尺寸"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analizar dimensiones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analizza dimensioni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Анализировать размеры"
+          }
         }
       }
     },
@@ -20634,6 +28464,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "轉換為 CBZ"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Convertir a CBZ"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Converti in CBZ"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Конвертировать в CBZ"
           }
         }
       }
@@ -20681,6 +28529,24 @@
             "state" : "translated",
             "value" : "掃描後清空回收站"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vaciar papelera tras escaneo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Svuota cestino dopo scansione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очищать корзину после сканирования"
+          }
         }
       }
     },
@@ -20726,6 +28592,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "排除項"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exclusiones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esclusioni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Исключения"
           }
         }
       }
@@ -20773,6 +28657,24 @@
             "state" : "translated",
             "value" : "計算文件哈希"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hash de archivos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hash file"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Хеш файлов"
+          }
         }
       }
     },
@@ -20818,6 +28720,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "計算 KOReader 哈希"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hash KOReader"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hash KOReader"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Хеш KOReader"
           }
         }
       }
@@ -20865,6 +28785,24 @@
             "state" : "translated",
             "value" : "計算頁面哈希"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hash de paginas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hash pagine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Хеш страниц"
+          }
         }
       }
     },
@@ -20910,6 +28848,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "導入條形碼/ISBN"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar codigo de barras/ISBN"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa codice a barre/ISBN"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импорт штрихкода/ISBN"
           }
         }
       }
@@ -20957,6 +28913,24 @@
             "state" : "translated",
             "value" : "導入 ComicInfo 圖書"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar ComicInfo de libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa ComicInfo libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импорт ComicInfo книги"
+          }
         }
       }
     },
@@ -21002,6 +28976,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "導入 ComicInfo 合集"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar ComicInfo de coleccion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa ComicInfo raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импорт ComicInfo коллекции"
           }
         }
       }
@@ -21049,6 +29041,24 @@
             "state" : "translated",
             "value" : "導入 ComicInfo 閱讀列表"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar ComicInfo de lista de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa ComicInfo lista di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импорт ComicInfo списка чтения"
+          }
         }
       }
     },
@@ -21094,6 +29104,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "導入 ComicInfo 系列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar ComicInfo de serie"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa ComicInfo serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импорт ComicInfo серии"
           }
         }
       }
@@ -21141,6 +29169,24 @@
             "state" : "translated",
             "value" : "將卷追加到系列"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anadir volumen al titulo de serie"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi volume al titolo serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавлять том к названию серии"
+          }
         }
       }
     },
@@ -21186,6 +29232,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "導入 EPUB 圖書"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar EPUB de libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa EPUB libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импорт EPUB книги"
           }
         }
       }
@@ -21233,6 +29297,24 @@
             "state" : "translated",
             "value" : "導入 EPUB 系列"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar EPUB de serie"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa EPUB serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импорт EPUB серии"
+          }
         }
       }
     },
@@ -21278,6 +29360,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "導入本地原畫"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar ilustraciones locales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa artwork locale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импорт локальных обложек"
           }
         }
       }
@@ -21325,6 +29425,24 @@
             "state" : "translated",
             "value" : "導入 Mylar 系列"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importar serie de Mylar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importa serie da Mylar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Импорт серии Mylar"
+          }
         }
       }
     },
@@ -21370,6 +29488,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "名稱"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название"
           }
         }
       }
@@ -21417,6 +29553,24 @@
             "state" : "translated",
             "value" : "新排除項"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nueva exclusion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nuova esclusione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Новое исключение"
+          }
         }
       }
     },
@@ -21462,6 +29616,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "單行本目錄"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directorio de one-shots"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Directory one-shot"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Каталог one-shot"
           }
         }
       }
@@ -21509,6 +29681,24 @@
             "state" : "translated",
             "value" : "修復擴展名"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reparar extensiones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ripara estensioni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Исправлять расширения"
+          }
         }
       }
     },
@@ -21554,6 +29744,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "根目錄"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carpeta raiz"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cartella radice"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Корневая папка"
           }
         }
       }
@@ -21601,6 +29809,24 @@
             "state" : "translated",
             "value" : "強制修改時間"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forzar fecha de modificacion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forza data modifica"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Принудительное время изменения"
+          }
         }
       }
     },
@@ -21646,6 +29872,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "掃描間隔"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervalo de escaneo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervallo scansione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Интервал сканирования"
           }
         }
       }
@@ -21693,6 +29937,24 @@
             "state" : "translated",
             "value" : "啟動時掃描"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escanear al iniciar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scansiona all'avvio"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканировать при запуске"
+          }
         }
       }
     },
@@ -21738,6 +30000,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系列封面"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Portada de serie"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copertina serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обложка серии"
           }
         }
       }
@@ -21785,6 +30065,24 @@
             "state" : "translated",
             "value" : "常規"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Общее"
+          }
         }
       }
     },
@@ -21830,6 +30128,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "元數據"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metadatos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metadati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метаданные"
           }
         }
       }
@@ -21877,6 +30193,24 @@
             "state" : "translated",
             "value" : "選項"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opciones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opzioni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Опции"
+          }
         }
       }
     },
@@ -21922,6 +30256,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "掃描器"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escáner"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scanner"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканер"
           }
         }
       }
@@ -21969,6 +30321,24 @@
             "state" : "translated",
             "value" : "分析"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Análisis"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analisi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Анализ"
+          }
         }
       }
     },
@@ -22011,6 +30381,24 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ComicInfo"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ComicInfo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ComicInfo"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ComicInfo"
@@ -22061,6 +30449,24 @@
             "state" : "translated",
             "value" : "EPUB"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB"
+          }
         }
       }
     },
@@ -22106,6 +30512,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文件管理"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestion de archivos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestione file"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управление файлами"
           }
         }
       }
@@ -22153,6 +30577,24 @@
             "state" : "translated",
             "value" : "其他"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Другое"
+          }
         }
       }
     },
@@ -22198,6 +30640,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "常規"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Общее"
           }
         }
       }
@@ -22245,6 +30705,24 @@
             "state" : "translated",
             "value" : "元數據"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metadatos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metadati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метаданные"
+          }
         }
       }
     },
@@ -22290,6 +30768,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選項"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opciones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opzioni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Опции"
           }
         }
       }
@@ -22337,6 +30833,24 @@
             "state" : "translated",
             "value" : "掃描器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escáner"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scanner"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканер"
+          }
         }
       }
     },
@@ -22382,6 +30896,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "添加庫"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agregar biblioteca"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi Libreria"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить библиотеку"
           }
         }
       }
@@ -22429,6 +30961,24 @@
             "state" : "translated",
             "value" : "編輯庫"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar biblioteca"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifica Libreria"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Редактировать библиотеку"
+          }
         }
       }
     },
@@ -22474,6 +31024,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 本書"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld libros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld libri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld книг"
           }
         }
       }
@@ -22521,6 +31089,24 @@
             "state" : "translated",
             "value" : "%lld 個收藏"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld colecciones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld raccolte"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld коллекций"
+          }
         }
       }
     },
@@ -22566,6 +31152,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 個閱讀列表"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld listas de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld liste di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld списков чтения"
           }
         }
       }
@@ -22613,6 +31217,24 @@
             "state" : "translated",
             "value" : "%lld 個系列"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld series"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld серий"
+          }
         }
       }
     },
@@ -22658,6 +31280,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld 個附加檔案"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld sidecars"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld sidecar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld sidecar"
           }
         }
       }
@@ -22705,6 +31345,24 @@
             "state" : "translated",
             "value" : "庫分析已開始"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analisis de biblioteca iniciado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analisi libreria avviata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Анализ библиотеки запущен"
+          }
         }
       }
     },
@@ -22750,6 +31408,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "庫中繼資料刷新已開始"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizacion de metadatos de biblioteca iniciada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiornamento metadati libreria avviato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновление метаданных библиотеки запущено"
           }
         }
       }
@@ -22797,6 +31473,24 @@
             "state" : "translated",
             "value" : "所有庫深度掃描已開始"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escaneo profundo de todas las bibliotecas iniciado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scansione profonda di tutte le librerie avviata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Глубокое сканирование всех библиотек запущено"
+          }
         }
       }
     },
@@ -22842,6 +31536,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "所有庫掃描已開始"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escaneo de todas las bibliotecas iniciado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scansione di tutte le librerie avviata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканирование всех библиотек запущено"
           }
         }
       }
@@ -22889,6 +31601,24 @@
             "state" : "translated",
             "value" : "庫深度掃描已開始"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escaneo profundo de biblioteca iniciado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scansione profonda libreria avviata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Глубокое сканирование библиотеки запущено"
+          }
         }
       }
     },
@@ -22934,6 +31664,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "庫掃描已開始"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escaneo de biblioteca iniciado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scansione libreria avviata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканирование библиотеки запущено"
           }
         }
       }
@@ -22981,6 +31729,24 @@
             "state" : "translated",
             "value" : "已清空所有庫的回收桶"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Papelera vaciada en todas las bibliotecas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cestino svuotato per tutte le librerie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Корзина очищена для всех библиотек"
+          }
         }
       }
     },
@@ -23026,6 +31792,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "回收桶已清空"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Papelera vaciada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cestino svuotato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Корзина очищена"
           }
         }
       }
@@ -23073,6 +31857,24 @@
             "state" : "translated",
             "value" : "條數"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limite"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limite"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Лимит"
+          }
         }
       }
     },
@@ -23118,6 +31920,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "行與段落"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linea y parrafo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linea e paragrafo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Строка и абзац"
           }
         }
       }
@@ -23165,6 +31985,24 @@
             "state" : "translated",
             "value" : "行高: %@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altura de linea: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altezza riga: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Высота строки: %@"
+          }
         }
       }
     },
@@ -23210,6 +32048,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "鏈結"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enlaces"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Links"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ссылки"
           }
         }
       }
@@ -23257,6 +32113,24 @@
             "state" : "translated",
             "value" : "實況文本"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Text"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Text"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Text"
+          }
         }
       }
     },
@@ -23302,6 +32176,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "實況文本：關閉"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Text: OFF"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Text: OFF"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Text: OFF"
           }
         }
       }
@@ -23349,6 +32241,24 @@
             "state" : "translated",
             "value" : "實況文本：開啟"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Text: ON"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Text: ON"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Text: ON"
+          }
         }
       }
     },
@@ -23394,6 +32304,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "載入預設"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargar preset"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carica preset"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузить пресет"
           }
         }
       }
@@ -23441,6 +32369,24 @@
             "state" : "translated",
             "value" : "載入中"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caricamento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка"
+          }
         }
       }
     },
@@ -23486,6 +32432,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在加載圖書..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando libro..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caricamento libro..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка книги..."
           }
         }
       }
@@ -23533,6 +32497,24 @@
             "state" : "translated",
             "value" : "正在載入圖書館…"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando bibliotecas..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caricamento librerie..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка библиотек..."
+          }
         }
       }
     },
@@ -23578,6 +32560,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在加載..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cargando..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caricamento..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка..."
           }
         }
       }
@@ -23625,6 +32625,24 @@
             "state" : "translated",
             "value" : "本地資料尚未同步。請先執行離線同步以產生閱讀統計。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los datos locales aun no se han sincronizado. Ejecuta primero la sincronizacion offline para generar estadisticas de lectura."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I dati locali non sono ancora sincronizzati. Esegui prima la sincronizzazione offline per generare le statistiche di lettura."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Локальные данные еще не синхронизированы. Сначала выполните офлайн-синхронизацию, чтобы получить статистику чтения."
+          }
         }
       }
     },
@@ -23670,6 +32688,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登入成功"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesion iniciada correctamente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accesso eseguito con successo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вход выполнен успешно"
           }
         }
       }
@@ -23717,6 +32753,24 @@
             "state" : "translated",
             "value" : "邏輯"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Logica"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Logica"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Логика"
+          }
         }
       }
     },
@@ -23762,6 +32816,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登入"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar sesion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accedi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Войти"
           }
         }
       }
@@ -23809,6 +32881,24 @@
             "state" : "translated",
             "value" : "登出"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar sesion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnetti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выйти"
+          }
         }
       }
     },
@@ -23854,6 +32944,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "日誌"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Registros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Log"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Логи"
           }
         }
       }
@@ -23901,6 +33009,24 @@
             "state" : "translated",
             "value" : "離線保存"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hacer offline"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendi offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сделать офлайн"
+          }
         }
       }
     },
@@ -23946,6 +33072,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "管理"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestionar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestisci"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управлять"
           }
         }
       }
@@ -23993,6 +33137,24 @@
             "state" : "translated",
             "value" : "管理自訂字體"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestionar fuentes personalizadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestisci font personalizzati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управление пользовательскими шрифтами"
+          }
         }
       }
     },
@@ -24038,6 +33200,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "管理訂閱"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestionar suscripcion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestisci abbonamento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управление подпиской"
           }
         }
       }
@@ -24085,6 +33265,24 @@
             "state" : "translated",
             "value" : "管理"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управление"
+          }
         }
       }
     },
@@ -24130,6 +33328,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "手動輸入"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrada manual"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inserimento manuale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ручной ввод"
           }
         }
       }
@@ -24177,6 +33393,24 @@
             "state" : "translated",
             "value" : "標為已讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marcar como leido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Segna come letto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отметить как прочитанное"
+          }
         }
       }
     },
@@ -24222,6 +33456,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "標為未讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marcar como no leido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Segna come non letto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отметить как непрочитанное"
           }
         }
       }
@@ -24269,6 +33521,24 @@
             "state" : "translated",
             "value" : "最大大小"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamano maximo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dimensione massima"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Максимальный размер"
+          }
         }
       }
     },
@@ -24314,6 +33584,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最大容量 (GB)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamano maximo (GB)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dimensione massima (GB)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Максимальный размер (ГБ)"
           }
         }
       }
@@ -24361,6 +33649,24 @@
             "state" : "translated",
             "value" : "最大容量 (MB)"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamano maximo (MB)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dimensione massima (MB)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Максимальный размер (МБ)"
+          }
         }
       }
     },
@@ -24406,6 +33712,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "MB"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MB"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MB"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "МБ"
           }
         }
       }
@@ -24453,6 +33777,24 @@
             "state" : "translated",
             "value" : "不支持的媒體格式"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El formato multimedia no es compatible"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il formato del media non e supportato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Формат медиа не поддерживается"
+          }
         }
       }
     },
@@ -24498,6 +33840,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "媒體資訊"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informacion multimedia"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informazioni media"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Информация о медиа"
           }
         }
       }
@@ -24545,6 +33905,24 @@
             "state" : "translated",
             "value" : "媒體已過期"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El contenido esta desactualizado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il media e obsoleto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Медиа устарело"
+          }
         }
       }
     },
@@ -24590,6 +33968,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "媒體狀態未知"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El estado del contenido es desconocido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lo stato del media e sconosciuto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статус медиа неизвестен"
           }
         }
       }
@@ -24637,6 +34033,24 @@
             "state" : "translated",
             "value" : "元數據"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metadatos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metadati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метаданные"
+          }
         }
       }
     },
@@ -24682,6 +34096,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "修改: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modificado: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modificato: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изменено: %@"
           }
         }
       }
@@ -24729,6 +34161,24 @@
             "state" : "translated",
             "value" : "名稱"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название"
+          }
         }
       }
     },
@@ -24774,6 +34224,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "原生 PDF 閱讀器使用系統 PDF 引擎，更適合以文字為主的 PDF 書籍。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El lector PDF nativo usa el motor PDF del sistema y funciona mejor con libros PDF de mucho texto."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il lettore PDF nativo usa il motore PDF di sistema e funziona al meglio con libri PDF ricchi di testo."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нативный PDF-ридер использует системный PDF-движок и лучше всего подходит для PDF-книг с большим количеством текста."
           }
         }
       }
@@ -24821,6 +34289,24 @@
             "state" : "translated",
             "value" : "網路"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Red"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rete"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сеть"
+          }
         }
       }
     },
@@ -24866,6 +34352,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "網路錯誤 - 請檢查伺服器網址"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error de red: revisa la URL del servidor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Errore di rete: controlla l'URL del server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ошибка сети: проверьте URL сервера"
           }
         }
       }
@@ -24913,6 +34417,24 @@
             "state" : "translated",
             "value" : "產生新的 API 金鑰"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generar nueva clave API"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genera nuova chiave API"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создать новый API-ключ"
+          }
         }
       }
     },
@@ -24958,6 +34480,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無活動紀錄"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontro actividad"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna attivita trovata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Активность не найдена"
           }
         }
       }
@@ -25005,6 +34545,24 @@
             "state" : "translated",
             "value" : "尚未產生 API 金鑰"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no se han creado claves API"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna Chiave API creata ancora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ни одного ключа API еще не создано"
+          }
         }
       }
     },
@@ -25050,6 +34608,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無可用作者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay autores disponibles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun autore disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет доступных авторов"
           }
         }
       }
@@ -25097,6 +34673,24 @@
             "state" : "translated",
             "value" : "目前沒有加入離线閱讀隊列的圖書。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualmente no hay libros en cola para lectura offline."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Al momento non ci sono libri in coda per la lettura offline."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сейчас нет книг в очереди для офлайн-чтения."
+          }
         }
       }
     },
@@ -25142,6 +34736,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到書"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron libros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun libro trovato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книги не найдены"
           }
         }
       }
@@ -25189,6 +34801,24 @@
             "state" : "translated",
             "value" : "未找到收藏"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron colecciones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna raccolta trovata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коллекции не найдены"
+          }
         }
       }
     },
@@ -25234,6 +34864,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無可用內容。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay contenido disponible."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun contenuto disponibile."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Контент недоступен."
           }
         }
       }
@@ -25281,6 +34929,24 @@
             "state" : "translated",
             "value" : "無資料"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin datos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun dato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет данных"
+          }
         }
       }
     },
@@ -25326,6 +34992,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暫無詳細資訊"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay detalles disponibles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun dettaglio disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет доступных подробностей"
           }
         }
       }
@@ -25373,6 +35057,24 @@
             "state" : "translated",
             "value" : "沒有下載任務"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin tareas de descarga"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna attivita di download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет задач загрузки"
+          }
         }
       }
     },
@@ -25418,6 +35120,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無可用風格"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay generos disponibles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun genere disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет доступных жанров"
           }
         }
       }
@@ -25465,6 +35185,24 @@
             "state" : "translated",
             "value" : "未找到歷史記錄"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontro historial"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna cronologia trovata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "История не найдена"
+          }
         }
       }
     },
@@ -25510,6 +35248,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無可用語言"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay idiomas disponibles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna lingua disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет доступных языков"
           }
         }
       }
@@ -25557,6 +35313,24 @@
             "state" : "translated",
             "value" : "未找到圖書館"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron bibliotecas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna libreria trovata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Библиотеки не найдены"
+          }
         }
       }
     },
@@ -25602,6 +35376,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到相符項目"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron coincidencias"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna corrispondenza trovata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Совпадения не найдены"
           }
         }
       }
@@ -25649,6 +35441,24 @@
             "state" : "translated",
             "value" : "無可用頁面"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay paginas disponibles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna pagina disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет доступных страниц"
+          }
         }
       }
     },
@@ -25694,6 +35504,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "沒有可用頁面。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay paginas disponibles."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna pagina disponibile."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет доступных страниц."
           }
         }
       }
@@ -25741,6 +35569,24 @@
             "state" : "translated",
             "value" : "無可用出版商"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay editoriales disponibles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun editore disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет доступных издателей"
+          }
         }
       }
     },
@@ -25786,6 +35632,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未找到閱讀列表"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron listas de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna lista di lettura trovata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Списки чтения не найдены"
           }
         }
       }
@@ -25833,6 +35697,24 @@
             "state" : "translated",
             "value" : "暫無閱讀統計資料"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay estadisticas de lectura disponibles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna statistica di lettura disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статистика чтения недоступна"
+          }
         }
       }
     },
@@ -25878,6 +35760,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "近期無活動"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin actividad reciente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna attività recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не обнаружено недавней активности"
           }
         }
       }
@@ -25925,6 +35825,24 @@
             "state" : "translated",
             "value" : "無記錄"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin registros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun record"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет записей"
+          }
         }
       }
     },
@@ -25970,6 +35888,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "沒有已儲存的篩選器"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin filtros guardados"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun filtro salvato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет сохраненных фильтров"
           }
         }
       }
@@ -26017,6 +35953,24 @@
             "state" : "translated",
             "value" : "未找到系列"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron series"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna serie trovata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серии не найдены"
+          }
         }
       }
     },
@@ -26062,6 +36016,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暫無伺服器資訊"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay informacion del servidor disponible"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna informazione server disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Информация о сервере недоступна"
           }
         }
       }
@@ -26109,6 +36081,24 @@
             "state" : "translated",
             "value" : "還沒有新增伺服器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aun no se han agregado servidores"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun server aggiunto finora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серверы еще не добавлены"
+          }
         }
       }
     },
@@ -26154,6 +36144,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無可用標籤"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay etiquetas disponibles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun tag disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет доступных тегов"
           }
         }
       }
@@ -26201,6 +36209,24 @@
             "state" : "translated",
             "value" : "無主題預設"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin presets de tema"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun preset tema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет пресетов темы"
+          }
         }
       }
     },
@@ -26246,6 +36272,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ninguno"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuno"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет"
           }
         }
       }
@@ -26293,6 +36337,24 @@
             "state" : "translated",
             "value" : "API 金鑰已刪除"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clave API eliminada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiave API eliminata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-ключ удален"
+          }
         }
       }
     },
@@ -26338,6 +36400,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已登出"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesion cerrada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disconnesso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выход выполнен"
           }
         }
       }
@@ -26385,6 +36465,24 @@
             "state" : "translated",
             "value" : "自動切換到離線模式"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambio automatico a modo sin conexion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passaggio automatico alla modalita offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматическое переключение в офлайн-режим"
+          }
         }
       }
     },
@@ -26430,6 +36528,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已開始分析書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analisis de libro iniciado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analisi libro avviata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Анализ книги запущен"
           }
         }
       }
@@ -26477,6 +36593,24 @@
             "state" : "translated",
             "value" : "已加入書單"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libros anadidos a la lista de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libri aggiunti alla lista di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книги добавлены в список чтения"
+          }
         }
       }
     },
@@ -26522,6 +36656,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已清除書籍快取"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache del libro limpiada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache libro cancellata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кэш книги очищен"
           }
         }
       }
@@ -26569,6 +36721,24 @@
             "state" : "translated",
             "value" : "封面已刷新"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Portada actualizada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copertina aggiornata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обложка обновлена"
+          }
         }
       }
     },
@@ -26614,6 +36784,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已刪除書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libro eliminado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libro eliminato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книга удалена"
           }
         }
       }
@@ -26661,6 +36849,24 @@
             "state" : "translated",
             "value" : "下載已取消"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descarga cancelada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download annullato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка отменена"
+          }
         }
       }
     },
@@ -26706,6 +36912,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下載已加入佇列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descarga en cola"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download in coda"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка поставлена в очередь"
           }
         }
       }
@@ -26753,6 +36977,24 @@
             "state" : "translated",
             "value" : "已標記為已讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marcado como leido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Segnato come letto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмечено как прочитанное"
+          }
         }
       }
     },
@@ -26798,6 +37040,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已標記為未讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marcado como no leido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Segnato come non letto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмечено как непрочитанное"
           }
         }
       }
@@ -26845,6 +37105,24 @@
             "state" : "translated",
             "value" : "已重新整理書籍中繼資料"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metadatos del libro actualizados"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metadati libro aggiornati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метаданные книги обновлены"
+          }
         }
       }
     },
@@ -26890,6 +37168,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已移除離線副本"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copia offline eliminada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copia offline rimossa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн-копия удалена"
           }
         }
       }
@@ -26937,6 +37233,24 @@
             "state" : "translated",
             "value" : "已更新書籍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libro actualizado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libro aggiornato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книга обновлена"
+          }
         }
       }
     },
@@ -26982,6 +37296,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已清除封面快取（所有伺服器）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache de portadas limpiada (todos los servidores)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache copertine cancellata (tutti i server)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кэш обложек очищен (все серверы)"
           }
         }
       }
@@ -27029,6 +37361,24 @@
             "state" : "translated",
             "value" : "已清除封面快取（目前伺服器）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache de portadas limpiada (servidor actual)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache copertine cancellata (server corrente)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кэш обложек очищен (текущий сервер)"
+          }
         }
       }
     },
@@ -27074,6 +37424,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已清除頁面快取（所有伺服器）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache de paginas limpiada (todos los servidores)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache pagine cancellata (tutti i server)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кэш страниц очищен (все серверы)"
           }
         }
       }
@@ -27121,6 +37489,24 @@
             "state" : "translated",
             "value" : "已清除頁面快取（目前伺服器）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache de paginas limpiada (servidor actual)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache pagine cancellata (server corrente)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кэш страниц очищен (текущий сервер)"
+          }
         }
       }
     },
@@ -27166,6 +37552,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "封面已刷新"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Portada actualizada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copertina aggiornata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обложка обновлена"
           }
         }
       }
@@ -27213,6 +37617,24 @@
             "state" : "translated",
             "value" : "合輯已建立"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coleccion creada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raccolta creata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коллекция создана"
+          }
         }
       }
     },
@@ -27258,6 +37680,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "合輯已刪除"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coleccion eliminada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raccolta eliminata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коллекция удалена"
           }
         }
       }
@@ -27305,6 +37745,24 @@
             "state" : "translated",
             "value" : "合輯已更新"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coleccion actualizada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raccolta aggiornata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коллекция обновлена"
+          }
         }
       }
     },
@@ -27350,6 +37808,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已複製"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copiato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скопировано"
           }
         }
       }
@@ -27397,6 +37873,24 @@
             "state" : "translated",
             "value" : "封面已重新整理"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Portada actualizada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copertina aggiornata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обложка обновлена"
+          }
         }
       }
     },
@@ -27442,6 +37936,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "封面重新整理失敗"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo actualizar la portada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile aggiornare la copertina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось обновить обложку"
           }
         }
       }
@@ -27489,6 +38001,24 @@
             "state" : "translated",
             "value" : "已清理本地項目"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entradas locales limpiadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elementi locali cancellati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Локальные записи очищены"
+          }
         }
       }
     },
@@ -27534,6 +38064,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "沒有可清理的本地項目"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay entradas locales para limpiar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun elemento locale da cancellare"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет локальных записей для очистки"
           }
         }
       }
@@ -27581,6 +38129,24 @@
             "state" : "translated",
             "value" : "庫已創建"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biblioteca creada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libreria creata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Библиотека создана"
+          }
         }
       }
     },
@@ -27626,6 +38192,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已刪除書庫"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biblioteca eliminada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libreria eliminata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Библиотека удалена"
           }
         }
       }
@@ -27673,6 +38257,24 @@
             "state" : "translated",
             "value" : "庫已更新"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Biblioteca actualizada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libreria aggiornata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Библиотека обновлена"
+          }
         }
       }
     },
@@ -27718,6 +38320,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已啟用已讀下載自動刪除"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autoeliminacion de leidos activada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-eliminazione letti abilitata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоудаление прочитанного включено"
           }
         }
       }
@@ -27765,6 +38385,24 @@
             "state" : "translated",
             "value" : "已移除所有離線書籍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos los libros offline eliminados"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutti i libri offline rimossi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все офлайн-книги удалены"
+          }
         }
       }
     },
@@ -27810,6 +38448,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已移除已讀離線書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libros offline leidos eliminados"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libri offline letti rimossi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прочитанные офлайн-книги удалены"
           }
         }
       }
@@ -27857,6 +38513,24 @@
             "state" : "translated",
             "value" : "失敗的下載已取消"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargas fallidas canceladas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download non riusciti annullati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Неудачные загрузки отменены"
+          }
         }
       }
     },
@@ -27902,6 +38576,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀歷史同步完成"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizacion del historial de lectura completada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzazione cronologia lettura completata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация истории чтения завершена"
           }
         }
       }
@@ -27949,6 +38641,24 @@
             "state" : "translated",
             "value" : "正在重試失敗的下載"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reintentando descargas fallidas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ritento download non riusciti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повтор неудачных загрузок"
+          }
         }
       }
     },
@@ -27994,6 +38704,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "離線資料同步完成"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizacion de datos offline completada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzazione dati offline completata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация офлайн-данных завершена"
           }
         }
       }
@@ -28041,6 +38769,24 @@
             "state" : "translated",
             "value" : "離線同步已完成，但存在部分錯誤"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizacion offline completada con algunos errores"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzazione offline completata con alcuni errori"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн-синхронизация завершена с ошибками"
+          }
         }
       }
     },
@@ -28086,6 +38832,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "離線背景任務已完成"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tareas en segundo plano offline completadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attivita offline in background completate"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фоновые офлайн-задачи завершены"
           }
         }
       }
@@ -28133,6 +38897,24 @@
             "state" : "translated",
             "value" : "閱讀進度已同步"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso de lectura sincronizado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progresso lettura sincronizzato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прогресс чтения синхронизирован"
+          }
         }
       }
     },
@@ -28178,6 +38960,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀進度同步失敗"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo sincronizar el progreso de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile sincronizzare il progresso di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось синхронизировать прогресс чтения"
           }
         }
       }
@@ -28225,6 +39025,24 @@
             "state" : "translated",
             "value" : "圖片已儲存到照片"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imagen guardada en Fotos correctamente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Immagine salvata in Foto con successo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изображение успешно сохранено в Фото"
+          }
         }
       }
     },
@@ -28270,6 +39088,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已從書單移除書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libros eliminados de la lista de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libri rimossi dalla lista di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книги удалены из списка чтения"
           }
         }
       }
@@ -28317,6 +39153,24 @@
             "state" : "translated",
             "value" : "封面已刷新"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Portada actualizada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copertina aggiornata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обложка обновлена"
+          }
         }
       }
     },
@@ -28362,6 +39216,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書單已建立"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lista de lectura creada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lista di lettura creata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Список чтения создан"
           }
         }
       }
@@ -28409,6 +39281,24 @@
             "state" : "translated",
             "value" : "書單已刪除"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lista de lectura eliminada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lista di lettura eliminata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Список чтения удален"
+          }
         }
       }
     },
@@ -28454,6 +39344,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書單下載已加入佇列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descarga de lista de lectura en cola"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download lista di lettura in coda"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка списка чтения поставлена в очередь"
           }
         }
       }
@@ -28501,6 +39409,24 @@
             "state" : "translated",
             "value" : "書單離線已移除"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo offline de lista de lectura eliminado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline lista di lettura rimosso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн списка чтения удален"
+          }
         }
       }
     },
@@ -28546,6 +39472,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書單已更新"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lista de lectura actualizada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lista di lettura aggiornata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Список чтения обновлен"
           }
         }
       }
@@ -28593,6 +39537,24 @@
             "state" : "translated",
             "value" : "刷新完成"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizacion completada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiornamento completato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновление завершено"
+          }
         }
       }
     },
@@ -28638,6 +39600,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在刷新..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizando..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiornamento..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновление..."
           }
         }
       }
@@ -28685,6 +39665,24 @@
             "state" : "translated",
             "value" : "系列已新增到合輯"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie anadida a la coleccion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie aggiunta alla raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серия добавлена в коллекцию"
+          }
         }
       }
     },
@@ -28730,6 +39728,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已開始分析系列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analisis de serie iniciado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analisi serie avviata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Анализ серии запущен"
           }
         }
       }
@@ -28777,6 +39793,24 @@
             "state" : "translated",
             "value" : "封面已刷新"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Portada actualizada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copertina aggiornata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обложка обновлена"
+          }
         }
       }
     },
@@ -28822,6 +39856,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系列已刪除"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie eliminada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie eliminata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серия удалена"
           }
         }
       }
@@ -28869,6 +39921,24 @@
             "state" : "translated",
             "value" : "系列已標記為已讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie marcada como leida"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie segnata come letta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серия отмечена как прочитанная"
+          }
         }
       }
     },
@@ -28914,6 +39984,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系列已標記為未讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie marcada como no leida"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie segnata come non letta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серия отмечена как непрочитанная"
           }
         }
       }
@@ -28961,6 +40049,24 @@
             "state" : "translated",
             "value" : "已重新整理系列中繼資料"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metadatos de serie actualizados"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Metadati serie aggiornati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метаданные серии обновлены"
+          }
         }
       }
     },
@@ -29006,6 +40112,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系列下載已加入佇列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descarga de serie en cola"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download serie in coda"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка серии поставлена в очередь"
           }
         }
       }
@@ -29053,6 +40177,24 @@
             "state" : "translated",
             "value" : "系列離線內容已移除"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo offline de serie eliminado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline serie rimosso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн серии удален"
+          }
         }
       }
     },
@@ -29098,6 +40240,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系列已從合輯移除"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie eliminada de la coleccion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie rimossa dalla raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серия удалена из коллекции"
           }
         }
       }
@@ -29145,6 +40305,24 @@
             "state" : "translated",
             "value" : "系列已更新"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie actualizada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie aggiornata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серия обновлена"
+          }
         }
       }
     },
@@ -29190,6 +40368,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "伺服器已刪除"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servidor eliminado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server eliminato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сервер удален"
           }
         }
       }
@@ -29237,6 +40433,24 @@
             "state" : "translated",
             "value" : "無法編碼憑證。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron codificar las credenciales."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile codificare le credenziali."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось закодировать учетные данные."
+          }
         }
       }
     },
@@ -29282,6 +40496,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "即時更新已連接"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizaciones en tiempo real conectadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiornamenti in tempo reale connessi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновления в реальном времени подключены"
           }
         }
       }
@@ -29329,6 +40561,24 @@
             "state" : "translated",
             "value" : "即時更新已斷開"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizaciones en tiempo real desconectadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiornamenti in tempo reale disconnessi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновления в реальном времени отключены"
+          }
         }
       }
     },
@@ -29374,6 +40624,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "伺服器任務已全部完成"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todas las tareas del servidor finalizadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutte le attivita server terminate"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все задачи сервера завершены"
           }
         }
       }
@@ -29421,6 +40689,24 @@
             "state" : "translated",
             "value" : "所有任務已取消"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todas las tareas canceladas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutte le attivita annullate"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все задачи отменены"
+          }
         }
       }
     },
@@ -29466,6 +40752,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "通知"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notificaciones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifiche"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Уведомления"
           }
         }
       }
@@ -29513,6 +40817,24 @@
             "state" : "translated",
             "value" : "編號"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numero"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numero"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Номер"
+          }
         }
       }
     },
@@ -29558,6 +40880,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "排序序號"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orden por numero"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordinamento numero"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сортировка по номеру"
           }
         }
       }
@@ -29605,6 +40945,24 @@
             "state" : "translated",
             "value" : "離線"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin conexion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн"
+          }
         }
       }
     },
@@ -29650,6 +41008,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "離線 DIVINA 渲染"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renderizado DIVINA offline"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendering DIVINA offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн-рендеринг DIVINA"
           }
         }
       }
@@ -29697,6 +41073,24 @@
             "state" : "translated",
             "value" : "離線 PDF 檔案遺失，請重新下載。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falta el archivo PDF offline. Intenta descargarlo de nuevo."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manca il file PDF offline. Prova a scaricarlo di nuovo."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн PDF-файл отсутствует. Попробуйте скачать снова."
+          }
         }
       }
     },
@@ -29742,6 +41136,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "離線策略"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Politica offline"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criterio offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн-политика"
           }
         }
       }
@@ -29789,6 +41201,24 @@
             "state" : "translated",
             "value" : "瀏覽已下載書籍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Explorar libros descargados"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sfoglia i libri scaricati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Просмотр загруженных книг"
+          }
         }
       }
     },
@@ -29834,6 +41264,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "管理下載佇列與狀態"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestionar cola y estado de descargas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestisci coda e stato download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Управление очередью и статусом загрузок"
           }
         }
       }
@@ -29881,6 +41329,24 @@
             "state" : "translated",
             "value" : "立即同步"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizar ahora"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizza ora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизировать сейчас"
+          }
         }
       }
     },
@@ -29926,6 +41392,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "強制完整同步"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forzar sincronizacion completa"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forza sincronizzazione completa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Принудительная полная синхронизация"
           }
         }
       }
@@ -29973,6 +41457,24 @@
             "state" : "translated",
             "value" : "將刷新用於離線瀏覽的資料庫、系列和書籍資料。大型資料庫同步可能需要較長時間。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto actualizara bibliotecas, series y libros para navegacion offline. Las bibliotecas grandes pueden tardar mas en sincronizarse."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo aggiornera librerie, serie e libri per la navigazione offline. Le librerie grandi potrebbero richiedere piu tempo per sincronizzarsi."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это обновит библиотеки, серии и книги для офлайн-просмотра. Большим библиотекам может потребоваться больше времени на синхронизацию."
+          }
         }
       }
     },
@@ -30018,6 +41520,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "同步閱讀歷史"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizar historial de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizza cronologia lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизировать историю чтения"
           }
         }
       }
@@ -30065,6 +41585,24 @@
             "state" : "translated",
             "value" : "同步離線資料？"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizar datos offline?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzare i dati offline?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизировать офлайн-данные?"
+          }
         }
       }
     },
@@ -30110,6 +41648,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近閱讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Последнее чтение"
           }
         }
       }
@@ -30157,6 +41713,24 @@
             "state" : "translated",
             "value" : "確定"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
         }
       }
     },
@@ -30202,6 +41776,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "單行本"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "One-shot"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "One-shot"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "One-shot"
           }
         }
       }
@@ -30249,6 +41841,24 @@
             "state" : "translated",
             "value" : "编作者"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autores"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autori"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Авторы"
+          }
         }
       }
     },
@@ -30294,6 +41904,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "常规"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Общее"
           }
         }
       }
@@ -30341,6 +41969,24 @@
             "state" : "translated",
             "value" : "链接"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enlaces"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Links"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ссылки"
+          }
         }
       }
     },
@@ -30386,6 +42032,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "共享"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Condivisione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Доступ"
           }
         }
       }
@@ -30433,6 +42097,24 @@
             "state" : "translated",
             "value" : "标签"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etiquetas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etichette"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Теги"
+          }
         }
       }
     },
@@ -30478,6 +42160,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "連載中"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En curso"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In corso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выпускается"
           }
         }
       }
@@ -30525,6 +42225,24 @@
             "state" : "translated",
             "value" : "只有選取的資料庫會被索引。變更會影響後續索引與切換實例時的重新索引。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo se indexaran las bibliotecas seleccionadas. Los cambios afectaran la indexacion futura y la reindexacion al cambiar de instancia."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verranno indicizzate solo le librerie selezionate. Le modifiche influenzeranno l'indicizzazione futura e la reindicizzazione al cambio istanza."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Будут индексироваться только выбранные библиотеки. Изменения повлияют на будущую индексацию и переиндексацию при смене инстанса."
+          }
         }
       }
     },
@@ -30570,6 +42288,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "作業系統"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema operativo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema operativo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Операционная система"
           }
         }
       }
@@ -30617,6 +42353,24 @@
             "state" : "translated",
             "value" : "選擇單頁、自動跨頁或強制雙頁（僅橫向）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige pagina unica, dobles paginas detectadas automaticamente o doble pagina forzada (solo horizontal)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scegli pagina singola, doppie pagine rilevate automaticamente o doppia pagina forzata (solo orizzontale)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите одиночную страницу, автопределяемые развороты или принудительный двойной режим (только альбомный)"
+          }
         }
       }
     },
@@ -30662,6 +42416,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "有序"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordenado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordinato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Упорядочено"
           }
         }
       }
@@ -30709,6 +42481,24 @@
             "state" : "translated",
             "value" : "其他"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Другое"
+          }
         }
       }
     },
@@ -30755,6 +42545,24 @@
             "state" : "translated",
             "value" : "過期"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactualizado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obsoleto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Устарело"
+          }
         }
       }
     },
@@ -30800,6 +42608,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "頁"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Página"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Страница"
           }
         }
       }
@@ -30848,6 +42674,24 @@
             "state" : "translated",
             "value" : "第 %d 頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina %d"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina %d"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Страница %d"
+          }
         }
       }
     },
@@ -30895,6 +42739,24 @@
             "state" : "translated",
             "value" : "第 %lld 頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Страница %lld"
+          }
         }
       }
     },
@@ -30940,6 +42802,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "讀到 %1$lld / %2$lld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina %1$lld / %2$lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina %1$lld / %2$lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Страница %1$lld / %2$lld"
           }
         }
       }
@@ -30987,6 +42867,24 @@
             "state" : "translated",
             "value" : "頁面版面"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diseno de pagina"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Layout pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Макет страницы"
+          }
         }
       }
     },
@@ -31032,6 +42930,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "頁面邊距: %@x"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Margenes de pagina: %@x"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Margini pagina: %@x"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поля страницы: %@x"
           }
         }
       }
@@ -31079,6 +42995,24 @@
             "state" : "translated",
             "value" : "頁面導航"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navegacion de pagina"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navigazione pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Навигация по страницам"
+          }
         }
       }
     },
@@ -31124,6 +43058,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "翻頁風格"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estilo de transicion de pagina"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stile transizione pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Стиль перехода страниц"
           }
         }
       }
@@ -31171,6 +43123,24 @@
             "state" : "translated",
             "value" : "翻頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paso de pagina"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambio pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перелистывание"
+          }
         }
       }
     },
@@ -31216,6 +43186,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已讀頁數"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paginas leidas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagine lette"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прочитанные страницы"
           }
         }
       }
@@ -31263,6 +43251,24 @@
             "state" : "translated",
             "value" : "正在對章節進行分頁..."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paginando capitulos..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paginazione capitoli..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пагинация глав..."
+          }
         }
       }
     },
@@ -31308,6 +43314,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "段落縮排: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sangria de parrafo: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rientro paragrafo: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отступ абзаца: %@"
           }
         }
       }
@@ -31355,6 +43379,24 @@
             "state" : "translated",
             "value" : "段落間距: %@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espaciado de parrafo: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spaziatura paragrafo: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Интервал абзаца: %@"
+          }
         }
       }
     },
@@ -31400,6 +43442,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密碼"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contraseña"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Password"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пароль"
           }
         }
       }
@@ -31447,6 +43507,24 @@
             "state" : "translated",
             "value" : "密碼不符"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las contrasenas no coinciden"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le password non corrispondono"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пароли не совпадают"
+          }
         }
       }
     },
@@ -31493,6 +43571,24 @@
             "state" : "translated",
             "value" : "已暫停"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pausado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In pausa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Приостановлено"
+          }
         }
       }
     },
@@ -31535,6 +43631,24 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "PDF"
@@ -31585,6 +43699,24 @@
             "state" : "translated",
             "value" : "PDF 書籍會使用 DIVINA Reader 開啟，推薦用於 PDF 漫畫，尤其適合將離線下載頁面渲染為圖片的場景。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los libros PDF se abren con el lector DIVINA. Recomendado para PDF de comics y manga, especialmente cuando las paginas descargadas offline se renderizan como imagenes."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I libri PDF si aprono con il lettore DIVINA. Consigliato per PDF di fumetti e manga, soprattutto quando le pagine scaricate offline sono renderizzate come immagini."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF-книги открываются в ридере DIVINA. Рекомендуется для комиксов и манги в PDF, особенно когда офлайн-загруженные страницы рендерятся как изображения."
+          }
         }
       }
     },
@@ -31630,6 +43762,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "PDF 檔案無法使用"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archivo PDF no disponible"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "File PDF non disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF-файл недоступен"
           }
         }
       }
@@ -31677,6 +43827,24 @@
             "state" : "translated",
             "value" : "PDF 閱讀器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lector PDF"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettore PDF"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ридер PDF"
+          }
         }
       }
     },
@@ -31722,6 +43890,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "PDF 閱讀器無法使用"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lector PDF no disponible"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettore PDF non disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ридер PDF недоступен"
           }
         }
       }
@@ -31769,6 +43955,24 @@
             "state" : "translated",
             "value" : "僅 iOS 和 macOS 支援 PDF 閱讀。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La lectura PDF solo es compatible con iOS y macOS."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La lettura PDF e supportata solo su iOS e macOS."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чтение PDF поддерживается только на iOS и macOS."
+          }
         }
       }
     },
@@ -31814,6 +44018,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "等待中"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendiente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In attesa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В ожидании"
           }
         }
       }
@@ -31861,6 +44083,24 @@
             "state" : "translated",
             "value" : "隊列中等待..."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendiente en cola..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In attesa in coda..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ожидает в очереди..."
+          }
         }
       }
     },
@@ -31906,6 +44146,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "從系統選擇字體"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elegir fuente del sistema"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scegli font di sistema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрать системный шрифт"
           }
         }
       }
@@ -31953,6 +44211,24 @@
             "state" : "translated",
             "value" : "從側邊欄選擇一項以開始。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elige algo en la barra lateral para comenzar."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scegli qualcosa dalla barra laterale per iniziare."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите что-нибудь в боковой панели, чтобы начать."
+          }
         }
       }
     },
@@ -31998,6 +44274,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "請務必立即複製您的 API 金鑰。您將無法再看到它！"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Asegurate de copiar tu clave API ahora. No volvera a mostrarse."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Assicurati di copiare ora la tua chiave API. Non verra mostrata di nuovo."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обязательно скопируйте API-ключ сейчас. Он больше не будет показан."
           }
         }
       }
@@ -32045,6 +44339,24 @@
             "state" : "translated",
             "value" : "全部"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Todos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все"
+          }
         }
       }
     },
@@ -32090,6 +44402,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "手動"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manual"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Manuale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вручную"
           }
         }
       }
@@ -32137,6 +44467,24 @@
             "state" : "translated",
             "value" : "僅未讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo no leidos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo non letti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Только непрочитанные"
+          }
         }
       }
     },
@@ -32182,6 +44530,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "僅未讀+自動清理"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo no leidos + limpieza"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo non letti + pulizia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Только непрочитанные + очистка"
           }
         }
       }
@@ -32229,6 +44595,24 @@
             "state" : "translated",
             "value" : "首選方向"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direccion preferida"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direzione preferita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предпочтительное направление"
+          }
         }
       }
     },
@@ -32274,6 +44658,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在準備 PDF..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando PDF..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione PDF..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка PDF..."
           }
         }
       }
@@ -32321,6 +44723,24 @@
             "state" : "translated",
             "value" : "正在準備閱讀器視圖"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando vista del lector"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione vista lettore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка вида ридера"
+          }
         }
       }
     },
@@ -32366,6 +44786,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在準備閱讀器..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando lector..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione lettore..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка ридера..."
           }
         }
       }
@@ -32413,6 +44851,24 @@
             "state" : "translated",
             "value" : "已套用預設：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preset aplicado: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preset applicato: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пресет применен: %@"
+          }
         }
       }
     },
@@ -32458,6 +44914,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "預設名稱"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre del preset"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome preset"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название пресета"
           }
         }
       }
@@ -32505,6 +44979,24 @@
             "state" : "translated",
             "value" : "已儲存預設：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preset guardado: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preset salvato: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пресет сохранен: %@"
+          }
         }
       }
     },
@@ -32550,6 +45042,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "預設"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Presets"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preset"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пресеты"
           }
         }
       }
@@ -32597,6 +45107,24 @@
             "state" : "translated",
             "value" : "隱私權政策"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Politica de privacidad"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informativa sulla privacy"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Политика конфиденциальности"
+          }
         }
       }
     },
@@ -32642,6 +45170,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "出版"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publicacion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pubblicazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Публикация"
           }
         }
       }
@@ -32689,6 +45235,24 @@
             "state" : "translated",
             "value" : "出版商"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editorial"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Издатель"
+          }
         }
       }
     },
@@ -32734,6 +45298,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "出版商預設"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Predeterminado del editor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Predefinito editore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "По умолчанию издателя"
           }
         }
       }
@@ -32781,6 +45363,24 @@
             "state" : "translated",
             "value" : "出版商"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editoriales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editori"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Издатели"
+          }
         }
       }
     },
@@ -32826,6 +45426,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下拉重新整理以根據本地資料重新計算閱讀統計。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desliza para actualizar y recalcular estadisticas de lectura desde datos locales."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trascina per aggiornare e ricalcolare le statistiche di lettura dai dati locali."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Потяните для обновления, чтобы пересчитать статистику чтения по локальным данным."
           }
         }
       }
@@ -32873,6 +45491,24 @@
             "state" : "translated",
             "value" : "購買請求超時。請稍後再試。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La solicitud de compra excedio el tiempo de espera. Intentalo de nuevo."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La richiesta di acquisto e scaduta. Riprova."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время ожидания запроса на покупку истекло. Повторите попытку."
+          }
         }
       }
     },
@@ -32918,6 +45554,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "範圍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rango"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intervallo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Диапазон"
           }
         }
       }
@@ -32965,6 +45619,24 @@
             "state" : "translated",
             "value" : "評價此應用程式"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valorar esta app"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valuta questa app"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оценить приложение"
+          }
         }
       }
     },
@@ -33010,6 +45682,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прочитано"
           }
         }
       }
@@ -33057,6 +45747,24 @@
             "state" : "translated",
             "value" : "無痕閱讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leer en incognito"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leggi in incognito"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Читать в режиме инкогнито"
+          }
         }
       }
     },
@@ -33102,6 +45810,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀清單名稱"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre de lista de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome lista di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название списка чтения"
           }
         }
       }
@@ -33149,6 +45875,24 @@
             "state" : "translated",
             "value" : "閱讀列表"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listas de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liste di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Списки чтения"
+          }
         }
       }
     },
@@ -33194,6 +45938,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀狀態"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stato di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статус чтения"
           }
         }
       }
@@ -33241,6 +46003,24 @@
             "state" : "translated",
             "value" : "閱讀器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lector"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ридер"
+          }
         }
       }
     },
@@ -33286,6 +46066,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀器背景"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fondo del lector"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sfondo lettore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фон ридера"
           }
         }
       }
@@ -33333,6 +46131,24 @@
             "state" : "translated",
             "value" : "閱讀器設定"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes del lector"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impostazioni Lettore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки Ридера"
+          }
         }
       }
     },
@@ -33378,6 +46194,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "黑色"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Negro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nero"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чёрный"
           }
         }
       }
@@ -33425,6 +46259,24 @@
             "state" : "translated",
             "value" : "灰色"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gris"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grigio"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серый"
+          }
         }
       }
     },
@@ -33470,6 +46322,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "棕褐色"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sepia"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seppia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сепия"
           }
         }
       }
@@ -33517,6 +46387,24 @@
             "state" : "translated",
             "value" : "系統"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Системная"
+          }
         }
       }
     },
@@ -33562,6 +46450,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "白色"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blanco"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bianco"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Белый"
           }
         }
       }
@@ -33609,6 +46515,24 @@
             "state" : "translated",
             "value" : "下一本"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siguiente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prossimo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Далее"
+          }
         }
       }
     },
@@ -33654,6 +46578,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "仿真翻頁"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paso de pagina curvado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volta pagina a effetto curl"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перелистывание с загибом"
           }
         }
       }
@@ -33701,6 +46643,24 @@
             "state" : "translated",
             "value" : "經典的仿真翻頁效果，僅在 iPhone 和 iPad 上可用。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Efecto clasico de cambio de pagina, disponible en iPhone y iPad."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Classico effetto di cambio pagina, disponibile su iPhone e iPad."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Классический эффект перелистывания страницы, доступен на iPhone и iPad."
+          }
         }
       }
     },
@@ -33746,6 +46706,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "捲動"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desplazarse"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scorri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Непрерывный"
           }
         }
       }
@@ -33793,6 +46771,24 @@
             "state" : "translated",
             "value" : "平滑的捲動過渡效果，在所有平台上可用。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transicion de desplazamiento suave, disponible en todas las plataformas."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transizione di scorrimento fluida, disponibile su tutte le piattaforme."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Плавный переход прокруткой, доступен на всех платформах."
+          }
         }
       }
     },
@@ -33838,6 +46834,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "結束"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FIN"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FINE"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "КОНЕЦ"
           }
         }
       }
@@ -33885,6 +46899,24 @@
             "state" : "translated",
             "value" : "自動"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatico"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatico"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Авто"
+          }
         }
       }
     },
@@ -33930,6 +46962,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "雙頁"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doble pagina"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doppia pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Двойная страница"
           }
         }
       }
@@ -33977,6 +47027,24 @@
             "state" : "translated",
             "value" : "單頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina unica"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina singola"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Одиночная страница"
+          }
         }
       }
     },
@@ -34022,6 +47090,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在準備閱讀器…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando lector..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione lettore..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка ридера..."
           }
         }
       }
@@ -34069,6 +47155,24 @@
             "state" : "translated",
             "value" : "上一本"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anterior"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Precedente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Предыдущая"
+          }
         }
       }
     },
@@ -34114,6 +47218,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "立方體"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cubo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cubo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Куб"
           }
         }
       }
@@ -34161,6 +47283,24 @@
             "state" : "translated",
             "value" : "翻頁時立方體翻轉效果"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las paginas giran como un cubo al desplazarse"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le pagine ruotano come un cubo durante lo scorrimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Страницы вращаются как куб при прокрутке"
+          }
         }
       }
     },
@@ -34206,6 +47346,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "預設"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Predeterminado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Predefinito"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "По умолчанию"
           }
         }
       }
@@ -34253,6 +47411,24 @@
             "state" : "translated",
             "value" : "標準滾動，無視覺效果"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desplazamiento estandar sin efectos visuales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scorrimento standard senza effetti visivi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Стандартная прокрутка без визуальных эффектов"
+          }
         }
       }
     },
@@ -34298,6 +47474,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "淡入淡出"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desvanecer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dissolvenza"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Затухание"
           }
         }
       }
@@ -34345,6 +47539,24 @@
             "state" : "translated",
             "value" : "翻頁時淡入淡出效果"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las paginas aparecen y desaparecen al desplazarse"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le pagine sfumano in entrata e uscita durante lo scorrimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Страницы плавно появляются и исчезают при прокрутке"
+          }
         }
       }
     },
@@ -34390,6 +47602,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "3D旋轉"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotacion 3D"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotazione 3D"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3D-поворот"
           }
         }
       }
@@ -34437,6 +47667,24 @@
             "state" : "translated",
             "value" : "翻頁時頁面在3D空間中旋轉"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las paginas rotan en espacio 3D al desplazarse"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le pagine ruotano nello spazio 3D durante lo scorrimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Страницы вращаются в 3D-пространстве при прокрутке"
+          }
         }
       }
     },
@@ -34482,6 +47730,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "縮放"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escala"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scala"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Масштаб"
           }
         }
       }
@@ -34529,6 +47795,24 @@
             "state" : "translated",
             "value" : "翻頁時頁面縮放效果"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las paginas se escalan al desplazarse"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le pagine aumentano e diminuiscono di scala durante lo scorrimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Страницы увеличиваются и уменьшаются при прокрутке"
+          }
         }
       }
     },
@@ -34574,6 +47858,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自動"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatico"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatico"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Авто"
           }
         }
       }
@@ -34621,6 +47923,24 @@
             "state" : "translated",
             "value" : "禁用"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ninguno"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuno"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет"
+          }
         }
       }
     },
@@ -34666,6 +47986,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "大"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grande"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grande"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Большой"
           }
         }
       }
@@ -34713,6 +48051,24 @@
             "state" : "translated",
             "value" : "中"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medio"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medio"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Средний"
+          }
         }
       }
     },
@@ -34758,6 +48114,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "小"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pequeno"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piccolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Малый"
           }
         }
       }
@@ -34805,6 +48179,24 @@
             "state" : "translated",
             "value" : "阅读与语言"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lectura e idioma"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettura e lingua"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чтение и язык"
+          }
         }
       }
     },
@@ -34850,6 +48242,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "按小時閱讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lectura por hora"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettura per ora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чтение по часам"
           }
         }
       }
@@ -34897,6 +48307,24 @@
             "state" : "translated",
             "value" : "按星期閱讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lectura por dia de la semana"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettura per giorno della settimana"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чтение по дням недели"
+          }
         }
       }
     },
@@ -34942,6 +48370,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀天數"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dias de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giorni di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дни чтения"
           }
         }
       }
@@ -34989,6 +48435,24 @@
             "state" : "translated",
             "value" : "閱讀方向"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dirección de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direzione Lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Направление чтения"
+          }
         }
       }
     },
@@ -35034,6 +48498,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀設定"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impostazioni lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки чтения"
           }
         }
       }
@@ -35081,6 +48563,24 @@
             "state" : "translated",
             "value" : "閱讀應該是舒適和愉快的。請花時間自定義這些設定，直到找到完美的組合。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leer debe ser comodo y agradable. Toma tu tiempo para ajustar estas opciones hasta encontrar la combinacion perfecta."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La lettura dovrebbe essere comoda e piacevole. Prenditi il tempo necessario per personalizzare queste impostazioni finche non trovi la combinazione perfetta."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чтение должно быть комфортным и приятным. Настраивайте параметры столько, сколько нужно, чтобы найти идеальное сочетание."
+          }
         }
       }
     },
@@ -35126,6 +48626,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀統計"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estadisticas de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Statistiche di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статистика чтения"
           }
         }
       }
@@ -35173,6 +48691,24 @@
             "state" : "translated",
             "value" : "閱讀狀態"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stato di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статус чтения"
+          }
         }
       }
     },
@@ -35218,6 +48754,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀時長"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tempo di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время чтения"
           }
         }
       }
@@ -35265,6 +48819,24 @@
             "state" : "translated",
             "value" : "閱讀時長：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de lectura: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tempo di lettura: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время чтения: %@"
+          }
         }
       }
     },
@@ -35310,6 +48882,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "從左到右"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Izquierda a derecha"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da sinistra a destra"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Слева направо"
           }
         }
       }
@@ -35357,6 +48947,24 @@
             "state" : "translated",
             "value" : "從右到左"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Derecha a izquierda"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da destra a sinistra"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Справа налево"
+          }
         }
       }
     },
@@ -35402,6 +49010,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "垂直模式"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vertical"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verticale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вертикально"
           }
         }
       }
@@ -35449,6 +49075,24 @@
             "state" : "translated",
             "value" : "Webtoon (條漫)"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webtoon"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webtoon"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Webtoon"
+          }
         }
       }
     },
@@ -35494,6 +49138,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "進行中"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En progreso"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In corso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В процессе"
           }
         }
       }
@@ -35541,6 +49203,24 @@
             "state" : "translated",
             "value" : "已讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прочитано"
+          }
         }
       }
     },
@@ -35586,6 +49266,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No leido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non letto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Непрочитано"
           }
         }
       }
@@ -35633,6 +49331,24 @@
             "state" : "translated",
             "value" : "就緒"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pronto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готов"
+          }
         }
       }
     },
@@ -35678,6 +49394,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "即時更新"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizaciones en tiempo real"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiornamenti in tempo reale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновления в реальном времени"
           }
         }
       }
@@ -35725,6 +49459,24 @@
             "state" : "translated",
             "value" : "開啟後伺服器變更會自動刷新。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las actualizaciones en tiempo real permiten que la app se actualice automaticamente cuando cambia el contenido en el servidor."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gli aggiornamenti in tempo reale consentono all'app di aggiornarsi automaticamente quando i contenuti cambiano sul server."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновления в реальном времени позволяют приложению автоматически обновляться при изменении контента на сервере."
+          }
         }
       }
     },
@@ -35770,6 +49522,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "近期活動"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actividad reciente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attivita recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавняя активность"
           }
         }
       }
@@ -35817,6 +49587,24 @@
             "state" : "translated",
             "value" : "刷新"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiorna"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновить"
+          }
         }
       }
     },
@@ -35862,6 +49650,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新整理封面"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar portada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiorna copertina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновить обложку"
           }
         }
       }
@@ -35909,6 +49715,24 @@
             "state" : "translated",
             "value" : "刷新主頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar panel"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiorna dashboard"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновить панель"
+          }
         }
       }
     },
@@ -35954,6 +49778,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刷新中繼資料"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar metadatos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiorna metadati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновить метаданные"
           }
         }
       }
@@ -36001,6 +49843,24 @@
             "state" : "translated",
             "value" : "發佈日期"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de publicación"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di uscita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата выхода"
+          }
         }
       }
     },
@@ -36046,6 +49906,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "發行日期 (YYYY-MM-DD)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de lanzamiento (YYYY-MM-DD)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di uscita (YYYY-MM-DD)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата выпуска (YYYY-MM-DD)"
           }
         }
       }
@@ -36093,6 +49971,24 @@
             "state" : "translated",
             "value" : "發行日期：%@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de lanzamiento: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di uscita: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата выпуска: %@"
+          }
         }
       }
     },
@@ -36138,6 +50034,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "發行：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lanzamiento: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rilascio: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Релиз: %@"
           }
         }
       }
@@ -36185,6 +50099,24 @@
             "state" : "translated",
             "value" : "移除全部"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar todo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuovi tutto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить все"
+          }
         }
       }
     },
@@ -36230,6 +50162,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除離線"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar offline"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuovi offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить офлайн"
           }
         }
       }
@@ -36277,6 +50227,24 @@
             "state" : "translated",
             "value" : "移除已讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar leidos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuovi letti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить прочитанное"
+          }
         }
       }
     },
@@ -36322,6 +50290,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新命名"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renombrar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rinomina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переименовать"
           }
         }
       }
@@ -36369,6 +50355,24 @@
             "state" : "translated",
             "value" : "重新命名篩選器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renombrar filtro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rinomina filtro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переименовать фильтр"
+          }
         }
       }
     },
@@ -36414,6 +50418,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新命名預設"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renombrar preset"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rinomina preset"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переименовать пресет"
           }
         }
       }
@@ -36461,6 +50483,24 @@
             "state" : "translated",
             "value" : "渲染品質"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calidad de renderizado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Qualita render"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Качество рендеринга"
+          }
         }
       }
     },
@@ -36506,6 +50546,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reimposta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить"
           }
         }
       }
@@ -36553,6 +50611,24 @@
             "state" : "translated",
             "value" : "重設為全域設定"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restablecer a global"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ripristina globale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить к глобальным"
+          }
         }
       }
     },
@@ -36598,6 +50674,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "恢復購買"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurar compras"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ripristina acquisti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Восстановить покупки"
           }
         }
       }
@@ -36645,6 +50739,24 @@
             "state" : "translated",
             "value" : "恢復請求超時，請重試。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La solicitud de restauracion excedio el tiempo de espera. Intentalo de nuevo."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La richiesta di ripristino e scaduta. Riprova."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время ожидания запроса на восстановление истекло. Повторите попытку."
+          }
         }
       }
     },
@@ -36690,6 +50802,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "繼續閱讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reanudar lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riprendi lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить чтение"
           }
         }
       }
@@ -36737,6 +50867,24 @@
             "state" : "translated",
             "value" : "重試"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reintentar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riprova"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторить"
+          }
         }
       }
     },
@@ -36782,6 +50930,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "全部重試"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reintentar todo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riprova tutto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторить все"
           }
         }
       }
@@ -36829,6 +50995,24 @@
             "state" : "translated",
             "value" : "返回"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Volver"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ritorna"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вернуться"
+          }
         }
       }
     },
@@ -36874,6 +51058,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "反色"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invertir"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inverti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обратный"
           }
         }
       }
@@ -36921,6 +51123,24 @@
             "state" : "translated",
             "value" : "角色"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rol"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Роль"
+          }
         }
       }
     },
@@ -36966,6 +51186,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "角色"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funciones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Permessi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Роли"
           }
         }
       }
@@ -37013,6 +51251,24 @@
             "state" : "translated",
             "value" : "執行中的任務：%lld"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tareas en ejecucion: %lld"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attivita in esecuzione: %lld"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выполняющиеся задачи: %lld"
+          }
         }
       }
     },
@@ -37058,6 +51314,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "執行階段"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entorno de ejecucion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Runtime"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Среда выполнения"
           }
         }
       }
@@ -37105,6 +51379,24 @@
             "state" : "translated",
             "value" : "執行階段版本"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version del runtime"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versione runtime"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Версия среды выполнения"
+          }
         }
       }
     },
@@ -37150,6 +51442,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "秒"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "s"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "s"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "с"
           }
         }
       }
@@ -37197,6 +51507,24 @@
             "state" : "translated",
             "value" : "儲存"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salva"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранить"
+          }
         }
       }
     },
@@ -37242,6 +51570,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "另存為預設"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar como preset"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salva come preset"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранить как пресет"
           }
         }
       }
@@ -37289,6 +51635,24 @@
             "state" : "translated",
             "value" : "儲存篩選器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar filtro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salva filtro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранить фильтр"
+          }
         }
       }
     },
@@ -37334,6 +51698,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "儲存預設"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar preset"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salva preset"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранить пресет"
           }
         }
       }
@@ -37381,6 +51763,24 @@
             "state" : "translated",
             "value" : "儲存您喜愛的 EPUB 閱讀主題以便快速存取"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guarda tus temas EPUB favoritos para acceso rapido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salva i tuoi temi EPUB preferiti per un accesso rapido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохраните любимые темы EPUB для быстрого доступа"
+          }
         }
       }
     },
@@ -37426,6 +51826,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "儲存常用的 %1$@ 篩選器以便快速存取"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guarda tus filtros de %1$@ mas usados para acceso rapido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salva i filtri %1$@ usati piu spesso per un accesso rapido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохраняйте часто используемые фильтры %1$@ для быстрого доступа"
           }
         }
       }
@@ -37473,6 +51891,24 @@
             "state" : "translated",
             "value" : "已儲存的篩選器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtros guardados"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtri salvati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохраненные фильтры"
+          }
         }
       }
     },
@@ -37518,6 +51954,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已儲存的預設"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Presets guardados"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preset salvati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохраненные пресеты"
           }
         }
       }
@@ -37565,6 +52019,24 @@
             "state" : "translated",
             "value" : "掃描所有圖書館"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escanear todas las bibliotecas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scansiona tutte le librerie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканировать все библиотеки"
+          }
         }
       }
     },
@@ -37610,6 +52082,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "深度掃描所有圖書館"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escanear todas las bibliotecas (profundo)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scansiona tutte le librerie (profonda)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканировать все библиотеки (глубоко)"
           }
         }
       }
@@ -37657,6 +52147,24 @@
             "state" : "translated",
             "value" : "掃描圖書館檔案"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escanear archivos de biblioteca"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scansiona file libreria"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканировать файлы библиотеки"
+          }
         }
       }
     },
@@ -37702,6 +52210,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "深度掃描圖書館檔案"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escanear archivos de biblioteca (profundo)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scansiona file libreria (profonda)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканировать файлы библиотеки (глубоко)"
           }
         }
       }
@@ -37749,6 +52275,24 @@
             "state" : "translated",
             "value" : "Webtoon 模式下點擊翻頁的捲動距離"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distancia de desplazamiento al tocar para navegar en modo webtoon"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distanza di scorrimento al tocco per navigare in modalita webtoon"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дистанция прокрутки по касанию для навигации в режиме webtoon"
+          }
         }
       }
     },
@@ -37794,6 +52338,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "滾動翻頁效果"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transicion de pagina por desplazamiento"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transizione pagina a scorrimento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переход страниц прокруткой"
           }
         }
       }
@@ -37841,6 +52403,24 @@
             "state" : "translated",
             "value" : "搜尋"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск"
+          }
         }
       }
     },
@@ -37886,6 +52466,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在 PDF 中搜尋"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar en PDF"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca nel PDF"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск в PDF"
           }
         }
       }
@@ -37933,6 +52531,24 @@
             "state" : "translated",
             "value" : "搜尋中..."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscando..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ricerca..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск..."
+          }
         }
       }
     },
@@ -37978,6 +52594,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрать"
           }
         }
       }
@@ -38025,6 +52659,24 @@
             "state" : "translated",
             "value" : "選擇一個類別"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona una categoria"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona una categoria"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите категорию"
+          }
         }
       }
     },
@@ -38070,6 +52722,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇一項設定"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona una opcion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona un'impostazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите настройку"
           }
         }
       }
@@ -38117,6 +52787,24 @@
             "state" : "translated",
             "value" : "選擇全部"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar todo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona tutto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрать все"
+          }
         }
       }
     },
@@ -38162,6 +52850,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇所有資料庫"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar todas las bibliotecas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona tutte le librerie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрать все библиотеки"
           }
         }
       }
@@ -38209,6 +52915,24 @@
             "state" : "translated",
             "value" : "選擇收藏"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar coleccion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрать коллекцию"
+          }
         }
       }
     },
@@ -38254,6 +52978,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇系統預載字體"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona entre las fuentes preinstaladas del sistema"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona tra i font preinstallati di sistema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите из предустановленных системных шрифтов"
           }
         }
       }
@@ -38301,6 +53043,24 @@
             "state" : "translated",
             "value" : "選擇閱讀列表"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccionar lista de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona lista di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрать список чтения"
+          }
         }
       }
     },
@@ -38346,6 +53106,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Series"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серии"
           }
         }
       }
@@ -38393,6 +53171,24 @@
             "state" : "translated",
             "value" : "系列 ID"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID de serie"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID серии"
+          }
         }
       }
     },
@@ -38438,6 +53234,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系列狀態"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado de serie"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stato serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статус серии"
           }
         }
       }
@@ -38485,6 +53299,24 @@
             "state" : "translated",
             "value" : "常规"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Общее"
+          }
         }
       }
     },
@@ -38530,6 +53362,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "链接"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enlaces"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Links"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ссылки"
           }
         }
       }
@@ -38577,6 +53427,24 @@
             "state" : "translated",
             "value" : "共享"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Condivisione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Доступ"
+          }
         }
       }
     },
@@ -38622,6 +53490,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标签"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etiquetas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etichette"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Теги"
           }
         }
       }
@@ -38669,6 +53555,24 @@
             "state" : "translated",
             "value" : "标题"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titulo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название"
+          }
         }
       }
     },
@@ -38714,6 +53618,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書籍數量"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cantidad de libros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numero libri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Количество книг"
           }
         }
       }
@@ -38761,6 +53683,24 @@
             "state" : "translated",
             "value" : "新增日期"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de adicion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di aggiunta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата добавления"
+          }
         }
       }
     },
@@ -38806,6 +53746,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀日期"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата чтения"
           }
         }
       }
@@ -38853,6 +53811,24 @@
             "state" : "translated",
             "value" : "更新日期"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de actualizacion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di aggiornamento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата обновления"
+          }
         }
       }
     },
@@ -38898,6 +53874,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下載時間"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hora de descarga"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ora download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время загрузки"
           }
         }
       }
@@ -38945,6 +53939,24 @@
             "state" : "translated",
             "value" : "資料夾名稱"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre de carpeta"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome cartella"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Имя папки"
+          }
         }
       }
     },
@@ -38990,6 +54002,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "名稱"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название"
           }
         }
       }
@@ -39037,6 +54067,24 @@
             "state" : "translated",
             "value" : "隨機"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aleatorio"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Casuale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В случайном порядке"
+          }
         }
       }
     },
@@ -39082,6 +54130,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "發行日期"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de publicación"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di uscita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата выхода"
           }
         }
       }
@@ -39129,6 +54195,24 @@
             "state" : "translated",
             "value" : "書籍數量（最少）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cantidad de libros (menos)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numero libri (meno)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Количество книг (меньше)"
+          }
         }
       }
     },
@@ -39174,6 +54258,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書籍數量（最多）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cantidad de libros (mas)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numero libri (piu)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Количество книг (больше)"
           }
         }
       }
@@ -39221,6 +54323,24 @@
             "state" : "translated",
             "value" : "新增日期（最早）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de adicion (mas antiguo)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data aggiunta (piu vecchia)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата добавления (сначала старые)"
+          }
         }
       }
     },
@@ -39266,6 +54386,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新增日期（最新）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de adicion (mas reciente)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data aggiunta (piu recente)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата добавления (сначала новые)"
           }
         }
       }
@@ -39313,6 +54451,24 @@
             "state" : "translated",
             "value" : "閱讀日期（最早）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de lectura (mas antigua)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data lettura (piu vecchia)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата чтения (сначала старые)"
+          }
         }
       }
     },
@@ -39358,6 +54514,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀日期（最新）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de lectura (mas reciente)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data lettura (piu recente)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата чтения (сначала новые)"
           }
         }
       }
@@ -39405,6 +54579,24 @@
             "state" : "translated",
             "value" : "更新日期（最早）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de actualizacion (mas antigua)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data aggiornamento (piu vecchia)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата обновления (сначала старые)"
+          }
         }
       }
     },
@@ -39450,6 +54642,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新日期（最新）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de actualizacion (mas reciente)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data aggiornamento (piu recente)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата обновления (сначала новые)"
           }
         }
       }
@@ -39497,6 +54707,24 @@
             "state" : "translated",
             "value" : "資料夾名稱（A-Z）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre de carpeta (A-Z)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome cartella (A-Z)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Имя папки (A-Z)"
+          }
         }
       }
     },
@@ -39542,6 +54770,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "資料夾名稱（Z-A）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre de carpeta (Z-A)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome cartella (Z-A)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Имя папки (Z-A)"
           }
         }
       }
@@ -39589,6 +54835,24 @@
             "state" : "translated",
             "value" : "名稱（A-Z）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre (A-Z)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome (A-Z)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название (A-Z)"
+          }
         }
       }
     },
@@ -39634,6 +54898,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "名稱（Z-A）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre (Z-A)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome (Z-A)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название (Z-A)"
           }
         }
       }
@@ -39681,6 +54963,24 @@
             "state" : "translated",
             "value" : "隨機"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aleatorio"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Casuale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В случайном порядке"
+          }
         }
       }
     },
@@ -39726,6 +55026,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "發行日期（最早）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de lanzamiento (mas antigua)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di uscita (piu vecchia)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата выпуска (сначала старые)"
           }
         }
       }
@@ -39773,6 +55091,24 @@
             "state" : "translated",
             "value" : "發行日期（最新）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de lanzamiento (mas reciente)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di uscita (piu recente)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата выпуска (сначала новые)"
+          }
         }
       }
     },
@@ -39818,6 +55154,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已放棄"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abandonado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbandonato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Заброшена"
           }
         }
       }
@@ -39865,6 +55219,24 @@
             "state" : "translated",
             "value" : "已完結"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Concluso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закончена"
+          }
         }
       }
     },
@@ -39910,6 +55282,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "有生之年"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interrumpido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hiatus"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Заморожена"
           }
         }
       }
@@ -39957,6 +55347,24 @@
             "state" : "translated",
             "value" : "連載中"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En curso"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In corso"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выпускается"
+          }
         }
       }
     },
@@ -40002,6 +55410,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "伺服器"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servidor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сервер"
           }
         }
       }
@@ -40049,6 +55475,24 @@
             "state" : "translated",
             "value" : "伺服器資訊"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informacion del servidor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Info server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Информация о сервере"
+          }
         }
       }
     },
@@ -40094,6 +55538,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "伺服器尚未更新"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servidor aun no actualizado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server non ancora aggiornato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сервер еще не обновлялся"
           }
         }
       }
@@ -40141,6 +55603,24 @@
             "state" : "translated",
             "value" : "無法連線伺服器，已切換至離線模式"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servidor inaccesible, cambiado a modo offline"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server non raggiungibile, passaggio alla modalita offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сервер недоступен, переключено в офлайн-режим"
+          }
         }
       }
     },
@@ -40186,6 +55666,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "伺服器於 %@ 前已更新"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servidor actualizado hace %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server aggiornato %@ fa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сервер обновлен %@ назад"
           }
         }
       }
@@ -40233,6 +55731,24 @@
             "state" : "translated",
             "value" : "伺服器 URL"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL del servidor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL сервера"
+          }
         }
       }
     },
@@ -40278,6 +55794,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切換伺服器"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar servidor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambia server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сменить сервер"
           }
         }
       }
@@ -40325,6 +55859,24 @@
             "state" : "translated",
             "value" : "伺服器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servidores"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серверы"
+          }
         }
       }
     },
@@ -40370,6 +55922,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impostazioni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки"
           }
         }
       }
@@ -40417,6 +55987,24 @@
             "state" : "translated",
             "value" : "iOS 26.1 及以上模擬器目前無法切換 App 圖示。請在實機或較低版本的模擬器執行環境測試。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El cambio de icono de app no esta disponible actualmente en el simulador iOS 26.1+. Pruebalo en un dispositivo real o en un runtime de simulador anterior."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il cambio dell'icona app non e attualmente disponibile su Simulator iOS 26.1+. Prova su un dispositivo reale o su un runtime simulatore precedente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Смена иконки приложения сейчас недоступна в iOS 26.1+ Simulator. Проверьте на реальном устройстве или более старом runtime симулятора."
+          }
         }
       }
     },
@@ -40462,6 +56050,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "瀏覽"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Explorar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esplora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обзор"
           }
         }
       }
@@ -40509,6 +56115,24 @@
             "state" : "translated",
             "value" : "卡片"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tarjetas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schede"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Карточки"
+          }
         }
       }
     },
@@ -40554,6 +56178,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在封面上使用柔和的漸變遮罩顯示標題與詳情"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar titulos y detalles con una superposicion de degradado suave sobre las portadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra titoli e dettagli con una morbida sovrapposizione sfumata sulle copertine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать заголовки и детали с мягким градиентным наложением на обложках"
           }
         }
       }
@@ -40601,6 +56243,24 @@
             "state" : "translated",
             "value" : "卡片文字覆蓋"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Superposicion de texto en tarjetas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Overlay testo schede"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Наложение текста на карточках"
+          }
         }
       }
     },
@@ -40646,6 +56306,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顏色"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Color"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цвет"
           }
         }
       }
@@ -40693,6 +56371,24 @@
             "state" : "translated",
             "value" : "深色"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oscuro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scuro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тёмная"
+          }
         }
       }
     },
@@ -40738,6 +56434,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "淺色"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Claro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiaro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Светлая"
           }
         }
       }
@@ -40785,6 +56499,24 @@
             "state" : "translated",
             "value" : "跟隨系統"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Системная"
+          }
         }
       }
     },
@@ -40830,6 +56562,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "外觀界面"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esquema de color"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schema colori"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цветовая схема"
           }
         }
       }
@@ -40877,6 +56627,24 @@
             "state" : "translated",
             "value" : "僅顯示封面，隱藏卡片下方所有文字"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar solo portadas, ocultar todo el texto bajo las tarjetas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra solo copertine, nascondi tutto il testo sotto le schede"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать только обложки, скрывая весь текст под карточками"
+          }
         }
       }
     },
@@ -40922,6 +56690,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "僅顯示封面"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tarjetas solo con portada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schede solo copertina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Карточки только с обложкой"
           }
         }
       }
@@ -40969,6 +56755,24 @@
             "state" : "translated",
             "value" : "在書籍封面上顯示閱讀進度條"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar la barra de progreso de lectura en las portadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra la barra di avanzamento lettura sulle copertine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать индикатор прогресса чтения на обложках"
+          }
         }
       }
     },
@@ -41014,6 +56818,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示封面閱讀進度"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar progreso de lectura en portadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra avanzamento lettura sulle copertine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать прогресс чтения на обложках"
           }
         }
       }
@@ -41061,6 +56883,24 @@
             "state" : "translated",
             "value" : "關閉封面陰影可提升舊設備性能"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactiva sombras de portada para mejorar rendimiento en dispositivos antiguos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disabilita le ombre delle copertine per migliorare le prestazioni su dispositivi piu vecchi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отключите тени обложек для повышения производительности на старых устройствах"
+          }
         }
       }
     },
@@ -41106,6 +56946,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示封面陰影"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar sombras de portada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra ombre copertina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать тени обложек"
           }
         }
       }
@@ -41153,6 +57011,24 @@
             "state" : "translated",
             "value" : "在書籍與系列封面上顯示未讀標識"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar indicadores de no leido en portadas de libros y series"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra indicatori di non letto sulle copertine di libri e serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать индикаторы непрочитанного на обложках книг и серий"
+          }
         }
       }
     },
@@ -41198,6 +57074,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示封面未讀標識"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar indicadores de no leido en portadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra indicatori non letto sulle copertine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать индикаторы непрочитанного на обложках"
           }
         }
       }
@@ -41245,6 +57139,24 @@
             "state" : "translated",
             "value" : "調整網格中卡片的大小和間距"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajusta tamano y espaciado de tarjetas en la cuadricula"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regola dimensione e spaziatura delle schede nella griglia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройте размер и интервалы карточек в сетке"
+          }
         }
       }
     },
@@ -41290,6 +57202,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "緊湊"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compacto"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compatto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Компактно"
           }
         }
       }
@@ -41337,6 +57267,24 @@
             "state" : "translated",
             "value" : "寬鬆"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comodo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comodo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Уютно"
+          }
         }
       }
     },
@@ -41382,6 +57330,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "網格密度"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Densidad de cuadricula"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Densita griglia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Плотность сетки"
           }
         }
       }
@@ -41429,6 +57395,24 @@
             "state" : "translated",
             "value" : "標準"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estandar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standard"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Стандарт"
+          }
         }
       }
     },
@@ -41474,6 +57458,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "語言"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Idioma"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lingua"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Язык"
           }
         }
       }
@@ -41521,6 +57523,24 @@
             "state" : "translated",
             "value" : "打開應用程式設定以更改語言"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abre la configuracion de la app para cambiar idioma"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apri le impostazioni dell'app per cambiare lingua"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Откройте настройки приложения, чтобы изменить язык"
+          }
         }
       }
     },
@@ -41566,6 +57586,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更改語言"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiar idioma"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambia lingua"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изменить язык"
           }
         }
       }
@@ -41613,6 +57651,24 @@
             "state" : "translated",
             "value" : "保持封面長寬比"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conservar relacion de aspecto para imagenes de portada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantieni il rapporto d'aspetto delle immagini di copertina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранять соотношение сторон изображений обложек"
+          }
         }
       }
     },
@@ -41658,6 +57714,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保持封面比例"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conservar relacion de aspecto de portada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantieni rapporto copertina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранять пропорции обложек"
           }
         }
       }
@@ -41705,6 +57779,24 @@
             "state" : "translated",
             "value" : "隱私"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacidad"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Приватность"
+          }
         }
       }
     },
@@ -41750,6 +57842,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在應用切換器中顯示模糊遮罩以保護隱私。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar una superposicion borrosa en el selector de apps para proteger tu privacidad."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra un overlay sfocato nello switcher app per proteggere la tua privacy."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать размытие в переключателе приложений для защиты приватности."
           }
         }
       }
@@ -41797,6 +57907,24 @@
             "state" : "translated",
             "value" : "隱私保護"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proteccion de privacidad"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protezione privacy"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Защита приватности"
+          }
         }
       }
     },
@@ -41842,6 +57970,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜尋"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск"
           }
         }
       }
@@ -41889,6 +58035,24 @@
             "state" : "translated",
             "value" : "啟用後，搜尋時忽略過濾條件，僅按庫篩選"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si esta activado, la busqueda ignora condiciones de filtro y solo usa la seleccion de biblioteca"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se abilitato, la ricerca ignora le condizioni filtro e usa solo la selezione libreria"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Если включено, поиск игнорирует условия фильтра и использует только выбор библиотеки"
+          }
         }
       }
     },
@@ -41934,6 +58098,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搜尋時忽略過濾條件"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignorar filtros al buscar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignora filtri durante la ricerca"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Игнорировать фильтры при поиске"
           }
         }
       }
@@ -41981,6 +58163,24 @@
             "state" : "translated",
             "value" : "在書籍卡片顯示系列標題"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar titulos de serie para libros en tarjetas de vista"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra titoli serie per i libri nelle schede di visualizzazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать названия серий для книг на карточках"
+          }
         }
       }
     },
@@ -42026,6 +58226,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示書籍系列標題"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar titulos de serie en tarjetas de libro"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra titoli serie sulle schede libro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать названия серий на карточках книг"
           }
         }
       }
@@ -42073,6 +58291,24 @@
             "state" : "translated",
             "value" : "主題"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tema"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тема"
+          }
         }
       }
     },
@@ -42118,6 +58354,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "瀏覽"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Explorar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esplora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обзор"
           }
         }
       }
@@ -42165,6 +58419,24 @@
             "state" : "translated",
             "value" : "連線已恢復"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conexion restaurada"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connessione ripristinata"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подключение восстановлено"
+          }
         }
       }
     },
@@ -42210,6 +58482,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "刪除"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить"
           }
         }
       }
@@ -42257,6 +58547,24 @@
             "state" : "translated",
             "value" : "這會永久從 Komga 刪除 %1$@。\n\n要確認，請輸入圖書館名稱：%2$@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto eliminara permanentemente %1$@ de Komga.\n\nPara confirmar, escribe el nombre de la biblioteca: %2$@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo eliminera definitivamente %1$@ da Komga.\n\nPer confermare, digita il nome della libreria: %2$@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это навсегда удалит %1$@ из Komga.\n\nДля подтверждения введите имя библиотеки: %2$@"
+          }
         }
       }
     },
@@ -42302,6 +58610,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "輸入圖書館名稱"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduce el nombre de biblioteca"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inserisci nome libreria"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Введите имя библиотеки"
           }
         }
       }
@@ -42349,6 +58675,24 @@
             "state" : "translated",
             "value" : "刪除圖書館？"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar biblioteca?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminare libreria?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить библиотеку?"
+          }
         }
       }
     },
@@ -42394,6 +58738,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "找不到日誌"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron registros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun log trovato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Логи не найдены"
           }
         }
       }
@@ -42441,6 +58803,24 @@
             "state" : "translated",
             "value" : "搜尋日誌..."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar registros..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerca nei log..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поиск по логам..."
+          }
         }
       }
     },
@@ -42486,6 +58866,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "失敗請求的重試次數（排除 401 錯誤）。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numero de reintentos para solicitudes fallidas (excepto 401)."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numero di tentativi per richieste non riuscite (escluso 401)."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Количество повторов для неудачных запросов (кроме 401)."
           }
         }
       }
@@ -42533,6 +58931,24 @@
             "state" : "translated",
             "value" : "API 重試次數"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cantidad de reintentos API"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numero tentativi API"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Число повторов API"
+          }
         }
       }
     },
@@ -42578,6 +58994,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "認證請求超時時間（秒）。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de espera para solicitudes de autenticacion en segundos."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout per le richieste di autenticazione in secondi."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймаут запросов аутентификации в секундах."
           }
         }
       }
@@ -42625,6 +59059,24 @@
             "state" : "translated",
             "value" : "認證超時"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de espera de autenticacion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout autenticazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймаут аутентификации"
+          }
         }
       }
     },
@@ -42670,6 +59122,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下載請求超時時間（秒）。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de espera para solicitudes de descarga en segundos."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout per le richieste di download in secondi."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймаут запросов загрузки в секундах."
           }
         }
       }
@@ -42717,6 +59187,24 @@
             "state" : "translated",
             "value" : "下載超時"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de espera de descarga"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout download"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймаут загрузки"
+          }
         }
       }
     },
@@ -42762,6 +59250,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "一般"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "General"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Общее"
           }
         }
       }
@@ -42809,6 +59315,24 @@
             "state" : "translated",
             "value" : "接力"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff"
+          }
         }
       }
     },
@@ -42854,6 +59378,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在其他裝置上繼續瀏覽"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar navegacion en otros dispositivos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continua la navigazione su altri dispositivi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить просмотр на других устройствах"
           }
         }
       }
@@ -42901,6 +59443,24 @@
             "state" : "translated",
             "value" : "瀏覽器接力"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff de exploracion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff esplorazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff обзора"
+          }
         }
       }
     },
@@ -42946,6 +59506,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "在其他裝置上繼續閱讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuar lectura en otros dispositivos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continua la lettura su altri dispositivi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить чтение на других устройствах"
           }
         }
       }
@@ -42993,6 +59571,24 @@
             "state" : "translated",
             "value" : "閱讀器接力"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff del lector"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff lettore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handoff ридера"
+          }
         }
       }
     },
@@ -43038,6 +59634,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "請求超時時間（秒）。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de espera para solicitudes en segundos."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout per le richieste in secondi."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймаут запросов в секундах."
           }
         }
       }
@@ -43085,6 +59699,24 @@
             "state" : "translated",
             "value" : "請求超時"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de espera de solicitud"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout richiesta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Таймаут запроса"
+          }
         }
       }
     },
@@ -43130,6 +59762,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "離線"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin conexion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн"
           }
         }
       }
@@ -43177,6 +59827,24 @@
             "state" : "translated",
             "value" : "清理孤立離線檔案"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpiar archivos huerfanos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulisci file orfani"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистить потерянные файлы"
+          }
         }
       }
     },
@@ -43222,6 +59890,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未發現孤立的離線檔案。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron archivos offline huerfanos."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun file offline orfano trovato."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Потерянные офлайн-файлы не найдены."
           }
         }
       }
@@ -43269,6 +59955,24 @@
             "state" : "translated",
             "value" : "已刪除 %1$lld 個，釋放 %2$@。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminados %1$lld elementos, liberados %2$@."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminati %1$lld elementi, liberati %2$@."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалено %1$lld элементов, освобождено %2$@."
+          }
         }
       }
     },
@@ -43314,6 +60018,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "單發作品"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "One-shots"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "One-shot"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "One-shot"
           }
         }
       }
@@ -43361,6 +60083,24 @@
             "state" : "translated",
             "value" : "刪除全部"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar todo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuovi tutto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить все"
+          }
         }
       }
     },
@@ -43406,6 +60146,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "將刪除所有離線書籍，此操作無法撤銷。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto eliminara todos los libros offline. Esta accion no se puede deshacer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo rimuovera tutti i libri offline. Questa azione non puo essere annullata."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это удалит все офлайн-книги. Это действие нельзя отменить."
           }
         }
       }
@@ -43453,6 +60211,24 @@
             "state" : "translated",
             "value" : "刪除已讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar leidos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimuovi letti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить прочитанные"
+          }
         }
       }
     },
@@ -43498,6 +60274,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "將刪除所有已讀離線書籍，此操作無法撤銷。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto eliminara todos los libros offline leidos. Esta accion no se puede deshacer."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo rimuovera tutti i libri offline letti. Questa azione non puo essere annullata."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это удалит все прочитанные офлайн-книги. Это действие нельзя отменить."
           }
         }
       }
@@ -43545,6 +60339,24 @@
             "state" : "translated",
             "value" : "總大小"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamano total"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dimensione totale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Общий размер"
+          }
         }
       }
     },
@@ -43590,6 +60402,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自動刪除已讀書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autoeliminar libros leidos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto elimina libri letti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоудаление прочитанных книг"
           }
         }
       }
@@ -43637,6 +60467,24 @@
             "state" : "translated",
             "value" : "同步時將自動刪除已讀書籍。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los libros leidos se eliminaran automaticamente durante la sincronizacion."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I libri letti verranno eliminati automaticamente durante la sincronizzazione."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прочитанные книги будут автоматически удаляться во время синхронизации."
+          }
         }
       }
     },
@@ -43682,6 +60530,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無離線書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin libros offline"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun libro offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет офлайн-книг"
           }
         }
       }
@@ -43729,6 +60595,24 @@
             "state" : "translated",
             "value" : "您尚未下載過任何書籍用於離線閱讀。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aun no has descargado libros para lectura offline."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non hai ancora scaricato libri per la lettura offline."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы еще не загрузили книги для офлайн-чтения."
+          }
         }
       }
     },
@@ -43774,6 +60658,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "同步資料"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizar datos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizza dati"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизировать данные"
           }
         }
       }
@@ -43821,6 +60723,24 @@
             "state" : "translated",
             "value" : "同步系列和書籍資料以供離線瀏覽"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizar datos de series y libros para exploracion offline"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizza dati di serie e libri per la navigazione offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизировать данные серий и книг для офлайн-обзора"
+          }
         }
       }
     },
@@ -43866,6 +60786,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "從未"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nunca"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mai"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Никогда"
           }
         }
       }
@@ -43913,6 +60851,24 @@
             "state" : "translated",
             "value" : "搖一搖打開實況文本"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agitar para abrir Live Text"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scuoti per aprire Live Text"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Встряхните, чтобы открыть Live Text"
+          }
         }
       }
     },
@@ -43958,6 +60914,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "搖晃設備來切換實況文本"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agita tu dispositivo para activar o desactivar Live Text"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scuoti il dispositivo per attivare/disattivare Live Text"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Потрясите устройство, чтобы включить или выключить Live Text"
           }
         }
       }
@@ -44005,6 +60979,24 @@
             "state" : "translated",
             "value" : "分享"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Condividi"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поделиться"
+          }
         }
       }
     },
@@ -44050,6 +61042,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分享第%d頁"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir pagina %d"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Condividi pagina %d"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поделиться страницей %d"
           }
         }
       }
@@ -44097,6 +61107,24 @@
             "state" : "translated",
             "value" : "共享標籤"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etiquetas de comparticion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etichette di condivisione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метки общего доступа"
+          }
         }
       }
     },
@@ -44142,6 +61170,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文字和線稿更清晰，推薦用於 iPad 和 Mac。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Texto y lineas mas nitidos. Recomendado para iPad y Mac."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Testo e line art piu nitidi. Consigliato per iPad e Mac."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Более четкий текст и штриховая графика. Рекомендуется для iPad и Mac."
           }
         }
       }
@@ -44189,6 +61235,24 @@
             "state" : "translated",
             "value" : "顯示連線狀態與任務完成提示"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar estado de conexion y notificaciones de finalizacion de tareas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra stato connessione e notifiche completamento attivita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать статус подключения и уведомления о завершении задач"
+          }
         }
       }
     },
@@ -44234,6 +61298,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示鍵盤輔助疊層"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar superposicion de ayuda de teclado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra overlay aiuto tastiera"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать оверлей помощи по клавиатуре"
           }
         }
       }
@@ -44281,6 +61363,24 @@
             "state" : "translated",
             "value" : "收起"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar menos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra meno"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показать меньше"
+          }
         }
       }
     },
@@ -44326,6 +61426,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "展開"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar mas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra di piu"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показать больше"
           }
         }
       }
@@ -44373,6 +61491,24 @@
             "state" : "translated",
             "value" : "顯示通知"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar notificaciones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra notifiche"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать уведомления"
+          }
         }
       }
     },
@@ -44418,6 +61554,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示點擊區提示"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar sugerencias de zonas tactiles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra suggerimenti zone di tocco"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать подсказки зон касания"
           }
         }
       }
@@ -44465,6 +61619,24 @@
             "state" : "translated",
             "value" : "進入雙頁跨頁前先單獨顯示第一頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar la primera pagina sola antes de entrar en doble pagina"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra la prima pagina da sola prima di passare alla doppia pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать первую страницу отдельно перед переходом к развороту"
+          }
         }
       }
     },
@@ -44510,6 +61682,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登入 Komga"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar sesion en Komga"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accedi a Komga"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Войти в Komga"
           }
         }
       }
@@ -44557,6 +61747,24 @@
             "state" : "translated",
             "value" : "新增日期"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de adicion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di aggiunta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата добавления"
+          }
         }
       }
     },
@@ -44602,6 +61810,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新日期"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de actualizacion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di aggiornamento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата обновления"
           }
         }
       }
@@ -44649,6 +61875,24 @@
             "state" : "translated",
             "value" : "名稱"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название"
+          }
         }
       }
     },
@@ -44694,6 +61938,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "翻頁點觸區域大小"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamano de zonas tactiles para navegacion de pagina"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dimensione zone di tocco per la navigazione pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размер зон касания для навигации по страницам"
           }
         }
       }
@@ -44741,6 +62003,24 @@
             "state" : "translated",
             "value" : "慢速"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lento"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Медленно"
+          }
         }
       }
     },
@@ -44786,6 +62066,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "離線檔案更小，在大多數手機上也有不錯的品質。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archivos offline mas pequenos con buena calidad en la mayoria de telefonos."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "File offline piu piccoli con buona qualita sulla maggior parte dei telefoni."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Более маленькие офлайн-файлы с хорошим качеством на большинстве телефонов."
           }
         }
       }
@@ -44833,6 +62131,24 @@
             "state" : "translated",
             "value" : "離線檔案最小，適合手機和儲存空間有限的場景。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los archivos offline mas pequenos. Ideal para telefonos y almacenamiento limitado."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I file offline piu piccoli. Ideale per telefoni e spazio limitato."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Самые маленькие офлайн-файлы. Лучше всего для телефонов и ограниченного хранилища."
+          }
         }
       }
     },
@@ -44878,6 +62194,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "排序"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordenar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сортировка"
           }
         }
       }
@@ -44925,6 +62259,24 @@
             "state" : "translated",
             "value" : "排序依據"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordenar por"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordina per"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сортировать по"
+          }
         }
       }
     },
@@ -44970,6 +62322,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "排序標題"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Título para el orden"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titolo di Ordinamento"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сортировать по названию"
           }
         }
       }
@@ -45017,6 +62387,24 @@
             "state" : "translated",
             "value" : "遞增"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ascendente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crescente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "По возрастанию"
+          }
         }
       }
     },
@@ -45062,6 +62450,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "遞減"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descendente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Decrescente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "По убыванию"
           }
         }
       }
@@ -45109,6 +62515,24 @@
             "state" : "translated",
             "value" : "原始碼"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codigo fuente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Codice sorgente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Исходный код"
+          }
         }
       }
     },
@@ -45154,6 +62578,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在連接伺服器..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectando al servidor..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connessione al server..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подключение к серверу..."
           }
         }
       }
@@ -45201,6 +62643,24 @@
             "state" : "translated",
             "value" : "正在準備您的收藏..."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando tu coleccion..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione della tua raccolta..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка вашей коллекции..."
+          }
         }
       }
     },
@@ -45246,6 +62706,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在同步您的媒體庫..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizando tu biblioteca..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzazione della tua libreria..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация вашей библиотеки..."
           }
         }
       }
@@ -45293,6 +62771,24 @@
             "state" : "translated",
             "value" : "正在更新您的個人資料..."
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizando tu perfil..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiornamento del tuo profilo..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновление вашего профиля..."
+          }
         }
       }
     },
@@ -45338,6 +62834,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "大型書庫遷移可能需要 1-2 分鐘，請保持 KMReader 開啟。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Las bibliotecas grandes pueden tardar 1-2 minutos en migrar. Mantén KMReader abierto."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le librerie grandi possono richiedere 1-2 minuti per la migrazione. Tieni KMReader aperto."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Миграция больших библиотек может занять 1-2 минуты. Не закрывайте KMReader."
           }
         }
       }
@@ -45385,6 +62899,24 @@
             "state" : "translated",
             "value" : "正在完成本機資料遷移"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizando migracion de datos locales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizzazione migrazione dati locali"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завершение миграции локальных данных"
+          }
         }
       }
     },
@@ -45430,6 +62962,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在遷移現有本機資料"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrando datos locales existentes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Migrazione dati locali esistenti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Миграция существующих локальных данных"
           }
         }
       }
@@ -45477,6 +63027,24 @@
             "state" : "translated",
             "value" : "準備本機資料庫遷移"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando migracion de base de datos local"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione migrazione database locale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка миграции локальной базы данных"
+          }
         }
       }
     },
@@ -45523,6 +63091,24 @@
             "state" : "translated",
             "value" : "分割寬頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dividir paginas anchas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dividi pagine larghe"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Разделять широкие страницы"
+          }
         }
       }
     },
@@ -45565,6 +63151,24 @@
           }
         },
         "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spotlight"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spotlight"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spotlight"
+          }
+        },
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Spotlight"
@@ -45615,6 +63219,24 @@
             "state" : "translated",
             "value" : "開始閱讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empezar a leer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inizia a leggere"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Начать чтение"
+          }
         }
       }
     },
@@ -45660,6 +63282,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "KMReader 無法開啟或升級本機資料。這可能發生在從很舊的版本升級時，或本機資料庫已經損壞時。請先再試一次。如果仍然失敗，請重新安裝 KMReader 以重設本機資料，然後重新登入。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader no pudo abrir o actualizar sus datos locales. Esto puede ocurrir al actualizar desde una version muy antigua, o si la base de datos local ya esta dañada. Intentalo una vez mas. Si aun falla, reinstala KMReader para restablecer los datos locales y vuelve a iniciar sesion."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader non e riuscito ad aprire o aggiornare i dati locali. Questo puo accadere durante l'aggiornamento da una versione molto vecchia, o se il database locale e gia corrotto. Riprova una volta. Se continua a fallire, reinstalla KMReader per ripristinare i dati locali, poi accedi di nuovo."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KMReader не удалось открыть или обновить локальные данные. Это может произойти при обновлении с очень старой версии или если локальная база данных уже повреждена. Попробуйте еще раз. Если ошибка повторится, переустановите KMReader, чтобы сбросить локальные данные, затем войдите снова."
           }
         }
       }
@@ -45707,6 +63347,24 @@
             "state" : "translated",
             "value" : "無法開啟本機資料"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron abrir los datos locales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile aprire i dati locali"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось открыть локальные данные"
+          }
         }
       }
     },
@@ -45752,6 +63410,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "狀態"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статус"
           }
         }
       }
@@ -45799,6 +63475,24 @@
             "state" : "translated",
             "value" : "已下載"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descargado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scaricato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загружено"
+          }
         }
       }
     },
@@ -45844,6 +63538,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未下載"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No descargado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non scaricato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не загружено"
           }
         }
       }
@@ -45891,6 +63603,24 @@
             "state" : "translated",
             "value" : "%1$lld/%2$lld 已下載"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld/%2$lld descargado"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld/%2$lld scaricato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld/%2$lld загружено"
+          }
         }
       }
     },
@@ -45936,6 +63666,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "等待中"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendiente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In attesa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В ожидании"
           }
         }
       }
@@ -45983,6 +63731,24 @@
             "state" : "translated",
             "value" : "%1$lld+%2$lld/%3$lld 等待中"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld+%2$lld/%3$lld pendiente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld+%2$lld/%3$lld in attesa"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld+%2$lld/%3$lld в ожидании"
+          }
         }
       }
     },
@@ -46028,6 +63794,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "成功"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Éxito"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Successo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Успех"
           }
         }
       }
@@ -46075,6 +63859,24 @@
             "state" : "translated",
             "value" : "概要"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resumen"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riepilogo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Описание"
+          }
         }
       }
     },
@@ -46120,6 +63922,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "摘要（可選）"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resumen (opcional)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riepilogo (opzionale)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Описание (необязательно)"
           }
         }
       }
@@ -46167,6 +63987,24 @@
             "state" : "translated",
             "value" : "已切換到 %@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cambiado a %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passato a %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переключено на %@"
+          }
         }
       }
     },
@@ -46212,6 +64050,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "同步中"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizando"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzazione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация"
           }
         }
       }
@@ -46259,6 +64115,24 @@
             "state" : "translated",
             "value" : "系統字體選擇器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selector de fuentes del sistema"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selettore font di sistema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбор системного шрифта"
+          }
         }
       }
     },
@@ -46304,6 +64178,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "書籍"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Книги"
           }
         }
       }
@@ -46351,6 +64243,24 @@
             "state" : "translated",
             "value" : "瀏覽"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Explorar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esplora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обзор"
+          }
         }
       }
     },
@@ -46396,6 +64306,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "收藏"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colecciones"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raccolte"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коллекции"
           }
         }
       }
@@ -46443,6 +64371,24 @@
             "state" : "translated",
             "value" : "主頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicio"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Главная"
+          }
         }
       }
     },
@@ -46488,6 +64434,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "離線"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin conexion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн"
           }
         }
       }
@@ -46535,6 +64499,24 @@
             "state" : "translated",
             "value" : "閱讀列表"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listas de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Liste di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Списки чтения"
+          }
         }
       }
     },
@@ -46580,6 +64562,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Series"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Серии"
           }
         }
       }
@@ -46627,6 +64627,24 @@
             "state" : "translated",
             "value" : "伺服器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servidor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сервер"
+          }
         }
       }
     },
@@ -46672,6 +64690,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impostazioni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки"
           }
         }
       }
@@ -46719,6 +64755,24 @@
             "state" : "translated",
             "value" : "目錄"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tabla de contenido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indice"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Оглавление"
+          }
         }
       }
     },
@@ -46764,6 +64818,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "標籤"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etiqueta"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tag"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тег"
           }
         }
       }
@@ -46811,6 +64883,24 @@
             "state" : "translated",
             "value" : "標籤"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etiquetas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etichette"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Теги"
+          }
         }
       }
     },
@@ -46856,6 +64946,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "標籤分布"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distribucion de etiquetas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Distribuzione tag"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Распределение тегов"
           }
         }
       }
@@ -46903,6 +65011,24 @@
             "state" : "translated",
             "value" : "點擊翻頁捲動時長"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Duracion de desplazamiento al tocar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durata scorrimento al tocco"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Длительность прокрутки по касанию"
+          }
         }
       }
     },
@@ -46948,6 +65074,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "點擊區域模式"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo de zona tactil"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modalita zona di tocco"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Режим зон касания"
           }
         }
       }
@@ -46995,6 +65139,24 @@
             "state" : "translated",
             "value" : "點觸區域大小"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamano de zona tactil"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dimensione zona di tocco"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размер зоны касания"
+          }
         }
       }
     },
@@ -47040,6 +65202,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "任務佇列狀態"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado de cola de tareas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stato coda attivita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статус очереди задач"
           }
         }
       }
@@ -47087,6 +65267,24 @@
             "state" : "translated",
             "value" : "任務"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tareas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attivita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задачи"
+          }
         }
       }
     },
@@ -47132,6 +65330,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已執行任務"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tareas ejecutadas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attivita eseguite"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выполненные задачи"
           }
         }
       }
@@ -47179,6 +65395,24 @@
             "state" : "translated",
             "value" : "任務總耗時"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo total de tareas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tempo totale attivita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Общее время задач"
+          }
         }
       }
     },
@@ -47224,6 +65458,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用條款"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminos de uso"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Termini di utilizzo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Условия использования"
           }
         }
       }
@@ -47271,6 +65523,24 @@
             "state" : "translated",
             "value" : "感謝支持"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gracias por tu apoyo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grazie per il supporto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Спасибо за поддержку"
+          }
         }
       }
     },
@@ -47316,6 +65586,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "謝謝你的咖啡！☕️"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gracias por el cafe! ☕️"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grazie per il caffe! ☕️"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Спасибо за кофе! ☕️"
           }
         }
       }
@@ -47363,6 +65651,24 @@
             "state" : "translated",
             "value" : "閱讀器背景色"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El color de fondo del lector"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il colore di sfondo del lettore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цвет фона ридера"
+          }
         }
       }
     },
@@ -47408,6 +65714,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "快速的棕色狐狸跳過懶狗。這是一段示例文本，用於預覽您的閱讀偏好設定。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El veloz zorro marron salta sobre el perro perezoso. Este es un texto de ejemplo para previsualizar tus preferencias de lectura."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La rapida volpe marrone salta sopra il cane pigro. Questo e un testo di esempio per visualizzare in anteprima le preferenze di lettura."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Быстрая бурая лиса перепрыгивает через ленивую собаку. Это пример текста для предпросмотра ваших настроек чтения."
           }
         }
       }
@@ -47455,6 +65779,24 @@
             "state" : "translated",
             "value" : "主題"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tema"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тема"
+          }
         }
       }
     },
@@ -47500,6 +65842,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "主題預設"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Presets de tema"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preset tema"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пресеты темы"
           }
         }
       }
@@ -47547,6 +65907,24 @@
             "state" : "translated",
             "value" : "主題與設置"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temas y ajustes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temi e impostazioni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Темы и настройки"
+          }
         }
       }
     },
@@ -47592,6 +65970,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "此功能僅管理員可用"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta funcion solo esta disponible para administradores"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questa funzione e disponibile solo per gli amministratori"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Эта функция доступна только администраторам"
           }
         }
       }
@@ -47639,6 +66035,24 @@
             "state" : "translated",
             "value" : "本週"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta semana"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questa settimana"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Эта неделя"
+          }
         }
       }
     },
@@ -47684,6 +66098,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "這將從 Komga 永久刪除 %@。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto eliminara permanentemente %@ de Komga."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo eliminera definitivamente %@ da Komga."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это навсегда удалит %@ из Komga."
           }
         }
       }
@@ -47731,6 +66163,24 @@
             "state" : "translated",
             "value" : "將移除 %@、其憑證與所有快取資料。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto eliminara %@, sus credenciales y todos los datos en cache de este servidor."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo rimuovera %@, le sue credenziali e tutti i dati in cache per questo server."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это удалит %@, его учетные данные и все кэшированные данные этого сервера."
+          }
         }
       }
     },
@@ -47776,6 +66226,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "將移除所有伺服器的快取封面，需要時會重新下載。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto eliminara todas las portadas en cache de todos los servidores. Las portadas se volveran a descargar cuando sea necesario."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo rimuovera tutte le copertine in cache per tutti i server. Le copertine verranno riscaricate quando necessario."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это удалит все кэшированные обложки для всех серверов. При необходимости обложки будут загружены заново."
           }
         }
       }
@@ -47823,6 +66291,24 @@
             "state" : "translated",
             "value" : "這將刪除所有服務器上緩存的頁面圖像。需要時將重新下載圖像。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto eliminara todas las imagenes de pagina en cache de todos los servidores. Las imagenes se volveran a descargar cuando sea necesario."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo rimuovera tutte le immagini pagina in cache per tutti i server. Le immagini verranno riscaricate quando necessario."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это удалит все кэшированные изображения страниц для всех серверов. При необходимости изображения будут загружены заново."
+          }
         }
       }
     },
@@ -47868,6 +66354,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "將移除當前伺服器的快取封面，需要時會重新下載。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto eliminara las portadas en cache del servidor actual. Las portadas se volveran a descargar cuando sea necesario."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo rimuovera le copertine in cache per il server corrente. Le copertine verranno riscaricate quando necessario."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это удалит кэшированные обложки текущего сервера. При необходимости обложки будут загружены заново."
           }
         }
       }
@@ -47915,6 +66419,24 @@
             "state" : "translated",
             "value" : "這將刪除當前服務器上緩存的頁面圖像。需要时將重新下載圖像。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esto eliminara las imagenes de pagina en cache del servidor actual. Las imagenes se volveran a descargar cuando sea necesario."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questo rimuovera le immagini pagina in cache per il server corrente. Le immagini verranno riscaricate quando necessario."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Это удалит кэшированные изображения страниц текущего сервера. При необходимости изображения будут загружены заново."
+          }
         }
       }
     },
@@ -47960,6 +66482,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "時間"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tempo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Время"
           }
         }
       }
@@ -48007,6 +66547,24 @@
             "state" : "translated",
             "value" : "超時時間（秒）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Segundos de espera"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Secondi timeout"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Секунды таймаута"
+          }
         }
       }
     },
@@ -48052,6 +66610,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "時間戳"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marca de tiempo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timestamp"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метка времени"
           }
         }
       }
@@ -48099,6 +66675,24 @@
             "state" : "translated",
             "value" : "提示：點擊或拖動資料點可查看詳情。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Consejo: toca o arrastra un punto para ver detalles."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suggerimento: tocca o trascina un punto per vedere i dettagli."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Совет: коснитесь или перетащите точку, чтобы посмотреть детали."
+          }
         }
       }
     },
@@ -48144,6 +66738,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "標題"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titulo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название"
           }
         }
       }
@@ -48191,6 +66803,24 @@
             "state" : "translated",
             "value" : "標題排序"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orden de titulo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ordinamento titolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сортировка по названию"
+          }
         }
       }
     },
@@ -48236,6 +66866,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "瀏覽"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Explorar"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esplora"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обзор"
           }
         }
       }
@@ -48283,6 +66931,24 @@
             "state" : "translated",
             "value" : "章節"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capitulos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capitoli"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Главы"
+          }
         }
       }
     },
@@ -48328,6 +66994,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "收藏"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Coleccion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raccolta"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Коллекция"
           }
         }
       }
@@ -48375,6 +67059,24 @@
             "state" : "translated",
             "value" : "主頁"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Panel"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dashboard"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Панель"
+          }
         }
       }
     },
@@ -48420,6 +67122,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀列表"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lista de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elenco di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Список чтения"
           }
         }
       }
@@ -48467,6 +67187,24 @@
             "state" : "translated",
             "value" : "設定"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impostazioni"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки"
+          }
         }
       }
     },
@@ -48512,6 +67250,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "标题"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titulos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titoli"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Названия"
           }
         }
       }
@@ -48559,6 +67315,24 @@
             "state" : "translated",
             "value" : "要查看字體名稱，請到裝置「設定 > 一般 > 字體」，含個人安裝字體。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para encontrar nombres de fuentes, ve a Ajustes > General > Fuentes en tu dispositivo. Todas las fuentes, incluidas las instaladas por perfil, estan disponibles."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Per trovare i nomi dei font, vai su Impostazioni > Generali > Font sul tuo dispositivo. Tutti i font, inclusi quelli installati tramite profilo, sono disponibili."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чтобы найти имена шрифтов, откройте Настройки > Основные > Шрифты на устройстве. Доступны все шрифты, включая установленные через профиль."
+          }
         }
       }
     },
@@ -48604,6 +67378,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "熱門作者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autores principales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autori principali"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Топ авторов"
           }
         }
       }
@@ -48651,6 +67443,24 @@
             "state" : "translated",
             "value" : "熱門類型"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generos principales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generi principali"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Топ жанров"
+          }
         }
       }
     },
@@ -48696,6 +67506,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "熱門標籤"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etiquetas principales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tag principali"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Топ тегов"
           }
         }
       }
@@ -48743,6 +67571,24 @@
             "state" : "translated",
             "value" : "書籍總數"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cantidad total de libros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fumetti totali"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Общее количество книг"
+          }
         }
       }
     },
@@ -48788,6 +67634,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "圖書總數"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total de libros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libri totali"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Всего книг"
           }
         }
       }
@@ -48835,6 +67699,24 @@
             "state" : "translated",
             "value" : "任務總數"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Total de tareas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Totale attivita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Всего задач"
+          }
         }
       }
     },
@@ -48880,6 +67762,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "交易驗證失敗"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fallo la verificacion de transaccion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifica transazione non riuscita"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверка транзакции не удалась"
           }
         }
       }
@@ -48927,6 +67827,24 @@
             "state" : "translated",
             "value" : "重試"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intentar de nuevo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riprova"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Попробовать снова"
+          }
         }
       }
     },
@@ -48972,6 +67890,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "嘗試選擇不同的庫"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intenta seleccionar una biblioteca diferente."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prova a selezionare una libreria diversa."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Попробуйте выбрать другую библиотеку."
           }
         }
       }
@@ -49019,6 +67955,24 @@
             "state" : "translated",
             "value" : "類型"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тип"
+          }
         }
       }
     },
@@ -49064,6 +68018,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "字體"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipografia"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipo di carattere"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Гарнитура"
           }
         }
       }
@@ -49111,6 +68083,24 @@
             "state" : "translated",
             "value" : "超高（5120 px）"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultra (5120 px)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultra (5120 px)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ультра (5120 px)"
+          }
         }
       }
     },
@@ -49156,6 +68146,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無法編碼憑證"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron codificar las credenciales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile codificare le credenziali"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось закодировать учетные данные"
           }
         }
       }
@@ -49203,6 +68211,24 @@
             "state" : "translated",
             "value" : "無法載入篩選器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron cargar los filtros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile caricare i filtri"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить фильтры"
+          }
         }
       }
     },
@@ -49248,6 +68274,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無法載入該書頁面，格式可能不受支援。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron cargar las paginas de este libro. Puede que este formato no sea compatible."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile caricare le pagine di questo libro. Questo formato potrebbe non essere supportato."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось загрузить страницы этой книги. Возможно, этот формат не поддерживается."
           }
         }
       }
@@ -49295,6 +68339,24 @@
             "state" : "translated",
             "value" : "不可用"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No disponible"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недоступно"
+          }
         }
       }
     },
@@ -49340,6 +68402,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "未知"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desconocido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sconosciuto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Неизвестный"
           }
         }
       }
@@ -49387,6 +68467,24 @@
             "state" : "translated",
             "value" : "未讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No leido"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non letto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Непрочитано"
+          }
         }
       }
     },
@@ -49432,6 +68530,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不支持"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No compatible"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non supportato"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не поддерживается"
           }
         }
       }
@@ -49479,6 +68595,24 @@
             "state" : "translated",
             "value" : "URL 連結"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL"
+          }
         }
       }
     },
@@ -49524,6 +68658,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用原生 PDF 閱讀器"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usar lector PDF nativo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa lettore PDF nativo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Использовать нативный PDF-ридер"
           }
         }
       }
@@ -49571,6 +68723,24 @@
             "state" : "translated",
             "value" : "用於由 DIVINA Reader 渲染的離線下載 PDF 書籍。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se usa para libros PDF descargados offline renderizados por el lector DIVINA."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usato per libri PDF scaricati offline renderizzati dal lettore DIVINA."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Используется для офлайн-загруженных PDF-книг, отрисованных ридером DIVINA."
+          }
         }
       }
     },
@@ -49616,6 +68786,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "用於連續捲動模式下的單頁與雙頁顯示"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se usa para presentacion de pagina unica y doble en modo continuo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usato per la presentazione a pagina singola e doppia in modalita continua"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Используется для одиночного и двойного отображения страниц в непрерывном режиме"
           }
         }
       }
@@ -49663,6 +68851,24 @@
             "state" : "translated",
             "value" : "當書籍或系列未指定閱讀方向時使用"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se usa cuando un libro o serie no especifica direccion de lectura"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usato quando un libro o una serie non specificano una direzione di lettura"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Используется, когда книга или серия не задают направление чтения"
+          }
         }
       }
     },
@@ -49708,6 +68914,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuario"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пользователь"
           }
         }
       }
@@ -49755,6 +68979,24 @@
             "state" : "translated",
             "value" : "普通用戶"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acceso de usuario"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accesso utente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Доступ пользователя"
+          }
         }
       }
     },
@@ -49800,6 +69042,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "管理員"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Administrador"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amministratore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Администратор"
           }
         }
       }
@@ -49847,6 +69107,24 @@
             "state" : "translated",
             "value" : "檔案下載"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descarga de archivos"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download file"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка файлов"
+          }
         }
       }
     },
@@ -49892,6 +69170,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kobo 同步"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizar con Kobo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kobo Sync"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация с Kobo"
           }
         }
       }
@@ -49939,6 +69235,24 @@
             "state" : "translated",
             "value" : "KOReader 同步"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizar con KOReader"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "KOReader Sync"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация с KOReader"
+          }
         }
       }
     },
@@ -49984,6 +69298,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "無角色"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sin roles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun ruolo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет ролей"
           }
         }
       }
@@ -50031,6 +69363,24 @@
             "state" : "translated",
             "value" : "流式閱讀"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Streaming de paginas"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Streaming pagine"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Потоковая передача страниц"
+          }
         }
       }
     },
@@ -50076,6 +69426,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用者"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuario"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пользователь"
           }
         }
       }
@@ -50123,6 +69491,24 @@
             "state" : "translated",
             "value" : "使用者名稱"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre de usuario"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome utente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Имя пользователя"
+          }
         }
       }
     },
@@ -50168,6 +69554,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用者名稱和密碼"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuario y contrasena"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nome utente e password"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Имя пользователя и пароль"
           }
         }
       }
@@ -50215,6 +69619,24 @@
             "state" : "translated",
             "value" : "驗證連線"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validar conexion"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifica connessione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверить подключение"
+          }
         }
       }
     },
@@ -50260,6 +69682,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "驗證失敗：%@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validacion fallida: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validazione non riuscita: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверка не пройдена: %@"
           }
         }
       }
@@ -50307,6 +69747,24 @@
             "state" : "translated",
             "value" : "數值"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Значение"
+          }
         }
       }
     },
@@ -50352,6 +69810,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "廠商"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proveedor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fornitore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поставщик"
           }
         }
       }
@@ -50399,6 +69875,24 @@
             "state" : "translated",
             "value" : "廠商版本"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version del proveedor"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versione fornitore"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Версия поставщика"
+          }
         }
       }
     },
@@ -50444,6 +69938,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "版本"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versione"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Версия"
           }
         }
       }
@@ -50491,6 +70003,24 @@
             "state" : "translated",
             "value" : "檢視詳細資訊"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver detalles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vedi dettagli"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Смотреть детали"
+          }
         }
       }
     },
@@ -50536,6 +70066,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "檢視系列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver serie"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vedi serie"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открыть серию"
           }
         }
       }
@@ -50583,6 +70131,24 @@
             "state" : "translated",
             "value" : "Waifu2x 模式"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo Waifu2x"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modalita Waifu2x"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Режим Waifu2x"
+          }
         }
       }
     },
@@ -50628,6 +70194,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Webtoon 頁寬"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ancho de pagina webtoon"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Larghezza pagina webtoon"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ширина страницы webtoon"
           }
         }
       }
@@ -50675,6 +70259,24 @@
             "state" : "translated",
             "value" : "Webtoon 點擊捲動高度"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altura de desplazamiento al tocar en webtoon"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Altezza scorrimento al tocco in webtoon"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Высота прокрутки по касанию в webtoon"
+          }
         }
       }
     },
@@ -50720,6 +70322,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "每週"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semanal"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settimanale"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Еженедельно"
           }
         }
       }
@@ -50767,6 +70387,24 @@
             "state" : "translated",
             "value" : "字重: %@"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Peso: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Peso: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вес: %@"
+          }
         }
       }
     },
@@ -50812,6 +70450,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "關閉後不再顯示連線狀態與任務完成訊息。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuando esta desactivado, no se mostraran el estado de conexion ni los mensajes de tareas completadas."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando disabilitato, non verranno mostrati lo stato connessione e i messaggi di completamento attivita."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Если отключено, статус подключения и сообщения о завершении задач не будут показаны."
           }
         }
       }
@@ -50859,6 +70515,24 @@
             "state" : "translated",
             "value" : "停用後，Spotlight 將不會索引任何書籍。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuando esta desactivado, no se indexara ningun libro en Spotlight."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando disabilitato, nessun libro verra indicizzato in Spotlight."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Если отключено, книги не будут индексироваться в Spotlight."
+          }
         }
       }
     },
@@ -50904,6 +70578,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "關閉後即使收到 SSE 也不會自動刷新，可手動更新。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuando esta desactivado, el panel no se actualizara automaticamente al recibir eventos SSE. Aun puedes actualizar manualmente."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando disabilitato, la dashboard non si aggiornera automaticamente alla ricezione di eventi SSE. Puoi comunque aggiornare manualmente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Если отключено, панель не будет автоматически обновляться при получении SSE-событий. Вы все равно можете обновить вручную."
           }
         }
       }
@@ -50951,6 +70643,24 @@
             "state" : "translated",
             "value" : "啟用後，Spotlight 會索引目前伺服器中所有資料庫裡已下載的書籍。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuando esta activado, Spotlight indexa libros descargados de todas las bibliotecas del servidor actual."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quando abilitato, Spotlight indicizza i libri scaricati da tutte le librerie del server corrente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Если включено, Spotlight индексирует загруженные книги из всех библиотек текущего сервера."
+          }
         }
       }
     },
@@ -50996,6 +70706,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "詞間距: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espaciado de palabras: %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spaziatura parole: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Интервал между словами: %@"
           }
         }
       }
@@ -51043,6 +70771,24 @@
             "state" : "translated",
             "value" : "X軸：日期，Y軸：預計閱讀小時。"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eje X: fecha, eje Y: horas estimadas de lectura."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Asse X: data, asse Y: ore di lettura stimate."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ось X: дата, ось Y: оценочные часы чтения."
+          }
         }
       }
     },
@@ -51088,6 +70834,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "您可以調整字體大小、間距和其他設定，以找到最適合您的效果。每個段落都展示了文本在當前設定下的顯示效果。"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puedes ajustar tamano de fuente, espaciado y otras opciones para encontrar lo que mejor te funcione. Cada parrafo muestra como se vera el texto con tus elecciones actuales."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Puoi regolare dimensione font, spaziatura e altre impostazioni per trovare cio che funziona meglio per te. Ogni paragrafo mostra come apparira il testo con le tue scelte attuali."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы можете настроить размер шрифта, интервалы и другие параметры, чтобы найти лучший вариант для себя. Каждый абзац показывает, как будет выглядеть текст при текущих настройках."
           }
         }
       }
@@ -51135,6 +70899,24 @@
             "state" : "translated",
             "value" : "已讀完"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estas al dia!"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei aggiornato!"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы все прочитали!"
+          }
         }
       }
     },
@@ -51180,6 +70962,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你太棒了！"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eres increible!"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sei fantastico!"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вы великолепны!"
           }
         }
       }
@@ -51227,6 +71027,24 @@
             "state" : "translated",
             "value" : "你的漫畫閱讀器"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu lector personal de manga y comics"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il tuo lettore personale di manga e fumetti"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваш персональный ридер манги и комиксов"
+          }
         }
       }
     },
@@ -51272,6 +71090,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "你的漫畫閱讀器"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu lector personal de manga"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il tuo lettore personale di manga"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваш персональный ридер манги"
           }
         }
       }
@@ -51319,6 +71155,24 @@
             "state" : "translated",
             "value" : "雙擊頁面時的縮放比例"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nivel de zoom al tocar dos veces una pagina"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Livello zoom al doppio tocco su una pagina"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Уровень увеличения при двойном касании страницы"
+          }
         }
       }
     },
@@ -51364,6 +71218,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "縮放"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Масштабирование"
           }
         }
       }

--- a/KMReaderWidgets/Localizable.xcstrings
+++ b/KMReaderWidgets/Localizable.xcstrings
@@ -50,6 +50,24 @@
             "state" : "translated",
             "value" : "從上次中斷的地方繼續"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continúa donde lo dejaste"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continua da dove avevi interrotto"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжайте с того места, где остановились"
+          }
         }
       }
     },
@@ -95,6 +113,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "繼續閱讀"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seguir leyendo"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continua a leggere"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продолжить чтение"
           }
         }
       }
@@ -142,6 +178,24 @@
             "state" : "translated",
             "value" : "暫無書籍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay libros disponibles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun libro disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет доступных книг"
+          }
         }
       }
     },
@@ -187,6 +241,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "暫無系列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay series disponibles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna serie disponibile"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет доступных серий"
           }
         }
       }
@@ -234,6 +306,24 @@
             "state" : "translated",
             "value" : "查看最近新增的書籍"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver libros añadidos recientemente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vedi i libri aggiunti di recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Посмотреть недавно добавленные книги"
+          }
         }
       }
     },
@@ -279,6 +369,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近新增"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadidos recientemente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiunti di recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавно добавленные"
           }
         }
       }
@@ -326,6 +434,24 @@
             "state" : "translated",
             "value" : "查看最近更新的系列"
           }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ver series actualizadas recientemente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vedi le serie aggiornate di recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Посмотреть недавно обновленные серии"
+          }
         }
       }
     },
@@ -371,6 +497,24 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "最近更新的系列"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Series actualizadas recientemente"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serie aggiornate di recente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавно обновленные серии"
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - Save and reuse filters across browse surfaces.
 - Reading history and stats help surface recent activity from synced local data.
 - Spotlight integration for downloaded content on iOS/macOS, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
+- UI localization includes English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
 
 ### Offline and Sync
 

--- a/misc/translate.py
+++ b/misc/translate.py
@@ -10,7 +10,18 @@ from localize_sort import sort_keys
 
 # Path to the xcstrings file relative to the project root
 XISTRINGS_PATH = "KMReader/Localizable.xcstrings"
-REQUIRED_LANGUAGES = ["de", "en", "fr", "ja", "ko", "zh-Hans", "zh-Hant"]
+REQUIRED_LANGUAGES = [
+    "de",
+    "en",
+    "es",
+    "fr",
+    "it",
+    "ja",
+    "ko",
+    "ru",
+    "zh-Hans",
+    "zh-Hant",
+]
 
 
 def eprint(*args, **kwargs):
@@ -86,9 +97,12 @@ def main():
     update_parser.add_argument("key", help="The key to update")
     update_parser.add_argument("--de", help="German translation")
     update_parser.add_argument("--en", help="English translation")
+    update_parser.add_argument("--es", help="Spanish translation")
     update_parser.add_argument("--fr", help="French translation")
+    update_parser.add_argument("--it", help="Italian translation")
     update_parser.add_argument("--ja", help="Japanese translation")
     update_parser.add_argument("--ko", help="Korean translation")
+    update_parser.add_argument("--ru", help="Russian translation")
     update_parser.add_argument("--zh-hans", help="Simplified Chinese translation")
     update_parser.add_argument("--zh-hant", help="Traditional Chinese translation")
 
@@ -130,9 +144,12 @@ def main():
         translations = {
             "de": args.de,
             "en": args.en,
+            "es": args.es,
             "fr": args.fr,
+            "it": args.it,
             "ja": args.ja,
             "ko": args.ko,
+            "ru": args.ru,
             "zh-Hans": args.zh_hans,
             "zh-Hant": args.zh_hant,
         }

--- a/static/index.html
+++ b/static/index.html
@@ -130,6 +130,15 @@
                             view logs directly in KMReader.
                         </p>
                     </article>
+                    <article class="card">
+                        <span class="pill">Localization</span>
+                        <h3>Read and manage in your language</h3>
+                        <p>
+                            KMReader UI supports English, German, French,
+                            Japanese, Korean, Simplified Chinese, Traditional
+                            Chinese, Italian, Russian, and Spanish.
+                        </p>
+                    </article>
                 </div>
             </section>
 


### PR DESCRIPTION
## Summary
- add `es`, `it`, and `ru` to the project known regions and localization tooling (`misc/translate.py`)
- update localization/docs skills and repo contributor docs so translation workflows include the new languages
- refresh product-facing docs (`README.md`, `APP_STORE_DESCRIPTION.txt`, `static/index.html`) with updated language support
- complete `es/it/ru` translations for app, widget, and InfoPlist string catalogs

## Testing
- [x] `python3 misc/translate.py list`
- [x] `python3 -m py_compile misc/translate.py`
