### PR TITLE
fix: ignore 409 conflicts in progress sync

### DIFF
--- a/KMReader/Core/Storage/Errors/APIError.swift
+++ b/KMReader/Core/Storage/Errors/APIError.swift
@@ -149,4 +149,29 @@ enum APIError: Error, CustomStringConvertible, LocalizedError {
   var errorDescription: String? {
     description
   }
+
+  var statusCode: Int? {
+    switch self {
+    case .badRequest:
+      return 400
+    case .unauthorized:
+      return 401
+    case .forbidden:
+      return 403
+    case .notFound:
+      return 404
+    case .tooManyRequests:
+      return 429
+    case .httpError(let code, _, _, _, _):
+      return code
+    case .serverError(let code, _, _, _, _):
+      return code
+    case .invalidURL, .invalidResponse, .decodingError, .networkError, .offline:
+      return nil
+    }
+  }
+
+  var isConflict: Bool {
+    statusCode == 409
+  }
 }

--- a/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
+++ b/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
@@ -471,6 +471,13 @@ actor ReaderProgressDispatchService {
         try await Self.performPageProgressServerUpdate(update, timeout: progressRequestTimeout)
         return .serverUpdated
       } catch {
+        if let apiError = error as? APIError, apiError.isConflict {
+          logger.info(
+            "⏭️ [Progress/Page] Ignored conflict (409): book=\(update.bookId), version=\(update.version), page=\(update.page)"
+          )
+          return .serverUpdated
+        }
+
         guard Self.isTimeoutError(error) else {
           logger.error(
             "❌ [Progress/Page] Update failed: book=\(update.bookId), version=\(update.version), page=\(update.page), error=\(error.localizedDescription)"
@@ -523,6 +530,13 @@ actor ReaderProgressDispatchService {
         }
         return .serverUpdated
       } catch {
+        if let apiError = error as? APIError, apiError.isConflict {
+          logger.info(
+            "⏭️ [Progress/Epub] Ignored conflict (409): book=\(update.bookId), version=\(update.version)"
+          )
+          return .serverUpdated
+        }
+
         guard Self.isTimeoutError(error) else {
           logger.error(
             "❌ [Progress/Epub] Update failed: book=\(update.bookId), version=\(update.version), error=\(error.localizedDescription)"

--- a/KMReader/Features/Sync/Services/ProgressSyncService.swift
+++ b/KMReader/Features/Sync/Services/ProgressSyncService.swift
@@ -45,6 +45,7 @@ actor ProgressSyncService {
 
     var successCount = 0
     var failureCount = 0
+    var ignoredConflictCount = 0
     var completedBookIds = Set<String>()
 
     for item in pending {
@@ -62,6 +63,18 @@ actor ProgressSyncService {
           completedBookIds.insert(item.bookId)
         }
       } catch {
+        if let apiError = error as? APIError, apiError.isConflict {
+          logger.info(
+            "⏭️ Ignored progress conflict (409) for book \(item.bookId) (pending id=\(item.id))"
+          )
+          await DatabaseOperator.shared.deletePendingProgress(id: item.id)
+          await DatabaseOperator.shared.commit()
+          ignoredConflictCount += 1
+          if item.completed {
+            completedBookIds.insert(item.bookId)
+          }
+          continue
+        }
         logger.error(
           "❌ Failed to sync progress for book \(item.bookId) (pending id=\(item.id)): \(error.localizedDescription)"
         )
@@ -92,6 +105,10 @@ actor ProgressSyncService {
           )
         }
       }
+    }
+
+    if ignoredConflictCount > 0 {
+      logger.info("⏭️ Ignored \(ignoredConflictCount) progress conflicts (409)")
     }
 
     if failureCount > 0 {


### PR DESCRIPTION
## Summary
- Ignore HTTP 409 conflict responses during pending progress sync and remove the queued item instead of treating it as a failure.
- Ignore HTTP 409 conflict responses during live reader progress dispatch for both page and EPUB progression updates.
- Extract `APIError.statusCode` and `APIError.isConflict` to centralize conflict classification and remove duplicated service-level helpers.

## Testing
- [x] `make format`
- [x] `make build-macos`
