### PR TITLE
feat: add Dynamic Island live activity for reader and downloads

### DIFF
--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -522,6 +522,18 @@ enum AppConfig {
     }
   }
 
+  static nonisolated var useNativePdfReader: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "useNativePdfReader") != nil {
+        return UserDefaults.standard.bool(forKey: "useNativePdfReader")
+      }
+      return true
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: "useNativePdfReader")
+    }
+  }
+
   static nonisolated var pageLayout: PageLayout {
     get {
       if let stored = UserDefaults.standard.string(forKey: "pageLayout") {

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -45,6 +45,9 @@ actor OfflineManager {
   private var syncTaskID: UUID?
   private var isProcessingQueue = false
   private var completedDownloadsSinceLastNotification = 0
+  #if os(iOS)
+    private var foregroundDownloadInfoByBookId: [String: (instanceId: String, info: DownloadInfo)] = [:]
+  #endif
 
   private let logger = AppLogger(.offline)
   private let pageImageCache = ImageCache()
@@ -827,6 +830,19 @@ actor OfflineManager {
   private func startForegroundDownload(
     instanceId: String, info: DownloadInfo, bookDir: URL
   ) async {
+    #if os(iOS)
+      foregroundDownloadInfoByBookId[info.bookId] = (instanceId: instanceId, info: info)
+      let pendingBooks = await DatabaseOperator.shared.fetchPendingBooks(instanceId: instanceId)
+      let failedCount = await DatabaseOperator.shared.fetchFailedBooksCount(instanceId: instanceId)
+      await LiveActivityManager.shared.startActivity(
+        seriesTitle: info.seriesTitle,
+        bookInfo: info.bookInfo,
+        totalBooks: pendingBooks.count + 1,
+        pendingCount: pendingBooks.count,
+        failedCount: failedCount
+      )
+    #endif
+
     activeTasks[info.bookId] = Task { [weak self, logger] in
       guard let self else { return }
       do {
@@ -847,6 +863,9 @@ actor OfflineManager {
           bookId: info.bookId,
           bookDir: bookDir
         )
+        #if os(iOS)
+          await self.finishForegroundLiveActivity(bookId: info.bookId, instanceId: instanceId)
+        #endif
         logger.info("✅ Download complete for book: \(info.bookId)")
 
         // Trigger next download
@@ -877,6 +896,9 @@ actor OfflineManager {
           }
         }
         await removeActiveTask(info.bookId)
+        #if os(iOS)
+          await self.finishForegroundLiveActivity(bookId: info.bookId, instanceId: instanceId)
+        #endif
 
         // Trigger next download even on failure or cancellation
         await syncDownloadQueue(instanceId: instanceId)
@@ -1076,6 +1098,56 @@ actor OfflineManager {
       }
     }
   }
+
+  #if os(iOS)
+    private func updateForegroundLiveActivityProgress(bookId: String, progress: Double) async {
+      guard let entry = foregroundDownloadInfoByBookId[bookId] else { return }
+      let pendingBooks = await DatabaseOperator.shared.fetchPendingBooks(instanceId: entry.instanceId)
+      let failedCount = await DatabaseOperator.shared.fetchFailedBooksCount(
+        instanceId: entry.instanceId
+      )
+      await LiveActivityManager.shared.updateActivity(
+        seriesTitle: entry.info.seriesTitle,
+        bookInfo: entry.info.bookInfo,
+        progress: progress,
+        pendingCount: pendingBooks.count,
+        failedCount: failedCount
+      )
+    }
+
+    private func finishForegroundLiveActivity(bookId: String, instanceId: String) async {
+      foregroundDownloadInfoByBookId.removeValue(forKey: bookId)
+
+      let pendingBooks = await DatabaseOperator.shared.fetchPendingBooks(instanceId: instanceId)
+      let failedCount = await DatabaseOperator.shared.fetchFailedBooksCount(instanceId: instanceId)
+
+      if pendingBooks.isEmpty {
+        if failedCount > 0 {
+          await LiveActivityManager.shared.updateActivity(
+            seriesTitle: String(localized: "Offline"),
+            bookInfo: String(localized: "Download finished with failures"),
+            progress: 1.0,
+            pendingCount: 0,
+            failedCount: failedCount
+          )
+        } else {
+          await LiveActivityManager.shared.endActivity()
+        }
+        return
+      }
+
+      let candidate = foregroundDownloadInfoByBookId.values.first?.info
+      let seriesTitle = candidate?.seriesTitle ?? String(localized: "Offline")
+      let bookInfo = candidate?.bookInfo ?? String(localized: "Downloading")
+      await LiveActivityManager.shared.updateActivity(
+        seriesTitle: seriesTitle,
+        bookInfo: bookInfo,
+        progress: 1.0,
+        pendingCount: pendingBooks.count,
+        failedCount: failedCount
+      )
+    }
+  #endif
 
   private nonisolated func isNetworkRelatedError(_ error: Error) -> Bool {
     if let apiError = error as? APIError {
@@ -1289,6 +1361,9 @@ actor OfflineManager {
     await MainActor.run {
       DownloadProgressTracker.shared.updateProgress(bookId: bookId, value: 1.0)
     }
+    #if os(iOS)
+      await updateForegroundLiveActivityProgress(bookId: bookId, progress: 1.0)
+    #endif
   }
 
   private func downloadWebPubResources(

--- a/KMReader/Features/Reader/Services/ReaderLiveActivityManager.swift
+++ b/KMReader/Features/Reader/Services/ReaderLiveActivityManager.swift
@@ -1,0 +1,136 @@
+//
+// ReaderLiveActivityManager.swift
+//
+
+import Foundation
+
+#if os(iOS)
+  import ActivityKit
+
+  @MainActor
+  final class ReaderLiveActivityManager {
+    static let shared = ReaderLiveActivityManager()
+
+    private let logger = AppLogger(.reader)
+    private var currentActivity: Activity<ReaderActivityAttributes>?
+    private var pendingEndTask: Task<Void, Never>?
+
+    private init() {}
+
+    func readerDidOpen(book: Book) {
+      pendingEndTask?.cancel()
+      pendingEndTask = nil
+
+      let state = makeState(sessionState: .reading, book: book)
+
+      if let activity = resolveActivity() {
+        update(activity: activity, with: state)
+        return
+      }
+
+      guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+        logger.info("Reader Live Activities are disabled for this app.")
+        return
+      }
+
+      let attributes = ReaderActivityAttributes(bookId: book.id)
+
+      do {
+        currentActivity = try Activity.request(
+          attributes: attributes,
+          content: .init(state: state, staleDate: nil),
+          pushType: nil
+        )
+        logger.info("✅ Reader Live Activity started.")
+      } catch {
+        logger.error("❌ Failed to start reader Live Activity: \(error)")
+      }
+    }
+
+    func readerDidClose(book: Book?) {
+      guard let activity = resolveActivity() else { return }
+
+      let state = makeState(sessionState: .closed, book: book)
+      update(activity: activity, with: state)
+
+      pendingEndTask?.cancel()
+      pendingEndTask = Task { [weak self] in
+        try? await Task.sleep(for: .seconds(12))
+        guard !Task.isCancelled else { return }
+        self?.endCurrentActivity()
+      }
+    }
+
+    private func endCurrentActivity() {
+      guard let activity = resolveActivity() else { return }
+      Task {
+        await activity.end(nil, dismissalPolicy: .immediate)
+      }
+      currentActivity = nil
+    }
+
+    private func makeState(
+      sessionState: ReaderActivityAttributes.SessionState,
+      book: Book?
+    ) -> ReaderActivityAttributes.ContentState {
+      ReaderActivityAttributes.ContentState(
+        sessionState: sessionState,
+        readerKind: resolveReaderKind(for: book),
+        seriesTitle: book?.seriesTitle ?? "",
+        chapterTitle: resolveChapterTitle(for: book)
+      )
+    }
+
+    private func resolveChapterTitle(for book: Book?) -> String {
+      guard let book else {
+        return "No active reader"
+      }
+
+      if book.metadata.title.isEmpty {
+        return book.name
+      }
+
+      if book.oneshot {
+        return book.metadata.title
+      }
+
+      return "#\(book.metadata.number) - \(book.metadata.title)"
+    }
+
+    private func resolveReaderKind(for book: Book?) -> ReaderActivityAttributes.ReaderKind {
+      guard let book else {
+        return .divina
+      }
+
+      let mediaProfile = book.media.mediaProfileValue ?? .unknown
+      switch mediaProfile {
+      case .epub:
+        return (book.media.epubDivinaCompatible ?? false) ? .divina : .epub
+      case .pdf:
+        return AppConfig.useNativePdfReader ? .pdf : .divina
+      case .divina, .unknown:
+        return .divina
+      }
+    }
+
+    private func update(
+      activity: Activity<ReaderActivityAttributes>,
+      with state: ReaderActivityAttributes.ContentState
+    ) {
+      Task {
+        await activity.update(.init(state: state, staleDate: nil))
+      }
+    }
+
+    private func resolveActivity() -> Activity<ReaderActivityAttributes>? {
+      if let currentActivity {
+        return currentActivity
+      }
+      if let existing = Activity<ReaderActivityAttributes>.activities.first {
+        currentActivity = existing
+        return existing
+      }
+      return nil
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
+++ b/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
@@ -62,6 +62,10 @@ final class ReaderPresentationManager {
     )
     readerState = state
 
+    #if os(iOS)
+      ReaderLiveActivityManager.shared.readerDidOpen(book: book)
+    #endif
+
     #if os(macOS)
       guard let openWindowHandler else {
         assertionFailure("Reader window opener not configured")
@@ -89,6 +93,7 @@ final class ReaderPresentationManager {
       return
     }
     let isIncognito = readerState?.incognito ?? false
+    let currentBook = readerState?.book
 
     // Flush progress before clearing reader state to avoid race with waitUntilSettled
     readerFlushHandler?()
@@ -136,6 +141,10 @@ final class ReaderPresentationManager {
     } else if syncVisited && isIncognito {
       logger.debug("⏭️ [Progress/Checkpoint] Skip visited sync: incognito mode enabled")
     }
+
+    #if os(iOS)
+      ReaderLiveActivityManager.shared.readerDidClose(book: currentBook)
+    #endif
 
     readerState = nil
     sourceBookId = nil

--- a/KMReaderWidgets/KMReaderReaderLiveActivity.swift
+++ b/KMReaderWidgets/KMReaderReaderLiveActivity.swift
@@ -1,0 +1,174 @@
+//
+//  KMReaderReaderLiveActivity.swift
+//  KMReaderWidgets
+//
+
+import SwiftUI
+import WidgetKit
+
+#if os(iOS)
+  import ActivityKit
+
+  struct KMReaderReaderLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+      ActivityConfiguration(for: ReaderActivityAttributes.self) { context in
+        VStack(spacing: 10) {
+          HStack(spacing: 10) {
+            Image(systemName: context.state.readerKind.iconName)
+              .font(.title3.weight(.semibold))
+              .foregroundStyle(context.state.tintColor)
+              .frame(width: 22, height: 22)
+
+            VStack(alignment: .leading, spacing: 2) {
+              Text(context.state.seriesTitle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+              Text(context.state.chapterTitle)
+                .font(.subheadline.weight(.medium))
+                .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+
+            VStack(alignment: .trailing, spacing: 2) {
+              Text(context.state.readerKind.label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+              Text(context.state.statusTitle)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(context.state.tintColor)
+            }
+          }
+
+          Capsule()
+            .fill(context.state.tintColor.opacity(0.3))
+            .frame(height: 6)
+            .overlay(alignment: .leading) {
+              Capsule()
+                .fill(context.state.tintColor)
+                .frame(width: context.state.isReading ? 80 : 28, height: 6)
+            }
+            .animation(.easeInOut(duration: 0.25), value: context.state.isReading)
+        }
+        .padding(12)
+        .activityBackgroundTint(Color(.systemBackground).opacity(0.95))
+        .activitySystemActionForegroundColor(.primary)
+
+      } dynamicIsland: { context in
+        DynamicIsland {
+          DynamicIslandExpandedRegion(.leading) {
+            Image(systemName: context.state.readerKind.iconName)
+              .foregroundStyle(context.state.tintColor)
+              .font(.title2)
+          }
+          DynamicIslandExpandedRegion(.trailing) {
+            Text(context.state.statusShortTitle)
+              .font(.caption.weight(.bold))
+              .foregroundStyle(context.state.tintColor)
+          }
+          DynamicIslandExpandedRegion(.center) {
+            VStack(spacing: 2) {
+              Text(context.state.seriesTitle)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+              Text(context.state.chapterTitle)
+                .font(.caption)
+                .lineLimit(1)
+            }
+          }
+          DynamicIslandExpandedRegion(.bottom) {
+            HStack(spacing: 6) {
+              Text(context.state.readerKind.label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+              Circle()
+                .fill(context.state.tintColor)
+                .frame(width: 6, height: 6)
+              Text(context.state.statusTitle)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(context.state.tintColor)
+            }
+          }
+        } compactLeading: {
+          Image(systemName: context.state.readerKind.iconName)
+            .foregroundStyle(context.state.tintColor)
+        } compactTrailing: {
+          Text(context.state.statusShortTitle)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(context.state.tintColor)
+        } minimal: {
+          Image(systemName: context.state.readerKind.iconName)
+            .foregroundStyle(context.state.tintColor)
+        }
+        .keylineTint(context.state.tintColor)
+      }
+    }
+  }
+
+  extension ReaderActivityAttributes.ContentState {
+    fileprivate var isReading: Bool {
+      sessionState == .reading
+    }
+
+    fileprivate var statusTitle: String {
+      isReading ? "Reading" : "Closed"
+    }
+
+    fileprivate var statusShortTitle: String {
+      isReading ? "ON" : "OFF"
+    }
+
+    fileprivate var tintColor: Color {
+      isReading ? .green : .gray
+    }
+  }
+
+  extension ReaderActivityAttributes.ReaderKind {
+    fileprivate var label: String {
+      switch self {
+      case .divina:
+        return "DIVINA"
+      case .epub:
+        return "EPUB"
+      case .pdf:
+        return "PDF"
+      }
+    }
+
+    fileprivate var iconName: String {
+      switch self {
+      case .divina:
+        return "book.pages"
+      case .epub:
+        return "character.book.closed"
+      case .pdf:
+        return "doc.richtext"
+      }
+    }
+  }
+
+  extension ReaderActivityAttributes {
+    fileprivate static var preview: ReaderActivityAttributes {
+      ReaderActivityAttributes(bookId: "preview-book-id")
+    }
+  }
+
+  extension ReaderActivityAttributes.ContentState {
+    fileprivate static var readingPreview: ReaderActivityAttributes.ContentState {
+      ReaderActivityAttributes.ContentState(
+        sessionState: .reading,
+        readerKind: .divina,
+        seriesTitle: "One Piece",
+        chapterTitle: "#1058 - The Flame Emperor's Triumph"
+      )
+    }
+  }
+
+  #Preview("Reader Notification", as: .content, using: ReaderActivityAttributes.preview) {
+    KMReaderReaderLiveActivity()
+  } contentStates: {
+    ReaderActivityAttributes.ContentState.readingPreview
+  }
+#endif

--- a/KMReaderWidgets/KMReaderWidgetsBundle.swift
+++ b/KMReaderWidgets/KMReaderWidgetsBundle.swift
@@ -13,6 +13,7 @@ struct KMReaderWidgetsBundle: WidgetBundle {
   var body: some Widget {
     #if os(iOS)
       KMReaderWidgetsLiveActivity()
+      KMReaderReaderLiveActivity()
     #endif
     KeepReadingWidget()
     RecentlyAddedWidget()

--- a/Shared/ReaderActivityAttributes.swift
+++ b/Shared/ReaderActivityAttributes.swift
@@ -1,0 +1,51 @@
+//
+//  ReaderActivityAttributes.swift
+//  KMReader
+//
+//  Shared ActivityAttributes for reader Live Activity.
+//  This file must be included in both the main app and widget extension targets.
+//
+
+import Foundation
+
+#if os(iOS)
+  import ActivityKit
+
+  public struct ReaderActivityAttributes: ActivityAttributes {
+    public enum ReaderKind: String, Codable, Hashable {
+      case divina
+      case epub
+      case pdf
+    }
+
+    public enum SessionState: String, Codable, Hashable {
+      case reading
+      case closed
+    }
+
+    public struct ContentState: Codable, Hashable {
+      public var sessionState: SessionState
+      public var readerKind: ReaderKind
+      public var seriesTitle: String
+      public var chapterTitle: String
+
+      public init(
+        sessionState: SessionState,
+        readerKind: ReaderKind,
+        seriesTitle: String,
+        chapterTitle: String
+      ) {
+        self.sessionState = sessionState
+        self.readerKind = readerKind
+        self.seriesTitle = seriesTitle
+        self.chapterTitle = chapterTitle
+      }
+    }
+
+    public var bookId: String
+
+    public init(bookId: String) {
+      self.bookId = bookId
+    }
+  }
+#endif


### PR DESCRIPTION
## Summary
- add a dedicated reader Live Activity for Dynamic Island with distinct `Reading` and `Closed` states
- show different reader metadata and icons for DIVINA, EPUB, and PDF, with icons aligned to existing app semantics
- hook reader open/close lifecycle in `ReaderPresentationManager` to start/update/end the reader activity
- add shared `ReaderActivityAttributes` used by app and widget extension
- extend offline foreground downloads to update the existing download Live Activity so EPUB/PDF foreground flows are reflected in Dynamic Island

## Testing
- [x] `make format`
- [x] `make build-ios`
- [x] `make build`
