### PR TITLE
feat(reader): add cover transition style for DIVINA

### DIFF
--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -618,7 +618,7 @@ enum AppConfig {
       if UserDefaults.standard.object(forKey: "tapPageTransitionDuration") != nil {
         return UserDefaults.standard.double(forKey: "tapPageTransitionDuration")
       }
-      return 0.2
+      return 0.3
     }
     set {
       UserDefaults.standard.set(newValue, forKey: "tapPageTransitionDuration")

--- a/KMReader/Features/Reader/Models/PageTransitionStyle.swift
+++ b/KMReader/Features/Reader/Models/PageTransitionStyle.swift
@@ -8,6 +8,7 @@ import Foundation
 enum PageTransitionStyle: String, CaseIterable, Hashable {
   case scroll = "scroll"
   case pageCurl = "pageCurl"
+  case cover = "cover"
 
   /// Platform-specific available cases
   static var availableCases: [PageTransitionStyle] {
@@ -18,10 +19,19 @@ enum PageTransitionStyle: String, CaseIterable, Hashable {
     #endif
   }
 
+  static var epubAvailableCases: [PageTransitionStyle] {
+    #if os(iOS)
+      return [.scroll, .pageCurl]
+    #else
+      return [.scroll]
+    #endif
+  }
+
   var displayName: String {
     switch self {
     case .scroll: return String(localized: "reader.page_transition.scroll")
     case .pageCurl: return String(localized: "reader.page_transition.page_curl")
+    case .cover: return String(localized: "reader.page_transition.cover")
     }
   }
 
@@ -29,6 +39,7 @@ enum PageTransitionStyle: String, CaseIterable, Hashable {
     switch self {
     case .scroll: return String(localized: "reader.page_transition.scroll.description")
     case .pageCurl: return String(localized: "reader.page_transition.page_curl.description")
+    case .cover: return String(localized: "reader.page_transition.cover.description")
     }
   }
 }

--- a/KMReader/Features/Reader/Views/CoverPageView.swift
+++ b/KMReader/Features/Reader/Views/CoverPageView.swift
@@ -1,0 +1,482 @@
+//
+// CoverPageView.swift
+//
+//
+
+#if os(iOS)
+  import SwiftUI
+
+  struct CoverPageView: View {
+    let mode: PageViewMode
+    let readingDirection: ReadingDirection
+    let splitWidePageMode: SplitWidePageMode
+    let renderConfig: ReaderRenderConfig
+    @Bindable var viewModel: ReaderViewModel
+    let readListContext: ReaderReadListContext?
+    let onDismiss: () -> Void
+
+    @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.3
+
+    @State private var currentItem: ReaderViewItem?
+    @State private var pendingTargetItem: ReaderViewItem?
+    @State private var dragOffset: CGFloat = 0
+    @State private var viewportSize: CGSize = .zero
+    @State private var isAnimatingTransition = false
+    @State private var transitionToken: Int = 0
+    @State private var postTransitionTask: Task<Void, Never>?
+
+    private var shouldDisableScrollInteraction: Bool {
+      viewModel.isZoomed || viewModel.liveTextActivePageIndex != nil
+    }
+
+    private var isCurrentItemValid: Bool {
+      guard let currentItem else { return false }
+      return viewModel.viewItemIndex(for: currentItem) != nil
+    }
+
+    private var primaryExtent: CGFloat {
+      max(mode.isVertical ? viewportSize.height : viewportSize.width, 1)
+    }
+
+    private var transitionDuration: Double {
+      max(tapPageTransitionDuration, 0)
+    }
+
+    private var nextItem: ReaderViewItem? {
+      viewModel.adjacentViewItem(from: currentItem, offset: 1)
+    }
+
+    private var transitionOffset: Int? {
+      guard let currentItem,
+        let pendingTargetItem,
+        let currentIndex = viewModel.viewItemIndex(for: currentItem),
+        let targetIndex = viewModel.viewItemIndex(for: pendingTargetItem)
+      else {
+        return nil
+      }
+      let delta = targetIndex - currentIndex
+      guard abs(delta) == 1 else { return nil }
+      return delta > 0 ? 1 : -1
+    }
+
+    var body: some View {
+      GeometryReader { geometry in
+        ZStack {
+          if let currentItem {
+            if transitionOffset == 1, let nextItem {
+              pageView(for: nextItem, isActive: true)
+                .zIndex(0)
+              pageView(for: currentItem, isActive: true)
+                .offset(
+                  x: mode.isVertical ? 0 : dragOffset,
+                  y: mode.isVertical ? dragOffset : 0
+                )
+                .zIndex(1)
+            } else if transitionOffset == -1, let pendingTargetItem {
+              pageView(for: currentItem)
+                .zIndex(0)
+              pageView(for: pendingTargetItem, isActive: true)
+                .offset(
+                  x: mode.isVertical ? 0 : dragOffset,
+                  y: mode.isVertical ? dragOffset : 0
+                )
+                .zIndex(1)
+            } else {
+              pageView(for: currentItem, isActive: true)
+                .offset(
+                  x: mode.isVertical ? 0 : dragOffset,
+                  y: mode.isVertical ? dragOffset : 0
+                )
+                .zIndex(1)
+            }
+          }
+        }
+        .frame(width: geometry.size.width, height: geometry.size.height)
+        .clipped()
+        .contentShape(Rectangle())
+        .background(
+          CoverPanGestureBridge(
+            isEnabled: !shouldDisableScrollInteraction && !isAnimatingTransition,
+            mode: mode,
+            onPanChanged: { translation in
+              handlePanChanged(translation: translation)
+            },
+            onPanEnded: { translation, velocity in
+              handlePanEnded(translation: translation, velocity: velocity)
+            },
+            onPanCancelled: {
+              resetDragStateImmediately()
+            }
+          )
+        )
+        .onAppear {
+          viewportSize = geometry.size
+          syncCurrentItemFromViewModel(force: true)
+        }
+        .onDisappear {
+          postTransitionTask?.cancel()
+          postTransitionTask = nil
+        }
+        .onChange(of: geometry.size) { _, newSize in
+          viewportSize = newSize
+        }
+        .onChange(of: viewModel.viewItems) { _, _ in
+          guard !isAnimatingTransition else { return }
+          syncCurrentItemFromViewModel(force: true)
+        }
+        .onChange(of: viewModel.currentViewItem()) { _, newItem in
+          guard !isAnimatingTransition else { return }
+          guard pendingTargetItem == nil else { return }
+          guard !isCurrentItemValid || currentItem == nil else { return }
+          if let resolved = viewModel.resolvedViewItem(for: newItem) ?? newItem ?? viewModel.viewItems.first {
+            currentItem = resolved
+            pendingTargetItem = nil
+            dragOffset = 0
+          }
+        }
+        .onChange(of: viewModel.navigationTarget) { _, newTarget in
+          guard let newTarget else { return }
+          handleNavigationTarget(newTarget)
+        }
+      }
+    }
+
+    @ViewBuilder
+    private func pageView(for item: ReaderViewItem, isActive: Bool = false) -> some View {
+      Group {
+        if case .end(let id) = item {
+          EndPageView(
+            previousBook: viewModel.currentBook(forSegmentBookId: id.bookId),
+            nextBook: viewModel.nextBook(forSegmentBookId: id.bookId),
+            readListContext: readListContext,
+            onDismiss: onDismiss,
+            readingDirection: readingDirection
+          )
+        } else {
+          ReaderViewItemImageView(
+            viewModel: viewModel,
+            item: item,
+            isPlaybackActive: isActive,
+            screenSize: viewportSize,
+            renderConfig: renderConfig,
+            readingDirection: readingDirection,
+            splitWidePageMode: splitWidePageMode
+          )
+        }
+      }
+      .frame(width: viewportSize.width, height: viewportSize.height)
+    }
+
+    private func handlePanChanged(translation: CGSize) {
+      guard !shouldDisableScrollInteraction else { return }
+      guard !isAnimatingTransition else { return }
+      guard let currentItem else { return }
+      guard isPrimaryDirectionalDrag(translation) else { return }
+
+      let primary = primaryTranslation(from: translation)
+      guard abs(primary) > 1 else { return }
+
+      let directionOffset = adjacentOffset(for: primary)
+      guard let targetItem = viewModel.adjacentViewItem(from: currentItem, offset: directionOffset) else {
+        dragOffset = primary * 0.2
+        pendingTargetItem = nil
+        return
+      }
+
+      pendingTargetItem = targetItem
+      if directionOffset == 1 {
+        dragOffset = primary
+      } else {
+        dragOffset = backwardInteractiveOffset(for: primary)
+      }
+    }
+
+    private func handlePanEnded(translation: CGSize, velocity: CGSize) {
+      guard !isAnimatingTransition else { return }
+      guard isPrimaryDirectionalDrag(translation) else {
+        resetDragStateImmediately()
+        return
+      }
+
+      guard pendingTargetItem != nil else {
+        if abs(dragOffset) > 0.5 {
+          cancelDragWithAnimation()
+        } else {
+          resetDragStateImmediately()
+        }
+        return
+      }
+
+      let primary = primaryTranslation(from: translation)
+      let primaryVelocity = primaryVelocity(from: velocity)
+      let shouldCommit =
+        abs(primary) > primaryExtent * 0.18
+        || abs(primaryVelocity) > 700
+
+      if shouldCommit {
+        commitCurrentDrag()
+      } else {
+        cancelDragWithAnimation()
+      }
+    }
+
+    private func primaryTranslation(from size: CGSize) -> CGFloat {
+      mode.isVertical ? size.height : size.width
+    }
+
+    private func secondaryTranslation(from size: CGSize) -> CGFloat {
+      mode.isVertical ? size.width : size.height
+    }
+
+    private func isPrimaryDirectionalDrag(_ size: CGSize) -> Bool {
+      abs(primaryTranslation(from: size)) > abs(secondaryTranslation(from: size)) + 4
+    }
+
+    private func primaryVelocity(from size: CGSize) -> CGFloat {
+      mode.isVertical ? size.height : size.width
+    }
+
+    private func adjacentOffset(for translation: CGFloat) -> Int {
+      if mode.isVertical {
+        return translation < 0 ? 1 : -1
+      }
+      if mode.isRTL {
+        return translation > 0 ? 1 : -1
+      }
+      return translation < 0 ? 1 : -1
+    }
+
+    private func transitionDirectionSign(from currentIndex: Int, to targetIndex: Int) -> CGFloat {
+      let isForward = targetIndex > currentIndex
+      if mode.isVertical {
+        return isForward ? -1 : 1
+      }
+      if mode.isRTL {
+        return isForward ? 1 : -1
+      }
+      return isForward ? -1 : 1
+    }
+
+    private func backwardStartOffset(for directionSign: CGFloat) -> CGFloat {
+      -directionSign * primaryExtent
+    }
+
+    private func backwardInteractiveOffset(for translation: CGFloat) -> CGFloat {
+      let translationSign: CGFloat = translation >= 0 ? 1 : -1
+      let start = backwardStartOffset(for: translationSign)
+      let raw = start + translation
+      if start < 0 {
+        return min(max(raw, start), 0)
+      }
+      return max(min(raw, start), 0)
+    }
+
+    private func syncCurrentItemFromViewModel(force: Bool = false) {
+      if !force && isCurrentItemValid {
+        return
+      }
+      currentItem = viewModel.currentViewItem() ?? viewModel.viewItems.first
+      pendingTargetItem = nil
+      dragOffset = 0
+    }
+
+    private func resolveNavigationTarget(_ target: ReaderViewItem) -> ReaderViewItem? {
+      if let exactIndex = viewModel.viewItemIndex(for: target) {
+        return viewModel.viewItem(at: exactIndex)
+      }
+      return viewModel.viewItem(for: target.pageID)
+    }
+
+    private func handleNavigationTarget(_ target: ReaderViewItem) {
+      guard let targetItem = resolveNavigationTarget(target) else {
+        viewModel.clearNavigationTarget()
+        return
+      }
+
+      guard let currentItem else {
+        self.currentItem = targetItem
+        applyCurrentItem(targetItem)
+        viewModel.clearNavigationTarget()
+        return
+      }
+
+      guard let currentIndex = viewModel.viewItemIndex(for: currentItem),
+        let targetIndex = viewModel.viewItemIndex(for: targetItem)
+      else {
+        viewModel.clearNavigationTarget()
+        return
+      }
+
+      guard targetIndex != currentIndex else {
+        viewModel.clearNavigationTarget()
+        return
+      }
+
+      if abs(targetIndex - currentIndex) == 1 {
+        pendingTargetItem = targetItem
+        dragOffset = 0
+        commitTransition(to: targetItem)
+      } else {
+        self.currentItem = targetItem
+        pendingTargetItem = nil
+        dragOffset = 0
+        applyCurrentItem(targetItem)
+      }
+
+      viewModel.clearNavigationTarget()
+    }
+
+    private func commitCurrentDrag() {
+      guard let targetItem = pendingTargetItem else {
+        cancelDragWithAnimation()
+        return
+      }
+      commitTransition(to: targetItem)
+    }
+
+    private func commitTransition(to targetItem: ReaderViewItem) {
+      guard let currentItem,
+        let currentIndex = viewModel.viewItemIndex(for: currentItem),
+        let targetIndex = viewModel.viewItemIndex(for: targetItem)
+      else {
+        completeTransition(to: targetItem)
+        return
+      }
+
+      let directionSign = transitionDirectionSign(from: currentIndex, to: targetIndex)
+      let endOffset = directionSign * primaryExtent
+
+      isAnimatingTransition = true
+      transitionToken += 1
+      let token = transitionToken
+
+      if targetIndex > currentIndex {
+        animateDragOffset(to: endOffset, token: token) {
+          completeTransition(to: targetItem)
+        }
+      } else {
+        if abs(dragOffset) < 0.5 {
+          dragOffset = backwardStartOffset(for: directionSign)
+        }
+        animateDragOffset(to: 0, token: token) {
+          completeTransition(to: targetItem)
+        }
+      }
+    }
+
+    private func completeTransition(to targetItem: ReaderViewItem) {
+      var transaction = Transaction(animation: nil)
+      transaction.disablesAnimations = true
+      withTransaction(transaction) {
+        currentItem = targetItem
+        pendingTargetItem = nil
+        dragOffset = 0
+        isAnimatingTransition = false
+      }
+      applyCurrentItem(targetItem)
+    }
+
+    private func cancelDragWithAnimation() {
+      transitionToken += 1
+      let token = transitionToken
+      let cancelTargetOffset: CGFloat = {
+        guard transitionOffset == -1,
+          let currentItem,
+          let pendingTargetItem,
+          let currentIndex = viewModel.viewItemIndex(for: currentItem),
+          let targetIndex = viewModel.viewItemIndex(for: pendingTargetItem)
+        else {
+          return 0
+        }
+        let directionSign = transitionDirectionSign(from: currentIndex, to: targetIndex)
+        return backwardStartOffset(for: directionSign)
+      }()
+
+      isAnimatingTransition = true
+      animateDragOffset(to: cancelTargetOffset, token: token) {
+        resetDragStateImmediately()
+      }
+    }
+
+    private func resetDragStateImmediately() {
+      var transaction = Transaction(animation: nil)
+      transaction.disablesAnimations = true
+      withTransaction(transaction) {
+        pendingTargetItem = nil
+        dragOffset = 0
+        isAnimatingTransition = false
+      }
+    }
+
+    private func animateDragOffset(
+      to targetOffset: CGFloat,
+      token: Int,
+      completion: @escaping () -> Void
+    ) {
+      if transitionDuration <= 0 {
+        dragOffset = targetOffset
+        guard token == transitionToken else { return }
+        completion()
+        return
+      }
+
+      withAnimation(.easeOut(duration: transitionDuration), completionCriteria: .removed) {
+        dragOffset = targetOffset
+      } completion: {
+        guard token == transitionToken else { return }
+        completion()
+      }
+    }
+
+    private func applyCurrentItem(_ item: ReaderViewItem) {
+      postTransitionTask?.cancel()
+      let token = transitionToken
+
+      postTransitionTask = Task(priority: .utility) {
+        guard !Task.isCancelled else { return }
+
+        let shouldSyncPosition = await MainActor.run { () -> Bool in
+          guard token == transitionToken else { return false }
+          guard currentItem == item else { return false }
+          viewModel.updateCurrentPosition(viewItem: item)
+          return true
+        }
+        guard shouldSyncPosition else { return }
+
+        let shouldPreload = await MainActor.run { () -> Bool in
+          guard token == transitionToken else { return false }
+          guard currentItem == item else { return false }
+          preloadVisiblePages(for: item)
+          return true
+        }
+        guard shouldPreload else { return }
+
+        await viewModel.preloadPages()
+      }
+    }
+
+    private func preloadVisiblePages(for item: ReaderViewItem) {
+      let visiblePageIndices: [Int]
+      switch item {
+      case .page(let id):
+        visiblePageIndices = [viewModel.pageIndex(for: id)].compactMap { $0 }
+      case .split(let id, _):
+        visiblePageIndices = [viewModel.pageIndex(for: id)].compactMap { $0 }
+      case .dual(let first, let second):
+        visiblePageIndices = [viewModel.pageIndex(for: first), viewModel.pageIndex(for: second)].compactMap {
+          $0
+        }
+      case .end:
+        visiblePageIndices = []
+      }
+
+      guard !visiblePageIndices.isEmpty else { return }
+
+      Task(priority: .utility) {
+        for pageIndex in visiblePageIndices {
+          _ = await viewModel.preloadImageForPage(at: pageIndex)
+        }
+      }
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Views/CoverPanGestureBridge.swift
+++ b/KMReader/Features/Reader/Views/CoverPanGestureBridge.swift
@@ -1,0 +1,361 @@
+//
+// CoverPanGestureBridge.swift
+//
+//
+
+#if os(iOS)
+  import SwiftUI
+  import UIKit
+
+  struct CoverPanGestureBridge: View {
+    let isEnabled: Bool
+    let mode: PageViewMode
+    let onPanChanged: (CGSize) -> Void
+    let onPanEnded: (_ translation: CGSize, _ velocity: CGSize) -> Void
+    let onPanCancelled: () -> Void
+
+    var body: some View {
+      PlatformBridge(
+        configuration: configuration,
+        onPanChanged: onPanChanged,
+        onPanEnded: onPanEnded,
+        onPanCancelled: onPanCancelled
+      )
+      .frame(width: 0, height: 0)
+      .allowsHitTesting(false)
+      .accessibilityHidden(true)
+    }
+
+    private var configuration: Configuration {
+      Configuration(
+        isEnabled: isEnabled,
+        isVerticalMode: mode.isVertical
+      )
+    }
+
+    private struct Configuration: Equatable {
+      let isEnabled: Bool
+      let isVerticalMode: Bool
+    }
+
+    private struct PlatformBridge: UIViewControllerRepresentable {
+      let configuration: Configuration
+      let onPanChanged: (CGSize) -> Void
+      let onPanEnded: (_ translation: CGSize, _ velocity: CGSize) -> Void
+      let onPanCancelled: () -> Void
+
+      func makeCoordinator() -> Coordinator {
+        Coordinator(
+          configuration: configuration,
+          onPanChanged: onPanChanged,
+          onPanEnded: onPanEnded,
+          onPanCancelled: onPanCancelled
+        )
+      }
+
+      func makeUIViewController(context: Context) -> BridgeViewController {
+        let viewController = BridgeViewController()
+        viewController.coordinator = context.coordinator
+        return viewController
+      }
+
+      func updateUIViewController(_ uiViewController: BridgeViewController, context: Context) {
+        context.coordinator.update(
+          configuration: configuration,
+          onPanChanged: onPanChanged,
+          onPanEnded: onPanEnded,
+          onPanCancelled: onPanCancelled
+        )
+        uiViewController.coordinator = context.coordinator
+        context.coordinator.attachIfNeeded(anchorView: uiViewController.view)
+      }
+
+      static func dismantleUIViewController(
+        _ uiViewController: BridgeViewController,
+        coordinator: Coordinator
+      ) {
+        coordinator.detach()
+      }
+
+      @MainActor
+      final class BridgeViewController: UIViewController {
+        weak var coordinator: Coordinator?
+
+        override func viewDidAppear(_ animated: Bool) {
+          super.viewDidAppear(animated)
+          coordinator?.attachIfNeeded(anchorView: view)
+        }
+
+        override func viewDidLayoutSubviews() {
+          super.viewDidLayoutSubviews()
+          coordinator?.attachIfNeeded(anchorView: view)
+        }
+
+        override func viewWillDisappear(_ animated: Bool) {
+          super.viewWillDisappear(animated)
+          coordinator?.detach()
+        }
+      }
+
+      @MainActor
+      final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        private struct DependencyCache {
+          var viewChainSignature: [ObjectIdentifier] = []
+          var navigationRecognizers: [UIGestureRecognizer] = []
+          var boundRecognizerIDs: Set<ObjectIdentifier> = []
+        }
+
+        private var configuration: Configuration
+        private var onPanChanged: (CGSize) -> Void
+        private var onPanEnded: (_ translation: CGSize, _ velocity: CGSize) -> Void
+        private var onPanCancelled: () -> Void
+
+        private weak var attachedView: UIView?
+        private var panRecognizer: UIPanGestureRecognizer?
+        private var dependencyCache = DependencyCache()
+        private var lastDependencyRefreshTime: TimeInterval = 0
+
+        init(
+          configuration: Configuration,
+          onPanChanged: @escaping (CGSize) -> Void,
+          onPanEnded: @escaping (_ translation: CGSize, _ velocity: CGSize) -> Void,
+          onPanCancelled: @escaping () -> Void
+        ) {
+          self.configuration = configuration
+          self.onPanChanged = onPanChanged
+          self.onPanEnded = onPanEnded
+          self.onPanCancelled = onPanCancelled
+          super.init()
+        }
+
+        func update(
+          configuration: Configuration,
+          onPanChanged: @escaping (CGSize) -> Void,
+          onPanEnded: @escaping (_ translation: CGSize, _ velocity: CGSize) -> Void,
+          onPanCancelled: @escaping () -> Void
+        ) {
+          let wasEnabled = self.configuration.isEnabled
+          self.configuration = configuration
+          self.onPanChanged = onPanChanged
+          self.onPanEnded = onPanEnded
+          self.onPanCancelled = onPanCancelled
+          applyRecognizerState(previouslyEnabled: wasEnabled)
+          configureRecognizerDependenciesIfNeeded()
+        }
+
+        func attachIfNeeded(anchorView: UIView?) {
+          guard let targetView = gestureContainer(from: anchorView) else { return }
+          if attachedView === targetView {
+            applyRecognizerState(previouslyEnabled: configuration.isEnabled)
+            configureRecognizerDependenciesIfNeeded()
+            return
+          }
+
+          detach()
+          installRecognizer(on: targetView)
+          configureRecognizerDependenciesIfNeeded(force: true)
+          applyRecognizerState(previouslyEnabled: configuration.isEnabled)
+        }
+
+        func detach() {
+          if let panRecognizer {
+            panRecognizer.view?.removeGestureRecognizer(panRecognizer)
+          }
+
+          panRecognizer = nil
+          attachedView = nil
+          dependencyCache = DependencyCache()
+          lastDependencyRefreshTime = 0
+        }
+
+        private func installRecognizer(on view: UIView) {
+          let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+          pan.maximumNumberOfTouches = 1
+          pan.cancelsTouchesInView = false
+          pan.delegate = self
+          view.addGestureRecognizer(pan)
+          panRecognizer = pan
+          attachedView = view
+        }
+
+        private func applyRecognizerState(previouslyEnabled: Bool) {
+          guard panRecognizer?.isEnabled != configuration.isEnabled else { return }
+          let previousState = panRecognizer?.state
+          panRecognizer?.isEnabled = configuration.isEnabled
+
+          guard previouslyEnabled, !configuration.isEnabled else { return }
+          guard previousState == .began || previousState == .changed else { return }
+          DispatchQueue.main.async { [onPanCancelled] in
+            onPanCancelled()
+          }
+        }
+
+        private func configureRecognizerDependenciesIfNeeded(force: Bool = false) {
+          guard let panRecognizer, let attachedView else { return }
+          let viewChain = buildViewChain(from: attachedView)
+          let signature = viewChain.map { ObjectIdentifier($0) }
+          let now = Date().timeIntervalSinceReferenceDate
+          let shouldPeriodicRefresh = now - lastDependencyRefreshTime > 1.0
+
+          if force
+            || dependencyCache.viewChainSignature != signature
+            || dependencyCache.navigationRecognizers.isEmpty
+            || shouldPeriodicRefresh
+          {
+            dependencyCache.viewChainSignature = signature
+            dependencyCache.navigationRecognizers = navigationRecognizers(from: viewChain, excluding: panRecognizer)
+            dependencyCache.boundRecognizerIDs.removeAll()
+            lastDependencyRefreshTime = now
+          }
+
+          dependencyCache.navigationRecognizers.removeAll { $0.view == nil }
+
+          for recognizer in dependencyCache.navigationRecognizers where recognizer !== panRecognizer {
+            let id = ObjectIdentifier(recognizer)
+            if dependencyCache.boundRecognizerIDs.contains(id) {
+              continue
+            }
+            panRecognizer.require(toFail: recognizer)
+            dependencyCache.boundRecognizerIDs.insert(id)
+          }
+        }
+
+        private func buildViewChain(from view: UIView) -> [UIView] {
+          var chain: [UIView] = []
+          var current: UIView? = view
+          while let candidate = current {
+            chain.append(candidate)
+            current = candidate.superview
+          }
+          return chain
+        }
+
+        private func navigationRecognizers(
+          from viewChain: [UIView],
+          excluding panRecognizer: UIPanGestureRecognizer
+        ) -> [UIGestureRecognizer] {
+          var collected: [UIGestureRecognizer] = []
+          var seen: Set<ObjectIdentifier> = []
+
+          for candidate in viewChain {
+            if let gestures = candidate.gestureRecognizers {
+              for recognizer in gestures {
+                let typeName = String(describing: type(of: recognizer))
+                let id = ObjectIdentifier(recognizer)
+                if recognizer === panRecognizer {
+                  continue
+                }
+                if isSystemNavigationGesture(typeName: typeName), !seen.contains(id) {
+                  seen.insert(id)
+                  collected.append(recognizer)
+                }
+              }
+            }
+          }
+
+          return collected
+        }
+
+        private func isSystemNavigationGesture(typeName: String) -> Bool {
+          typeName.contains("Parallax")
+            || typeName.contains("ZoomTransition")
+            || typeName.contains("ScreenEdgePan")
+            || typeName.contains("FullPageSwipe")
+            || typeName == "_UIContentSwipeDismissGestureRecognizer"
+        }
+
+        @objc
+        private func handlePan(_ recognizer: UIPanGestureRecognizer) {
+          guard configuration.isEnabled else { return }
+          guard let view = recognizer.view else { return }
+          let translationPoint = recognizer.translation(in: view)
+          let translation = CGSize(width: translationPoint.x, height: translationPoint.y)
+
+          switch recognizer.state {
+          case .changed:
+            onPanChanged(translation)
+          case .ended:
+            let velocityPoint = recognizer.velocity(in: view)
+            let velocity = CGSize(width: velocityPoint.x, height: velocityPoint.y)
+            onPanEnded(translation, velocity)
+          case .cancelled, .failed:
+            onPanCancelled()
+          default:
+            break
+          }
+        }
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+          guard configuration.isEnabled else { return false }
+          guard let pan = gestureRecognizer as? UIPanGestureRecognizer else { return true }
+
+          let velocity = pan.velocity(in: pan.view)
+          let primary = configuration.isVerticalMode ? abs(velocity.y) : abs(velocity.x)
+          let secondary = configuration.isVerticalMode ? abs(velocity.x) : abs(velocity.y)
+          return primary > secondary + 12
+        }
+
+        func gestureRecognizer(
+          _ gestureRecognizer: UIGestureRecognizer,
+          shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+          isSystemNavigationGesture(typeName: String(describing: type(of: otherGestureRecognizer)))
+        }
+
+        func gestureRecognizer(
+          _ gestureRecognizer: UIGestureRecognizer,
+          shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+          let gestureType = String(describing: type(of: gestureRecognizer))
+          let otherType = String(describing: type(of: otherGestureRecognizer))
+          return isSystemNavigationGesture(typeName: gestureType)
+            || isSystemNavigationGesture(typeName: otherType)
+        }
+
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+          configuration.isEnabled && !isInteractiveElement(touch.view)
+        }
+
+        private func isInteractiveElement(_ view: UIView?) -> Bool {
+          var current = view
+          while let candidate = current {
+            if candidate is UIControl {
+              return true
+            }
+
+            let className = NSStringFromClass(type(of: candidate))
+            if className.contains("Button")
+              || className.contains("Slider")
+              || className.contains("Switch")
+              || className.contains("TextField")
+              || className.contains("TextView")
+              || className.contains("Segmented")
+              || className.contains("NavigationBar")
+              || className.contains("Toolbar")
+              || className.contains("Menu")
+              || className.contains("ContextMenu")
+              || className.contains("Popover")
+            {
+              return true
+            }
+
+            current = candidate.superview
+          }
+
+          return false
+        }
+
+        private func gestureContainer(from anchorView: UIView?) -> UIView? {
+          var current = anchorView
+          while let candidate = current {
+            if candidate.bounds.width > 1, candidate.bounds.height > 1 {
+              return candidate
+            }
+            current = candidate.superview
+          }
+          return nil
+        }
+      }
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -581,7 +581,8 @@ struct DivinaReaderView: View {
             #endif
           } else {
             #if os(iOS)
-              if pageTransitionStyle == .pageCurl {
+              switch pageTransitionStyle {
+              case .pageCurl:
                 if useDualPage {
                   CurlDualPageView(
                     viewModel: viewModel,
@@ -603,7 +604,7 @@ struct DivinaReaderView: View {
                     onDismiss: { closeReader() }
                   )
                 }
-              } else {
+              case .scroll:
                 ScrollPageView(
                   mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
                   readingDirection: readingDirection,
@@ -615,6 +616,16 @@ struct DivinaReaderView: View {
                   onDismiss: { closeReader() },
                   toggleControls: { toggleControls() },
                   onScrollActivityChange: { _ in }
+                )
+              case .cover:
+                CoverPageView(
+                  mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
+                  readingDirection: readingDirection,
+                  splitWidePageMode: splitWidePageMode,
+                  renderConfig: renderConfig,
+                  viewModel: viewModel,
+                  readListContext: readListContext,
+                  onDismiss: { closeReader() }
                 )
               }
             #else

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -282,6 +282,23 @@
                 }
               }
             ).readerIgnoresSafeArea()
+          case .cover:
+            WebPubPagedScrollView(
+              viewModel: viewModel,
+              preferences: activePreferences,
+              colorScheme: colorScheme,
+              showingControls: shouldShowControls,
+              bookTitle: currentBook?.metadata.title,
+              onCenterTap: {
+                toggleControls()
+              },
+              onEndReached: {
+                if !showingEndPage {
+                  viewModel.syncEndProgression()
+                  showingEndPage = true
+                }
+              }
+            ).readerIgnoresSafeArea()
           case .pageCurl:
             WebPubPagedCurlView(
               viewModel: viewModel,

--- a/KMReader/Features/Reader/Views/ScrollPageView.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView.swift
@@ -19,7 +19,7 @@ struct ScrollPageView: View {
 
   private let logger = AppLogger(.reader)
 
-  @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.2
+  @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.3
 
   @State private var hasSyncedInitialScroll = false
   @State private var scrollPosition: ReaderViewItem?

--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -21,7 +21,7 @@ struct ReaderSettingsSheet: View {
   @AppStorage("tapZoneMode") private var tapZoneMode: TapZoneMode = .auto
   @AppStorage("showTapZoneHints") private var showTapZoneHints: Bool = true
   @AppStorage("tapZoneSize") private var tapZoneSize: TapZoneSize = .large
-  @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.2
+  @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.3
   @AppStorage("showKeyboardHelpOverlay") private var showKeyboardHelpOverlay: Bool = true
   @AppStorage("autoFullscreenOnOpen") private var autoFullscreenOnOpen: Bool = false
   @AppStorage("enableLiveText") private var enableLiveText: Bool = false
@@ -46,6 +46,14 @@ struct ReaderSettingsSheet: View {
   private var shouldShowScrollTransitionStyle: Bool {
     #if os(iOS)
       shouldShowPagedTurnSettings && pageTransitionStyle == .scroll
+    #else
+      shouldShowPagedTurnSettings
+    #endif
+  }
+
+  private var shouldShowTapTransitionDuration: Bool {
+    #if os(iOS)
+      shouldShowPagedTurnSettings && pageTransitionStyle != .pageCurl
     #else
       shouldShowPagedTurnSettings
     #endif
@@ -288,7 +296,7 @@ struct ReaderSettingsSheet: View {
                 .frame(height: 60)
               }
 
-              if shouldShowScrollTransitionStyle {
+              if shouldShowTapTransitionDuration {
                 VStack(alignment: .leading, spacing: 8) {
                   HStack {
                     Text("Tap Page Scroll Duration")

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -20,7 +20,7 @@ struct DivinaPreferencesView: View {
   @AppStorage("defaultReadingDirection") private var readDirection: ReadingDirection = .ltr
   @AppStorage("forceDefaultReadingDirection") private var forceDefaultReadingDirection: Bool = false
   @AppStorage("showPageNumber") private var showPageNumber: Bool = true
-  @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.2
+  @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.3
   @AppStorage("pageTransitionStyle") private var pageTransitionStyle: PageTransitionStyle = .scroll
   @AppStorage("scrollPageTransitionStyle") private var scrollPageTransitionStyle: ScrollPageTransitionStyle = .default
   @AppStorage("doubleTapZoomScale") private var doubleTapZoomScale: Double = 3.0
@@ -53,6 +53,14 @@ struct DivinaPreferencesView: View {
   private var shouldShowScrollTransitionStyle: Bool {
     #if os(iOS)
       shouldShowPagedSpecificSettings && pageTransitionStyle == .scroll
+    #else
+      shouldShowPagedSpecificSettings
+    #endif
+  }
+
+  private var shouldShowTapTransitionDuration: Bool {
+    #if os(iOS)
+      shouldShowPagedSpecificSettings && pageTransitionStyle != .pageCurl
     #else
       shouldShowPagedSpecificSettings
     #endif
@@ -411,7 +419,7 @@ struct DivinaPreferencesView: View {
                 .foregroundColor(.secondary)
             }
 
-            if shouldShowScrollTransitionStyle {
+            if shouldShowTapTransitionDuration {
               VStack(alignment: .leading, spacing: 8) {
                 HStack {
                   Text("Tap Page Scroll Duration")

--- a/KMReader/Features/Settings/EpubPreferencesView.swift
+++ b/KMReader/Features/Settings/EpubPreferencesView.swift
@@ -164,7 +164,7 @@
 
           if draft.flowStyle.isPaged {
             Picker(String(localized: "Page Transition Style"), selection: $epubPageTransitionStyle) {
-              ForEach(PageTransitionStyle.availableCases, id: \.self) { style in
+              ForEach(PageTransitionStyle.epubAvailableCases, id: \.self) { style in
                 Text(style.displayName).tag(style)
               }
             }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -46536,6 +46536,134 @@
         }
       }
     },
+    "reader.page_transition.cover" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cover"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cover"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capa"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couverture"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copertura"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カバー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커버"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Накрытие"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "覆盖"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "覆蓋"
+          }
+        }
+      }
+    },
+    "reader.page_transition.cover.description" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die aktuelle Seite gleitet wie ein Deckblatt weg, während die nächste Seite stehen bleibt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The current page slides away like a cover while the next page stays still"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La página actual se desliza como una cubierta y la siguiente permanece quieta"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La page actuelle glisse comme une couverture tandis que la suivante reste immobile"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La pagina corrente scivola via come una copertina mentre la successiva resta ferma"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のページがカバーのように滑って外れ、次のページはその場に留まります"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 페이지가 커버처럼 밀려나고 다음 페이지는 고정된 상태로 유지됩니다"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Текущая страница сдвигается как обложка, а следующая остается неподвижной"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前页像盖板一样滑开，下一页保持静止"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "當前頁像蓋板一樣滑開，下一頁保持靜止"
+          }
+        }
+      }
+    },
     "reader.page_transition.page_curl" : {
       "localizations" : {
         "de" : {

--- a/KMReader/Shared/UI/ReaderDismissGestureConfigurator.swift
+++ b/KMReader/Shared/UI/ReaderDismissGestureConfigurator.swift
@@ -53,10 +53,13 @@
         let recognizerType = String(describing: type(of: gestureRecognizer))
 
         switch recognizerType {
-        case let type
-        where type.contains("Parallax") || type.contains("ZoomTransition")
-          || type.contains("FullPageSwipe") || type.contains("ScreenEdgePan"):
-          // Navigation/Edge/Zoom swipe - allow only for vertical reading
+        case let type where isZoomNavigationGesture(type):
+          // Navigation/zoom swipe - allow only for vertical reading.
+          // In horizontal reading, this must be blocked to avoid gesture conflicts.
+          return isVerticalReading
+
+        case let type where type.contains("FullPageSwipe") || type.contains("ScreenEdgePan"):
+          // Edge-style dismiss remains vertical-reading only to avoid conflicts with horizontal page turns.
           return isVerticalReading
 
         case "_UIContentSwipeDismissGestureRecognizer":
@@ -84,9 +87,12 @@
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
       ) -> Bool {
-        // Don't allow dismiss gestures to work alongside other gestures (like scrolling or curling)
-        // to avoid conflicting animations/actions.
+        // Don't allow dismiss/navigation gestures to run with other gestures.
         return false
+      }
+
+      private func isZoomNavigationGesture(_ recognizerType: String) -> Bool {
+        recognizerType.contains("Parallax") || recognizerType.contains("ZoomTransition")
       }
 
       func restoreOriginalDelegates() {


### PR DESCRIPTION
## Summary
- add a dedicated cover page transition style for DIVINA on iOS
- introduce CoverPageView with a custom UIKit pan bridge and a 3-page ZStack render model
- wire the new style into reader settings and localization while keeping EPUB transition options unchanged
- set tap page transition duration default to 0.3 and align settings visibility rules
- tighten dismiss/navigation gesture coordination for horizontal/vertical reading behavior

## Validation
- make format
- make build
