### PR TITLE
fix: retain media error code localizations

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -11,9 +11,9 @@
 		193F577A2EFA1C1D003362E1 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 193F57792EFA1C1D003362E1 /* SwiftUI.framework */; };
 		193F578B2EFA1C1F003362E1 /* KMReaderWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 193F57752EFA1C1D003362E1 /* KMReaderWidgetsExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		196028592ED9F7980066E8A4 /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = 196028582ED9F7980066E8A4 /* SwiftSoup */; };
-		19B0A1022F08A00000AB1234 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 19B0A1012F08A00000AB1234 /* ZIPFoundation */; };
 		19AEC07F2EE714150073EB5F /* Flow in Frameworks */ = {isa = PBXBuildFile; productRef = 19AEC07E2EE714150073EB5F /* Flow */; };
 		19AEFE572EFC62E200EC7D3B /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19AEFE562EFC62E200EC7D3B /* StoreKit.framework */; };
+		19B0A1022F08A00000AB1234 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 19B0A1012F08A00000AB1234 /* ZIPFoundation */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */

--- a/KMReader/Shared/Helpers/KomgaErrorCodeFormatter.swift
+++ b/KMReader/Shared/Helpers/KomgaErrorCodeFormatter.swift
@@ -12,7 +12,85 @@ nonisolated enum KomgaErrorCodeFormatter {
 
     return message.replacing(errorCodePattern) { match in
       let code = String(match.0)
-      return Bundle.main.localizedString(forKey: code, value: code, table: nil)
+      return localizedErrorCode(for: code) ?? code
+    }
+  }
+
+  private static func localizedErrorCode(for code: String) -> String? {
+    // Keep these keys as string literals so Xcode string extraction can retain them.
+    switch code {
+    case "ERR_1000":
+      return String(localized: "ERR_1000")
+    case "ERR_1001":
+      return String(localized: "ERR_1001")
+    case "ERR_1002":
+      return String(localized: "ERR_1002")
+    case "ERR_1003":
+      return String(localized: "ERR_1003")
+    case "ERR_1004":
+      return String(localized: "ERR_1004")
+    case "ERR_1005":
+      return String(localized: "ERR_1005")
+    case "ERR_1006":
+      return String(localized: "ERR_1006")
+    case "ERR_1007":
+      return String(localized: "ERR_1007")
+    case "ERR_1008":
+      return String(localized: "ERR_1008")
+    case "ERR_1009":
+      return String(localized: "ERR_1009")
+    case "ERR_1015":
+      return String(localized: "ERR_1015")
+    case "ERR_1016":
+      return String(localized: "ERR_1016")
+    case "ERR_1017":
+      return String(localized: "ERR_1017")
+    case "ERR_1018":
+      return String(localized: "ERR_1018")
+    case "ERR_1019":
+      return String(localized: "ERR_1019")
+    case "ERR_1020":
+      return String(localized: "ERR_1020")
+    case "ERR_1021":
+      return String(localized: "ERR_1021")
+    case "ERR_1022":
+      return String(localized: "ERR_1022")
+    case "ERR_1023":
+      return String(localized: "ERR_1023")
+    case "ERR_1024":
+      return String(localized: "ERR_1024")
+    case "ERR_1025":
+      return String(localized: "ERR_1025")
+    case "ERR_1026":
+      return String(localized: "ERR_1026")
+    case "ERR_1027":
+      return String(localized: "ERR_1027")
+    case "ERR_1028":
+      return String(localized: "ERR_1028")
+    case "ERR_1029":
+      return String(localized: "ERR_1029")
+    case "ERR_1030":
+      return String(localized: "ERR_1030")
+    case "ERR_1031":
+      return String(localized: "ERR_1031")
+    case "ERR_1032":
+      return String(localized: "ERR_1032")
+    case "ERR_1033":
+      return String(localized: "ERR_1033")
+    case "ERR_1034":
+      return String(localized: "ERR_1034")
+    case "ERR_1035":
+      return String(localized: "ERR_1035")
+    case "ERR_1036":
+      return String(localized: "ERR_1036")
+    case "ERR_1037":
+      return String(localized: "ERR_1037")
+    case "ERR_1038":
+      return String(localized: "ERR_1038")
+    case "ERR_1039":
+      return String(localized: "ERR_1039")
+    default:
+      return nil
     }
   }
 }


### PR DESCRIPTION
## Summary
- replace runtime `Bundle.main.localizedString(forKey:)` lookups for Komga `ERR_####` media comments with static `String(localized:)` references so Xcode string extraction keeps these entries active
- preserve the existing runtime replacement fallback for unknown error codes
- bump `CURRENT_PROJECT_VERSION` from 347 to 348

## Testing
- [x] `make build`
- [x] `make localize`
- [x] `./misc/translate.py list`
