### PR TITLE
fix: warm epub cover adjacent pages

### DIFF
--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
@@ -496,6 +496,7 @@
           nextVC.view.frame = container.view.bounds
           nextVC.view.layer.zPosition = 0
           nextVC.view.isHidden = true
+          warmAdjacentController(nextVC)
         } else {
           nextController = nil
         }
@@ -513,6 +514,7 @@
           prevVC.view.frame = container.view.bounds
           prevVC.view.layer.zPosition = 0
           prevVC.view.isHidden = true
+          warmAdjacentController(prevVC)
         } else {
           previousController = nil
         }
@@ -532,6 +534,11 @@
         parent.view.addSubview(child.view)
         child.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         child.didMove(toParent: parent)
+      }
+
+      private func warmAdjacentController(_ controller: EpubPageViewController) {
+        controller.loadViewIfNeeded()
+        controller.forceEnsureContentLoaded()
       }
 
       private func removeChildController(_ child: EpubPageViewController?, from parent: UIViewController) {
@@ -791,6 +798,7 @@
           newNextVC.view.frame = container.view.bounds
           newNextVC.view.layer.zPosition = 0
           newNextVC.view.isHidden = true
+          warmAdjacentController(newNextVC)
         }
 
         transitionDirection = nil
@@ -856,6 +864,7 @@
           newPrevVC.view.frame = container.view.bounds
           newPrevVC.view.layer.zPosition = 0
           newPrevVC.view.isHidden = true
+          warmAdjacentController(newPrevVC)
         }
 
         transitionDirection = nil


### PR DESCRIPTION
## Problem
EPUB cover mode did not reproduce the first-turn blank issue reliably, but its deck setup still only attached hidden adjacent controllers without explicitly forcing their chapter content to load. That left the same structural risk on the first cover-style transition, especially when the next page lived in a different chapter or needed a fresh web view load.

## Approach
Warm adjacent EPUB cover controllers as soon as they are attached to the deck. This keeps the hidden next and previous controllers aligned with the already-visible front controller, so the first cover transition does not depend on lazy content loading.

## Scope
- add a shared helper to warm adjacent `EpubPageViewController` instances
- force hidden next and previous cover controllers to load content during initial deck construction
- apply the same warm-up step after forward and backward cover transitions rebuild adjacent controllers

## Testing
- [x] `make format`
- [x] `make build-macos`
