### PR TITLE
feat: blur unread book and series covers

### DIFF
--- a/KMReader/Features/Book/Models/Book.swift
+++ b/KMReader/Features/Book/Models/Book.swift
@@ -24,4 +24,20 @@ struct Book: Codable, Identifiable, Equatable {
   let deleted: Bool
   let fileHash: String?
   let oneshot: Bool
+
+  var hasStartedReading: Bool {
+    readProgress != nil
+  }
+
+  var isUnread: Bool {
+    !hasStartedReading
+  }
+
+  var isCompleted: Bool {
+    readProgress?.completed == true
+  }
+
+  var isInProgress: Bool {
+    hasStartedReading && !isCompleted
+  }
 }

--- a/KMReader/Features/Book/Models/KomgaBook.swift
+++ b/KMReader/Features/Book/Models/KomgaBook.swift
@@ -111,6 +111,22 @@ final class KomgaBook {
     }
   }
 
+  var hasStartedReading: Bool {
+    readProgress != nil
+  }
+
+  var isUnread: Bool {
+    !hasStartedReading
+  }
+
+  var isCompleted: Bool {
+    progressCompleted == true
+  }
+
+  var isInProgress: Bool {
+    hasStartedReading && !isCompleted
+  }
+
   init(
     id: String? = nil,
     bookId: String,

--- a/KMReader/Features/Book/Views/BookCardView.swift
+++ b/KMReader/Features/Book/Views/BookCardView.swift
@@ -17,6 +17,7 @@ struct BookCardView: View {
   @AppStorage("cardTextOverlayMode") private var cardTextOverlayMode: Bool = false
   @AppStorage("thumbnailShowUnreadIndicator") private var thumbnailShowUnreadIndicator: Bool = true
   @AppStorage("thumbnailShowProgressBar") private var thumbnailShowProgressBar: Bool = true
+  @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
   @State private var showReadListPicker = false
   @State private var showDeleteConfirmation = false
   @State private var showEditSheet = false
@@ -25,11 +26,6 @@ struct BookCardView: View {
     guard let progressPage = komgaBook.progressPage else { return 0 }
     guard komgaBook.mediaPagesCount > 0 else { return 0 }
     return Double(progressPage) / Double(komgaBook.mediaPagesCount)
-  }
-
-  private var isInProgress: Bool {
-    guard let progressCompleted = komgaBook.progressCompleted else { return false }
-    return !progressCompleted
   }
 
   var shouldShowSeriesTitle: Bool {
@@ -57,12 +53,17 @@ struct BookCardView: View {
     return 12
   }
 
+  private var coverBlurRadius: CGFloat {
+    thumbnailBlurUnreadCovers && komgaBook.isUnread ? CoverBlurStyle.unreadRadius : 0
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: contentSpacing) {
       ThumbnailImage(
         id: komgaBook.bookId,
         type: .book,
         shadowStyle: .platform,
+        contentBlurRadius: coverBlurRadius,
         alignment: .bottom,
         preserveAspectRatioOverride: cardTextOverlayMode ? false : nil,
         onAction: { onReadBook?(false) }
@@ -74,7 +75,7 @@ struct BookCardView: View {
             }
           }
 
-          if komgaBook.progressCompleted == nil && thumbnailShowUnreadIndicator {
+          if komgaBook.isUnread && thumbnailShowUnreadIndicator {
             UnreadIndicator()
               .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
           }
@@ -99,7 +100,7 @@ struct BookCardView: View {
 
       if thumbnailShowProgressBar && !cardTextOverlayMode {
         ReadingProgressBar(progress: progress, type: .card)
-          .opacity(isInProgress ? 1 : 0)
+          .opacity(komgaBook.isInProgress ? 1 : 0)
       }
 
       if !cardTextOverlayMode && !coverOnlyCards {
@@ -179,7 +180,7 @@ struct BookCardView: View {
   private var overlayTextContent: some View {
     let style = CardOverlayTextStyle.standard
     let showDownloadIcon = komgaBook.downloadStatus != .notDownloaded
-    let showProgressBar = isInProgress && thumbnailShowProgressBar
+    let showProgressBar = komgaBook.isInProgress && thumbnailShowProgressBar
 
     CardOverlayTextStack(
       title: bookTitleLine,

--- a/KMReader/Features/Book/Views/BookContextMenu.swift
+++ b/KMReader/Features/Book/Views/BookContextMenu.swift
@@ -18,10 +18,6 @@ struct BookContextMenu: View {
   @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("isOffline") private var isOffline: Bool = false
 
-  private var isCompleted: Bool {
-    book.readProgress?.completed ?? false
-  }
-
   private var menuTitle: String {
     if book.oneshot {
       return book.metadata.title
@@ -52,14 +48,14 @@ struct BookContextMenu: View {
         } label: {
           Label("Add to Read List", systemImage: ContentIcon.readList)
         }
-        if !isCompleted {
+        if !book.isCompleted {
           Button {
             markAsRead(bookId: book.id)
           } label: {
             Label("Mark as Read", systemImage: "checkmark.circle")
           }
         }
-        if book.readProgress != nil {
+        if book.hasStartedReading {
           Button {
             markAsUnread(bookId: book.id)
           } label: {

--- a/KMReader/Features/Book/Views/BookDetailContentView.swift
+++ b/KMReader/Features/Book/Views/BookDetailContentView.swift
@@ -11,10 +11,12 @@ struct BookDetailContentView: View {
   let downloadStatus: DownloadStatus?
   let inSheet: Bool
 
+  @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
+
   @State private var thumbnailRefreshKey = UUID()
 
-  private var isCompleted: Bool {
-    book.readProgress?.completed ?? false
+  private var coverBlurRadius: CGFloat {
+    thumbnailBlurUnreadCovers && book.isUnread ? CoverBlurStyle.unreadRadius : 0
   }
 
   var body: some View {
@@ -32,6 +34,7 @@ struct BookDetailContentView: View {
         ThumbnailImage(
           id: book.id,
           type: .book,
+          contentBlurRadius: coverBlurRadius,
           width: PlatformHelper.detailThumbnailWidth,
           isTransitionSource: false,
           onAction: {}
@@ -95,7 +98,7 @@ struct BookDetailContentView: View {
           }
 
           if let readProgress = book.readProgress {
-            if isCompleted {
+            if book.isCompleted {
               InfoChip(
                 labelKey: "Completed",
                 systemImage: "checkmark.circle.fill",

--- a/KMReader/Features/Book/Views/BookDetailView.swift
+++ b/KMReader/Features/Book/Views/BookDetailView.swift
@@ -268,7 +268,7 @@ struct BookDetailView: View {
         }
 
         if let book = book {
-          if !(book.readProgress?.completed ?? false) {
+          if !book.isCompleted {
             Button {
               markBookAsRead()
             } label: {
@@ -276,7 +276,7 @@ struct BookDetailView: View {
             }
           }
 
-          if book.readProgress != nil {
+          if book.hasStartedReading {
             Button {
               markBookAsUnread()
             } label: {

--- a/KMReader/Features/Book/Views/BookRowView.swift
+++ b/KMReader/Features/Book/Views/BookRowView.swift
@@ -12,24 +12,16 @@ struct BookRowView: View {
   var showSeriesTitle: Bool = false
   var showSeriesNavigation: Bool = true
 
+  @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
+
   @State private var showReadListPicker = false
   @State private var showDeleteConfirmation = false
   @State private var showEditSheet = false
-
-  var completed: Bool {
-    guard let progressCompleted = komgaBook.progressCompleted else { return false }
-    return progressCompleted
-  }
 
   private var progress: Double {
     guard let progressPage = komgaBook.progressPage else { return 0 }
     guard komgaBook.mediaPagesCount > 0 else { return 0 }
     return Double(progressPage) / Double(komgaBook.mediaPagesCount)
-  }
-
-  private var isInProgress: Bool {
-    guard let progressCompleted = komgaBook.progressCompleted else { return false }
-    return !progressCompleted
   }
 
   var shouldShowSeriesTitle: Bool {
@@ -47,12 +39,21 @@ struct BookRowView: View {
     (shouldShowSeriesTitle || komgaBook.oneshot) ? 1 : 2
   }
 
+  private var coverBlurRadius: CGFloat {
+    thumbnailBlurUnreadCovers && komgaBook.isUnread ? CoverBlurStyle.unreadRadius : 0
+  }
+
   var body: some View {
     HStack(spacing: 12) {
       Button {
         onReadBook?(false)
       } label: {
-        ThumbnailImage(id: komgaBook.bookId, type: .book, width: 60)
+        ThumbnailImage(
+          id: komgaBook.bookId,
+          type: .book,
+          contentBlurRadius: coverBlurRadius,
+          width: 60
+        )
       }.adaptiveButtonStyle(.plain)
 
       VStack(alignment: .leading, spacing: 4) {
@@ -71,7 +72,7 @@ struct BookRowView: View {
                 .lineLimit(1)
             }
             Text("#\(komgaBook.metaNumber) - \(komgaBook.metaTitle)")
-              .foregroundColor(completed ? .secondary : .primary)
+              .foregroundColor(komgaBook.isCompleted ? .secondary : .primary)
               .lineLimit(bookTitleLineLimit)
           }
         }.adaptiveButtonStyle(.plain)

--- a/KMReader/Features/History/Services/ReadingStatsService.swift
+++ b/KMReader/Features/History/Services/ReadingStatsService.swift
@@ -35,7 +35,7 @@ class ReadingStatsService {
     let completedSeriesIds = Set(
       readBooks
         .lazy
-        .filter { $0.readProgress?.completed == true }
+        .filter(\.isCompleted)
         .map { $0.seriesId }
     )
     let readSeries = await database.fetchSeriesByIdsForStats(
@@ -53,8 +53,8 @@ class ReadingStatsService {
   // MARK: - Aggregation
 
   private func buildPayload(filteredBooks: [Book], readSeries: [Series], totalBooks: Int) -> ReadingStatsPayload {
-    let booksWithProgress = filteredBooks.filter { $0.readProgress != nil }
-    let completedBooks = filteredBooks.filter { $0.readProgress?.completed == true }
+    let booksWithProgress = filteredBooks.filter(\.hasStartedReading)
+    let completedBooks = filteredBooks.filter(\.isCompleted)
 
     let totalPagesRead = completedBooks.reduce(0.0) { partial, book in
       partial + Double(book.readProgress?.page ?? 0)
@@ -111,10 +111,7 @@ class ReadingStatsService {
     completedBooks: [Book]
   ) -> [ReadingStatsItem] {
     let completedCount = completedBooks.count
-    let inProgressCount = filteredBooks.filter { book in
-      guard let progress = book.readProgress else { return false }
-      return progress.completed == false
-    }.count
+    let inProgressCount = filteredBooks.filter(\.isInProgress).count
     let unreadCount = max(totalBooks - filteredBooks.count, 0)
 
     return [

--- a/KMReader/Features/OneShot/OneShotDetailContentView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailContentView.swift
@@ -12,10 +12,12 @@ struct OneShotDetailContentView: View {
   let downloadStatus: DownloadStatus?
   let inSheet: Bool
 
+  @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
+
   @State private var thumbnailRefreshKey = UUID()
 
-  private var isCompleted: Bool {
-    book.readProgress?.completed ?? false
+  private var coverBlurRadius: CGFloat {
+    thumbnailBlurUnreadCovers && book.isUnread ? CoverBlurStyle.unreadRadius : 0
   }
 
   private var hasReadInfo: Bool {
@@ -44,6 +46,7 @@ struct OneShotDetailContentView: View {
         ThumbnailImage(
           id: book.id,
           type: .book,
+          contentBlurRadius: coverBlurRadius,
           width: PlatformHelper.detailThumbnailWidth,
           isTransitionSource: false,
           onAction: {}
@@ -100,7 +103,7 @@ struct OneShotDetailContentView: View {
           }
 
           if let readProgress = book.readProgress {
-            if isCompleted {
+            if book.isCompleted {
               InfoChip(
                 labelKey: "Completed",
                 systemImage: "checkmark.circle.fill",

--- a/KMReader/Features/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailView.swift
@@ -329,7 +329,7 @@ struct OneshotDetailView: View {
         Divider()
 
         if let book = book {
-          if !(book.readProgress?.completed ?? false) {
+          if !book.isCompleted {
             Button {
               markOneshotAsRead()
             } label: {
@@ -337,7 +337,7 @@ struct OneshotDetailView: View {
             }
           }
 
-          if book.readProgress != nil {
+          if book.hasStartedReading {
             Button {
               markOneshotAsUnread()
             } label: {

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -136,7 +136,7 @@
 
     func load(book: Book) async {
       downloadInfo = book.downloadInfo
-      let shouldResumeFromProgression = book.readProgress?.completed != true
+      let shouldResumeFromProgression = !book.isCompleted
       await load(
         bookId: book.id,
         shouldResumeFromProgression: shouldResumeFromProgression

--- a/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
@@ -73,7 +73,7 @@
       beginLoading()
       bookId = book.id
       downloadInfo = book.downloadInfo
-      if book.readProgress?.completed == true {
+      if book.isCompleted {
         initialPageNumber = 1
       } else {
         initialPageNumber = max(1, book.readProgress?.page ?? 1)

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -916,7 +916,7 @@ struct DivinaReaderView: View {
       }
       if incognito {
         initialPageNumber = nil
-      } else if resolvedBook.readProgress?.completed == true {
+      } else if resolvedBook.isCompleted {
         initialPageNumber = nil
       } else {
         initialPageNumber = resolvedBook.readProgress?.page

--- a/KMReader/Features/Series/Models/KomgaSeries.swift
+++ b/KMReader/Features/Series/Models/KomgaSeries.swift
@@ -82,6 +82,14 @@ final class KomgaSeries {
     return .notDownloaded
   }
 
+  var hasStartedReading: Bool {
+    booksReadCount > 0 || booksInProgressCount > 0
+  }
+
+  var isUnread: Bool {
+    !hasStartedReading
+  }
+
   /// Computed property for offline policy.
   var offlinePolicy: SeriesOfflinePolicy {
     get {

--- a/KMReader/Features/Series/Models/Series.swift
+++ b/KMReader/Features/Series/Models/Series.swift
@@ -24,4 +24,12 @@ struct Series: Codable, Identifiable, Equatable {
   var unreadCount: Int {
     booksUnreadCount + booksInProgressCount
   }
+
+  var hasStartedReading: Bool {
+    booksReadCount > 0 || booksInProgressCount > 0
+  }
+
+  var isUnread: Bool {
+    !hasStartedReading
+  }
 }

--- a/KMReader/Features/Series/Services/SeriesContinueReadingResolver.swift
+++ b/KMReader/Features/Series/Services/SeriesContinueReadingResolver.swift
@@ -134,6 +134,6 @@ enum SeriesContinueReadingResolver {
   }
 
   private static func isUnread(_ book: KomgaBook) -> Bool {
-    book.progressReadDate == nil
+    book.isUnread
   }
 }

--- a/KMReader/Features/Series/Views/SeriesCardView.swift
+++ b/KMReader/Features/Series/Views/SeriesCardView.swift
@@ -12,6 +12,7 @@ struct SeriesCardView: View {
   @AppStorage("coverOnlyCards") private var coverOnlyCards: Bool = false
   @AppStorage("cardTextOverlayMode") private var cardTextOverlayMode: Bool = false
   @AppStorage("thumbnailShowUnreadIndicator") private var thumbnailShowUnreadIndicator: Bool = true
+  @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
 
   @State private var showCollectionPicker = false
   @State private var showDeleteConfirmation = false
@@ -34,12 +35,17 @@ struct SeriesCardView: View {
     cardTextOverlayMode ? 0 : 12
   }
 
+  private var coverBlurRadius: CGFloat {
+    thumbnailBlurUnreadCovers && komgaSeries.isUnread ? CoverBlurStyle.unreadRadius : 0
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: contentSpacing) {
       ThumbnailImage(
         id: komgaSeries.seriesId,
         type: .series,
         shadowStyle: .platform,
+        contentBlurRadius: coverBlurRadius,
         alignment: .bottom,
         navigationLink: navDestination,
         preserveAspectRatioOverride: cardTextOverlayMode ? false : nil

--- a/KMReader/Features/Series/Views/SeriesDetailContentView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailContentView.swift
@@ -9,9 +9,15 @@ import SwiftUI
 struct SeriesDetailContentView: View {
   let series: Series
 
+  @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
+
   @State private var thumbnailRefreshKey = UUID()
 
   private let collapsedMetadataChipLimit = 10
+
+  private var coverBlurRadius: CGFloat {
+    thumbnailBlurUnreadCovers && series.isUnread ? CoverBlurStyle.unreadRadius : 0
+  }
 
   var body: some View {
     VStack(alignment: .leading) {
@@ -28,6 +34,7 @@ struct SeriesDetailContentView: View {
         ThumbnailImage(
           id: series.id,
           type: .series,
+          contentBlurRadius: coverBlurRadius,
           width: PlatformHelper.detailThumbnailWidth,
           isTransitionSource: false,
           onAction: {}

--- a/KMReader/Features/Series/Views/SeriesRowView.swift
+++ b/KMReader/Features/Series/Views/SeriesRowView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 struct SeriesRowView: View {
   @Bindable var komgaSeries: KomgaSeries
 
+  @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
+
   @State private var showCollectionPicker = false
   @State private var showDeleteConfirmation = false
   @State private var showEditSheet = false
@@ -35,10 +37,19 @@ struct SeriesRowView: View {
     return Double(komgaSeries.booksReadCount) / Double(komgaSeries.booksCount)
   }
 
+  private var coverBlurRadius: CGFloat {
+    thumbnailBlurUnreadCovers && komgaSeries.isUnread ? CoverBlurStyle.unreadRadius : 0
+  }
+
   var body: some View {
     HStack(spacing: 12) {
       NavigationLink(value: navDestination) {
-        ThumbnailImage(id: series.id, type: .series, width: 80)
+        ThumbnailImage(
+          id: series.id,
+          type: .series,
+          contentBlurRadius: coverBlurRadius,
+          width: 80
+        )
       }
       .adaptiveButtonStyle(.plain)
 

--- a/KMReader/Features/Settings/Components/SettingsBrowseCardPreview.swift
+++ b/KMReader/Features/Settings/Components/SettingsBrowseCardPreview.swift
@@ -11,6 +11,7 @@ struct SettingsBrowseCardPreview: View {
   let detail: String
   let unreadCount: Int?
   let showUnreadDot: Bool
+  let shouldBlurCover: Bool
   let progress: Double?
 
   @AppStorage("coverOnlyCards") private var coverOnlyCards: Bool = false
@@ -20,6 +21,7 @@ struct SettingsBrowseCardPreview: View {
   @AppStorage("thumbnailShowShadow") private var thumbnailShowShadow: Bool = true
   @AppStorage("thumbnailShowUnreadIndicator") private var thumbnailShowUnreadIndicator: Bool = true
   @AppStorage("thumbnailShowProgressBar") private var thumbnailShowProgressBar: Bool = true
+  @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
 
   private let cornerRadius: CGFloat = 8
   private let imageCornerRadius: CGFloat = 6
@@ -35,6 +37,7 @@ struct SettingsBrowseCardPreview: View {
     detail: String,
     unreadCount: Int? = nil,
     showUnreadDot: Bool = false,
+    shouldBlurCover: Bool = false,
     progress: Double? = nil
   ) {
     self.title = title
@@ -42,6 +45,7 @@ struct SettingsBrowseCardPreview: View {
     self.detail = detail
     self.unreadCount = unreadCount
     self.showUnreadDot = showUnreadDot
+    self.shouldBlurCover = shouldBlurCover
     self.progress = progress
   }
 
@@ -79,6 +83,10 @@ struct SettingsBrowseCardPreview: View {
 
   private var effectivePreserveAspectRatio: Bool {
     thumbnailPreserveAspectRatio && !cardTextOverlayMode
+  }
+
+  private var shouldBlurPreviewCover: Bool {
+    shouldBlurCover && thumbnailBlurUnreadCovers
   }
 
   private static func randomImageRatio() -> CGFloat {
@@ -122,6 +130,7 @@ struct SettingsBrowseCardPreview: View {
     .animation(animation, value: thumbnailShowShadow)
     .animation(animation, value: thumbnailShowUnreadIndicator)
     .animation(animation, value: thumbnailShowProgressBar)
+    .animation(animation, value: thumbnailBlurUnreadCovers)
     .animation(animation, value: cardTextOverlayMode)
   }
 
@@ -140,9 +149,20 @@ struct SettingsBrowseCardPreview: View {
     .aspectRatio(CoverAspectRatio.widthToHeight, contentMode: .fit)
   }
 
+  @ViewBuilder
   private var imageCard: some View {
-    RoundedRectangle(cornerRadius: imageCornerRadius)
-      .fill(imageFill)
+    if shouldBlurPreviewCover {
+      styledImageCard(
+        baseImageCard
+          .blur(radius: CoverBlurStyle.unreadRadius)
+      )
+    } else {
+      styledImageCard(baseImageCard)
+    }
+  }
+
+  private func styledImageCard<Content: View>(_ content: Content) -> some View {
+    content
       .overlay { imageBorderOverlay }
       .shadowStyle(effectiveShadowStyle, cornerRadius: imageCornerRadius)
       .overlay {
@@ -161,6 +181,12 @@ struct SettingsBrowseCardPreview: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
         }
       }
+  }
+
+  private var baseImageCard: some View {
+    RoundedRectangle(cornerRadius: imageCornerRadius)
+      .fill(imageFill)
+      .clipShape(RoundedRectangle(cornerRadius: imageCornerRadius))
   }
 
   @ViewBuilder

--- a/KMReader/Features/Settings/SettingsBrowseView.swift
+++ b/KMReader/Features/Settings/SettingsBrowseView.swift
@@ -15,6 +15,7 @@ struct SettingsBrowseView: View {
   @AppStorage("thumbnailShowShadow") private var thumbnailShowShadow: Bool = true
   @AppStorage("thumbnailShowUnreadIndicator") private var thumbnailShowUnreadIndicator: Bool = true
   @AppStorage("thumbnailShowProgressBar") private var thumbnailShowProgressBar: Bool = true
+  @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
   @AppStorage("searchIgnoreFilters") private var searchIgnoreFilters: Bool = false
 
   private var gridDensityBinding: Binding<GridDensity> {
@@ -57,7 +58,8 @@ struct SettingsBrowseView: View {
           SettingsBrowseCardPreview(
             title: "Series Title",
             detail: "12 books",
-            unreadCount: 3
+            unreadCount: 12,
+            shouldBlurCover: true
           )
           .frame(maxWidth: .infinity)
 
@@ -73,7 +75,8 @@ struct SettingsBrowseView: View {
             title: "#1 - Book Title",
             subtitle: "Series Title",
             detail: "200 pages",
-            showUnreadDot: true
+            showUnreadDot: true,
+            shouldBlurCover: true
           )
           .frame(maxWidth: .infinity)
         }
@@ -134,6 +137,15 @@ struct SettingsBrowseView: View {
           VStack(alignment: .leading, spacing: 4) {
             Text(String(localized: "settings.appearance.coverShowUnreadIndicator.title"))
             Text(String(localized: "settings.appearance.coverShowUnreadIndicator.caption"))
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+        }
+
+        Toggle(isOn: $thumbnailBlurUnreadCovers) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text(String(localized: "settings.appearance.coverBlurUnread.title"))
+            Text(String(localized: "settings.appearance.coverBlurUnread.caption"))
               .font(.caption)
               .foregroundColor(.secondary)
           }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -61192,6 +61192,134 @@
         }
       }
     },
+    "settings.appearance.coverBlurUnread.caption" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buch- und Seriencover weichzeichnen, bis du mit dem Lesen beginnst"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blur book and series covers until you start reading them"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Difumina las portadas de libros y series hasta que empieces a leerlos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flouter les couvertures des livres et des séries jusqu'à ce que vous commenciez à les lire"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sfoca le copertine di libri e serie finché non inizi a leggerli"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読み始めるまで本とシリーズのカバーをぼかして表示します"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽기 시작할 때까지 책과 시리즈 표지를 흐리게 표시합니다"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размывать обложки книг и серий, пока вы не начнёте их читать"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在开始阅读前模糊书籍与系列封面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在開始閱讀前模糊書籍與系列封面"
+          }
+        }
+      }
+    },
+    "settings.appearance.coverBlurUnread.title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungelesene Cover weichzeichnen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blur Unread Covers"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Difuminar portadas no leídas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flouter les couvertures non lues"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sfoca copertine non lette"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未読カバーをぼかす"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽지 않은 표지 흐리기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размывать непрочитанные обложки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模糊未读封面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模糊未讀封面"
+          }
+        }
+      }
+    },
     "settings.appearance.coverOnlyCards.caption" : {
       "localizations" : {
         "de" : {

--- a/KMReader/Shared/UI/CoverBlurStyle.swift
+++ b/KMReader/Shared/UI/CoverBlurStyle.swift
@@ -1,0 +1,10 @@
+//
+// CoverBlurStyle.swift
+//
+//
+
+import SwiftUI
+
+enum CoverBlurStyle {
+  static let unreadRadius: CGFloat = 5
+}

--- a/KMReader/Shared/UI/ThumbnailImage.swift
+++ b/KMReader/Shared/UI/ThumbnailImage.swift
@@ -10,6 +10,7 @@ struct ThumbnailImage<Overlay: View, Menu: View>: View {
   let id: String
   let type: ThumbnailType
   let shadowStyle: ShadowStyle
+  let contentBlurRadius: CGFloat
   let width: CGFloat?
   let cornerRadius: CGFloat
   let alignment: Alignment
@@ -73,6 +74,7 @@ struct ThumbnailImage<Overlay: View, Menu: View>: View {
     id: String,
     type: ThumbnailType = .book,
     shadowStyle: ShadowStyle = .basic,
+    contentBlurRadius: CGFloat = 0,
     width: CGFloat? = nil,
     cornerRadius: CGFloat = 8,
     alignment: Alignment = .center,
@@ -86,6 +88,7 @@ struct ThumbnailImage<Overlay: View, Menu: View>: View {
     self.id = id
     self.type = type
     self.shadowStyle = shadowStyle
+    self.contentBlurRadius = max(0, contentBlurRadius)
     self.width = width
     self.cornerRadius = cornerRadius
     self.alignment = alignment
@@ -151,6 +154,7 @@ struct ThumbnailImage<Overlay: View, Menu: View>: View {
     }
     .animation(.easeInOut(duration: 0.18), value: image != nil)
     .animation(.easeInOut(duration: 0.18), value: shouldShowPlaceholder)
+    .animation(.easeInOut(duration: 0.18), value: contentBlurRadius)
     .aspectRatio(CoverAspectRatio.widthToHeight, contentMode: .fit)
     .frame(width: width)
     .overlay {
@@ -191,16 +195,32 @@ struct ThumbnailImage<Overlay: View, Menu: View>: View {
   var imageContent: some View {
     if let platformImage = image {
       if effectivePreserveAspectRatio {
-        Image(platformImage: platformImage)
-          .resizable()
-          .aspectRatio(contentMode: .fit)
-      } else {
-        GeometryReader { proxy in
+        if contentBlurRadius > 0 {
           Image(platformImage: platformImage)
             .resizable()
-            .aspectRatio(contentMode: .fill)
-            .frame(width: proxy.size.width, height: proxy.size.height)
-            .clipped()
+            .aspectRatio(contentMode: .fit)
+            .blur(radius: contentBlurRadius)
+        } else {
+          Image(platformImage: platformImage)
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+        }
+      } else {
+        GeometryReader { proxy in
+          if contentBlurRadius > 0 {
+            Image(platformImage: platformImage)
+              .resizable()
+              .aspectRatio(contentMode: .fill)
+              .frame(width: proxy.size.width, height: proxy.size.height)
+              .blur(radius: contentBlurRadius)
+              .clipped()
+          } else {
+            Image(platformImage: platformImage)
+              .resizable()
+              .aspectRatio(contentMode: .fill)
+              .frame(width: proxy.size.width, height: proxy.size.height)
+              .clipped()
+          }
         }
       }
     }
@@ -208,8 +228,18 @@ struct ThumbnailImage<Overlay: View, Menu: View>: View {
 
   @ViewBuilder
   private var imageCard: some View {
-    let base =
-      imageContent
+    if effectivePreserveAspectRatio {
+      framedImageCard
+        .aspectRatio(imageAspectRatio, contentMode: .fit)
+        .shadowStyle(effectiveShadowStyle, cornerRadius: cornerRadius)
+    } else {
+      framedImageCard
+        .shadowStyle(effectiveShadowStyle, cornerRadius: cornerRadius)
+    }
+  }
+
+  private var framedImageCard: some View {
+    imageContent
       .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
       .overlay { borderOverlay }
       .overlay {
@@ -217,15 +247,6 @@ struct ThumbnailImage<Overlay: View, Menu: View>: View {
           overlay()
         }
       }
-
-    if effectivePreserveAspectRatio {
-      base
-        .aspectRatio(imageAspectRatio, contentMode: .fit)
-        .shadowStyle(effectiveShadowStyle, cornerRadius: cornerRadius)
-    } else {
-      base
-        .shadowStyle(effectiveShadowStyle, cornerRadius: cornerRadius)
-    }
   }
 
   private var placeholderCard: some View {
@@ -240,6 +261,7 @@ extension ThumbnailImage where Overlay == EmptyView, Menu == EmptyView {
     id: String,
     type: ThumbnailType = .book,
     shadowStyle: ShadowStyle = .basic,
+    contentBlurRadius: CGFloat = 0,
     width: CGFloat? = nil,
     cornerRadius: CGFloat = 8,
     alignment: Alignment = .center,
@@ -249,7 +271,7 @@ extension ThumbnailImage where Overlay == EmptyView, Menu == EmptyView {
     onAction: (() -> Void)? = nil,
   ) {
     self.init(
-      id: id, type: type, shadowStyle: shadowStyle,
+      id: id, type: type, shadowStyle: shadowStyle, contentBlurRadius: contentBlurRadius,
       width: width, cornerRadius: cornerRadius,
       alignment: alignment,
       isTransitionSource: isTransitionSource,
@@ -267,6 +289,7 @@ extension ThumbnailImage where Menu == EmptyView {
     id: String,
     type: ThumbnailType = .book,
     shadowStyle: ShadowStyle = .basic,
+    contentBlurRadius: CGFloat = 0,
     width: CGFloat? = nil,
     cornerRadius: CGFloat = 8,
     alignment: Alignment = .center,
@@ -277,7 +300,7 @@ extension ThumbnailImage where Menu == EmptyView {
     @ViewBuilder overlay: @escaping () -> Overlay
   ) {
     self.init(
-      id: id, type: type, shadowStyle: shadowStyle,
+      id: id, type: type, shadowStyle: shadowStyle, contentBlurRadius: contentBlurRadius,
       width: width, cornerRadius: cornerRadius,
       alignment: alignment,
       isTransitionSource: isTransitionSource,


### PR DESCRIPTION
## Problem
Issue #618 asks for a way to hide spoiler-heavy covers until reading has actually started. The existing UI could show unread indicators, but unread book, oneshot, and series covers still rendered fully in browse and detail surfaces.

## Approach
Add a browse appearance setting that blurs unread covers and apply it through the shared thumbnail renderer so only the image content is blurred while badges, overlays, and actions stay readable. Reading-state helpers are centralized on `Book`, `KomgaBook`, `Series`, and `KomgaSeries` so cover UI, detail actions, reader resume logic, and reading stats use the same unread/in-progress/completed semantics.

## Scope
- Add `thumbnailBlurUnreadCovers` settings UI, preview support, and localized strings
- Blur unread covers for books, oneshots, and series in browse cards, rows, and detail headers
- Keep blur optional and avoid attaching blur modifiers when the radius is zero
- Consolidate repeated reading-state checks into shared computed properties

## Validation
- [x] `make format`
- [x] `make build`

Closes #618.
