### PR TITLE
fix(server): exclude all libraries id from fetched libraries

### DIFF
--- a/KMReader/Features/Server/MediaAnalysisView.swift
+++ b/KMReader/Features/Server/MediaAnalysisView.swift
@@ -222,6 +222,7 @@ struct MediaAnalysisView: View {
     let instanceId = AppConfig.current.instanceId
     guard !instanceId.isEmpty else { return }
     libraries = await DatabaseOperator.shared.fetchLibraries(instanceId: instanceId)
+      .filter { $0.id != KomgaLibrary.allLibrariesId }
   }
 
   private func loadData(refresh: Bool) async {


### PR DESCRIPTION
Filter out the special "all libraries" ID to prevent it from appearing in the library list.