### PR TITLE
chore: prepare 4.2 release

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,22 +1,15 @@
-KMReader - What's New (from v4.0 to current)
+Reader Improvements
+- Added cover-style page transitions across DIVINA on iPhone, iPad, Mac, and Apple TV, plus new cover transitions for EPUB on iPhone, iPad, and Mac.
+- Animated GIF and WebP pages now start faster, zoom with the page, and stay stable when you navigate, scroll, or reopen a page.
+- Improved dual-page spread handling, adjacent-page preloading, and cover-turn reliability for smoother reading.
+- Improved Komga media error messages so unsupported files and analysis issues are easier to understand inside the app.
 
-Reader Experience
-- Added a new cover-style page transition for DIVINA on iPhone, making comic-style navigation feel more natural.
-- Animated pages now play more smoothly with native inline playback, clearer loading progress, and better battery-friendly performance.
-- Improved page-turn reliability in cover mode and fixed end-page flicker so navigation stays stable.
-- Fixed an issue where some offline PDF pages could appear upside down, and added visible preparation progress while pages are generated.
-- Polished reader responsiveness across table-of-contents jumps, page changes, and gesture handling.
+Offline and Library Workflows
+- EPUB downloads are now saved as a single file and extracted locally, making offline downloads faster and more reliable.
+- Improved offline sync and iOS background downloads so long-running downloads and reconnects behave more predictably.
+- Added an option to blur unread book and series covers to help avoid spoiler-heavy artwork.
 
-Offline and Sync
-- Added a manual Offline Mode action so you can switch modes when needed.
-- Strengthened iOS background downloads for pages, PDFs, and EPUB resources so long downloads are more reliable.
-- Improved progress syncing behavior to avoid interruptions when server-side conflicts happen.
-- Optimized sync flow so heavy cleanup runs only during full sync, reducing unnecessary work during regular refreshes.
-
-iPhone and Dashboard
-- Added Dynamic Island Live Activities for both active reading sessions and download progress.
-- Updated splash and landing visuals to match your selected app icon style.
-- Improved thumbnail appearance animations for a smoother browsing feel.
-
-Localization
-- Expanded UI localization support with Spanish, Italian, and Russian coverage across the app and widgets.
+Management and Platform Polish
+- Added in-app media management tools for media analysis, missing posters, duplicate files, duplicate pages, and page-hash matches.
+- Moved macOS reader actions into the system menu bar for quicker keyboard-first control.
+- Refined reader and browse behavior across page sync, thumbnail presentation, and other everyday interactions.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -5,20 +5,21 @@ KMReader helps you read, browse, download, and manage your Komga library with a 
 IMPORTANT FEATURES
 
 - Native readers for every format
-DIVINA on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl (iOS), and cover-style transitions (all platforms).
-EPUB on iOS and macOS with paged or scrolled flow, custom fonts, themes, and per-book preferences.
-Animated pages use native inline playback with smooth progress feedback while media prepares.
+DIVINA on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl (iOS), and cover-style transitions on all platforms.
+EPUB on iOS and macOS with paged, scrolled, or cover layouts, custom fonts, themes, and per-book preferences.
+Animated GIF and WebP pages start immediately, zoom naturally, and stay stable while you move through a book.
 PDF on iOS and macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality, and clearer offline preparation progress.
 Incognito mode and iOS Live Text support let you read your way.
 
 - Dashboard, discovery, and shortcuts
 Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists keep important items close.
-Browse Series, Books, Collections, and Read Lists with advanced metadata filters and saved filters.
+Browse Series, Books, Collections, and Read Lists with advanced metadata filters, saved filters, and optional unread-cover blur.
 Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions, help you jump back into reading faster.
 KMReader UI is localized in English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
 
 - Offline that actually works
 Download books for offline reading.
+EPUB downloads use a single-file workflow with local extraction for faster, more reliable saves.
 Use manual offline mode controls and more reliable iOS background downloads.
 Get Live Activities for both active reading sessions and downloads.
 Set per-series policies: Manual, Unread only, Unread + cleanup, or All books.
@@ -28,6 +29,7 @@ Sync progress and offline changes when you reconnect, with safer conflict handli
 Save multiple Komga servers and switch instantly.
 Sign in with password or API key, and manage API keys in the app.
 Edit metadata, manage libraries and media (analysis, missing posters, duplicate files and pages), monitor tasks, and view logs.
+On macOS, reader actions also live in the system menu bar for faster keyboard-first control.
 
 KMReader targets Komga 1.19.0+ and supports API v1/v2.
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@
 
 ### Native Reading Experience
 
-- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, customizable tap zones, page curl (iOS), and cover-style page transitions (all platforms).
-- EPUB reader on iOS/macOS with paged, scrolled, and curl layouts, custom font importing (`.ttf`/`.otf`), theme presets, multi-column reading, and nested table of contents.
-- Animated pages use native inline playback with visible preparation progress and smoother performance for long reading sessions.
+- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, customizable tap zones, page curl (iOS), and cover-style page transitions on all platforms.
+- EPUB reader on iOS/macOS with paged, scrolled, and cover layouts, custom font importing (`.ttf`/`.otf`), theme presets, multi-column reading, and nested table of contents.
+- Animated GIF and WebP pages start immediately, zoom naturally with the page, and stay stable across long reading sessions.
 - PDF reading on iOS/macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality tiers for offline preparation, and clearer progress feedback.
 - Per-book preferences save reading direction, page layout, and theme settings.
 - Incognito mode and iOS Live Text support, including optional shake-to-toggle.
@@ -34,6 +34,7 @@
 - Dashboard sections for Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists.
 - Browse Series, Books, Collections, and Read Lists with metadata filters for publishers, authors, genres, tags, and languages using all/any logic.
 - Save and reuse filters across browse surfaces.
+- Optional unread-cover blur helps hide spoiler-heavy artwork until you start reading.
 - Reading history and stats help surface recent activity from synced local data.
 - Spotlight integration for downloaded content on iOS/macOS, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
 - UI localization includes English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
@@ -41,6 +42,7 @@
 ### Offline and Sync
 
 - Download books for full offline reading across DIVINA, EPUB, and PDF workflows.
+- EPUB downloads use a single-file download plus local extraction for faster, more reliable offline saves.
 - Manual offline mode controls and resilient iOS background downloads for page files and extra resources.
 - iOS Live Activities for both active reading sessions and downloads.
 - Per-series download policies: Manual, Unread only, Unread + cleanup, and All books.
@@ -58,7 +60,7 @@
 
 - iOS/iPadOS: widgets, quick actions, Spotlight search, Dynamic Island Live Activities for reader/downloads, background downloads, Live Text, and page curl/cover transitions.
 - macOS: dedicated reader windows, reader actions in the system menu bar, Spotlight search for downloaded content, keyboard shortcuts, and keyboard help overlay.
-- tvOS: remote-first DIVINA reading with a TV-optimized browsing experience.
+- tvOS: remote-first DIVINA reading with cover transitions and a TV-optimized browsing experience.
 
 ## Getting Started
 

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
         <title>KMReader · Native Komga Client for iOS, macOS & tvOS</title>
         <meta
             name="description"
-            content="KMReader is a native SwiftUI Komga client with DIVINA, EPUB, and PDF readers, animated page playback, offline downloads, Live Activities, media management, multi-server switching, and admin tools."
+            content="KMReader is a native SwiftUI Komga client with DIVINA, EPUB, and PDF readers, cover transitions, immediate animated page playback, reliable offline downloads, media management, and multi-server support."
         />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -27,9 +27,10 @@
                 <h1>KMReader</h1>
                 <p class="tagline">
                     Read, download, browse, and manage your Komga library with
-                    native readers, reliable offline sync, and practical
-                    Apple-platform extras like widgets, Spotlight, and Dynamic
-                    Island updates on iPhone, iPad, Mac, and Apple TV.
+                    native readers, cover-style transitions, reliable offline
+                    sync, and practical Apple-platform extras like widgets,
+                    Spotlight, Dynamic Island updates, and keyboard-first
+                    controls on iPhone, iPad, Mac, and Apple TV.
                 </p>
                 <div class="cta">
                     <a
@@ -81,12 +82,12 @@
                         <p>
                             DIVINA on iOS/macOS/tvOS with LTR, RTL, vertical,
                             Webtoon, spreads, zoom, tap zones, page curl
-                            (iOS), and cover transitions (all platforms). EPUB
-                            on iOS/macOS with custom fonts and flexible
-                            layouts. Animated pages play natively with progress
-                            feedback, and PDF on iOS/macOS offers a native
-                            reader or DIVINA mode with search, TOC, and
-                            configurable render quality.
+                            (iOS), and cover transitions on all platforms.
+                            EPUB on iOS/macOS adds custom fonts and paged,
+                            scrolled, or cover layouts. Animated pages play
+                            immediately and zoom naturally, while PDF on
+                            iOS/macOS offers a native reader or DIVINA mode
+                            with search, TOC, and configurable render quality.
                         </p>
                     </article>
                     <article class="card">
@@ -94,7 +95,8 @@
                         <h3>Keep reading, recent updates, and favorites</h3>
                         <p>
                             Keep Reading, On Deck, Recently Added, Recently
-                            Updated, and pinned collections/read lists keep the
+                            Updated, pinned collections/read lists, saved
+                            filters, and optional unread-cover blur keep the
                             most useful parts of your library close.
                         </p>
                     </article>
@@ -102,10 +104,11 @@
                         <span class="pill">Offline</span>
                         <h3>Download and keep reading anywhere</h3>
                         <p>
-                            Download books for offline reading, run background
-                            downloads on iOS, use a manual offline mode switch,
-                            and apply per-series policies to automate what
-                            stays on device.
+                            Download books for offline reading, use single-file
+                            EPUB downloads with local extraction, run
+                            background downloads on iOS, switch Offline mode
+                            manually, and apply per-series policies to
+                            automate what stays on device.
                         </p>
                     </article>
                     <article class="card">
@@ -142,8 +145,8 @@
                         <p>
                             Edit metadata, manage libraries and media
                             (analysis, missing posters, duplicate files and
-                            pages), monitor tasks, and view logs directly in
-                            KMReader.
+                            pages, page-hash matches), monitor tasks, and view
+                            logs directly in KMReader.
                         </p>
                     </article>
                     <article class="card">
@@ -205,8 +208,9 @@
                         <h4>Which readers are available?</h4>
                         <p>
                             DIVINA is available on iOS, macOS, and tvOS. EPUB
-                            and PDF are available on iOS and macOS, with PDF
-                            support offering a native reader or DIVINA mode.
+                            and PDF are available on iOS and macOS, with EPUB
+                            supporting cover mode and PDF offering a native
+                            reader or DIVINA mode.
                         </p>
                     </article>
                     <article class="faq-item">


### PR DESCRIPTION
## Problem
Preparing the 4.2 release required the checked-in product copy and the App Store Connect metadata to describe the same feature set, while the project version also needed to move forward for post-release work.

## Approach
Refresh the local release copy with the 4.2 feature set, sync that description and release notes to the new 4.2 App Store versions for iOS, macOS, and tvOS, then bump the Xcode marketing/build version after the release metadata commit.

## Scope
- update the README, landing page, App Store description, and App Store changelog for 4.2
- create App Store Connect 4.2 versions for iOS, macOS, and tvOS and sync the English release metadata

