### PR TITLE
fix: repair animated playback in scroll reader

### DIFF
--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -47,7 +47,6 @@ class ReaderViewModel {
   private var animatedPageStates: [ReaderPageID: Bool] = [:]
   /// Source file URL for animated pages keyed by reader page ID.
   private var animatedPageSourceFileURLs: [ReaderPageID: URL] = [:]
-  private var animatedPlaybackFocusedPageIDs: Set<ReaderPageID> = []
   private var isolateCoverPageEnabled: Bool
   private var forceDualPagePairs: Bool
   private var splitWidePageMode: SplitWidePageMode
@@ -612,7 +611,6 @@ class ReaderViewModel {
     segmentPageRangeByBookId.removeAll()
     animatedPageStates.removeAll()
     animatedPageSourceFileURLs.removeAll()
-    animatedPlaybackFocusedPageIDs.removeAll()
     liveTextActivePageIndex = nil
     currentPageID = nil
     currentViewItemID = nil
@@ -1456,27 +1454,6 @@ class ReaderViewModel {
     }
   }
 
-  func focusAnimatedPlayback(on pageID: ReaderPageID?) {
-    if let pageID {
-      focusAnimatedPlayback(on: [pageID])
-    } else {
-      focusAnimatedPlayback(on: [])
-    }
-  }
-
-  private func focusAnimatedPlayback(on pageIDs: Set<ReaderPageID>) {
-    guard animatedPlaybackFocusedPageIDs != pageIDs else { return }
-    animatedPlaybackFocusedPageIDs = pageIDs
-  }
-
-  func focusAnimatedPlayback(for viewItem: ReaderViewItem?) {
-    guard let viewItem, !viewItem.isEnd else {
-      focusAnimatedPlayback(on: nil)
-      return
-    }
-    focusAnimatedPlayback(on: Set(viewItem.pageIDs))
-  }
-
   func animatedSourceFileURL(for pageID: ReaderPageID) -> URL? {
     guard animatedPageStates[pageID] == true else { return nil }
     guard let fileURL = animatedPageSourceFileURLs[pageID] else { return nil }
@@ -1563,7 +1540,6 @@ class ReaderViewModel {
     preloadedImagesByID.removeAll()
     animatedPageStates.removeAll()
     animatedPageSourceFileURLs.removeAll()
-    animatedPlaybackFocusedPageIDs.removeAll()
     invalidateAllPagePresentations()
     logger.debug("🗑️ Cleared all preloaded images and cancelled tasks")
   }

--- a/KMReader/Features/Reader/Views/NativeImagePageViewController.swift
+++ b/KMReader/Features/Reader/Views/NativeImagePageViewController.swift
@@ -247,11 +247,6 @@
       let requestedPageID = pageID
       animatedInlinePreparationTask = Task { [weak self] in
         guard let self else { return }
-        if let currentViewItem = viewModel.currentViewItem() {
-          viewModel.focusAnimatedPlayback(for: currentViewItem)
-        } else {
-          viewModel.focusAnimatedPlayback(on: requestedPageID)
-        }
         guard !Task.isCancelled else { return }
         guard self.pageID == requestedPageID else { return }
         await viewModel.prepareAnimatedPagePlaybackURL(pageID: requestedPageID)

--- a/KMReader/Features/Reader/Views/NativePagedPageCell_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativePagedPageCell_iOS.swift
@@ -238,16 +238,8 @@
           splitWidePageMode: currentSplitWidePageMode,
           isPlaybackActive: isPlaybackActive
         )
-        guard playbackData.count == pageViews.count else {
-          currentPageData = playbackData
-          updatePages()
-          return
-        }
-
         currentPageData = playbackData
-        for (index, data) in playbackData.enumerated() {
-          pageViews[index].updateAnimatedPlayback(sourceFileURL: data.animatedSourceFileURL)
-        }
+        updatePages()
       }
 
       private func resetZoomState() {

--- a/KMReader/Features/Reader/Views/NativePagedPageCell_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativePagedPageCell_macOS.swift
@@ -219,16 +219,8 @@
           splitWidePageMode: currentSplitWidePageMode,
           isPlaybackActive: isPlaybackActive
         )
-        guard playbackData.count == pageViews.count else {
-          currentPageData = playbackData
-          updatePages()
-          return
-        }
-
         currentPageData = playbackData
-        for (index, data) in playbackData.enumerated() {
-          pageViews[index].updateAnimatedPlayback(sourceFileURL: data.animatedSourceFileURL)
-        }
+        updatePages()
       }
 
       private func resetMagnification() {

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
@@ -263,8 +263,8 @@
       layoutIfNeeded()
       if let sourceFileURL {
         animatedInlineContainer.isHidden = false
-        animatedInlineContainer.layer.contents = displayedCGImage()
-        updateAnimatedPresentationState(isActive: true)
+        animatedInlineContainer.layer.contents = nil
+        updateAnimatedPresentationState()
         animatedImageController.start(
           sourceFileURL: sourceFileURL,
           targetLayer: animatedInlineContainer.layer
@@ -273,7 +273,7 @@
         animatedImageController.stop()
         animatedInlineContainer.layer.contents = nil
         animatedInlineContainer.isHidden = true
-        updateAnimatedPresentationState(isActive: false)
+        updateAnimatedPresentationState()
       }
     }
 
@@ -281,13 +281,9 @@
       currentData?.animatedSourceFileURL != nil && !animatedInlineContainer.isHidden
     }
 
-    private func displayedCGImage() -> CGImage? {
-      imageView.image?.cgImage
-    }
-
-    private func updateAnimatedPresentationState(isActive: Bool) {
-      imageView.isHidden = isActive
-      imageView.layer.shadowOpacity = (isActive || imageView.image == nil) ? 0 : 0.25
+    private func updateAnimatedPresentationState() {
+      imageView.isHidden = false
+      imageView.layer.shadowOpacity = imageView.image == nil ? 0 : 0.25
       updateSepiaOverlay()
     }
 

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_macOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_macOS.swift
@@ -289,8 +289,8 @@
       layoutSubtreeIfNeeded()
       if let sourceFileURL {
         animatedInlineContainer.isHidden = false
-        animatedInlineContainer.layer?.contents = displayedCGImage()
-        updateAnimatedPresentationState(isActive: true)
+        animatedInlineContainer.layer?.contents = nil
+        updateAnimatedPresentationState()
         if let layer = animatedInlineContainer.layer {
           animatedImageController.start(
             sourceFileURL: sourceFileURL,
@@ -301,7 +301,7 @@
         animatedImageController.stop()
         animatedInlineContainer.layer?.contents = nil
         animatedInlineContainer.isHidden = true
-        updateAnimatedPresentationState(isActive: false)
+        updateAnimatedPresentationState()
       }
     }
 
@@ -309,13 +309,9 @@
       currentData?.animatedSourceFileURL != nil && !animatedInlineContainer.isHidden
     }
 
-    private func displayedCGImage() -> CGImage? {
-      imageView.image?.cgImage(forProposedRect: nil, context: nil, hints: nil)
-    }
-
-    private func updateAnimatedPresentationState(isActive: Bool) {
-      imageView.isHidden = isActive
-      imageView.layer?.shadowOpacity = (isActive || imageView.image == nil) ? 0 : 0.25
+    private func updateAnimatedPresentationState() {
+      imageView.isHidden = false
+      imageView.layer?.shadowOpacity = imageView.image == nil ? 0 : 0.25
       updateSepiaOverlay()
     }
 


### PR DESCRIPTION
## Problem
Animated image pages in the scroll reader could behave inconsistently. Tap-based navigation would start inline playback, but drag-based page changes only updated the committed item and left visible page views on a stale playback state. The temporary animated poster path also bypassed the normal fitted image presentation, so placeholders could render with the wrong geometry before playback began.

## Approach
Route playback state changes through the same native page reconfiguration path used for normal page rendering, instead of mutating only the animated source URL on existing views. Keep the static fitted image view visible as the poster placeholder while the animated layer starts, so the placeholder continues to inherit the established fit layout.

## Scope
- Reconfigure native paged cells on playback activation changes for iOS and macOS scroll reader implementations
- Remove the separate poster layer-copy path in native page items and simplify the animated presentation helper
- Delete unused focused animated playback state and related no-op calls from the reader view model flow

## Validation
- [x] `make format`
- [x] `make build-macos`
- [x] `make build-ios`
- [x] `make build-tvos`
