### PR TITLE
fix(reader): prevent scroll pager loading flash on sheet present/dismiss

### DIFF
--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -187,6 +187,7 @@ struct DivinaReaderView: View {
     logger.debug(
       "🚪 Closing DIVINA reader for book \(currentBookId), currentPage=\(viewModel.currentPage?.number ?? -1), totalPages=\(viewModel.pageCount)"
     )
+    viewModel.clearPreloadedImages()
     if let onClose {
       onClose()
     } else {
@@ -223,8 +224,8 @@ struct DivinaReaderView: View {
     return "\(Int(screenSize.width))x\(Int(screenSize.height))"
   }
 
-  private func readerContentKey(screenKey: String, useDualPage: Bool) -> String {
-    "\(currentBookId)-\(screenKey)-\(readingDirection)-\(useDualPage)"
+  private func readerContentKey(useDualPage: Bool) -> String {
+    "\(currentBookId)-\(readingDirection)-\(useDualPage)"
   }
 
   private func applyDualPagePresentationMode(_ useDualPage: Bool) {
@@ -389,8 +390,7 @@ struct DivinaReaderView: View {
 
         readerContent(
           useDualPage: useDualPage,
-          screenSize: screenSize,
-          screenKey: screenKey
+          screenSize: screenSize
         )
 
         #if os(tvOS)
@@ -523,7 +523,6 @@ struct DivinaReaderView: View {
       keyboardHelpTimer?.invalidate()
       deferredPageMaintenanceTask?.cancel()
       deferredPageMaintenanceTask = nil
-      viewModel.clearPreloadedImages()
       readerPresentation.clearFlushHandler(for: sessionID)
       #if os(macOS)
         readerPresentation.clearMacReaderCommands()
@@ -564,8 +563,7 @@ struct DivinaReaderView: View {
   @ViewBuilder
   private func readerContent(
     useDualPage: Bool,
-    screenSize: CGSize,
-    screenKey: String
+    screenSize: CGSize
   ) -> some View {
     Group {
       if viewModel.hasPages {
@@ -636,7 +634,7 @@ struct DivinaReaderView: View {
           }
         }
         .readerIgnoresSafeArea()
-        .id(readerContentKey(screenKey: screenKey, useDualPage: useDualPage))
+        .id(readerContentKey(useDualPage: useDualPage))
         #if os(iOS) || os(macOS)
           .background(
             DivinaTapZoneGestureBridge(

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
@@ -192,7 +192,7 @@
         loadingIndicator.stopAnimating()
         errorLabel.text = error
         errorLabel.isHidden = false
-      } else if pageSourceImage == nil || data.isLoading {
+      } else if pageSourceImage == nil {
         errorLabel.isHidden = true
         loadingIndicator.startAnimating()
       } else {

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_macOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_macOS.swift
@@ -234,7 +234,7 @@
         progressIndicator.stopAnimation(nil)
         errorLabel.stringValue = error
         errorLabel.isHidden = false
-      } else if pageSourceImage == nil || data.isLoading {
+      } else if pageSourceImage == nil {
         errorLabel.isHidden = true
         progressIndicator.startAnimation(nil)
       } else {


### PR DESCRIPTION
## Problem

In the DIVINA reader's scroll mode, opening or dismissing settings/TOC/page-jump sheets causes the current page to show a loading spinner. The page stays in loading state until the user toggles controls or turns a page. The same loading flash can also appear on initial reader open.

**Root cause**: SwiftUI fires `.onDisappear` when a `.sheet()` is presented over the view — not just when the reader actually closes. The `onDisappear` handler called `viewModel.clearPreloadedImages()`, which wiped all cached page images and cancelled in-flight preload tasks. When the sheet was dismissed, `onAppear` fired but nothing re-triggered preloading, so cells remained stuck in loading state.

A secondary issue: `NativePageItem.update()` checked `data.isLoading` to decide whether to show the loading spinner, but this value was computed during `configure()` and cached — it could become stale when `layoutSubviews()` triggered `updatePages()` without a fresh `configure()`, showing loading even when the image was already available.

## Approach

1. **Move image cleanup to `closeReader()`** — `clearPreloadedImages()` now only runs when the reader is actually dismissed, not when a sheet is presented over it.
2. **Remove `screenKey` from view identity** — the `readerContentKey` no longer includes screen dimensions, preventing `ScrollPageView` destruction/recreation on safe-area changes (status bar toggle, sheet present/dismiss). The `ScrollPageView` coordinator already handles size changes via layout invalidation.
3. **Use fresh image state for loading indicator** — `NativePageItem` now bases the loading indicator on `pageSourceImage == nil` (fetched fresh from the view model every time) instead of the stale `data.isLoading` flag.

## Scope

- `DivinaReaderView.swift`: move `clearPreloadedImages()` from `onDisappear` to `closeReader()`; remove `screenKey` from `readerContentKey` and `readerContent()` signature
- `NativePageItem_iOS.swift`, `NativePageItem_macOS.swift`: simplify loading indicator condition

## Validation

- Open a book in DIVINA scroll mode → show controls → open settings/TOC/page-jump sheet → page should NOT show loading
- Dismiss sheet → page should remain stable
- Rotate device → layout should adapt correctly
- Switch single/dual page, change reading direction → view correctly recreates
- PageCurl and Cover modes → no regression
