### PR TITLE
fix: prevent DIVINA scroll RTL loading stalls

### DIFF
--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -276,7 +276,7 @@ class ReaderViewModel {
   }
 
   private func setPreloadedImage(_ image: PlatformImage, for pageID: ReaderPageID) {
-    preloadedImagesByID[pageID] = image
+    _ = preloadedImagesByID.updateValue(image, forKey: pageID)
     invalidatePagePresentation(for: pageID)
   }
 

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -567,6 +567,7 @@ struct DivinaReaderView: View {
     screenSize: CGSize,
     screenKey: String
   ) -> some View {
+    let contentKey = readerContentKey(screenKey: screenKey, useDualPage: useDualPage)
     Group {
       if viewModel.hasPages {
         Group {
@@ -636,7 +637,7 @@ struct DivinaReaderView: View {
           }
         }
         .readerIgnoresSafeArea()
-        .id(readerContentKey(screenKey: screenKey, useDualPage: useDualPage))
+        .id(contentKey)
         #if os(iOS) || os(macOS)
           .background(
             DivinaTapZoneGestureBridge(

--- a/KMReader/Features/Reader/Views/Models/PageViewMode.swift
+++ b/KMReader/Features/Reader/Views/Models/PageViewMode.swift
@@ -32,4 +32,9 @@ enum PageViewMode {
   var isVertical: Bool {
     self == .vertical
   }
+
+  func displayOrderedItems(_ items: [ReaderViewItem]) -> [ReaderViewItem] {
+    guard isRTL && !isVertical else { return items }
+    return Array(items.reversed())
+  }
 }

--- a/KMReader/Features/Reader/Views/NativePagedPagePresentationCoordinator.swift
+++ b/KMReader/Features/Reader/Views/NativePagedPagePresentationCoordinator.swift
@@ -25,7 +25,9 @@ final class NativePagedPagePresentationCoordinator {
   }
 
   func flushIfPossible() {
-    guard let host, host.hasVisiblePagePresentationContent(), let pendingInvalidation else { return }
+    guard let pendingInvalidation else { return }
+    guard let host else { return }
+    guard host.hasVisiblePagePresentationContent() else { return }
     self.pendingInvalidation = nil
     host.applyPagePresentationInvalidation(pendingInvalidation)
   }

--- a/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
@@ -39,7 +39,8 @@
       collectionView.contentInsetAdjustmentBehavior = .never
       collectionView.bounces = false
       collectionView.isPrefetchingEnabled = false
-      collectionView.semanticContentAttribute = mode.isRTL ? .forceRightToLeft : .forceLeftToRight
+      // Keep collection coordinates canonical. RTL is represented by display order, not container mirroring.
+      collectionView.semanticContentAttribute = .forceLeftToRight
 
       #if !os(tvOS)
         collectionView.isPagingEnabled = true
@@ -65,7 +66,7 @@
     func updateUIView(_ collectionView: UICollectionView, context: Context) {
       context.coordinator.update(parent: self, collectionView: collectionView)
       collectionView.backgroundColor = UIColor(renderConfig.readerBackground.color)
-      collectionView.semanticContentAttribute = mode.isRTL ? .forceRightToLeft : .forceLeftToRight
+      collectionView.semanticContentAttribute = .forceLeftToRight
       collectionView.isScrollEnabled = !shouldDisableScrollInteraction
       if let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
         let targetDirection: UICollectionView.ScrollDirection = mode.isVertical ? .vertical : .horizontal
@@ -120,17 +121,18 @@
         self.parent = parent
         self.collectionView = collectionView
         pagePresentationCoordinator.update(viewModel: parent.viewModel)
+        let displayedItems = parent.mode.displayOrderedItems(parent.viewModel.viewItems)
 
         let sizeChanged = updateLayoutIfNeeded(for: collectionView)
         let renderInputsChanged = updateRenderInputsIfNeeded()
         var refreshedVisibleContent = false
 
-        if session.installInitialSnapshotIfNeeded(parent.viewModel.viewItems) {
+        if session.installInitialSnapshotIfNeeded(displayedItems) {
           collectionView.reloadData()
           collectionView.layoutIfNeeded()
           refreshedVisibleContent = synchronizeInitialPositionIfPossible(in: collectionView)
-        } else if parent.viewModel.viewItems != session.renderedItems {
-          handleViewItemsChange(parent.viewModel.viewItems, in: collectionView)
+        } else if displayedItems != session.renderedItems {
+          handleViewItemsChange(displayedItems, in: collectionView)
           refreshedVisibleContent = true
         }
 
@@ -274,7 +276,7 @@
         switch session.navigationPlan(
           for: targetItem,
           centeredItem: centeredItem(in: collectionView),
-          latestViewItems: parent.viewModel.viewItems
+          latestViewItems: parent.mode.displayOrderedItems(parent.viewModel.viewItems)
         ) {
         case .none:
           return

--- a/KMReader/Features/Reader/Views/ScrollPageView_macOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_macOS.swift
@@ -28,6 +28,7 @@
       collectionView.dataSource = context.coordinator
       collectionView.backgroundColors = [NSColor(renderConfig.readerBackground.color)]
       collectionView.isSelectable = false
+      collectionView.userInterfaceLayoutDirection = .leftToRight
       collectionView.register(
         NativePagedPageCell.self,
         forItemWithIdentifier: NSUserInterfaceItemIdentifier(Coordinator.pageCellReuseIdentifier)
@@ -59,7 +60,7 @@
       guard let collectionView = scrollView.documentView as? NSCollectionView else { return }
 
       collectionView.backgroundColors = [NSColor(renderConfig.readerBackground.color)]
-      collectionView.userInterfaceLayoutDirection = mode.isRTL ? .rightToLeft : .leftToRight
+      collectionView.userInterfaceLayoutDirection = .leftToRight
 
       if let layout = collectionView.collectionViewLayout as? NSCollectionViewFlowLayout {
         let targetDirection: NSCollectionView.ScrollDirection = mode.isVertical ? .vertical : .horizontal
@@ -144,20 +145,21 @@
         self.collectionView = collectionView
         installObservers()
         pagePresentationCoordinator.update(viewModel: parent.viewModel)
+        let displayedItems = parent.mode.displayOrderedItems(parent.viewModel.viewItems)
 
         let sizeChanged = updateLayoutIfNeeded(for: collectionView)
         let renderInputsChanged = updateRenderInputsIfNeeded()
         var refreshedVisibleContent = false
 
-        if session.installInitialSnapshotIfNeeded(parent.viewModel.viewItems) {
+        if session.installInitialSnapshotIfNeeded(displayedItems) {
           collectionView.reloadData()
           collectionView.layoutSubtreeIfNeeded()
           refreshedVisibleContent = synchronizeInitialPositionIfPossible(
             in: scrollView,
             collectionView: collectionView
           )
-        } else if parent.viewModel.viewItems != session.renderedItems {
-          handleViewItemsChange(parent.viewModel.viewItems, in: scrollView, collectionView: collectionView)
+        } else if displayedItems != session.renderedItems {
+          handleViewItemsChange(displayedItems, in: scrollView, collectionView: collectionView)
           refreshedVisibleContent = true
         }
 
@@ -317,7 +319,7 @@
         switch session.navigationPlan(
           for: targetItem,
           centeredItem: centeredItem(in: collectionView),
-          latestViewItems: parent.viewModel.viewItems
+          latestViewItems: parent.mode.displayOrderedItems(parent.viewModel.viewItems)
         ) {
         case .none:
           return


### PR DESCRIPTION
## Problem
DIVINA scroll mode could leave the visible page stuck in loading when opening the reader, toggling controls, or opening and dismissing settings, TOC, and page-jump sheets in RTL mode.

The issue was not an image cache miss. The native scroll host was mixing logical page order with collection-view semantic mirroring, so visible cells could resolve to the mirrored item instead of the committed reader position.

## Approach
Keep the native scroll collections in canonical left-to-right coordinates and model RTL through an explicit display-order projection.

This keeps `ReaderViewModel.viewItems` in logical order, while the scroll host uses a reversed display snapshot for RTL mode. Initial positioning, navigation-target handling, and visible-item commits now all run against the same coordinate space instead of relying on container semantic mirroring.

## Scope
- Add `PageViewMode.displayOrderedItems(_:)` for scroll-mode display projection
- Update iOS and macOS `ScrollPageView` to use canonical collection coordinates and display-order snapshots
- Keep `DivinaReaderView` identity handling intact while avoiding repeated content-key recomputation in the subtree
- Preserve the follow-up invalidation and image-cache behavior, and remove the temporary investigation-only debug logging

## Validation
- [x] `make format`
- [x] `make build-macos`
- [x] `make build-ios`
- [x] `make build-tvos`
