### PR TITLE
feat: improve reader live activity controls

### DIFF
--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -496,6 +496,18 @@ enum AppConfig {
     }
   }
 
+  static nonisolated var enableReaderLiveActivity: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "enableReaderLiveActivity") != nil {
+        return UserDefaults.standard.bool(forKey: "enableReaderLiveActivity")
+      }
+      return true
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: "enableReaderLiveActivity")
+    }
+  }
+
   static nonisolated var autoFullscreenOnOpen: Bool {
     get {
       if UserDefaults.standard.object(forKey: "autoFullscreenOnOpen") != nil {

--- a/KMReader/Features/Reader/Services/ReaderLiveActivityManager.swift
+++ b/KMReader/Features/Reader/Services/ReaderLiveActivityManager.swift
@@ -9,22 +9,92 @@ import Foundation
 
   @MainActor
   final class ReaderLiveActivityManager {
+    private struct SessionSnapshot {
+      var book: Book
+      var incognito: Bool
+      var readingProgress: Double
+    }
+
     static let shared = ReaderLiveActivityManager()
 
     private let logger = AppLogger(.reader)
     private var currentActivity: Activity<ReaderActivityAttributes>?
-    private var pendingEndTask: Task<Void, Never>?
+    private var currentSnapshot: SessionSnapshot?
+    private var lastDeliveredState: ReaderActivityAttributes.ContentState?
+    private var preferenceObserverTask: Task<Void, Never>?
 
-    private init() {}
+    private init() {
+      preferenceObserverTask = Task { [weak self] in
+        guard let self else { return }
+        self.syncActivity()
+        for await _ in NotificationCenter.default.notifications(named: UserDefaults.didChangeNotification) {
+          self.syncActivity()
+        }
+      }
+    }
 
-    func readerDidOpen(book: Book) {
-      pendingEndTask?.cancel()
-      pendingEndTask = nil
+    func readerDidOpen(book: Book, incognito: Bool) {
+      currentSnapshot = SessionSnapshot(
+        book: book,
+        incognito: incognito,
+        readingProgress: initialProgress(for: book, incognito: incognito)
+      )
+      syncActivity()
+    }
 
-      let state = makeState(sessionState: .reading, book: book)
+    func readerDidUpdateBook(_ book: Book, incognito: Bool) {
+      let updatedProgress: Double
+      if currentSnapshot?.book.id == book.id {
+        updatedProgress = currentSnapshot?.readingProgress ?? initialProgress(for: book, incognito: incognito)
+      } else {
+        updatedProgress = initialProgress(for: book, incognito: incognito)
+      }
 
-      if let activity = resolveActivity() {
-        update(activity: activity, with: state)
+      currentSnapshot = SessionSnapshot(
+        book: book,
+        incognito: incognito,
+        readingProgress: updatedProgress
+      )
+      syncActivity()
+    }
+
+    func updateReadingProgress(_ progress: Double) {
+      guard var snapshot = currentSnapshot else { return }
+      guard !snapshot.incognito else { return }
+
+      let normalizedProgress = Self.normalizedProgress(progress)
+      let previousPercent = Self.displayPercent(for: snapshot.readingProgress)
+      let newPercent = Self.displayPercent(for: normalizedProgress)
+      guard newPercent != previousPercent else { return }
+
+      snapshot.readingProgress = normalizedProgress
+      currentSnapshot = snapshot
+      syncActivity()
+    }
+
+    func readerDidClose() {
+      currentSnapshot = nil
+      endCurrentActivity()
+    }
+
+    private func endCurrentActivity() {
+      let activity = resolveActivity()
+      currentActivity = nil
+      lastDeliveredState = nil
+      guard let activity else { return }
+      Task {
+        await activity.end(nil, dismissalPolicy: .immediate)
+      }
+    }
+
+    private func syncActivity() {
+      guard AppConfig.enableReaderLiveActivity else {
+        endCurrentActivity()
+        return
+      }
+
+      guard let snapshot = currentSnapshot else {
+        endCurrentActivity()
         return
       }
 
@@ -33,7 +103,15 @@ import Foundation
         return
       }
 
-      let attributes = ReaderActivityAttributes(bookId: book.id)
+      let state = makeState(sessionState: .reading, snapshot: snapshot)
+
+      if let activity = resolveActivity() {
+        guard lastDeliveredState != state else { return }
+        update(activity: activity, with: state)
+        return
+      }
+
+      let attributes = ReaderActivityAttributes(bookId: snapshot.book.id)
 
       do {
         currentActivity = try Activity.request(
@@ -41,43 +119,24 @@ import Foundation
           content: .init(state: state, staleDate: nil),
           pushType: nil
         )
+        lastDeliveredState = state
         logger.info("✅ Reader Live Activity started.")
       } catch {
         logger.error("❌ Failed to start reader Live Activity: \(error)")
       }
     }
 
-    func readerDidClose(book: Book?) {
-      guard let activity = resolveActivity() else { return }
-
-      let state = makeState(sessionState: .closed, book: book)
-      update(activity: activity, with: state)
-
-      pendingEndTask?.cancel()
-      pendingEndTask = Task { [weak self] in
-        try? await Task.sleep(for: .seconds(12))
-        guard !Task.isCancelled else { return }
-        self?.endCurrentActivity()
-      }
-    }
-
-    private func endCurrentActivity() {
-      guard let activity = resolveActivity() else { return }
-      Task {
-        await activity.end(nil, dismissalPolicy: .immediate)
-      }
-      currentActivity = nil
-    }
-
     private func makeState(
       sessionState: ReaderActivityAttributes.SessionState,
-      book: Book?
+      snapshot: SessionSnapshot
     ) -> ReaderActivityAttributes.ContentState {
       ReaderActivityAttributes.ContentState(
         sessionState: sessionState,
-        readerKind: resolveReaderKind(for: book),
-        seriesTitle: book?.seriesTitle ?? "",
-        chapterTitle: resolveChapterTitle(for: book)
+        readerKind: resolveReaderKind(for: snapshot.book),
+        seriesTitle: snapshot.book.seriesTitle,
+        chapterTitle: resolveChapterTitle(for: snapshot.book),
+        isIncognito: snapshot.incognito,
+        readingProgress: snapshot.incognito ? 0 : snapshot.readingProgress
       )
     }
 
@@ -117,6 +176,7 @@ import Foundation
       activity: Activity<ReaderActivityAttributes>,
       with state: ReaderActivityAttributes.ContentState
     ) {
+      lastDeliveredState = state
       Task {
         await activity.update(.init(state: state, staleDate: nil))
       }
@@ -131,6 +191,29 @@ import Foundation
         return existing
       }
       return nil
+    }
+
+    private func initialProgress(for book: Book, incognito: Bool) -> Double {
+      guard !incognito else { return 0 }
+      if book.isCompleted {
+        return 1
+      }
+      guard book.media.pagesCount > 0 else { return 0 }
+      let page = max(0, book.readProgress?.page ?? 0)
+      return Self.normalizedPageProgress(currentPage: page, totalPages: book.media.pagesCount)
+    }
+
+    static nonisolated func normalizedProgress(_ progress: Double) -> Double {
+      min(max(progress, 0), 1)
+    }
+
+    static nonisolated func normalizedPageProgress(currentPage: Int, totalPages: Int) -> Double {
+      guard totalPages > 0 else { return 0 }
+      return normalizedProgress(Double(max(currentPage, 0)) / Double(totalPages))
+    }
+
+    private static nonisolated func displayPercent(for progress: Double) -> Int {
+      Int((normalizedProgress(progress) * 100).rounded())
     }
   }
 #endif

--- a/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
@@ -163,6 +163,14 @@
 
       guard !bookId.isEmpty else { return }
       guard normalizedTotal > 0 else { return }
+      #if os(iOS)
+        ReaderLiveActivityManager.shared.updateReadingProgress(
+          ReaderLiveActivityManager.normalizedPageProgress(
+            currentPage: normalizedPage,
+            totalPages: normalizedTotal
+          )
+        )
+      #endif
       guard !incognito else {
         logger.debug("⏭️ [Progress/Page] Skip PDF capture: incognito mode enabled")
         return

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -183,6 +183,21 @@ struct DivinaReaderView: View {
     readerPresentation.updateHandoff(sessionID: sessionID, title: handoffTitle, url: url)
   }
 
+  #if os(iOS)
+    private func updateReaderLiveActivityProgress() {
+      let segmentBookId = currentSegmentBookId
+      let totalPages = viewModel.pageCount(forSegmentBookId: segmentBookId)
+      guard totalPages > 0 else { return }
+      let currentPage = viewModel.currentPageNumber(inSegmentBookId: segmentBookId) ?? 0
+      ReaderLiveActivityManager.shared.updateReadingProgress(
+        ReaderLiveActivityManager.normalizedPageProgress(
+          currentPage: currentPage,
+          totalPages: totalPages
+        )
+      )
+    }
+  #endif
+
   private func closeReader() {
     logger.debug(
       "🚪 Closing DIVINA reader for book \(currentBookId), currentPage=\(viewModel.currentPage?.number ?? -1), totalPages=\(viewModel.pageCount)"
@@ -653,6 +668,9 @@ struct DivinaReaderView: View {
         #endif
         .onChange(of: viewModel.currentReaderPage?.id) { _, _ in
           updateHandoff()
+          #if os(iOS)
+            updateReaderLiveActivityProgress()
+          #endif
           // Keep progress sync responsive.
           Task(priority: .userInitiated) {
             await viewModel.updateProgress()

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -114,6 +114,11 @@
       readerPresentation.updateHandoff(sessionID: sessionID, title: handoffTitle, url: url)
     }
 
+    private func updateReaderLiveActivityProgress() {
+      let progress = viewModel.currentLocation?.totalProgression ?? 0
+      ReaderLiveActivityManager.shared.updateReadingProgress(progress)
+    }
+
     var body: some View {
       readerBody
         .iPadIgnoresSafeArea()
@@ -132,6 +137,13 @@
             readerPresentation.updatePresentedBook(sessionID: sessionID, book: newBook)
           }
           updateHandoff()
+        }
+        .onChange(of: viewModel.currentLocation) { _, _ in
+          updateReaderLiveActivityProgress()
+        }
+        .onChange(of: showingEndPage) { _, newValue in
+          guard newValue else { return }
+          ReaderLiveActivityManager.shared.updateReadingProgress(1)
         }
         .onChange(of: activePreferences) { _, newPrefs in
           viewModel.applyPreferences(newPrefs, colorScheme: colorScheme)

--- a/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
+++ b/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
@@ -85,7 +85,7 @@ final class ReaderPresentationManager {
     currentSession = session
 
     #if os(iOS)
-      ReaderLiveActivityManager.shared.readerDidOpen(book: book)
+      ReaderLiveActivityManager.shared.readerDidOpen(book: book, incognito: incognito)
     #endif
 
     #if os(macOS)
@@ -130,6 +130,9 @@ final class ReaderPresentationManager {
     guard var session = currentSession, session.id == sessionID else { return }
     session.book = book
     currentSession = session
+    #if os(iOS)
+      ReaderLiveActivityManager.shared.readerDidUpdateBook(book, incognito: session.incognito)
+    #endif
   }
 
   func closeReader(syncVisited: Bool = true) {
@@ -138,7 +141,7 @@ final class ReaderPresentationManager {
     finishSession(currentSession, syncVisited: syncVisited)
 
     #if os(iOS)
-      ReaderLiveActivityManager.shared.readerDidClose(book: currentSession.book)
+      ReaderLiveActivityManager.shared.readerDidClose()
     #endif
 
     #if os(macOS)

--- a/KMReader/Features/Settings/SettingsAppearanceView.swift
+++ b/KMReader/Features/Settings/SettingsAppearanceView.swift
@@ -12,6 +12,9 @@ struct SettingsAppearanceView: View {
   @AppStorage("privacyProtection") private var privacyProtection: Bool = false
   @AppStorage("dashboardShowGradient") private var dashboardShowGradient: Bool = true
   #if os(iOS)
+    @AppStorage("enableReaderLiveActivity") private var enableReaderLiveActivity: Bool = true
+  #endif
+  #if os(iOS)
     @State private var selectedAppIcon: AppIconOption = .primary
     @State private var isUpdatingAppIcon: Bool = false
   #endif
@@ -118,6 +121,19 @@ struct SettingsAppearanceView: View {
           }
         }
       }
+
+      #if os(iOS)
+        Section(header: Text("Live Activities")) {
+          Toggle(isOn: $enableReaderLiveActivity) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Reader Live Activity")
+              Text("Show reader progress on the Lock Screen and in Dynamic Island.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+          }
+        }
+      #endif
     }
     .formStyle(.grouped)
     .inlineNavigationBarTitle(SettingsSection.appearance.title)

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -35357,6 +35357,70 @@
         }
       }
     },
+    "Live Activities" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live-Aktivitäten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live Activities"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actividades en vivo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activités en direct"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attività in tempo reale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライブアクティビティ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "라이브 액티비티"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live-активности"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "实时活动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即時動態"
+          }
+        }
+      }
+    },
     "Live Text" : {
       "localizations" : {
         "de" : {
@@ -50463,6 +50527,70 @@
         }
       }
     },
+    "Reader Live Activity" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lese-Live-Aktivität"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reader Live Activity"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actividad en vivo del lector"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activité en direct du lecteur"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attività in tempo reale del lettore"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リーダーのライブアクティビティ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "리더 라이브 액티비티"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live-активность чтения"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读器实时活动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀器即時動態"
+          }
+        }
+      }
+    },
     "Reader Settings" : {
       "localizations" : {
         "de" : {
@@ -65051,6 +65179,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示通知"
+          }
+        }
+      }
+    },
+    "Show reader progress on the Lock Screen and in Dynamic Island." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeigt den Lesefortschritt auf dem Sperrbildschirm und in der Dynamic Island an."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show reader progress on the Lock Screen and in Dynamic Island."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra el progreso de lectura en la pantalla bloqueada y en la Dynamic Island."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Affiche la progression de lecture sur l’écran verrouillé et dans la Dynamic Island."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra i progressi di lettura nella schermata di blocco e nella Dynamic Island."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ロック画面とDynamic Islandに読書の進捗を表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잠금 화면과 Dynamic Island에 읽기 진행률을 표시합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывает прогресс чтения на экране блокировки и в Dynamic Island."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在锁定屏幕和灵动岛中显示阅读进度。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在鎖定畫面與動態島中顯示閱讀進度。"
           }
         }
       }

--- a/KMReaderWidgets/KMReaderReaderLiveActivity.swift
+++ b/KMReaderWidgets/KMReaderReaderLiveActivity.swift
@@ -35,21 +35,11 @@ import WidgetKit
               Text(context.state.readerKind.label)
                 .font(.caption2.weight(.semibold))
                 .foregroundStyle(.secondary)
-              Text(context.state.statusTitle)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(context.state.tintColor)
+              trailingStatusView(for: context.state)
             }
           }
 
-          Capsule()
-            .fill(context.state.tintColor.opacity(0.3))
-            .frame(height: 6)
-            .overlay(alignment: .leading) {
-              Capsule()
-                .fill(context.state.tintColor)
-                .frame(width: context.state.isReading ? 80 : 28, height: 6)
-            }
-            .animation(.easeInOut(duration: 0.25), value: context.state.isReading)
+          progressBar(for: context.state)
         }
         .padding(12)
         .activityBackgroundTint(Color(.systemBackground).opacity(0.95))
@@ -63,9 +53,7 @@ import WidgetKit
               .font(.title2)
           }
           DynamicIslandExpandedRegion(.trailing) {
-            Text(context.state.statusShortTitle)
-              .font(.caption.weight(.bold))
-              .foregroundStyle(context.state.tintColor)
+            trailingStatusView(for: context.state)
           }
           DynamicIslandExpandedRegion(.center) {
             VStack(spacing: 2) {
@@ -86,18 +74,14 @@ import WidgetKit
               Circle()
                 .fill(context.state.tintColor)
                 .frame(width: 6, height: 6)
-              Text(context.state.statusTitle)
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(context.state.tintColor)
+              trailingStatusView(for: context.state)
             }
           }
         } compactLeading: {
           Image(systemName: context.state.readerKind.iconName)
             .foregroundStyle(context.state.tintColor)
         } compactTrailing: {
-          Text(context.state.statusShortTitle)
-            .font(.caption2.weight(.semibold))
-            .foregroundStyle(context.state.tintColor)
+          compactTrailingStatusView(for: context.state)
         } minimal: {
           Image(systemName: context.state.readerKind.iconName)
             .foregroundStyle(context.state.tintColor)
@@ -105,23 +89,76 @@ import WidgetKit
         .keylineTint(context.state.tintColor)
       }
     }
+
+    @ViewBuilder
+    private func trailingStatusView(for state: ReaderActivityAttributes.ContentState) -> some View {
+      if state.isIncognitoSession {
+        Image(systemName: "eye.slash.fill")
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(state.tintColor)
+      } else {
+        Text(state.progressText)
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(state.tintColor)
+      }
+    }
+
+    @ViewBuilder
+    private func compactTrailingStatusView(for state: ReaderActivityAttributes.ContentState) -> some View {
+      if state.isIncognitoSession {
+        Image(systemName: "eye.slash.fill")
+          .font(.caption2.weight(.semibold))
+          .foregroundStyle(state.tintColor)
+      } else {
+        Text(state.progressText)
+          .font(.caption2.weight(.semibold))
+          .foregroundStyle(state.tintColor)
+      }
+    }
+
+    private func progressBar(for state: ReaderActivityAttributes.ContentState) -> some View {
+      Capsule()
+        .fill(state.tintColor.opacity(0.2))
+        .frame(height: 6)
+        .overlay {
+          GeometryReader { geometry in
+            if state.isIncognitoSession {
+              HStack {
+                Spacer()
+                Image(systemName: "eye.slash")
+                  .font(.caption2.weight(.semibold))
+                  .foregroundStyle(state.tintColor)
+                Spacer()
+              }
+            } else {
+              HStack {
+                Capsule()
+                  .fill(state.tintColor)
+                  .frame(width: geometry.size.width * state.progressFraction, height: 6)
+                Spacer(minLength: 0)
+              }
+            }
+          }
+        }
+        .animation(.easeInOut(duration: 0.25), value: state.progressFraction)
+    }
   }
 
   extension ReaderActivityAttributes.ContentState {
-    fileprivate var isReading: Bool {
-      sessionState == .reading
+    fileprivate var isIncognitoSession: Bool {
+      isIncognito
     }
 
-    fileprivate var statusTitle: String {
-      isReading ? "Reading" : "Closed"
+    fileprivate var progressFraction: Double {
+      min(max(readingProgress, 0), 1)
     }
 
-    fileprivate var statusShortTitle: String {
-      isReading ? "ON" : "OFF"
+    fileprivate var progressText: String {
+      "\(Int((progressFraction * 100).rounded()))%"
     }
 
     fileprivate var tintColor: Color {
-      isReading ? .green : .gray
+      isIncognitoSession ? .orange : .green
     }
   }
 
@@ -161,7 +198,9 @@ import WidgetKit
         sessionState: .reading,
         readerKind: .divina,
         seriesTitle: "One Piece",
-        chapterTitle: "#1058 - The Flame Emperor's Triumph"
+        chapterTitle: "#1058 - The Flame Emperor's Triumph",
+        isIncognito: false,
+        readingProgress: 0.58
       )
     }
   }

--- a/Shared/ReaderActivityAttributes.swift
+++ b/Shared/ReaderActivityAttributes.swift
@@ -28,17 +28,23 @@ import Foundation
       public var readerKind: ReaderKind
       public var seriesTitle: String
       public var chapterTitle: String
+      public var isIncognito: Bool
+      public var readingProgress: Double
 
       public init(
         sessionState: SessionState,
         readerKind: ReaderKind,
         seriesTitle: String,
-        chapterTitle: String
+        chapterTitle: String,
+        isIncognito: Bool,
+        readingProgress: Double
       ) {
         self.sessionState = sessionState
         self.readerKind = readerKind
         self.seriesTitle = seriesTitle
         self.chapterTitle = chapterTitle
+        self.isIncognito = isIncognito
+        self.readingProgress = readingProgress
       }
     }
 


### PR DESCRIPTION
## Problem
Reader live activity behavior was too rigid for the current reader UX. Users could not disable it, closing the reader left a stale closed activity behind for a while, and Dynamic Island only showed ON/OFF instead of meaningful reader state.

## Approach
Move reader live activity ownership into the reader session layer so the same manager handles preference changes, book switches, progress updates, and teardown. Extend the shared activity payload with progress and incognito metadata, then render percentage for normal reading sessions and an incognito indicator for privacy mode.

## Scope
- add an iOS appearance setting to disable reader live activities
- end reader live activities immediately when the reader closes or the setting is turned off
- feed DIVINA, EPUB, and PDF reading progress into the live activity state
- update the widget and Dynamic Island presentation to remove ON/OFF and show progress or incognito state
- sync localization entries for the new settings copy

## Validation
- [x] `make format`
- [x] `make build`
- [x] `make localize`
- [x] `./misc/translate.py list`
