### PR TITLE
fix: align split wide pages with dual-page mode

### DIFF
--- a/KMReader/Features/Reader/Models/SplitWidePageMode.swift
+++ b/KMReader/Features/Reader/Models/SplitWidePageMode.swift
@@ -11,6 +11,31 @@ enum SplitWidePageMode: String, CaseIterable, Hashable {
   case ltr = "ltr"
   case rtl = "rtl"
 
+  static func effectiveMode(
+    preference: SplitWidePageMode,
+    isUsingDualPage: Bool,
+    transitionStyle: PageTransitionStyle
+  ) -> SplitWidePageMode {
+    guard isUsingDualPage else { return preference }
+
+    switch transitionStyle {
+    case .pageCurl:
+      return .auto
+    case .cover, .scroll:
+      return .none
+    }
+  }
+
+  static func supportsManualSelection(
+    pageLayout: PageLayout,
+    readingDirection: ReadingDirection,
+    isUsingDualPage: Bool
+  ) -> Bool {
+    guard !isUsingDualPage else { return false }
+    guard readingDirection != .webtoon, readingDirection != .vertical else { return false }
+    return pageLayout == .single || pageLayout == .auto
+  }
+
   var displayName: String {
     switch self {
     case .none:

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -27,6 +27,7 @@ struct DivinaControlsOverlayView: View {
   let nextBook: Book?
   let onPreviousBook: ((String) -> Void)?
   let onNextBook: ((String) -> Void)?
+  let supportsSplitWidePageMode: Bool
   let controlsVisible: Bool
   let showingControls: Bool
 
@@ -341,7 +342,7 @@ struct DivinaControlsOverlayView: View {
         }
       }
 
-      if readingDirection != .webtoon && (pageLayout == .single || pageLayout == .auto) {
+      if supportsSplitWidePageMode {
         Picker(selection: $splitWidePageMode) {
           ForEach(SplitWidePageMode.allCases, id: \.self) { mode in
             Label(mode.displayName, systemImage: mode.icon).tag(mode)

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -51,6 +51,7 @@ struct DivinaReaderView: View {
   @State private var showKeyboardHelp = false
   @State private var keyboardHelpTimer: Timer?
   @State private var preserveReaderOptions = false
+  @State private var isUsingDualPagePresentation = false
 
   // UI Panels states
   @State private var showingPageJumpSheet = false
@@ -172,6 +173,22 @@ struct DivinaReaderView: View {
     max(tapPageTransitionDuration, 0)
   }
 
+  private var effectiveSplitWidePageMode: SplitWidePageMode {
+    SplitWidePageMode.effectiveMode(
+      preference: splitWidePageMode,
+      isUsingDualPage: isUsingDualPagePresentation,
+      transitionStyle: pageTransitionStyle
+    )
+  }
+
+  private var supportsManualSplitWidePageMode: Bool {
+    SplitWidePageMode.supportsManualSelection(
+      pageLayout: pageLayout,
+      readingDirection: readingDirection,
+      isUsingDualPage: isUsingDualPagePresentation
+    )
+  }
+
   private func shouldUseDualPage(screenSize: CGSize) -> Bool {
     guard screenSize.width > screenSize.height else { return false }  // Only in landscape
     guard pageLayout != .single else { return false }
@@ -235,7 +252,7 @@ struct DivinaReaderView: View {
     viewModel.updatePageLayout(pageLayout)
     isolateCoverPage = AppConfig.isolateCoverPage
     splitWidePageMode = AppConfig.splitWidePageMode
-    viewModel.updateSplitWidePageMode(splitWidePageMode)
+    viewModel.updateSplitWidePageMode(effectiveSplitWidePageMode)
     readingDirection = AppConfig.defaultReadingDirection
   }
 
@@ -243,14 +260,17 @@ struct DivinaReaderView: View {
     return "\(Int(screenSize.width))x\(Int(screenSize.height))"
   }
 
-  private func readerContentKey(useDualPage: Bool) -> String {
+  private func readerContentKey(
+    useDualPage: Bool,
+    effectiveSplitWidePageMode: SplitWidePageMode
+  ) -> String {
     [
       currentBookId,
       readingDirection.rawValue,
       pageTransitionStyle.rawValue,
       pageLayout.rawValue,
       isolateCoverPage.description,
-      splitWidePageMode.rawValue,
+      effectiveSplitWidePageMode.rawValue,
       String(useDualPage),
     ].joined(separator: "-")
   }
@@ -411,13 +431,24 @@ struct DivinaReaderView: View {
       let screenSize = geometry.size
       let screenKey = screenKey(screenSize: screenSize)
       let useDualPage = shouldUseDualPage(screenSize: screenSize)
+      let resolvedSplitWidePageMode = SplitWidePageMode.effectiveMode(
+        preference: splitWidePageMode,
+        isUsingDualPage: useDualPage,
+        transitionStyle: pageTransitionStyle
+      )
+      let shouldShowSplitWidePageModePicker = SplitWidePageMode.supportsManualSelection(
+        pageLayout: pageLayout,
+        readingDirection: readingDirection,
+        isUsingDualPage: useDualPage
+      )
 
       ZStack {
         readerBackground.color.readerIgnoresSafeArea()
 
         readerContent(
           useDualPage: useDualPage,
-          screenSize: screenSize
+          screenSize: screenSize,
+          splitWidePageMode: resolvedSplitWidePageMode
         )
 
         #if os(tvOS)
@@ -426,14 +457,21 @@ struct DivinaReaderView: View {
 
         helperOverlay(screenKey: screenKey)
 
-        controlsOverlay(useDualPage: useDualPage)
+        controlsOverlay(
+          useDualPage: useDualPage,
+          supportsSplitWidePageMode: shouldShowSplitWidePageModePicker
+        )
 
         #if os(macOS)
           keyboardHelpOverlay
         #endif
       }
       .onChange(of: useDualPage, initial: true) { _, newValue in
+        isUsingDualPagePresentation = newValue
         applyDualPagePresentationMode(newValue)
+      }
+      .onChange(of: resolvedSplitWidePageMode, initial: true) { _, newValue in
+        viewModel.updateSplitWidePageMode(newValue)
       }
       #if os(tvOS)
         .onPlayPauseCommand {
@@ -510,9 +548,6 @@ struct DivinaReaderView: View {
     }
     .onChange(of: pageLayout) { _, newValue in
       viewModel.updatePageLayout(newValue)
-    }
-    .onChange(of: splitWidePageMode) { _, newValue in
-      viewModel.updateSplitWidePageMode(newValue)
     }
     .task(id: currentBookId) {
       readerPresentation.registerFlushHandler(for: sessionID) {
@@ -599,9 +634,13 @@ struct DivinaReaderView: View {
   @ViewBuilder
   private func readerContent(
     useDualPage: Bool,
-    screenSize: CGSize
+    screenSize: CGSize,
+    splitWidePageMode: SplitWidePageMode
   ) -> some View {
-    let contentKey = readerContentKey(useDualPage: useDualPage)
+    let contentKey = readerContentKey(
+      useDualPage: useDualPage,
+      effectiveSplitWidePageMode: splitWidePageMode
+    )
     Group {
       if viewModel.hasPages {
         Group {
@@ -654,10 +693,18 @@ struct DivinaReaderView: View {
                   )
                 }
               #else
-                standardScrollPageView(useDualPage: useDualPage, screenSize: screenSize)
+                standardScrollPageView(
+                  useDualPage: useDualPage,
+                  screenSize: screenSize,
+                  splitWidePageMode: splitWidePageMode
+                )
               #endif
             case .scroll:
-              standardScrollPageView(useDualPage: useDualPage, screenSize: screenSize)
+              standardScrollPageView(
+                useDualPage: useDualPage,
+                screenSize: screenSize,
+                splitWidePageMode: splitWidePageMode
+              )
             case .cover:
               CoverPageView(
                 mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
@@ -718,7 +765,11 @@ struct DivinaReaderView: View {
   }
 
   @ViewBuilder
-  private func standardScrollPageView(useDualPage: Bool, screenSize: CGSize) -> some View {
+  private func standardScrollPageView(
+    useDualPage: Bool,
+    screenSize: CGSize,
+    splitWidePageMode: SplitWidePageMode
+  ) -> some View {
     ScrollPageView(
       mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
       viewportSize: screenSize,
@@ -767,7 +818,10 @@ struct DivinaReaderView: View {
     }
   #endif
 
-  private func controlsOverlay(useDualPage: Bool) -> some View {
+  private func controlsOverlay(
+    useDualPage: Bool,
+    supportsSplitWidePageMode: Bool
+  ) -> some View {
     DivinaControlsOverlayView(
       readingDirection: $readingDirection,
       pageLayout: $pageLayout,
@@ -786,6 +840,7 @@ struct DivinaReaderView: View {
       nextBook: currentSegmentNextBook,
       onPreviousBook: { openPreviousBook(previousBookId: $0) },
       onNextBook: { openNextBook(nextBookId: $0) },
+      supportsSplitWidePageMode: supportsSplitWidePageMode,
       controlsVisible: shouldShowControls,
       showingControls: showingControls
     )
@@ -1248,10 +1303,6 @@ struct DivinaReaderView: View {
         && readingDirection != .vertical
         && pageLayout.supportsDualPageOptions
 
-      let supportsSplitWidePageMode =
-        readingDirection != .webtoon
-        && (pageLayout == .single || pageLayout == .auto)
-
       return ReaderPresentationManager.MacReaderCommandState(
         isActive: true,
         hasPages: viewModel.hasPages,
@@ -1263,7 +1314,7 @@ struct DivinaReaderView: View {
         isolateCoverPage: isolateCoverPage,
         splitWidePageMode: splitWidePageMode,
         supportsDualPageOptions: supportsDualPageOptions,
-        supportsSplitWidePageMode: supportsSplitWidePageMode
+        supportsSplitWidePageMode: supportsManualSplitWidePageMode
       )
     }
 
@@ -1453,7 +1504,7 @@ struct DivinaReaderView: View {
     viewModel = ReaderViewModel(
       isolateCoverPage: isolateCoverPage,
       pageLayout: pageLayout,
-      splitWidePageMode: splitWidePageMode,
+      splitWidePageMode: effectiveSplitWidePageMode,
       incognitoMode: incognito
     )
     // Reset overlay state
@@ -1474,7 +1525,7 @@ struct DivinaReaderView: View {
     viewModel = ReaderViewModel(
       isolateCoverPage: isolateCoverPage,
       pageLayout: pageLayout,
-      splitWidePageMode: splitWidePageMode,
+      splitWidePageMode: effectiveSplitWidePageMode,
       incognitoMode: incognito
     )
     // Reset overlay state

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -121,9 +121,15 @@ struct DivinaPreferencesView: View {
               }
             }
             .pickerStyle(.menu)
-            Text("In single page mode, split landscape pages into two separate pages")
-              .font(.caption)
-              .foregroundColor(.secondary)
+            Text(
+              String(
+                localized: "reader.split_wide_pages.single_page_only.caption",
+                defaultValue:
+                  "Only applies in single-page mode. In dual-page mode, Page Curl uses Auto and Cover/Scroll disable splitting."
+              )
+            )
+            .font(.caption)
+            .foregroundColor(.secondary)
           }
         }
 

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -28381,70 +28381,6 @@
         }
       }
     },
-    "In single page mode, split landscape pages into two separate pages" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Im Einzelseitenmodus werden Querformatseiten in zwei separate Seiten aufgeteilt, entsprechend der Leserichtung"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In single page mode, split landscape pages into two separate pages according to reading direction"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En modo de pagina unica, divide las paginas horizontales en dos paginas segun la direccion de lectura"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En mode page unique, diviser les pages paysage en deux pages distinctes selon le sens de lecture"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In modalita pagina singola, dividi le pagine orizzontali in due pagine separate in base alla direzione di lettura"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "シングルページモードで、読み方向に応じて横長ページを2つの独立したページに分割します"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "단일 페이지 모드에서 읽기 방향에 따라 가로 페이지를 두 개의 별도 페이지로 분할합니다"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "В режиме одной страницы разделять горизонтальные страницы на две отдельные по направлению чтения"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在单页模式下，根据阅读方向将横向页面分割为两个独立页面"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在單頁模式下，根據閱讀方向將橫向頁面分割為兩個獨立頁面"
-          }
-        }
-      }
-    },
     "Index" : {
       "localizations" : {
         "de" : {
@@ -51803,6 +51739,71 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "上一本"
+          }
+        }
+      }
+    },
+    "reader.split_wide_pages.single_page_only.caption" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only applies in single-page mode. In dual-page mode, Page Curl uses Auto, and Cover/Scroll disable splitting."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gilt nur im Einzelseitenmodus. Im Doppelseitenmodus verwendet Seitenrollen Automatisch, und Cover/Scroll deaktivieren die Teilung."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo se aplica en modo de pagina unica. En modo de doble pagina, Paso de pagina curvado usa Automatico y Capa/Desplazarse desactivan la division."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S’applique uniquement en mode page unique. En mode double page, Tournement de page utilise Auto, et Couverture/Défilement désactivent le découpage."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si applica solo in modalità pagina singola. In modalità doppia pagina, Volta pagina a effetto curl usa Automatico e Copertura/Scorri disattivano la divisione."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "単ページモードでのみ適用されます。見開きモードでは、ページカールは自動を使い、カバー/スクロールでは分割を無効にします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단일 페이지 모드에서만 적용됩니다. 듀얼 페이지 모드에서는 페이지 컬이 자동을 사용하고, 커버/스크롤은 분할을 비활성화합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Применяется только в режиме одной страницы. В двухстраничном режиме Перелистывание с загибом использует Авто, а Накрытие/Непрерывный отключают разделение."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅在单页模式下生效。双页模式下，仿真翻页会使用自动，覆盖/滚动会禁用分割。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "僅在單頁模式下生效。雙頁模式下，仿真翻頁會使用自動，覆蓋/捲動會停用分割。"
           }
         }
       }

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -224,20 +224,22 @@ struct MainApp: App {
         }
         .disabled(!state.isActive || !state.supportsDualPageOptions)
 
-        Menu("Split Wide Pages") {
-          ForEach(SplitWidePageMode.allCases, id: \.self) { mode in
-            Button {
-              readerPresentation.setSplitWidePageModeFromCommand(mode)
-            } label: {
-              if state.splitWidePageMode == mode {
-                Label(mode.displayName, systemImage: "checkmark")
-              } else {
-                Text(mode.displayName)
+        if state.supportsSplitWidePageMode {
+          Menu("Split Wide Pages") {
+            ForEach(SplitWidePageMode.allCases, id: \.self) { mode in
+              Button {
+                readerPresentation.setSplitWidePageModeFromCommand(mode)
+              } label: {
+                if state.splitWidePageMode == mode {
+                  Label(mode.displayName, systemImage: "checkmark")
+                } else {
+                  Text(mode.displayName)
+                }
               }
             }
           }
+          .disabled(!state.isActive)
         }
-        .disabled(!state.isActive || !state.supportsSplitWidePageMode)
 
         Divider()
 


### PR DESCRIPTION
## Problem
The `Split Wide Pages` preference was still described and applied in terms of screen orientation, which exposed the setting when it was ineffective and made the behavior inconsistent across page transition styles.

## Approach
Resolve the effective split-wide-page mode from the actual dual-page presentation state instead of landscape detection. When dual-page reading is active, `Page Curl` now forces `Auto`, while `Cover` and `Scroll` force the setting off. Reader menus and the macOS command menu hide the control whenever dual-page presentation is active.

## Scope
- Centralize effective split-wide-page behavior in the reader flow
- Hide inactive split-wide-page controls from reader and macOS menus
- Update preferences copy and localizations to describe the single-page-only behavior

## Validation
- [x] `make format`
- [x] `make build`
- [x] `make localize`
- [x] `./misc/translate.py list`
- [x] `git diff --check`
