### PR TITLE
fix(reader): adjust wide page split eligibility condition

### DIFF
--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -1890,7 +1890,7 @@ private func generateViewItems(
       // Wide pages split only when enabled. In dual-page mode that produces a two-slot
       // spread; otherwise the page stays as a single item.
       let isWidePageEligibleForSplit =
-        (splitWidePages || pageCurl)
+        (splitWidePages || (pageCurl && allowDualPairs))
         && !currentPage.isPortrait
         && (noCover || isWideCoverPage || index != segmentStartIndex)
 


### PR DESCRIPTION
https://github.com/everpcpc/KMReader/commit/73a7112d20e4498761374ae367c6327929c08fb8 accidentally broke the split wide page option disable functionality in single page display, fixed.