### PR TITLE
fix(reader): enable swipe chapter navigation for single-page EPUB content

### DIFF
--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
@@ -419,6 +419,7 @@
       webView.scrollView.delegate = self
       webView.scrollView.isScrollEnabled = true
       webView.scrollView.bounces = true
+      webView.scrollView.alwaysBounceHorizontal = true
       webView.scrollView.alwaysBounceVertical = false
       webView.scrollView.showsHorizontalScrollIndicator = false
       webView.scrollView.showsVerticalScrollIndicator = false


### PR DESCRIPTION
## Problem

In the EPUB reader's paged scroll mode, chapters with only a single image (or any content that fits within one page) cannot be navigated via swipe gestures — only tap navigation works. This is because the WKWebView scroll view's content size equals its bounds width, leaving nothing to scroll, so `scrollViewWillEndDragging` never fires with meaningful velocity.

## Approach

Set `alwaysBounceHorizontal = true` on the web view's scroll view. This allows rubber-band dragging even when content fits in a single page, which:
- Triggers `scrollViewWillEndDragging` with proper velocity so the existing chapter navigation logic works
- Provides visual feedback (bounce effect) so the user knows their swipe was recognized
- Has no effect on multi-page chapters (already scrollable)

The vertical scroll mode (`WebPubScrolledView`) already sets `alwaysBounceVertical = true` and does not have this issue.

## Testing
- [ ] Open an EPUB with a single-image chapter in paged mode
- [ ] Verify swipe left/right navigates to next/previous chapter
- [ ] Verify multi-page chapters still work normally

Closes #647
