### PR TITLE
fix(reader): correct divina scroll page jump on app background/foreground

### DIFF
--- a/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
@@ -221,7 +221,7 @@
           object: nil,
           queue: .main
         ) { [weak self] _ in
-          Task { @MainActor [weak self] in
+          MainActor.assumeIsolated {
             self?.handleApplicationWillResignActive()
           }
         }
@@ -442,8 +442,8 @@
         guard !visibleIndexPaths.isEmpty else { return engine.committedItem }
 
         let center = CGPoint(
-          x: collectionView.contentOffset.x + collectionView.bounds.midX,
-          y: collectionView.contentOffset.y + collectionView.bounds.midY
+          x: collectionView.bounds.midX,
+          y: collectionView.bounds.midY
         )
 
         let nearestIndexPath = visibleIndexPaths.min { lhs, rhs in


### PR DESCRIPTION
## Problem

Minimizing and reopening the app while reading in Divina scroll mode causes the reader to jump backward by 2 pages (or 1 page from even-numbered pages, then 2 on subsequent cycles).

## Approach

The root cause is in `centeredItem()` which calculates the viewport center to find the nearest page. For `UIScrollView`, `bounds.origin` equals `contentOffset`, so `bounds.midX` already includes the content offset. The old code added `contentOffset` again, producing a center at `2 * contentOffset + width/2` instead of the correct `contentOffset + width/2`. This biased the nearest-item lookup toward wrong pages whenever multiple items were momentarily visible during app state transitions.

Additionally, the `willResignActive` notification handler dispatched via `Task { @MainActor }` which yields before executing, allowing the collection view state to change before the position was committed.

## Scope

- Fix `centeredItem()` center calculation to use `bounds.midX/midY` directly (matching the macOS implementation)
- Switch notification handler from async `Task` to synchronous `MainActor.assumeIsolated`

## Testing

- [x] iOS build passes
- [x] macOS build passes
- [ ] Manual: read in Divina scroll mode, minimize and reopen — position should be preserved
