### PR TITLE
fix: prefer server adjacent books in reader

### DIFF
--- a/KMReader/Features/Book/Services/BookService.swift
+++ b/KMReader/Features/Book/Services/BookService.swift
@@ -283,7 +283,7 @@ class BookService {
           path: "/api/v1/books/\(bookId)/next"
         )
       }
-    } catch {
+    } catch APIError.notFound {
       return nil
     }
   }
@@ -297,7 +297,7 @@ class BookService {
       } else {
         return try await apiClient.request(path: "/api/v1/books/\(bookId)/previous")
       }
-    } catch {
+    } catch APIError.notFound {
       return nil
     }
   }

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -303,6 +303,12 @@ class ReaderViewModel {
     return segments[segmentIndex].previousBook
   }
 
+  /// End page is rendered between the finished segment book and its next sibling.
+  /// The leading "previous" slot intentionally shows the finished/current segment book.
+  func endPagePreviousBook(forSegmentBookId bookId: String) -> Book? {
+    currentBook(forSegmentBookId: bookId)
+  }
+
   private func segmentPageRange(forSegmentBookId bookId: String) -> Range<Int>? {
     segmentPageRangeByBookId[bookId]
   }

--- a/KMReader/Features/Reader/Views/CoverPageView.swift
+++ b/KMReader/Features/Reader/Views/CoverPageView.swift
@@ -163,7 +163,7 @@ struct CoverPageView: View {
     Group {
       if case .end(let id) = item {
         NativeEndPageHostView(
-          previousBook: viewModel.currentBook(forSegmentBookId: id.bookId),
+          previousBook: viewModel.endPagePreviousBook(forSegmentBookId: id.bookId),
           nextBook: viewModel.nextBook(forSegmentBookId: id.bookId),
           readListContext: readListContext,
           readingDirection: readingDirection,

--- a/KMReader/Features/Reader/Views/CurlDualPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlDualPageView.swift
@@ -367,7 +367,7 @@
           sectionDisplayMode = slot == .first ? .previousOnly : .nextOnly
         }
         controller.configure(
-          previousBook: parent.viewModel.currentBook(forSegmentBookId: segmentBookId),
+          previousBook: parent.viewModel.endPagePreviousBook(forSegmentBookId: segmentBookId),
           nextBook: parent.viewModel.nextBook(forSegmentBookId: segmentBookId),
           readListContext: parent.readListContext,
           readingDirection: parent.readingDirection,

--- a/KMReader/Features/Reader/Views/CurlPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlPageView.swift
@@ -275,7 +275,7 @@
         segmentBookId: String
       ) {
         controller.configure(
-          previousBook: parent.viewModel.currentBook(forSegmentBookId: segmentBookId),
+          previousBook: parent.viewModel.endPagePreviousBook(forSegmentBookId: segmentBookId),
           nextBook: parent.viewModel.nextBook(forSegmentBookId: segmentBookId),
           readListContext: parent.readListContext,
           readingDirection: parent.readingDirection,

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -1048,31 +1048,101 @@ struct DivinaReaderView: View {
     let instanceId = AppConfig.current.instanceId
     let database = await DatabaseOperator.databaseIfConfigured()
 
-    var resolvedNextBook = await database?.getNextBook(
-      instanceId: instanceId,
+    let resolvedNextBook = await resolveAdjacentBook(
+      direction: .next,
       bookId: bookId,
-      readListId: readListId
-    )
-    if resolvedNextBook == nil && !AppConfig.isOffline {
-      resolvedNextBook = await SyncService.shared.syncNextBook(
-        bookId: bookId,
-        readListId: readListId
-      )
-    }
-
-    var resolvedPreviousBook = await database?.getPreviousBook(
+      readListId: readListId,
       instanceId: instanceId,
-      bookId: bookId,
-      readListId: readListId
+      database: database
     )
-    if resolvedPreviousBook == nil && !AppConfig.isOffline {
-      resolvedPreviousBook = await SyncService.shared.syncPreviousBook(
-        bookId: bookId,
-        readListId: readListId
-      )
-    }
+    let resolvedPreviousBook = await resolveAdjacentBook(
+      direction: .previous,
+      bookId: bookId,
+      readListId: readListId,
+      instanceId: instanceId,
+      database: database
+    )
 
     return (resolvedPreviousBook, resolvedNextBook)
+  }
+
+  private enum AdjacentBookDirection {
+    case previous
+    case next
+  }
+
+  private func resolveAdjacentBook(
+    direction: AdjacentBookDirection,
+    bookId: String,
+    readListId: String?,
+    instanceId: String,
+    database: DatabaseOperator?
+  ) async -> Book? {
+    if AppConfig.isOffline {
+      return await cachedAdjacentBook(
+        direction: direction,
+        bookId: bookId,
+        readListId: readListId,
+        instanceId: instanceId,
+        database: database
+      )
+    }
+
+    do {
+      let resolvedBook: Book?
+      switch direction {
+      case .previous:
+        resolvedBook = try await BookService.shared.getPreviousBook(
+          bookId: bookId,
+          readListId: readListId
+        )
+      case .next:
+        resolvedBook = try await BookService.shared.getNextBook(
+          bookId: bookId,
+          readListId: readListId
+        )
+      }
+
+      if let resolvedBook, let database {
+        await database.upsertBook(dto: resolvedBook, instanceId: instanceId)
+        await database.commit()
+      }
+      return resolvedBook
+    } catch {
+      logger.warning(
+        "⚠️ Failed to resolve \(direction == .next ? "next" : "previous") book from server for \(bookId): \(error)"
+      )
+      return await cachedAdjacentBook(
+        direction: direction,
+        bookId: bookId,
+        readListId: readListId,
+        instanceId: instanceId,
+        database: database
+      )
+    }
+  }
+
+  private func cachedAdjacentBook(
+    direction: AdjacentBookDirection,
+    bookId: String,
+    readListId: String?,
+    instanceId: String,
+    database: DatabaseOperator?
+  ) async -> Book? {
+    switch direction {
+    case .previous:
+      return await database?.getPreviousBook(
+        instanceId: instanceId,
+        bookId: bookId,
+        readListId: readListId
+      )
+    case .next:
+      return await database?.getNextBook(
+        instanceId: instanceId,
+        bookId: bookId,
+        readListId: readListId
+      )
+    }
   }
 
   private var segmentPreloadTriggerDistance: Int {

--- a/KMReader/Features/Reader/Views/NativeEndPagePresentation.swift
+++ b/KMReader/Features/Reader/Views/NativeEndPagePresentation.swift
@@ -37,6 +37,8 @@ struct NativeEndPagePresentation {
     readListContext: ReaderReadListContext?,
     sectionDisplayMode: SectionDisplayMode = .both
   ) -> NativeEndPagePresentation {
+    // End page sits between the finished book and its next sibling.
+    // `previousBook` intentionally represents the finished/current segment book shown on the leading side.
     let relationTitle = readListContext?.name ?? previousBook?.seriesTitle ?? nextBook?.seriesTitle ?? ""
     let previousVisible = sectionDisplayMode != .nextOnly && previousBook != nil
     let nextVisible = sectionDisplayMode != .previousOnly

--- a/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
@@ -587,7 +587,7 @@
           guard let endCell = cell as? NativePagedEndCell else { return }
           let segmentBookId = item.pageID.bookId
           endCell.configure(
-            previousBook: parent.viewModel.currentBook(forSegmentBookId: segmentBookId),
+            previousBook: parent.viewModel.endPagePreviousBook(forSegmentBookId: segmentBookId),
             nextBook: parent.viewModel.nextBook(forSegmentBookId: segmentBookId),
             readListContext: parent.readListContext,
             readingDirection: parent.readingDirection,

--- a/KMReader/Features/Reader/Views/ScrollPageView_macOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_macOS.swift
@@ -692,7 +692,7 @@
           guard let endItem = item as? NativePagedEndCell else { return }
           let segmentBookId = viewItem.pageID.bookId
           endItem.configure(
-            previousBook: parent.viewModel.currentBook(forSegmentBookId: segmentBookId),
+            previousBook: parent.viewModel.endPagePreviousBook(forSegmentBookId: segmentBookId),
             nextBook: parent.viewModel.nextBook(forSegmentBookId: segmentBookId),
             readListContext: parent.readListContext,
             readingDirection: parent.readingDirection,

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -268,7 +268,7 @@
           {
             footerCell.readerBackground = renderConfig.readerBackground
             footerCell.configure(
-              previousBook: viewModel.currentBook(forSegmentBookId: segmentBookId),
+              previousBook: viewModel.endPagePreviousBook(forSegmentBookId: segmentBookId),
               nextBook: viewModel.nextBook(forSegmentBookId: segmentBookId),
               readListContext: readListContext,
               onDismiss: onDismiss
@@ -557,7 +557,7 @@
           }
           cell.readerBackground = readerBackground
           cell.configure(
-            previousBook: viewModel?.currentBook(forSegmentBookId: segmentBookId),
+            previousBook: viewModel?.endPagePreviousBook(forSegmentBookId: segmentBookId),
             nextBook: viewModel?.nextBook(forSegmentBookId: segmentBookId),
             readListContext: readListContext,
             onDismiss: onDismiss

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
@@ -291,7 +291,7 @@
           {
             cell.readerBackground = renderConfig.readerBackground
             cell.configure(
-              previousBook: viewModel.currentBook(forSegmentBookId: segmentBookId),
+              previousBook: viewModel.endPagePreviousBook(forSegmentBookId: segmentBookId),
               nextBook: viewModel.nextBook(forSegmentBookId: segmentBookId),
               readListContext: readListContext,
               onDismiss: onDismiss
@@ -547,7 +547,7 @@
           }
           cell.readerBackground = readerBackground
           cell.configure(
-            previousBook: viewModel?.currentBook(forSegmentBookId: segmentBookId),
+            previousBook: viewModel?.endPagePreviousBook(forSegmentBookId: segmentBookId),
             nextBook: viewModel?.nextBook(forSegmentBookId: segmentBookId),
             readListContext: readListContext,
             onDismiss: onDismiss


### PR DESCRIPTION
## Problem
Reader end pages were resolving adjacent books from SwiftData before consulting Komga. When the local series cache was partial, the next slot could jump to a distant chapter instead of the true next book.

The end page also relies on a non-obvious convention: the leading "previous" slot shows the finished current book because the screen sits between two books.

## Approach
Prefer Komga's sibling-book endpoints while online and persist the returned books back into SwiftData. Fall back to cached adjacency only when the app is offline or the network request fails.

Make the end-page convention explicit with a dedicated helper and comments so future changes do not reinterpret the slot semantics.

## Scope
- Restrict `BookService.getNextBook` and `getPreviousBook` to treat only 404 as "no adjacent book"
- Route reader end-page call sites through `endPagePreviousBook(...)`
- Keep local adjacency lookup as the offline and error fallback path

## Related
- Related to #581

## Validation
- [x] `make build-macos`
