### PR TITLE
feat: add detail page share links

### DIFF
--- a/KMReader/Features/Book/Views/BookDetailView.swift
+++ b/KMReader/Features/Book/Views/BookDetailView.swift
@@ -239,11 +239,13 @@ struct BookDetailView: View {
   @ViewBuilder
   private var bookToolbarContent: some View {
     HStack {
-      if let shareURL {
-        ShareLink(item: shareURL, subject: Text(navigationTitle)) {
-          Image(systemName: "square.and.arrow.up")
+      #if !os(tvOS)
+        if let shareURL {
+          ShareLink(item: shareURL, subject: Text(navigationTitle)) {
+            Image(systemName: "square.and.arrow.up")
+          }
         }
-      }
+      #endif
 
       Menu {
         if current.isAdmin {

--- a/KMReader/Features/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailView.swift
@@ -293,11 +293,13 @@ struct OneshotDetailView: View {
   @ViewBuilder
   private var oneshotToolbarContent: some View {
     HStack {
-      if let shareURL {
-        ShareLink(item: shareURL, subject: Text(navigationTitle)) {
-          Image(systemName: "square.and.arrow.up")
+      #if !os(tvOS)
+        if let shareURL {
+          ShareLink(item: shareURL, subject: Text(navigationTitle)) {
+            Image(systemName: "square.and.arrow.up")
+          }
         }
-      }
+      #endif
 
       Menu {
         if current.isAdmin {

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -286,11 +286,13 @@ extension SeriesDetailView {
   @ViewBuilder
   private var seriesToolbarContent: some View {
     HStack {
-      if let shareURL {
-        ShareLink(item: shareURL, subject: Text(navigationTitle)) {
-          Image(systemName: "square.and.arrow.up")
+      #if !os(tvOS)
+        if let shareURL {
+          ShareLink(item: shareURL, subject: Text(navigationTitle)) {
+            Image(systemName: "square.and.arrow.up")
+          }
         }
-      }
+      #endif
 
       Button {
         showSavedFilters = true


### PR DESCRIPTION
## Summary
- add native share actions to book, series, and oneshot detail toolbars
- share direct Komga URLs instead of internal IDs
- keep the toolbar layout aligned with existing detail views

## Related
- Closes #662

## Testing
- make build-ios