### PR TITLE
fix: preserve current page across reader state regeneration

### DIFF
--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -988,7 +988,10 @@ class ReaderViewModel {
       preferredItem: preservedCurrentItem,
       preferredPageID: preservedCurrentPageID
     )
-    currentPageID = currentViewItemID?.pageID ?? preservedCurrentPageID
+    currentPageID = resolvedCurrentPageID(
+      for: currentViewItemID,
+      preferredPageID: preservedCurrentPageID
+    )
     syncPageLoadSchedulerCurrentPage()
   }
 
@@ -1063,6 +1066,17 @@ class ReaderViewModel {
     syncPageLoadSchedulerCurrentPage()
   }
 
+  private func resolvedCurrentPageID(
+    for viewItem: ReaderViewItem?,
+    preferredPageID: ReaderPageID?
+  ) -> ReaderPageID? {
+    guard let viewItem else { return preferredPageID }
+    if let preferredPageID, viewItem.pageIDs.contains(preferredPageID) {
+      return preferredPageID
+    }
+    return viewItem.pageID
+  }
+
   func updateCurrentPosition(viewItem: ReaderViewItem?) {
     guard let viewItem else {
       currentViewItemID = nil
@@ -1070,11 +1084,15 @@ class ReaderViewModel {
       syncPageLoadSchedulerCurrentPage()
       return
     }
+    let preferredPageID = currentPageID
     currentViewItemID = resolvedViewItem(
       preferredItem: viewItem,
-      preferredPageID: viewItem.pageID
+      preferredPageID: preferredPageID ?? viewItem.pageID
     )
-    currentPageID = currentViewItemID?.pageID
+    currentPageID = resolvedCurrentPageID(
+      for: currentViewItemID,
+      preferredPageID: preferredPageID
+    )
     syncPageLoadSchedulerCurrentPage()
   }
 


### PR DESCRIPTION
## Problem

Reader state regeneration could overwrite the actual current page with the primary page ID of the resolved view item. When the current item was a dual-page item, that collapsed the position back to the first page of the pair and could cause restore/navigation to drift away from the page the user was actually on.

## Approach

Preserve the preferred current page whenever it still belongs to the resolved view item, and only fall back to the item's primary page ID when needed.

## Scope

- add a helper to resolve the current page ID while preserving the preferred page when it is still part of the current view item
- use that helper during reader state regeneration
- use that helper when committing the current position from a resolved view item

## Validation

- [x] `make format`
- [x] `make build-ios`