### PR TITLE
refactor(ui): make metadata chip sections collapsible

### DIFF
--- a/KMReader/Features/Book/Views/BookDetailContentView.swift
+++ b/KMReader/Features/Book/Views/BookDetailContentView.swift
@@ -15,6 +15,8 @@ struct BookDetailContentView: View {
 
   @State private var thumbnailRefreshKey = UUID()
 
+  private let collapsedMetadataChipLimit = 10
+
   private var coverBlurRadius: CGFloat {
     thumbnailBlurUnreadCovers && book.isUnread ? CoverBlurStyle.unreadRadius : 0
   }
@@ -147,17 +149,15 @@ struct BookDetailContentView: View {
             )
           }
 
-          // Authors as chips
+          // Authors
           if let authors = book.metadata.authors, !authors.isEmpty {
-            HFlow {
-              ForEach(authors.sortedByRole(), id: \.self) { author in
-                TappableInfoChip(
-                  label: author.name,
-                  systemImage: author.role.icon,
-                  color: .purple,
-                  destination: MetadataFilterHelper.booksDestinationForAuthor(author.name)
-                )
-              }
+            CollapsibleChipSection(items: authors.sortedByRole(), collapsedLimit: collapsedMetadataChipLimit) { author in
+              TappableInfoChip(
+                label: author.name,
+                systemImage: author.role.icon,
+                color: .purple,
+                destination: MetadataFilterHelper.booksDestinationForAuthor(author.name)
+              )
             }
           }
         }
@@ -165,15 +165,13 @@ struct BookDetailContentView: View {
 
       // Tags
       if let tags = book.metadata.tags, !tags.isEmpty {
-        HFlow {
-          ForEach(tags.sorted(), id: \.self) { tag in
-            TappableInfoChip(
-              label: tag,
-              systemImage: "tag",
-              color: .secondary,
-              destination: MetadataFilterHelper.booksDestinationForTag(tag)
-            )
-          }
+        CollapsibleChipSection(items: tags.sorted(), collapsedLimit: collapsedMetadataChipLimit) { tag in
+          TappableInfoChip(
+            label: tag,
+            systemImage: "tag",
+            color: .secondary,
+            destination: MetadataFilterHelper.booksDestinationForTag(tag)
+          )
         }
       }
 

--- a/KMReader/Features/OneShot/OneShotDetailContentView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailContentView.swift
@@ -16,6 +16,8 @@ struct OneShotDetailContentView: View {
 
   @State private var thumbnailRefreshKey = UUID()
 
+  private let collapsedMetadataChipLimit = 10
+
   private var coverBlurRadius: CGFloat {
     thumbnailBlurUnreadCovers && book.isUnread ? CoverBlurStyle.unreadRadius : 0
   }
@@ -184,15 +186,13 @@ struct OneShotDetailContentView: View {
           }
 
           if let authors = book.metadata.authors, !authors.isEmpty {
-            HFlow {
-              ForEach(authors.sortedByRole(), id: \.self) { author in
-                TappableInfoChip(
-                  label: author.name,
-                  systemImage: author.role.icon,
-                  color: .purple,
-                  destination: MetadataFilterHelper.seriesDestinationForAuthor(author.name)
-                )
-              }
+            CollapsibleChipSection(items: authors.sortedByRole(), collapsedLimit: collapsedMetadataChipLimit) { author in
+              TappableInfoChip(
+                label: author.name,
+                systemImage: author.role.icon,
+                color: .purple,
+                destination: MetadataFilterHelper.seriesDestinationForAuthor(author.name)
+              )
             }
           }
         }
@@ -200,29 +200,25 @@ struct OneShotDetailContentView: View {
 
       // Series genres
       if let genres = series.metadata.genres, !genres.isEmpty {
-        HFlow {
-          ForEach(genres.sorted(), id: \.self) { genre in
-            TappableInfoChip(
-              label: genre,
-              systemImage: "theatermasks",
-              color: .teal,
-              destination: MetadataFilterHelper.seriesDestinationForGenre(genre)
-            )
-          }
+        CollapsibleChipSection(items: genres.sorted(), collapsedLimit: collapsedMetadataChipLimit) { genre in
+          TappableInfoChip(
+            label: genre,
+            systemImage: "theatermasks",
+            color: .teal,
+            destination: MetadataFilterHelper.seriesDestinationForGenre(genre)
+          )
         }
       }
 
       // Book tags
       if let tags = book.metadata.tags, !tags.isEmpty {
-        HFlow {
-          ForEach(tags.sorted(), id: \.self) { tag in
-            TappableInfoChip(
-              label: tag,
-              systemImage: "tag",
-              color: .secondary,
-              destination: MetadataFilterHelper.seriesDestinationForTag(tag)
-            )
-          }
+        CollapsibleChipSection(items: tags.sorted(), collapsedLimit: collapsedMetadataChipLimit) { tag in
+          TappableInfoChip(
+            label: tag,
+            systemImage: "tag",
+            color: .secondary,
+            destination: MetadataFilterHelper.seriesDestinationForTag(tag)
+          )
         }
       }
 


### PR DESCRIPTION
Replace HFlow with CollapsibleChipSection for authors, tags, and genres in book and one-shot detail views to limit the number of chips displayed initially.