### PR TITLE
refactor(ui): make links sections collapsible in detail views

### DIFF
--- a/KMReader/Features/Book/Views/BookDetailContentView.swift
+++ b/KMReader/Features/Book/Views/BookDetailContentView.swift
@@ -261,10 +261,8 @@ struct BookDetailContentView: View {
         VStack(alignment: .leading, spacing: 8) {
           Text("Links")
             .font(.headline)
-          HFlow {
-            ForEach(Array(links.enumerated()), id: \.offset) { _, link in
-              ExternalLinkChip(label: link.label, url: link.url)
-            }
+          CollapsibleChipSection(items: links, collapsedLimit: collapsedMetadataChipLimit) { link in
+            ExternalLinkChip(label: link.label, url: link.url)
           }
           Divider()
         }

--- a/KMReader/Features/OneShot/OneShotDetailContentView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailContentView.swift
@@ -277,10 +277,8 @@ struct OneShotDetailContentView: View {
           Divider()
           Text("Links")
             .font(.headline)
-          HFlow {
-            ForEach(Array(links.enumerated()), id: \.offset) { _, link in
-              ExternalLinkChip(label: link.label, url: link.url)
-            }
+          CollapsibleChipSection(items: links, collapsedLimit: collapsedMetadataChipLimit) { link in
+            ExternalLinkChip(label: link.label, url: link.url)
           }
         }
       }

--- a/KMReader/Features/Series/Views/SeriesDetailContentView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailContentView.swift
@@ -235,10 +235,8 @@ struct SeriesDetailContentView: View {
           Divider()
           Text("Links")
             .font(.headline)
-          HFlow {
-            ForEach(Array(links.enumerated()), id: \.offset) { _, link in
-              ExternalLinkChip(label: link.label, url: link.url)
-            }
+          CollapsibleChipSection(items: links, collapsedLimit: collapsedMetadataChipLimit) { link in
+            ExternalLinkChip(label: link.label, url: link.url)
           }
         }.padding(.bottom, 8)
       }


### PR DESCRIPTION
The `Alternate Titles` should also be collapsible, leaving it up to you to implement (