### PR TITLE
chore: ignore Playwright CLI artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ AuthKey_*.p8
 .env
 .env.local
 
+.playwright-cli/
+
 packages/
 worktrees/
 .alma-snapshots

--- a/KMReader/Features/Book/Views/BookDetailContentView.swift
+++ b/KMReader/Features/Book/Views/BookDetailContentView.swift
@@ -151,7 +151,8 @@ struct BookDetailContentView: View {
 
           // Authors
           if let authors = book.metadata.authors, !authors.isEmpty {
-            CollapsibleChipSection(items: authors.sortedByRole(), collapsedLimit: collapsedMetadataChipLimit) { author in
+            CollapsibleChipSection(items: authors.sortedByRole(), collapsedLimit: collapsedMetadataChipLimit) {
+              author in
               TappableInfoChip(
                 label: author.name,
                 systemImage: author.role.icon,

--- a/KMReader/Features/OneShot/OneShotDetailContentView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailContentView.swift
@@ -186,7 +186,8 @@ struct OneShotDetailContentView: View {
           }
 
           if let authors = book.metadata.authors, !authors.isEmpty {
-            CollapsibleChipSection(items: authors.sortedByRole(), collapsedLimit: collapsedMetadataChipLimit) { author in
+            CollapsibleChipSection(items: authors.sortedByRole(), collapsedLimit: collapsedMetadataChipLimit) {
+              author in
               TappableInfoChip(
                 label: author.name,
                 systemImage: author.role.icon,

--- a/KMReader/Features/Series/Views/SeriesDetailContentView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailContentView.swift
@@ -185,7 +185,8 @@ struct SeriesDetailContentView: View {
         )
       }
 
-      CollapsibleChipSection(items: combinedTagItems, collapsedLimit: collapsedMetadataChipLimit) { (tagItem: TagItem) in
+      CollapsibleChipSection(items: combinedTagItems, collapsedLimit: collapsedMetadataChipLimit) {
+        (tagItem: TagItem) in
         TappableInfoChip(
           label: tagItem.name,
           systemImage: "tag",


### PR DESCRIPTION
## Problem
Local browser automation runs create a `.playwright-cli/` workspace that should stay out of version control. The current diff also includes a few detail-view call sites whose formatting no longer matches the preferred multiline style.

## Approach
Ignore the Playwright CLI workspace at the repo root and normalize the affected `CollapsibleChipSection` closures so the working tree stays clean and future formatter runs do not keep revisiting the same lines.

## Scope
- add `.playwright-cli/` to `.gitignore`
- reflow `CollapsibleChipSection` calls in book, one-shot, and series detail views

## Validation
- `git diff --check`
