### PR TITLE
fix: localize network settings timeout options

### DIFF
--- a/KMReader/Features/Settings/SettingsNetworkView.swift
+++ b/KMReader/Features/Settings/SettingsNetworkView.swift
@@ -17,20 +17,20 @@ struct SettingsNetworkView: View {
     Form {
       Section(header: Text(String(localized: "settings.network.general"))) {
         timeoutRow(
-          labelKey: "settings.network.request_timeout.label",
-          descriptionKey: "settings.network.request_timeout.description",
+          label: "settings.network.request_timeout.label",
+          description: "settings.network.request_timeout.description",
           value: $requestTimeout
         )
 
         timeoutRow(
-          labelKey: "settings.network.download_timeout.label",
-          descriptionKey: "settings.network.download_timeout.description",
+          label: "settings.network.download_timeout.label",
+          description: "settings.network.download_timeout.description",
           value: $downloadTimeout
         )
 
         timeoutRow(
-          labelKey: "settings.network.auth_timeout.label",
-          descriptionKey: "settings.network.auth_timeout.description",
+          label: "settings.network.auth_timeout.label",
+          description: "settings.network.auth_timeout.description",
           value: $authTimeout
         )
 
@@ -88,13 +88,17 @@ struct SettingsNetworkView: View {
 
   @ViewBuilder
   private func timeoutRow(
-    labelKey: String,
-    descriptionKey: String,
+    label: LocalizedStringResource,
+    description: LocalizedStringResource,
     value: Binding<Double>
   ) -> some View {
     VStack(alignment: .leading, spacing: 8) {
       HStack {
-        Label(String(localized: .init(labelKey)), systemImage: "clock")
+        Label {
+          Text(label)
+        } icon: {
+          Image(systemName: "clock")
+        }
         Spacer()
         #if os(tvOS)
           Text("\(Int(value.wrappedValue))s")
@@ -106,7 +110,7 @@ struct SettingsNetworkView: View {
           Text("s")
             .foregroundStyle(.secondary)
         #else
-          TextField("Timeout Seconds", value: value, format: .number)
+          TextField(String(localized: "Timeout Seconds"), value: value, format: .number)
             .keyboardType(.numbersAndPunctuation)
             .multilineTextAlignment(.trailing)
             .frame(width: 50)
@@ -114,7 +118,7 @@ struct SettingsNetworkView: View {
             .foregroundStyle(.secondary)
         #endif
       }
-      Text(String(localized: .init(descriptionKey)))
+      Text(description)
         .font(.caption)
         .foregroundStyle(.secondary)
     }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -4317,71 +4317,6 @@
         }
       }
     },
-    "Always Show Page Number" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seitenzahl immer anzeigen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Always Show Page Number"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar siempre el número de página"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toujours afficher le numéro de page"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra sempre il numero di pagina"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "常にページ番号を表示"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "항상 페이지 번호 표시"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Всегда показывать номер страницы"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "始终显示页码"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "始終顯示頁碼"
-          }
-        }
-      }
-    },
     "Analyze" : {
       "localizations" : {
         "de" : {
@@ -63072,6 +63007,262 @@
         }
       }
     },
+    "settings.network.auth_timeout.description" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximale Wartezeit, bevor eine Anmeldung oder Token-Anfrage fehlschlägt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum time to wait before a sign-in or token request fails."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo máximo de espera antes de que falle un inicio de sesión o una solicitud de token."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temps d'attente maximal avant l'échec d'une connexion ou d'une requête de jeton."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tempo massimo di attesa prima che un accesso o una richiesta di token fallisca."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サインインまたはトークン要求が失敗するまでの最大待機時間。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로그인 또는 토큰 요청이 실패하기 전까지 기다리는 최대 시간입니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Максимальное время ожидания до сбоя входа или запроса токена."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登录或令牌请求失败前的最长等待时间。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登入或權杖請求失敗前的最長等待時間。"
+          }
+        }
+      }
+    },
+    "settings.network.auth_timeout.label" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitlimit für Authentifizierung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication Timeout"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de espera de autenticación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Délai d'attente d'authentification"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout autenticazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "認証のタイムアウト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인증 시간 초과"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тайм-аут аутентификации"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "认证超时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驗證逾時"
+          }
+        }
+      }
+    },
+    "settings.network.download_timeout.description" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximale Wartezeit, bevor ein Download fehlschlägt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum time to wait before a download fails."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo máximo de espera antes de que falle una descarga."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temps d'attente maximal avant l'échec d'un téléchargement."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tempo massimo di attesa prima che un download fallisca."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードが失敗するまでの最大待機時間。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드가 실패하기 전까지 기다리는 최대 시간입니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Максимальное время ожидания до сбоя загрузки."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载失败前的最长等待时间。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載失敗前的最長等待時間。"
+          }
+        }
+      }
+    },
+    "settings.network.download_timeout.label" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitlimit für Downloads"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download Timeout"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de espera de descarga"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Délai d'attente des téléchargements"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout download"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードのタイムアウト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드 시간 초과"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тайм-аут загрузки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载超时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載逾時"
+          }
+        }
+      }
+    },
     "settings.network.general" : {
       "localizations" : {
         "de" : {
@@ -63452,6 +63643,134 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀器接力"
+          }
+        }
+      }
+    },
+    "settings.network.request_timeout.description" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximale Wartezeit, bevor eine normale API-Anfrage fehlschlägt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximum time to wait before a standard API request fails."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo máximo de espera antes de que falle una solicitud API normal."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temps d'attente maximal avant l'échec d'une requête API standard."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tempo massimo di attesa prima che una richiesta API normale fallisca."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通常の API リクエストが失敗するまでの最大待機時間。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일반 API 요청이 실패하기 전까지 기다리는 최대 시간입니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Максимальное время ожидания до сбоя обычного API-запроса."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "普通 API 请求失败前的最长等待时间。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般 API 請求失敗前的最長等待時間。"
+          }
+        }
+      }
+    },
+    "settings.network.request_timeout.label" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeitlimit für Anfragen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Request Timeout"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiempo de espera de solicitud"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Délai d'attente des requêtes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timeout richiesta"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リクエストのタイムアウト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "요청 시간 초과"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тайм-аут запроса"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请求超时"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "請求逾時"
           }
         }
       }


### PR DESCRIPTION
## Problem
The Network section in Settings showed untranslated timeout option text because `SettingsNetworkView` built localization keys dynamically, so Xcode string extraction did not keep the timeout entries in `Localizable.xcstrings` in sync.

## Approach
Replace the dynamic string-key plumbing with static `LocalizedStringResource` arguments in `timeoutRow`, so the timeout labels and descriptions are visible to the localization pipeline. Then add the missing request, download, and authentication timeout translations and resync the string catalog after a full build.

## Scope
- Make the Network timeout rows use static localized resources in `SettingsNetworkView`
- Add translations for the missing Network timeout keys in `Localizable.xcstrings`
- Keep the current stale catalog cleanup that removes the unused `Always Show Page Number` entry

## Validation
- [x] `make build`
- [x] `make localize`
- [x] `./misc/translate.py list`
