### PR TITLE
fix: unify webtoon and end-page close button style

### DIFF
--- a/KMReader/Features/Reader/Views/EndPageCloseButtonStyle.swift
+++ b/KMReader/Features/Reader/Views/EndPageCloseButtonStyle.swift
@@ -1,0 +1,44 @@
+#if os(iOS) || os(tvOS)
+  import UIKit
+
+  enum EndPageCloseButtonStyle {
+    static func apply(to button: UIButton, textColor: UIColor) {
+      var configuration = borderedButtonConfiguration()
+      configuration.image = UIImage(systemName: "xmark")
+      configuration.imagePlacement = .leading
+      configuration.imagePadding = 8
+      configuration.preferredSymbolConfigurationForImage = buttonSymbolConfiguration
+      configuration.title = String(localized: "Close")
+      configuration.cornerStyle = .capsule
+      button.configuration = configuration
+      button.tintColor = textColor
+    }
+
+    private static func borderedButtonConfiguration() -> UIButton.Configuration {
+      #if os(iOS)
+        if #available(iOS 26.0, *) {
+          return .glass()
+        }
+      #endif
+      return .bordered()
+    }
+
+    private static var buttonSymbolConfiguration: UIImage.SymbolConfiguration {
+      UIImage.SymbolConfiguration(
+        textStyle: .subheadline,
+        scale: .small
+      )
+    }
+  }
+#elseif os(macOS)
+  import AppKit
+
+  enum EndPageCloseButtonStyle {
+    static func apply(to button: NSButton, textColor: NSColor) {
+      button.title = String(localized: "Close")
+      button.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: nil)
+      button.imagePosition = .imageLeading
+      button.contentTintColor = textColor
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Views/NativeEndPageContentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeEndPageContentView_iOS.swift
@@ -382,15 +382,7 @@
         nextDetailLabel.text = nil
       }
 
-      var closeConfig = borderedButtonConfiguration()
-      closeConfig.image = UIImage(systemName: "xmark")
-      closeConfig.imagePlacement = .leading
-      closeConfig.imagePadding = 8
-      closeConfig.preferredSymbolConfigurationForImage = buttonSymbolConfiguration
-      closeConfig.title = String(localized: "Close")
-      closeConfig.cornerStyle = .capsule
-      closeButton.configuration = closeConfig
-      closeButton.tintColor = textColor
+      EndPageCloseButtonStyle.apply(to: closeButton, textColor: textColor)
       closeButton.isHidden = !presentation.showsCloseButton
 
       applyDynamicMetrics()
@@ -550,22 +542,6 @@
       nextCoverWidthConstraint?.constant = coverWidth
       nextCoverHeightConstraint?.constant = coverHeight
       verticalDividerHeightConstraint?.constant = dividerHeight
-    }
-
-    private func borderedButtonConfiguration() -> UIButton.Configuration {
-      #if os(iOS)
-        if #available(iOS 26.0, *) {
-          return .glass()
-        }
-      #endif
-      return .bordered()
-    }
-
-    private var buttonSymbolConfiguration: UIImage.SymbolConfiguration {
-      UIImage.SymbolConfiguration(
-        textStyle: .subheadline,
-        scale: .small
-      )
     }
 
     private var contentColor: UIColor {

--- a/KMReader/Features/Reader/Views/NativeEndPageContentView_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativeEndPageContentView_macOS.swift
@@ -362,10 +362,7 @@
         nextCoverView.configure(bookID: nil)
       }
 
-      closeButton.title = String(localized: "Close")
-      closeButton.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: nil)
-      closeButton.imagePosition = .imageLeading
-      closeButton.contentTintColor = textColor
+      EndPageCloseButtonStyle.apply(to: closeButton, textColor: textColor)
       closeButton.isHidden = !presentation.showsCloseButton
 
       applyDynamicMetrics()

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_iOS.swift
@@ -160,7 +160,7 @@
       nextTitleLabel.textColor = textColor
       nextDetailLabel.textColor = textColor.withAlphaComponent(0.6)
       caughtUpLabel.textColor = textColor
-      closeButton.tintColor = textColor
+      EndPageCloseButtonStyle.apply(to: closeButton, textColor: textColor)
     }
 
     private func applyContent() {
@@ -189,13 +189,7 @@
         caughtUpLabel.text = String(localized: "You're all caught up!")
       }
 
-      var configuration = UIButton.Configuration.bordered()
-      configuration.image = UIImage(systemName: "xmark")
-      configuration.imagePlacement = .leading
-      configuration.imagePadding = 8
-      configuration.title = String(localized: "Close")
-      configuration.cornerStyle = .capsule
-      closeButton.configuration = configuration
+      EndPageCloseButtonStyle.apply(to: closeButton, textColor: UIColor(readerBackground.contentColor))
     }
 
     @objc private func handleClose() {

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_macOS.swift
@@ -160,7 +160,7 @@
       nextTitleLabel.textColor = textColor
       nextDetailLabel.textColor = textColor.withAlphaComponent(0.6)
       caughtUpLabel.textColor = textColor
-      closeButton.contentTintColor = textColor
+      EndPageCloseButtonStyle.apply(to: closeButton, textColor: textColor)
     }
 
     private func applyContent() {
@@ -190,9 +190,7 @@
         caughtUpLabel.stringValue = String(localized: "You're all caught up!")
       }
 
-      closeButton.title = String(localized: "Close")
-      closeButton.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: nil)
-      closeButton.imagePosition = .imageLeading
+      EndPageCloseButtonStyle.apply(to: closeButton, textColor: NSColor(readerBackground.contentColor))
     }
 
     func isInteractingWithCloseButton(at point: NSPoint, in sourceView: NSView) -> Bool {


### PR DESCRIPTION
## Problem
The explicit close button shown after finishing a webtoon used a separate footer implementation, so it could drift away from the standard reader end-page button style.

## Approach
Extract a shared end-page close button style helper and apply it to both the native end-page views and the webtoon footer cells on iOS and macOS. This keeps the visual treatment and platform-specific button configuration aligned in one place.

## Scope
- Add a shared close button style helper for reader completion surfaces
- Update native end-page views to use the shared helper
- Update webtoon footer cells to use the same helper

## Validation
- [x] `make format`
- [x] `make build-ios`
