### PR TITLE
fix: stabilize library picker tint on iOS

### DIFF
--- a/KMReader/Shared/UI/SheetView.swift
+++ b/KMReader/Shared/UI/SheetView.swift
@@ -17,6 +17,7 @@ import SwiftUI
 ///   - On tvOS controls are displayed at the top of the sheet in an HStack.
 ///   - A standard Close button is always appended unless `showsCloseButton` is false.
 struct SheetView<Content: View, Controls: View>: View {
+  @AppStorage("themeColorHex") private var themeColor: ThemeColor = .orange
   private let title: String?
   private let size: SheetPresentationSize
   private let showsCloseButton: Bool
@@ -70,7 +71,12 @@ struct SheetView<Content: View, Controls: View>: View {
       sheetContent()
         .padding(applyFormStyle ? 0 : PlatformHelper.sheetPadding)
         .inlineTitleIfNeeded(title)
-    }.applySheetSize(size)
+    }
+    #if os(iOS)
+      .tint(themeColor.color)
+      .accentColor(themeColor.color)
+    #endif
+    .applySheetSize(size)
   }
 
   @ViewBuilder


### PR DESCRIPTION
## Problem
The library picker sheet on iOS could occasionally fall back to the system default tint after a refresh. The issue showed up most often when the sheet rebuilt its navigation content after tapping Refresh.

## Approach
Apply the stored theme tint inside `SheetView` so sheet-hosted `NavigationStack` hierarchies keep a stable tint source even when the sheet content refreshes or rebuilds. Limit the override to iOS so macOS and tvOS continue using their existing behavior.

## Scope
- Read the stored `themeColorHex` inside `SheetView`
- Apply `tint` and `accentColor` to the sheet navigation stack on iOS only

## Validation
- [x] `make build-ios`
