### PR TITLE
fix: animate epub scrolled tap navigation

### DIFF
--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -21,6 +21,7 @@
     @AppStorage("currentAccount") private var current: Current = .init()
     @AppStorage("epubPreferences") private var globalPreferences: EpubReaderPreferences = .init()
     @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
+    @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.3
 
     @State private var viewModel: EpubReaderViewModel
     @State private var activePreferences: EpubReaderPreferences
@@ -145,8 +146,8 @@
 
     private func updateReaderLiveActivityProgress() {
       #if os(iOS)
-      let progress = viewModel.currentLocation?.totalProgression ?? 0
-      ReaderLiveActivityManager.shared.updateReadingProgress(progress)
+        let progress = viewModel.currentLocation?.totalProgression ?? 0
+        ReaderLiveActivityManager.shared.updateReadingProgress(progress)
       #endif
     }
 
@@ -398,6 +399,7 @@
             viewModel: viewModel,
             preferences: activePreferences,
             colorScheme: colorScheme,
+            tapPageTransitionDuration: tapPageTransitionDuration,
             showingControls: shouldShowControls,
             bookTitle: currentBook?.metadata.title,
             onCenterTap: {
@@ -472,6 +474,7 @@
             viewModel: viewModel,
             preferences: activePreferences,
             colorScheme: colorScheme,
+            tapPageTransitionDuration: tapPageTransitionDuration,
             showingControls: shouldShowControls,
             bookTitle: currentBook?.metadata.title,
             onCenterTap: {
@@ -674,7 +677,7 @@
           insertion: .move(edge: .trailing).combined(with: .opacity),
           removal: .move(edge: .trailing).combined(with: .opacity)
         )
-        )
+      )
     }
 
     private func toggleControls() {

--- a/KMReader/Features/Reader/Views/Epub/WebPubInfoOverlaySupport.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubInfoOverlaySupport.swift
@@ -9,384 +9,390 @@
   #endif
 
   enum WebPubInfoOverlaySupport {
-  enum FlowStyle {
-    case paged
-    case scrolled
-  }
-
-  struct Entry: Equatable {
-    let text: String?
-    let isVisible: Bool
-
-    static let hidden = Entry(text: nil, isVisible: false)
-  }
-
-  struct Content: Equatable {
-    let showingControls: Bool
-    let topTitle: Entry
-    let topProgress: Entry
-    let bottomLeading: Entry
-    let bottomCenter: Entry
-    let bottomTrailing: Entry
-  }
-
-  static func containerInsets(topOffset: CGFloat, bottomOffset: CGFloat) -> ReaderContainerInsets {
-    ReaderContainerInsets(top: topOffset + 24, left: 0, bottom: bottomOffset + 24, right: 0)
-  }
-
-  static func content(
-    flowStyle: FlowStyle,
-    bookTitle: String?,
-    chapterTitle: String?,
-    totalProgression: Double?,
-    currentPageIndex: Int,
-    totalPagesInChapter: Int,
-    showingControls: Bool
-  ) -> Content {
-    let topTitle = showingControls
-      ? Entry.hidden
-      : visibleEntry(bookTitle)
-    let topProgress: Entry
-    if showingControls, let totalProgression {
-      let percentage = String(format: "%.2f%%", totalProgression * 100)
-      topProgress = Entry(
-        text: String(localized: "Book Progress \(percentage)"),
-        isVisible: true
-      )
-    } else {
-      topProgress = .hidden
+    enum FlowStyle {
+      case paged
+      case scrolled
     }
 
-    guard totalPagesInChapter > 0 else {
+    struct Entry: Equatable {
+      let text: String?
+      let isVisible: Bool
+
+      static let hidden = Entry(text: nil, isVisible: false)
+    }
+
+    struct Content: Equatable {
+      let showingControls: Bool
+      let topTitle: Entry
+      let topProgress: Entry
+      let bottomLeading: Entry
+      let bottomCenter: Entry
+      let bottomTrailing: Entry
+    }
+
+    static func containerInsets(topOffset: CGFloat, bottomOffset: CGFloat) -> ReaderContainerInsets {
+      ReaderContainerInsets(top: topOffset + 24, left: 0, bottom: bottomOffset + 24, right: 0)
+    }
+
+    static func content(
+      flowStyle: FlowStyle,
+      bookTitle: String?,
+      chapterTitle: String?,
+      totalProgression: Double?,
+      currentPageIndex: Int,
+      totalPagesInChapter: Int,
+      showingControls: Bool
+    ) -> Content {
+      let topTitle =
+        showingControls
+        ? Entry.hidden
+        : visibleEntry(bookTitle)
+      let topProgress: Entry
+      if showingControls, let totalProgression {
+        let percentage = String(format: "%.2f%%", totalProgression * 100)
+        topProgress = Entry(
+          text: String(localized: "Book Progress \(percentage)"),
+          isVisible: true
+        )
+      } else {
+        topProgress = .hidden
+      }
+
+      guard totalPagesInChapter > 0 else {
+        return Content(
+          showingControls: showingControls,
+          topTitle: topTitle,
+          topProgress: topProgress,
+          bottomLeading: .hidden,
+          bottomCenter: .hidden,
+          bottomTrailing: .hidden
+        )
+      }
+
+      if showingControls {
+        return Content(
+          showingControls: showingControls,
+          topTitle: topTitle,
+          topProgress: topProgress,
+          bottomLeading: .hidden,
+          bottomCenter: controlsCenterEntry(
+            flowStyle: flowStyle,
+            currentPageIndex: currentPageIndex,
+            totalPagesInChapter: totalPagesInChapter
+          ),
+          bottomTrailing: .hidden
+        )
+      }
+
       return Content(
         showingControls: showingControls,
         topTitle: topTitle,
         topProgress: topProgress,
-        bottomLeading: .hidden,
+        bottomLeading: visibleEntry(chapterTitle),
         bottomCenter: .hidden,
-        bottomTrailing: .hidden
-      )
-    }
-
-    if showingControls {
-      return Content(
-        showingControls: showingControls,
-        topTitle: topTitle,
-        topProgress: topProgress,
-        bottomLeading: .hidden,
-        bottomCenter: controlsCenterEntry(
+        bottomTrailing: trailingEntry(
           flowStyle: flowStyle,
           currentPageIndex: currentPageIndex,
           totalPagesInChapter: totalPagesInChapter
-        ),
-        bottomTrailing: .hidden
+        )
       )
     }
 
-    return Content(
-      showingControls: showingControls,
-      topTitle: topTitle,
-      topProgress: topProgress,
-      bottomLeading: visibleEntry(chapterTitle),
-      bottomCenter: .hidden,
-      bottomTrailing: trailingEntry(
-        flowStyle: flowStyle,
-        currentPageIndex: currentPageIndex,
-        totalPagesInChapter: totalPagesInChapter
-      )
-    )
-  }
-
-  private static func visibleEntry(_ text: String?) -> Entry {
-    guard let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
-      return .hidden
-    }
-    return Entry(text: trimmed, isVisible: true)
-  }
-
-  private static func controlsCenterEntry(
-    flowStyle: FlowStyle,
-    currentPageIndex: Int,
-    totalPagesInChapter: Int
-  ) -> Entry {
-    switch flowStyle {
-    case .paged:
-      let current = currentPageIndex + 1
-      return Entry(
-        text: String(localized: "Chapter Progress \(current) / \(totalPagesInChapter)"),
-        isVisible: true
-      )
-    case .scrolled:
-      let progress = chapterProgress(
-        currentPageIndex: currentPageIndex,
-        totalPagesInChapter: totalPagesInChapter
-      )
-      let percentage = String(format: "%.1f%%", progress * 100)
-      return Entry(
-        text: String(localized: "Chapter Progress \(percentage)"),
-        isVisible: true
-      )
-    }
-  }
-
-  private static func trailingEntry(
-    flowStyle: FlowStyle,
-    currentPageIndex: Int,
-    totalPagesInChapter: Int
-  ) -> Entry {
-    switch flowStyle {
-    case .paged:
-      let remainingPages = totalPagesInChapter - (currentPageIndex + 1)
-      let text = remainingPages > 0
-        ? String(localized: "\(remainingPages) pages left")
-        : String(localized: "Last page")
-      return Entry(text: text, isVisible: true)
-    case .scrolled:
-      let progress = chapterProgress(
-        currentPageIndex: currentPageIndex,
-        totalPagesInChapter: totalPagesInChapter
-      )
-      let remaining = String(format: "%.1f%%", (1.0 - progress) * 100)
-      return Entry(text: String(localized: "\(remaining) left"), isVisible: true)
-    }
-  }
-
-  private static func chapterProgress(
-    currentPageIndex: Int,
-    totalPagesInChapter: Int
-  ) -> Double {
-    min(1.0, max(0.0, Double(currentPageIndex + 1) / Double(totalPagesInChapter)))
-  }
-
-  #if os(iOS)
-    @MainActor
-    final class UIKitOverlay {
-      private let topTitleLabel: UILabel
-      private let topProgressLabel: UILabel
-      private let bottomLeadingLabel: UILabel
-      private let bottomCenterLabel: UILabel
-      private let bottomTrailingLabel: UILabel
-      private var currentContent = Content(
-        showingControls: false,
-        topTitle: .hidden,
-        topProgress: .hidden,
-        bottomLeading: .hidden,
-        bottomCenter: .hidden,
-        bottomTrailing: .hidden
-      )
-
-      init(
-        containerView: UIView,
-        topAnchor: NSLayoutYAxisAnchor,
-        bottomAnchor: NSLayoutYAxisAnchor,
-        topOffset: CGFloat,
-        bottomOffset: CGFloat,
-        theme: ReaderTheme
-      ) {
-        topTitleLabel = Self.makeLabel(fontSize: 14, alignment: .center)
-        topProgressLabel = Self.makeLabel(fontSize: 14, alignment: .center)
-        bottomLeadingLabel = Self.makeLabel(fontSize: 12, alignment: .left)
-        bottomCenterLabel = Self.makeLabel(fontSize: 12, alignment: .center, monospaced: true)
-        bottomTrailingLabel = Self.makeLabel(fontSize: 12, alignment: .right, monospaced: true)
-
-        let bottomConstant = -bottomOffset
-        [topTitleLabel, topProgressLabel, bottomLeadingLabel, bottomCenterLabel, bottomTrailingLabel]
-          .forEach(containerView.addSubview)
-
-        NSLayoutConstraint.activate([
-          topTitleLabel.topAnchor.constraint(equalTo: topAnchor, constant: topOffset),
-          topTitleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-          topTitleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
-
-          topProgressLabel.topAnchor.constraint(equalTo: topAnchor, constant: topOffset),
-          topProgressLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-          topProgressLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
-
-          bottomLeadingLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomConstant),
-          bottomLeadingLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-
-          bottomCenterLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomConstant),
-          bottomCenterLabel.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
-
-          bottomTrailingLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomConstant),
-          bottomTrailingLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
-          bottomTrailingLabel.leadingAnchor.constraint(greaterThanOrEqualTo: bottomLeadingLabel.trailingAnchor, constant: 8),
-        ])
-
-        apply(theme: theme)
+    private static func visibleEntry(_ text: String?) -> Entry {
+      guard let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+        return .hidden
       }
+      return Entry(text: trimmed, isVisible: true)
+    }
 
-      func apply(theme: ReaderTheme) {
-        let labelColor = theme.uiColorText.withAlphaComponent(0.6)
-        [topTitleLabel, topProgressLabel, bottomLeadingLabel, bottomCenterLabel, bottomTrailingLabel]
-          .forEach { $0.textColor = labelColor }
+    private static func controlsCenterEntry(
+      flowStyle: FlowStyle,
+      currentPageIndex: Int,
+      totalPagesInChapter: Int
+    ) -> Entry {
+      switch flowStyle {
+      case .paged:
+        let current = currentPageIndex + 1
+        return Entry(
+          text: String(localized: "Chapter Progress \(current) / \(totalPagesInChapter)"),
+          isVisible: true
+        )
+      case .scrolled:
+        let progress = chapterProgress(
+          currentPageIndex: currentPageIndex,
+          totalPagesInChapter: totalPagesInChapter
+        )
+        let percentage = String(format: "%.1f%%", progress * 100)
+        return Entry(
+          text: String(localized: "Chapter Progress \(percentage)"),
+          isVisible: true
+        )
       }
+    }
 
-      func update(content: Content, animated: Bool) {
-        guard content != currentContent else { return }
-        currentContent = content
-        let updates = {
-          if let text = content.topTitle.text {
-            self.topTitleLabel.text = text
+    private static func trailingEntry(
+      flowStyle: FlowStyle,
+      currentPageIndex: Int,
+      totalPagesInChapter: Int
+    ) -> Entry {
+      switch flowStyle {
+      case .paged:
+        let remainingPages = totalPagesInChapter - (currentPageIndex + 1)
+        let text =
+          remainingPages > 0
+          ? String(localized: "\(remainingPages) pages left")
+          : String(localized: "Last page")
+        return Entry(text: text, isVisible: true)
+      case .scrolled:
+        let progress = chapterProgress(
+          currentPageIndex: currentPageIndex,
+          totalPagesInChapter: totalPagesInChapter
+        )
+        let remaining = String(format: "%.1f%%", (1.0 - progress) * 100)
+        return Entry(text: String(localized: "\(remaining) left"), isVisible: true)
+      }
+    }
+
+    private static func chapterProgress(
+      currentPageIndex: Int,
+      totalPagesInChapter: Int
+    ) -> Double {
+      min(1.0, max(0.0, Double(currentPageIndex + 1) / Double(totalPagesInChapter)))
+    }
+
+    #if os(iOS)
+      @MainActor
+      final class UIKitOverlay {
+        private let topTitleLabel: UILabel
+        private let topProgressLabel: UILabel
+        private let bottomLeadingLabel: UILabel
+        private let bottomCenterLabel: UILabel
+        private let bottomTrailingLabel: UILabel
+        private var currentContent = Content(
+          showingControls: false,
+          topTitle: .hidden,
+          topProgress: .hidden,
+          bottomLeading: .hidden,
+          bottomCenter: .hidden,
+          bottomTrailing: .hidden
+        )
+
+        init(
+          containerView: UIView,
+          topAnchor: NSLayoutYAxisAnchor,
+          bottomAnchor: NSLayoutYAxisAnchor,
+          topOffset: CGFloat,
+          bottomOffset: CGFloat,
+          theme: ReaderTheme
+        ) {
+          topTitleLabel = Self.makeLabel(fontSize: 14, alignment: .center)
+          topProgressLabel = Self.makeLabel(fontSize: 14, alignment: .center)
+          bottomLeadingLabel = Self.makeLabel(fontSize: 12, alignment: .left)
+          bottomCenterLabel = Self.makeLabel(fontSize: 12, alignment: .center, monospaced: true)
+          bottomTrailingLabel = Self.makeLabel(fontSize: 12, alignment: .right, monospaced: true)
+
+          let bottomConstant = -bottomOffset
+          [topTitleLabel, topProgressLabel, bottomLeadingLabel, bottomCenterLabel, bottomTrailingLabel]
+            .forEach(containerView.addSubview)
+
+          NSLayoutConstraint.activate([
+            topTitleLabel.topAnchor.constraint(equalTo: topAnchor, constant: topOffset),
+            topTitleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            topTitleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+
+            topProgressLabel.topAnchor.constraint(equalTo: topAnchor, constant: topOffset),
+            topProgressLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            topProgressLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+
+            bottomLeadingLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomConstant),
+            bottomLeadingLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+
+            bottomCenterLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomConstant),
+            bottomCenterLabel.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+
+            bottomTrailingLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomConstant),
+            bottomTrailingLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            bottomTrailingLabel.leadingAnchor.constraint(
+              greaterThanOrEqualTo: bottomLeadingLabel.trailingAnchor, constant: 8),
+          ])
+
+          apply(theme: theme)
+        }
+
+        func apply(theme: ReaderTheme) {
+          let labelColor = theme.uiColorText.withAlphaComponent(0.6)
+          [topTitleLabel, topProgressLabel, bottomLeadingLabel, bottomCenterLabel, bottomTrailingLabel]
+            .forEach { $0.textColor = labelColor }
+        }
+
+        func update(content: Content, animated: Bool) {
+          guard content != currentContent else { return }
+          currentContent = content
+          let updates = {
+            if let text = content.topTitle.text {
+              self.topTitleLabel.text = text
+            }
+            self.topTitleLabel.alpha = content.topTitle.isVisible ? 1.0 : 0.0
+
+            if let text = content.topProgress.text {
+              self.topProgressLabel.text = text
+            }
+            self.topProgressLabel.alpha = content.topProgress.isVisible ? 1.0 : 0.0
+
+            if let text = content.bottomLeading.text {
+              self.bottomLeadingLabel.text = text
+            }
+            self.bottomLeadingLabel.alpha = content.bottomLeading.isVisible ? 1.0 : 0.0
+
+            if let text = content.bottomCenter.text {
+              self.bottomCenterLabel.text = text
+            }
+            self.bottomCenterLabel.alpha = content.bottomCenter.isVisible ? 1.0 : 0.0
+
+            if let text = content.bottomTrailing.text {
+              self.bottomTrailingLabel.text = text
+            }
+            self.bottomTrailingLabel.alpha = content.bottomTrailing.isVisible ? 1.0 : 0.0
           }
-          self.topTitleLabel.alpha = content.topTitle.isVisible ? 1.0 : 0.0
 
-          if let text = content.topProgress.text {
-            self.topProgressLabel.text = text
+          guard animated else {
+            updates()
+            return
           }
-          self.topProgressLabel.alpha = content.topProgress.isVisible ? 1.0 : 0.0
 
-          if let text = content.bottomLeading.text {
-            self.bottomLeadingLabel.text = text
+          UIView.animate {
+            updates()
           }
-          self.bottomLeadingLabel.alpha = content.bottomLeading.isVisible ? 1.0 : 0.0
+        }
 
-          if let text = content.bottomCenter.text {
-            self.bottomCenterLabel.text = text
+        private static func makeLabel(
+          fontSize: CGFloat,
+          alignment: NSTextAlignment,
+          monospaced: Bool = false
+        ) -> UILabel {
+          let label = UILabel()
+          label.translatesAutoresizingMaskIntoConstraints = false
+          label.font =
+            monospaced
+            ? UIFont.monospacedDigitSystemFont(ofSize: fontSize, weight: .regular)
+            : .systemFont(ofSize: fontSize)
+          label.textAlignment = alignment
+          label.isUserInteractionEnabled = false
+          label.alpha = 0
+          return label
+        }
+      }
+    #elseif os(macOS)
+      @MainActor
+      final class AppKitOverlay {
+        private let topTitleLabel: NSTextField
+        private let topProgressLabel: NSTextField
+        private let bottomLeadingLabel: NSTextField
+        private let bottomCenterLabel: NSTextField
+        private let bottomTrailingLabel: NSTextField
+        private var currentContent = Content(
+          showingControls: false,
+          topTitle: .hidden,
+          topProgress: .hidden,
+          bottomLeading: .hidden,
+          bottomCenter: .hidden,
+          bottomTrailing: .hidden
+        )
+
+        init(
+          containerView: NSView,
+          topOffset: CGFloat,
+          bottomOffset: CGFloat,
+          theme: ReaderTheme
+        ) {
+          topTitleLabel = Self.makeLabel(fontSize: 14, alignment: .center)
+          topProgressLabel = Self.makeLabel(fontSize: 14, alignment: .center)
+          bottomLeadingLabel = Self.makeLabel(fontSize: 12, alignment: .left)
+          bottomCenterLabel = Self.makeLabel(fontSize: 12, alignment: .center, monospaced: true)
+          bottomTrailingLabel = Self.makeLabel(fontSize: 12, alignment: .right, monospaced: true)
+
+          let bottomConstant = -bottomOffset
+          [topTitleLabel, topProgressLabel, bottomLeadingLabel, bottomCenterLabel, bottomTrailingLabel]
+            .forEach(containerView.addSubview)
+
+          NSLayoutConstraint.activate([
+            topTitleLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: topOffset),
+            topTitleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            topTitleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+
+            topProgressLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: topOffset),
+            topProgressLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            topProgressLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+
+            bottomLeadingLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: bottomConstant),
+            bottomLeadingLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+
+            bottomCenterLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: bottomConstant),
+            bottomCenterLabel.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+
+            bottomTrailingLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: bottomConstant),
+            bottomTrailingLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            bottomTrailingLabel.leadingAnchor.constraint(
+              greaterThanOrEqualTo: bottomLeadingLabel.trailingAnchor, constant: 8),
+          ])
+
+          apply(theme: theme)
+        }
+
+        func apply(theme: ReaderTheme) {
+          let labelColor = (NSColor(hex: theme.textColorHex) ?? .labelColor).withAlphaComponent(0.6)
+          [topTitleLabel, topProgressLabel, bottomLeadingLabel, bottomCenterLabel, bottomTrailingLabel]
+            .forEach { $0.textColor = labelColor }
+        }
+
+        func update(content: Content, animated: Bool) {
+          guard content != currentContent else { return }
+          let isControlsTransition = currentContent.showingControls != content.showingControls
+          currentContent = content
+          let updates = {
+            self.apply(entry: content.topTitle, to: self.topTitleLabel)
+            self.apply(entry: content.topProgress, to: self.topProgressLabel)
+            self.apply(entry: content.bottomLeading, to: self.bottomLeadingLabel)
+            self.apply(entry: content.bottomCenter, to: self.bottomCenterLabel)
+            self.apply(entry: content.bottomTrailing, to: self.bottomTrailingLabel)
           }
-          self.bottomCenterLabel.alpha = content.bottomCenter.isVisible ? 1.0 : 0.0
 
-          if let text = content.bottomTrailing.text {
-            self.bottomTrailingLabel.text = text
+          guard animated, isControlsTransition else {
+            updates()
+            return
           }
-          self.bottomTrailingLabel.alpha = content.bottomTrailing.isVisible ? 1.0 : 0.0
+
+          NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.2
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            updates()
+          }
         }
 
-        guard animated else {
-          updates()
-          return
+        private func apply(entry: Entry, to label: NSTextField) {
+          if let text = entry.text {
+            label.stringValue = text
+          }
+          label.animator().alphaValue = entry.isVisible ? 1.0 : 0.0
         }
 
-        UIView.animate {
-          updates()
+        private static func makeLabel(
+          fontSize: CGFloat,
+          alignment: NSTextAlignment,
+          monospaced: Bool = false
+        ) -> NSTextField {
+          let label = NSTextField(labelWithString: "")
+          label.translatesAutoresizingMaskIntoConstraints = false
+          label.lineBreakMode = .byTruncatingTail
+          label.alignment = alignment
+          label.alphaValue = 0
+          label.font =
+            monospaced
+            ? .monospacedDigitSystemFont(ofSize: fontSize, weight: .regular)
+            : .systemFont(ofSize: fontSize)
+          return label
         }
       }
-
-      private static func makeLabel(
-        fontSize: CGFloat,
-        alignment: NSTextAlignment,
-        monospaced: Bool = false
-      ) -> UILabel {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = monospaced
-          ? UIFont.monospacedDigitSystemFont(ofSize: fontSize, weight: .regular)
-          : .systemFont(ofSize: fontSize)
-        label.textAlignment = alignment
-        label.isUserInteractionEnabled = false
-        label.alpha = 0
-        return label
-      }
-    }
-  #elseif os(macOS)
-    @MainActor
-    final class AppKitOverlay {
-      private let topTitleLabel: NSTextField
-      private let topProgressLabel: NSTextField
-      private let bottomLeadingLabel: NSTextField
-      private let bottomCenterLabel: NSTextField
-      private let bottomTrailingLabel: NSTextField
-      private var currentContent = Content(
-        showingControls: false,
-        topTitle: .hidden,
-        topProgress: .hidden,
-        bottomLeading: .hidden,
-        bottomCenter: .hidden,
-        bottomTrailing: .hidden
-      )
-
-      init(
-        containerView: NSView,
-        topOffset: CGFloat,
-        bottomOffset: CGFloat,
-        theme: ReaderTheme
-      ) {
-        topTitleLabel = Self.makeLabel(fontSize: 14, alignment: .center)
-        topProgressLabel = Self.makeLabel(fontSize: 14, alignment: .center)
-        bottomLeadingLabel = Self.makeLabel(fontSize: 12, alignment: .left)
-        bottomCenterLabel = Self.makeLabel(fontSize: 12, alignment: .center, monospaced: true)
-        bottomTrailingLabel = Self.makeLabel(fontSize: 12, alignment: .right, monospaced: true)
-
-        let bottomConstant = -bottomOffset
-        [topTitleLabel, topProgressLabel, bottomLeadingLabel, bottomCenterLabel, bottomTrailingLabel]
-          .forEach(containerView.addSubview)
-
-        NSLayoutConstraint.activate([
-          topTitleLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: topOffset),
-          topTitleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-          topTitleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
-
-          topProgressLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: topOffset),
-          topProgressLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-          topProgressLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
-
-          bottomLeadingLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: bottomConstant),
-          bottomLeadingLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-
-          bottomCenterLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: bottomConstant),
-          bottomCenterLabel.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
-
-          bottomTrailingLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: bottomConstant),
-          bottomTrailingLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
-          bottomTrailingLabel.leadingAnchor.constraint(greaterThanOrEqualTo: bottomLeadingLabel.trailingAnchor, constant: 8),
-        ])
-
-        apply(theme: theme)
-      }
-
-      func apply(theme: ReaderTheme) {
-        let labelColor = (NSColor(hex: theme.textColorHex) ?? .labelColor).withAlphaComponent(0.6)
-        [topTitleLabel, topProgressLabel, bottomLeadingLabel, bottomCenterLabel, bottomTrailingLabel]
-          .forEach { $0.textColor = labelColor }
-      }
-
-      func update(content: Content, animated: Bool) {
-        guard content != currentContent else { return }
-        let isControlsTransition = currentContent.showingControls != content.showingControls
-        currentContent = content
-        let updates = {
-          self.apply(entry: content.topTitle, to: self.topTitleLabel)
-          self.apply(entry: content.topProgress, to: self.topProgressLabel)
-          self.apply(entry: content.bottomLeading, to: self.bottomLeadingLabel)
-          self.apply(entry: content.bottomCenter, to: self.bottomCenterLabel)
-          self.apply(entry: content.bottomTrailing, to: self.bottomTrailingLabel)
-        }
-
-        guard animated, isControlsTransition else {
-          updates()
-          return
-        }
-
-        NSAnimationContext.runAnimationGroup { context in
-          context.duration = 0.2
-          context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-          updates()
-        }
-      }
-
-      private func apply(entry: Entry, to label: NSTextField) {
-        if let text = entry.text {
-          label.stringValue = text
-        }
-        label.animator().alphaValue = entry.isVisible ? 1.0 : 0.0
-      }
-
-      private static func makeLabel(
-        fontSize: CGFloat,
-        alignment: NSTextAlignment,
-        monospaced: Bool = false
-      ) -> NSTextField {
-        let label = NSTextField(labelWithString: "")
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.lineBreakMode = .byTruncatingTail
-        label.alignment = alignment
-        label.alphaValue = 0
-        label.font = monospaced
-          ? .monospacedDigitSystemFont(ofSize: fontSize, weight: .regular)
-          : .systemFont(ofSize: fontSize)
-        return label
-      }
-    }
-  #endif
+    #endif
   }
 #endif

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView_macOS.swift
@@ -271,18 +271,18 @@
       let maxOffset = max(0, contentWidth - pageWidth)
       let targetOffset = min(pageWidth * CGFloat(pageIndex), maxOffset)
       let js = """
-        (function() {
-          var left = \(Double(targetOffset));
-          if (\(animated ? "true" : "false")) {
-            window.scrollTo({ left: left, top: 0, behavior: 'smooth' });
-          } else {
-            window.scrollTo(left, 0);
-          }
-          if (document.documentElement) { document.documentElement.scrollLeft = left; }
-          if (document.body) { document.body.scrollLeft = left; }
-          return true;
-        })();
-      """
+          (function() {
+            var left = \(Double(targetOffset));
+            if (\(animated ? "true" : "false")) {
+              window.scrollTo({ left: left, top: 0, behavior: 'smooth' });
+            } else {
+              window.scrollTo(left, 0);
+            }
+            if (document.documentElement) { document.documentElement.scrollLeft = left; }
+            if (document.body) { document.body.scrollLeft = left; }
+            return true;
+          })();
+        """
       webView.evaluateJavaScript(js, completionHandler: nil)
     }
 

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
@@ -13,6 +13,7 @@
     @Bindable var viewModel: EpubReaderViewModel
     let preferences: EpubReaderPreferences
     let colorScheme: ColorScheme
+    let tapPageTransitionDuration: Double
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -42,6 +43,7 @@
         rootURL: viewModel.resourceRootURL,
         containerInsets: viewModel.containerInsetsForLabels().uiEdgeInsets,
         tapScrollPercentage: preferences.tapScrollPercentage,
+        tapPageTransitionDuration: tapPageTransitionDuration,
         theme: theme,
         contentCSS: readiumPayload.css,
         readiumProperties: readiumPayload.properties,
@@ -199,6 +201,7 @@
         rootURL: viewModel.resourceRootURL,
         containerInsets: containerInsets,
         tapScrollPercentage: preferences.tapScrollPercentage,
+        tapPageTransitionDuration: tapPageTransitionDuration,
         theme: theme,
         contentCSS: readiumPayload.css,
         readiumProperties: readiumPayload.properties,
@@ -244,6 +247,7 @@
     private var totalPagesInChapter: Int = 1
     private var containerInsets: UIEdgeInsets
     private var tapScrollPercentage: Double
+    private var tapPageTransitionDuration: TimeInterval
     private var theme: ReaderTheme
     private var contentCSS: String
     private var readiumProperties: [String: String?]
@@ -315,6 +319,7 @@
       rootURL: URL?,
       containerInsets: UIEdgeInsets,
       tapScrollPercentage: Double,
+      tapPageTransitionDuration: Double,
       theme: ReaderTheme,
       contentCSS: String,
       readiumProperties: [String: String?],
@@ -336,6 +341,7 @@
       self.rootURL = rootURL
       self.containerInsets = containerInsets
       self.tapScrollPercentage = Self.normalizedTapScrollPercentage(tapScrollPercentage)
+      self.tapPageTransitionDuration = Self.normalizedTapPageTransitionDuration(tapPageTransitionDuration)
       self.theme = theme
       self.contentCSS = contentCSS
       self.readiumProperties = readiumProperties
@@ -679,6 +685,7 @@
       rootURL: URL?,
       containerInsets: UIEdgeInsets,
       tapScrollPercentage: Double,
+      tapPageTransitionDuration: Double,
       theme: ReaderTheme,
       contentCSS: String,
       readiumProperties: [String: String?],
@@ -696,10 +703,14 @@
     ) {
       let shouldReload = chapterURL != self.chapterURL || rootURL != self.rootURL
       let normalizedTapScrollPercentage = Self.normalizedTapScrollPercentage(tapScrollPercentage)
+      let normalizedTapPageTransitionDuration = Self.normalizedTapPageTransitionDuration(
+        tapPageTransitionDuration
+      )
       let appearanceChanged =
         theme != self.theme
         || containerInsets != self.containerInsets
         || normalizedTapScrollPercentage != self.tapScrollPercentage
+        || normalizedTapPageTransitionDuration != self.tapPageTransitionDuration
         || contentCSS != self.contentCSS
         || readiumProperties != self.readiumProperties
         || publicationLanguage != self.publicationLanguage
@@ -712,6 +723,7 @@
       self.rootURL = rootURL
       self.containerInsets = containerInsets
       self.tapScrollPercentage = normalizedTapScrollPercentage
+      self.tapPageTransitionDuration = normalizedTapPageTransitionDuration
       self.theme = theme
       self.contentCSS = contentCSS
       self.readiumProperties = readiumProperties
@@ -745,6 +757,10 @@
 
     private static func normalizedTapScrollPercentage(_ value: Double) -> Double {
       min(100.0, max(25.0, value))
+    }
+
+    private static func normalizedTapPageTransitionDuration(_ value: Double) -> TimeInterval {
+      min(1.0, max(0.0, value))
     }
 
     private func loadContentIfNeeded(force: Bool) {
@@ -888,25 +904,72 @@
       let clampedOffset = max(0, targetOffset)
       lastKnownDocumentScrollTop = clampedOffset
       let offset = Double(clampedOffset)
+      let duration = animated ? tapPageTransitionDuration : 0
       let js = """
           (function() {
             var top = \(offset);
+            var duration = \(duration);
             var root = document.documentElement;
             var body = document.body;
             var scrolling = document.scrollingElement || root || body;
-            if (\(animated ? "true" : "false")) {
-              window.scrollTo({ top: top, left: 0, behavior: 'smooth' });
-            } else {
-              window.scrollTo(0, top);
+            var getCurrentTop = function() {
+              return Math.max(
+                0,
+                window.scrollY
+                || (scrolling && scrolling.scrollTop)
+                || (root && root.scrollTop)
+                || (body && body.scrollTop)
+                || 0
+              );
+            };
+            var setTop = function(value) {
+              window.scrollTo(0, value);
+              if (scrolling) { scrolling.scrollTop = value; }
+              if (root) { root.scrollTop = value; }
+              if (body) { body.scrollTop = value; }
+            };
+            var finish = function() {
+              if (window.__kmreaderPostMetrics) {
+                window.requestAnimationFrame(function() {
+                  window.__kmreaderPostMetrics('scroll');
+                });
+              }
+            };
+            if (window.__kmreaderScrollAnimationFrame) {
+              window.cancelAnimationFrame(window.__kmreaderScrollAnimationFrame);
+              window.__kmreaderScrollAnimationFrame = null;
             }
-            if (scrolling) { scrolling.scrollTop = top; }
-            if (root) { root.scrollTop = top; }
-            if (body) { body.scrollTop = top; }
-            if (window.__kmreaderPostMetrics) {
-              window.requestAnimationFrame(function() {
-                window.__kmreaderPostMetrics('scroll');
-              });
+            if (!(duration > 0)) {
+              setTop(top);
+              finish();
+              return true;
             }
+            var startTop = getCurrentTop();
+            var distance = top - startTop;
+            if (Math.abs(distance) < 0.5) {
+              setTop(top);
+              finish();
+              return true;
+            }
+            var startTime = null;
+            var easeOutCubic = function(progress) {
+              return 1 - Math.pow(1 - progress, 3);
+            };
+            var step = function(timestamp) {
+              if (startTime === null) {
+                startTime = timestamp;
+              }
+              var progress = Math.min(1, (timestamp - startTime) / (duration * 1000));
+              var eased = easeOutCubic(progress);
+              setTop(startTop + (distance * eased));
+              if (progress < 1) {
+                window.__kmreaderScrollAnimationFrame = window.requestAnimationFrame(step);
+                return;
+              }
+              window.__kmreaderScrollAnimationFrame = null;
+              finish();
+            };
+            window.__kmreaderScrollAnimationFrame = window.requestAnimationFrame(step);
             return true;
           })();
         """

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
@@ -7,6 +7,7 @@
     @Bindable var viewModel: EpubReaderViewModel
     let preferences: EpubReaderPreferences
     let colorScheme: ColorScheme
+    let tapPageTransitionDuration: Double
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -75,6 +76,7 @@
     private var lastKnownDocumentViewportHeight: CGFloat = 0
     private var chapterTitle: String?
     private var totalProgression: Double?
+    private var tapPageTransitionDuration: TimeInterval = 0.3
 
     init(parent: WebPubScrolledView) {
       self.parent = parent
@@ -114,11 +116,15 @@
       let nextChapterURL = parent.viewModel.chapterURL(at: selectedChapterIndex)
       let nextRootURL = parent.viewModel.resourceRootURL
       let shouldReload = nextChapterURL != chapterURL || nextRootURL != rootURL
+      let normalizedTapPageTransitionDuration = Self.normalizedTapPageTransitionDuration(
+        parent.tapPageTransitionDuration
+      )
       let appearanceChanged =
         contentCSS != readiumPayload.css
         || readiumProperties != readiumPayload.properties
         || publicationLanguage != parent.viewModel.publicationLanguage
         || publicationReadingProgression != parent.viewModel.publicationReadingProgression
+        || tapPageTransitionDuration != normalizedTapPageTransitionDuration
 
       chapterIndex = selectedChapterIndex
       chapterURL = nextChapterURL
@@ -128,6 +134,7 @@
       publicationLanguage = parent.viewModel.publicationLanguage
       publicationReadingProgression = parent.viewModel.publicationReadingProgression
       chapterTitle = currentLocation?.title
+      tapPageTransitionDuration = normalizedTapPageTransitionDuration
       totalProgression = currentLocation.flatMap { location in
         parent.viewModel.totalProgression(location: location, chapterProgress: nil)
       }
@@ -262,25 +269,80 @@
       let clampedOffset = max(0, targetOffset)
       lastKnownDocumentScrollTop = clampedOffset
       let offset = Double(clampedOffset)
+      let duration = tapPageTransitionDuration
       let js = """
-        (function() {
-          var top = \(offset);
-          var root = document.documentElement;
-          var body = document.body;
-          var scrolling = document.scrollingElement || root || body;
-          window.scrollTo(0, top);
-          if (scrolling) { scrolling.scrollTop = top; }
-          if (root) { root.scrollTop = top; }
-          if (body) { body.scrollTop = top; }
-          if (window.__kmreaderPostMetrics) {
-            window.requestAnimationFrame(function() {
-              window.__kmreaderPostMetrics('scroll');
-            });
-          }
-          return true;
-        })();
-      """
+          (function() {
+            var top = \(offset);
+            var duration = \(duration);
+            var root = document.documentElement;
+            var body = document.body;
+            var scrolling = document.scrollingElement || root || body;
+            var getCurrentTop = function() {
+              return Math.max(
+                0,
+                window.scrollY
+                || (scrolling && scrolling.scrollTop)
+                || (root && root.scrollTop)
+                || (body && body.scrollTop)
+                || 0
+              );
+            };
+            var setTop = function(value) {
+              window.scrollTo(0, value);
+              if (scrolling) { scrolling.scrollTop = value; }
+              if (root) { root.scrollTop = value; }
+              if (body) { body.scrollTop = value; }
+            };
+            var finish = function() {
+              if (window.__kmreaderPostMetrics) {
+                window.requestAnimationFrame(function() {
+                  window.__kmreaderPostMetrics('scroll');
+                });
+              }
+            };
+            if (window.__kmreaderScrollAnimationFrame) {
+              window.cancelAnimationFrame(window.__kmreaderScrollAnimationFrame);
+              window.__kmreaderScrollAnimationFrame = null;
+            }
+            if (!(duration > 0)) {
+              setTop(top);
+              finish();
+              return true;
+            }
+            var startTop = getCurrentTop();
+            var distance = top - startTop;
+            if (Math.abs(distance) < 0.5) {
+              setTop(top);
+              finish();
+              return true;
+            }
+            var startTime = null;
+            var easeOutCubic = function(progress) {
+              return 1 - Math.pow(1 - progress, 3);
+            };
+            var step = function(timestamp) {
+              if (startTime === null) {
+                startTime = timestamp;
+              }
+              var progress = Math.min(1, (timestamp - startTime) / (duration * 1000));
+              var eased = easeOutCubic(progress);
+              setTop(startTop + (distance * eased));
+              if (progress < 1) {
+                window.__kmreaderScrollAnimationFrame = window.requestAnimationFrame(step);
+                return;
+              }
+              window.__kmreaderScrollAnimationFrame = null;
+              finish();
+            };
+            window.__kmreaderScrollAnimationFrame = window.requestAnimationFrame(step);
+            return true;
+          })();
+        """
       webView.evaluateJavaScript(js, completionHandler: nil)
+    }
+
+    private static func normalizedTapPageTransitionDuration(_ value: Double) -> TimeInterval {
+      min(1.0, max(0.0, value))
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -388,149 +450,149 @@
 
     private func injectPaginationJS(on webView: WKWebView, targetPageIndex: Int, token: Int) {
       let js = """
-        (function() {
-          var target = \(targetPageIndex);
-          var token = \(token);
-          var hasFinalized = false;
-          var installMetricsBridge = function() {
-            window.__kmreaderCurrentToken = token;
-            if (window.__kmreaderPostMetrics) {
-              return;
-            }
-            window.__kmreaderPostMetrics = function(type) {
+          (function() {
+            var target = \(targetPageIndex);
+            var token = \(token);
+            var hasFinalized = false;
+            var installMetricsBridge = function() {
+              window.__kmreaderCurrentToken = token;
+              if (window.__kmreaderPostMetrics) {
+                return;
+              }
+              window.__kmreaderPostMetrics = function(type) {
+                var root = document.documentElement;
+                var body = document.body;
+                var scrolling = document.scrollingElement || root || body;
+                var viewportHeight =
+                  (window.visualViewport && window.visualViewport.height)
+                  || window.innerHeight
+                  || (root && root.clientHeight)
+                  || 1;
+                if (!viewportHeight || viewportHeight <= 0) { viewportHeight = 1; }
+
+                var bodyRectHeight = body ? Math.ceil(body.getBoundingClientRect().height) : 0;
+                var rootRectHeight = root ? Math.ceil(root.getBoundingClientRect().height) : 0;
+                var contentHeight = Math.max(
+                  scrolling ? (scrolling.scrollHeight || 0) : 0,
+                  root ? (root.scrollHeight || 0) : 0,
+                  body ? (body.scrollHeight || 0) : 0,
+                  bodyRectHeight,
+                  rootRectHeight,
+                  viewportHeight
+                );
+                var maxScroll = Math.max(0, contentHeight - viewportHeight);
+                var scrollTop = Math.max(
+                  0,
+                  Math.min(
+                    maxScroll,
+                    window.scrollY
+                    || (scrolling && scrolling.scrollTop)
+                    || (root && root.scrollTop)
+                    || (body && body.scrollTop)
+                    || 0
+                  )
+                );
+                var total = Math.max(1, Math.ceil(contentHeight / viewportHeight));
+                var currentPage = Math.max(
+                  0,
+                  Math.min(total - 1, Math.round(scrollTop / viewportHeight))
+                );
+
+                if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.readerBridge) {
+                  window.webkit.messageHandlers.readerBridge.postMessage({
+                    type: type,
+                    token: window.__kmreaderCurrentToken || 0,
+                    totalPages: total,
+                    currentPage: currentPage,
+                    scrollTop: scrollTop,
+                    contentHeight: contentHeight,
+                    viewportHeight: viewportHeight
+                  });
+                }
+              };
+
+              if (window.__kmreaderScrollMetricsInstalled) {
+                return;
+              }
+              window.__kmreaderScrollMetricsInstalled = true;
+              var scheduled = false;
+              var scheduleMetrics = function(type) {
+                if (scheduled) { return; }
+                scheduled = true;
+                window.requestAnimationFrame(function() {
+                  scheduled = false;
+                  window.__kmreaderPostMetrics(type || 'scroll');
+                });
+              };
+              window.addEventListener('scroll', function() {
+                scheduleMetrics('scroll');
+              }, { passive: true });
+              window.addEventListener('resize', function() {
+                scheduleMetrics('scroll');
+              });
+              if (window.visualViewport) {
+                window.visualViewport.addEventListener('resize', function() {
+                  scheduleMetrics('scroll');
+                }, { passive: true });
+              }
+            };
+
+            var finalize = function() {
+              if (hasFinalized) return;
+              hasFinalized = true;
+              installMetricsBridge();
+
               var root = document.documentElement;
               var body = document.body;
               var scrolling = document.scrollingElement || root || body;
-              var viewportHeight =
+              var pageHeight =
                 (window.visualViewport && window.visualViewport.height)
                 || window.innerHeight
-                || (root && root.clientHeight)
-                || 1;
-              if (!viewportHeight || viewportHeight <= 0) { viewportHeight = 1; }
+                || root.clientHeight;
+              if (!pageHeight || pageHeight <= 0) { pageHeight = 1; }
 
               var bodyRectHeight = body ? Math.ceil(body.getBoundingClientRect().height) : 0;
               var rootRectHeight = root ? Math.ceil(root.getBoundingClientRect().height) : 0;
-              var contentHeight = Math.max(
+              var currentHeight = Math.max(
                 scrolling ? (scrolling.scrollHeight || 0) : 0,
                 root ? (root.scrollHeight || 0) : 0,
                 body ? (body.scrollHeight || 0) : 0,
                 bodyRectHeight,
                 rootRectHeight,
-                viewportHeight
+                pageHeight
               );
-              var maxScroll = Math.max(0, contentHeight - viewportHeight);
-              var scrollTop = Math.max(
-                0,
-                Math.min(
-                  maxScroll,
-                  window.scrollY
-                  || (scrolling && scrolling.scrollTop)
-                  || (root && root.scrollTop)
-                  || (body && body.scrollTop)
-                  || 0
-                )
-              );
-              var total = Math.max(1, Math.ceil(contentHeight / viewportHeight));
-              var currentPage = Math.max(
-                0,
-                Math.min(total - 1, Math.round(scrollTop / viewportHeight))
-              );
+              var total = Math.max(1, Math.ceil(currentHeight / pageHeight));
+              var maxScroll = Math.max(0, currentHeight - pageHeight);
+              var finalTarget = Math.max(0, Math.min(total - 1, target));
+              var offset = Math.min(pageHeight * finalTarget, maxScroll);
 
-              if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.readerBridge) {
-                window.webkit.messageHandlers.readerBridge.postMessage({
-                  type: type,
-                  token: window.__kmreaderCurrentToken || 0,
-                  totalPages: total,
-                  currentPage: currentPage,
-                  scrollTop: scrollTop,
-                  contentHeight: contentHeight,
-                  viewportHeight: viewportHeight
-                });
-              }
+              window.scrollTo(0, offset);
+              if (document.documentElement) { document.documentElement.scrollTop = offset; }
+              if (document.body) { document.body.scrollTop = offset; }
+
+              setTimeout(function() {
+                if (window.__kmreaderPostMetrics) {
+                  window.__kmreaderPostMetrics('ready');
+                }
+              }, 60);
             };
 
-            if (window.__kmreaderScrollMetricsInstalled) {
-              return;
-            }
-            window.__kmreaderScrollMetricsInstalled = true;
-            var scheduled = false;
-            var scheduleMetrics = function(type) {
-              if (scheduled) { return; }
-              scheduled = true;
+            var timeout = setTimeout(finalize, 5000);
+            var start = function() {
+              clearTimeout(timeout);
               window.requestAnimationFrame(function() {
-                scheduled = false;
-                window.__kmreaderPostMetrics(type || 'scroll');
+                window.requestAnimationFrame(finalize);
               });
             };
-            window.addEventListener('scroll', function() {
-              scheduleMetrics('scroll');
-            }, { passive: true });
-            window.addEventListener('resize', function() {
-              scheduleMetrics('scroll');
-            });
-            if (window.visualViewport) {
-              window.visualViewport.addEventListener('resize', function() {
-                scheduleMetrics('scroll');
-              }, { passive: true });
+
+            if (document.readyState === 'complete') {
+              start();
+            } else {
+              window.addEventListener('load', start, { once: true });
+              document.addEventListener('DOMContentLoaded', start, { once: true });
             }
-          };
-
-          var finalize = function() {
-            if (hasFinalized) return;
-            hasFinalized = true;
-            installMetricsBridge();
-
-            var root = document.documentElement;
-            var body = document.body;
-            var scrolling = document.scrollingElement || root || body;
-            var pageHeight =
-              (window.visualViewport && window.visualViewport.height)
-              || window.innerHeight
-              || root.clientHeight;
-            if (!pageHeight || pageHeight <= 0) { pageHeight = 1; }
-
-            var bodyRectHeight = body ? Math.ceil(body.getBoundingClientRect().height) : 0;
-            var rootRectHeight = root ? Math.ceil(root.getBoundingClientRect().height) : 0;
-            var currentHeight = Math.max(
-              scrolling ? (scrolling.scrollHeight || 0) : 0,
-              root ? (root.scrollHeight || 0) : 0,
-              body ? (body.scrollHeight || 0) : 0,
-              bodyRectHeight,
-              rootRectHeight,
-              pageHeight
-            );
-            var total = Math.max(1, Math.ceil(currentHeight / pageHeight));
-            var maxScroll = Math.max(0, currentHeight - pageHeight);
-            var finalTarget = Math.max(0, Math.min(total - 1, target));
-            var offset = Math.min(pageHeight * finalTarget, maxScroll);
-
-            window.scrollTo(0, offset);
-            if (document.documentElement) { document.documentElement.scrollTop = offset; }
-            if (document.body) { document.body.scrollTop = offset; }
-
-            setTimeout(function() {
-              if (window.__kmreaderPostMetrics) {
-                window.__kmreaderPostMetrics('ready');
-              }
-            }, 60);
-          };
-
-          var timeout = setTimeout(finalize, 5000);
-          var start = function() {
-            clearTimeout(timeout);
-            window.requestAnimationFrame(function() {
-              window.requestAnimationFrame(finalize);
-            });
-          };
-
-          if (document.readyState === 'complete') {
-            start();
-          } else {
-            window.addEventListener('load', start, { once: true });
-            document.addEventListener('DOMContentLoaded', start, { once: true });
-          }
-        })();
-      """
+          })();
+        """
 
       webView.evaluateJavaScript(js, completionHandler: nil)
     }
@@ -556,75 +618,76 @@
         properties[key] = value ?? NSNull()
       }
       let propertiesJSON = WebPubJavaScriptSupport.encodeJSON(properties, fallback: "{}")
-      let propertyKeysJSON = WebPubJavaScriptSupport.encodeJSON(EpubReaderPreferences.readiumPropertyKeys, fallback: "[]")
+      let propertyKeysJSON = WebPubJavaScriptSupport.encodeJSON(
+        EpubReaderPreferences.readiumPropertyKeys, fallback: "[]")
       let languageJSON = WebPubJavaScriptSupport.escapedJSONString(publicationLanguage)
 
       let js = """
-        (function() {
-          var root = document.documentElement;
-          var lang = \(languageJSON);
-          if (lang) {
-            if (!root.hasAttribute('lang')) {
-              root.setAttribute('lang', lang);
-            }
-            if (!root.hasAttribute('xml:lang')) {
-              root.setAttribute('xml:lang', lang);
-            }
-            if (document.body) {
-              if (!document.body.hasAttribute('lang')) {
-                document.body.setAttribute('lang', lang);
+          (function() {
+            var root = document.documentElement;
+            var lang = \(languageJSON);
+            if (lang) {
+              if (!root.hasAttribute('lang')) {
+                root.setAttribute('lang', lang);
               }
-              if (!document.body.hasAttribute('xml:lang')) {
-                document.body.setAttribute('xml:lang', lang);
+              if (!root.hasAttribute('xml:lang')) {
+                root.setAttribute('xml:lang', lang);
+              }
+              if (document.body) {
+                if (!document.body.hasAttribute('lang')) {
+                  document.body.setAttribute('lang', lang);
+                }
+                if (!document.body.hasAttribute('xml:lang')) {
+                  document.body.setAttribute('xml:lang', lang);
+                }
               }
             }
-          }
-          if (\(shouldSetDir ? "true" : "false")) {
-            root.setAttribute('dir', 'rtl');
-            if (document.body) {
-              document.body.setAttribute('dir', 'rtl');
+            if (\(shouldSetDir ? "true" : "false")) {
+              root.setAttribute('dir', 'rtl');
+              if (document.body) {
+                document.body.setAttribute('dir', 'rtl');
+              }
             }
-          }
 
-          var props = \(propertiesJSON);
-          Object.keys(props).forEach(function(key) {
-            var value = props[key];
-            if (value === null || value === undefined) {
-              root.style.removeProperty(key);
-            } else {
-              root.style.setProperty(key, value, 'important');
+            var props = \(propertiesJSON);
+            Object.keys(props).forEach(function(key) {
+              var value = props[key];
+              if (value === null || value === undefined) {
+                root.style.removeProperty(key);
+              } else {
+                root.style.setProperty(key, value, 'important');
+              }
+            });
+            var knownKeys = \(propertyKeysJSON);
+            knownKeys.forEach(function(key) {
+              if (!(key in props)) {
+                root.style.removeProperty(key);
+              }
+            });
+
+            var meta = document.querySelector('meta[name=viewport]');
+            if (!meta) {
+              meta = document.createElement('meta');
+              meta.name = 'viewport';
+              document.head.appendChild(meta);
             }
-          });
-          var knownKeys = \(propertyKeysJSON);
-          knownKeys.forEach(function(key) {
-            if (!(key in props)) {
-              root.style.removeProperty(key);
+            meta.setAttribute('content', 'width=device-width, initial-scale=1.0');
+
+            var style = document.getElementById('kmreader-style');
+            if (!style) {
+              style = document.createElement('style');
+              style.id = 'kmreader-style';
+              document.head.appendChild(style);
             }
-          });
-
-          var meta = document.querySelector('meta[name=viewport]');
-          if (!meta) {
-            meta = document.createElement('meta');
-            meta.name = 'viewport';
-            document.head.appendChild(meta);
-          }
-          meta.setAttribute('content', 'width=device-width, initial-scale=1.0');
-
-          var style = document.getElementById('kmreader-style');
-          if (!style) {
-            style = document.createElement('style');
-            style.id = 'kmreader-style';
-            document.head.appendChild(style);
-          }
-          var hasStyles = document.querySelector("link[rel~='stylesheet'], style:not(#kmreader-style)") !== null;
-          var css = atob('\(readiumBefore)') + "\\n"
-            + (hasStyles ? "" : atob('\(readiumDefault)') + "\\n")
-            + atob('\(readiumAfter)') + "\\n"
-            + atob('\(customCSS)');
-          style.textContent = css;
-          return true;
-        })();
-      """
+            var hasStyles = document.querySelector("link[rel~='stylesheet'], style:not(#kmreader-style)") !== null;
+            var css = atob('\(readiumBefore)') + "\\n"
+              + (hasStyles ? "" : atob('\(readiumDefault)') + "\\n")
+              + atob('\(readiumAfter)') + "\\n"
+              + atob('\(customCSS)');
+            style.textContent = css;
+            return true;
+          })();
+        """
 
       webView.evaluateJavaScript(js) { _, _ in
         completion?()

--- a/KMReader/Features/Settings/SettingsView_macOS.swift
+++ b/KMReader/Features/Settings/SettingsView_macOS.swift
@@ -42,7 +42,7 @@ import SwiftUI
       } detail: {
         if let selectedSection {
           detailContent(for: selectedSection)
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
           Text("Select a setting")
             .foregroundColor(.secondary)


### PR DESCRIPTION
## Problem
The EPUB scrolled reader no longer showed a visible scroll animation when tap navigation advanced or rewound the document. The tap path requested smooth scrolling, but then immediately forced the final scroll position, so the transition looked like an instant jump.

## Approach
Use an explicit frame-driven scroll animation for scrolled EPUB navigation on both iOS and macOS, and wire it to the existing tap page transition duration setting so tap-driven movement behaves consistently with the rest of the reader.

## Scope
- Pass tap transition duration into the scrolled EPUB reader implementations
- Replace the immediate `scrollTop` override with cancellable animated scrolling logic
- Include the formatter changes produced in the touched EPUB and settings files

## Validation
- [x] `make format`
- [x] `make build-ios`
- [x] `make build-macos`
