### PR TITLE
fix: avoid blank epub settings preview on first advanced layout open

### DIFF
--- a/KMReader/Features/Reader/Views/Sheets/EpubSettingsPreviewView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubSettingsPreviewView.swift
@@ -301,8 +301,12 @@
           })();
           """
 
-        webView.evaluateJavaScript(js) { [weak self] _, _ in
-          self?.lastAppliedPayload = payload
+        webView.evaluateJavaScript(js) { [weak self] result, error in
+          guard let self else { return }
+          let didApply = (result as? Bool) == true && error == nil
+          if didApply {
+            self.lastAppliedPayload = payload
+          }
         }
       }
 


### PR DESCRIPTION
## Problem
Opening Advanced Layout in the EPUB settings sheet could leave the preview blank on the first expansion. The preview only recovered after another setting change triggered a new payload update.

## Approach
Keep the preview coordinator state honest by marking a payload as applied only after the WebView JavaScript update succeeds. This avoids caching a failed injection as if it had rendered successfully.

## Scope
- Update EPUB settings preview payload application logic in the sheet WebView coordinator
- Preserve the existing preview architecture and avoid adding extra retry state machinery

## Validation
- [x] `make build-ios`
- [ ] Manual check: first Advanced Layout expansion keeps the preview visible
