### PR TITLE
fix: stabilize webtoon page measurement

### DIFF
--- a/KMReader/Features/Reader/Views/Helpers/WebtoonConstants.swift
+++ b/KMReader/Features/Reader/Views/Helpers/WebtoonConstants.swift
@@ -12,6 +12,7 @@ enum WebtoonConstants {
   static let layoutReadyDelay: TimeInterval = 0.2
   static let bottomThreshold: CGFloat = 60
   static let footerHeight: CGFloat = 480
+  static let measuringPlaceholderHeight: CGFloat = 120
   static let scrollAnimationDuration: TimeInterval = 0.3
   static let clickDebounceAfterScroll: TimeInterval = 0.25
   static let preheatRadius: Int = 2

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonHelpers.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonHelpers.swift
@@ -5,6 +5,13 @@
 
 import CoreGraphics
 import Foundation
+import ImageIO
+
+#if os(iOS) || os(tvOS)
+  import UIKit
+#elseif os(macOS)
+  import AppKit
+#endif
 
 @MainActor
 func scheduleOnMain(after delay: TimeInterval, action: @escaping () -> Void) {
@@ -56,6 +63,10 @@ struct WebtoonPageHeightCache {
     lastPageWidth = newWidth
   }
 
+  func hasHeight(for pageID: ReaderPageID) -> Bool {
+    heights[pageID] != nil
+  }
+
   mutating func height(
     for pageID: ReaderPageID,
     page: BookPage,
@@ -73,6 +84,74 @@ struct WebtoonPageHeightCache {
         return targetHeight
       }
     }
-    return pageWidth * 3
+    return max(pageWidth, 1)
   }
+
+  mutating func updateHeight(
+    for pageID: ReaderPageID,
+    pixelSize: CGSize,
+    pageWidth: CGFloat
+  ) -> Bool {
+    guard let targetHeight = webtoonMeasuredHeight(pixelSize: pixelSize, pageWidth: pageWidth) else {
+      return false
+    }
+
+    if let cachedHeight = heights[pageID], abs(cachedHeight - targetHeight) < 0.5 {
+      return false
+    }
+
+    heights[pageID] = targetHeight
+    return true
+  }
+}
+
+func webtoonMeasuredHeight(pixelSize: CGSize, pageWidth: CGFloat) -> CGFloat? {
+  guard pageWidth > 0, pixelSize.width > 0, pixelSize.height > 0 else { return nil }
+  let ratio = pixelSize.height / pixelSize.width
+  guard ratio.isFinite, ratio > 0 else { return nil }
+  let targetHeight = pageWidth * ratio
+  guard targetHeight.isFinite, targetHeight > 0 else { return nil }
+  return targetHeight
+}
+
+func webtoonProbePixelSize(at fileURL: URL) -> CGSize? {
+  let options = [kCGImageSourceShouldCache: false] as CFDictionary
+  guard
+    let source = CGImageSourceCreateWithURL(fileURL as CFURL, options),
+    let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+    let pixelWidth = properties[kCGImagePropertyPixelWidth] as? CGFloat,
+    let pixelHeight = properties[kCGImagePropertyPixelHeight] as? CGFloat,
+    pixelWidth > 0,
+    pixelHeight > 0
+  else {
+    return nil
+  }
+
+  return CGSize(width: pixelWidth, height: pixelHeight)
+}
+
+func webtoonPixelSize(from image: PlatformImage) -> CGSize? {
+  #if os(iOS) || os(tvOS)
+    if let cgImage = image.cgImage {
+      return CGSize(width: cgImage.width, height: cgImage.height)
+    }
+    if let ciImage = image.ciImage {
+      let extent = ciImage.extent.integral
+      if extent.width > 0, extent.height > 0 {
+        return CGSize(width: extent.width, height: extent.height)
+      }
+    }
+    let size = image.size
+    let scale = image.scale
+    guard size.width > 0, size.height > 0, scale > 0 else { return nil }
+    return CGSize(width: size.width * scale, height: size.height * scale)
+  #elseif os(macOS)
+    for representation in image.representations where representation.pixelsWide > 0 && representation.pixelsHigh > 0 {
+      return CGSize(width: representation.pixelsWide, height: representation.pixelsHigh)
+    }
+
+    let size = image.size
+    guard size.width > 0, size.height > 0 else { return nil }
+    return size
+  #endif
 }

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -139,6 +139,8 @@
       private var singleTapWorkItem: DispatchWorkItem?
       private var deferredReloadWorkItem: DispatchWorkItem?
       private var deferredCleanupWorkItem: DispatchWorkItem?
+      private var sizeProbeTasks: [ReaderPageID: Task<Void, Never>] = [:]
+      private var pendingMeasuredPageIDs: Set<ReaderPageID> = []
 
       var heightCache = WebtoonPageHeightCache()
 
@@ -187,6 +189,77 @@
       private func indexPath(forPageID pageID: ReaderPageID?) -> IndexPath? {
         guard let itemIndex = itemIndex(forPageID: pageID) else { return nil }
         return IndexPath(item: itemIndex, section: 0)
+      }
+
+      private func hasKnownHeight(for pageID: ReaderPageID, page: BookPage?) -> Bool {
+        if heightCache.hasHeight(for: pageID) {
+          return true
+        }
+
+        guard let page else { return false }
+        return (page.width ?? 0) > 0 && (page.height ?? 0) > 0
+      }
+
+      private func applyMeasuredHeightIfNeeded(for pageID: ReaderPageID, pixelSize: CGSize) {
+        guard heightCache.updateHeight(for: pageID, pixelSize: pixelSize, pageWidth: pageWidth) else {
+          return
+        }
+        if isScrollInteractionActive {
+          pendingMeasuredPageIDs.insert(pageID)
+        } else {
+          invalidateLayout(for: pageID)
+        }
+      }
+
+      private func invalidateLayout(for pageID: ReaderPageID) {
+        guard let collectionView, let indexPath = indexPath(forPageID: pageID) else { return }
+
+        UIView.performWithoutAnimation {
+          collectionView.performBatchUpdates({
+            collectionView.reloadItems(at: [indexPath])
+          }, completion: nil)
+        }
+      }
+
+      private func applyPendingMeasuredLayoutUpdatesIfNeeded() {
+        guard !pendingMeasuredPageIDs.isEmpty else { return }
+        guard let collectionView else { return }
+
+        let indexPaths = pendingMeasuredPageIDs.compactMap { indexPath(forPageID: $0) }
+        pendingMeasuredPageIDs.removeAll()
+        guard !indexPaths.isEmpty else { return }
+
+        UIView.performWithoutAnimation {
+          collectionView.performBatchUpdates({
+            collectionView.reloadItems(at: indexPaths)
+          }, completion: nil)
+        }
+      }
+
+      private func ensureMeasuredHeightProbe(for pageID: ReaderPageID, page: BookPage?) {
+        guard !hasKnownHeight(for: pageID, page: page) else { return }
+        guard sizeProbeTasks[pageID] == nil else { return }
+        guard let viewModel else { return }
+
+        sizeProbeTasks[pageID] = Task { @MainActor [weak self, weak viewModel] in
+          defer { self?.sizeProbeTasks[pageID] = nil }
+          guard let self, let viewModel else { return }
+          guard let fileURL = await viewModel.getPageImageFileURL(pageID: pageID) else { return }
+          guard let pixelSize = webtoonProbePixelSize(at: fileURL) else { return }
+          self.applyMeasuredHeightIfNeeded(for: pageID, pixelSize: pixelSize)
+        }
+      }
+
+      private func displayImageIfReady(
+        _ image: PlatformImage?,
+        for pageID: ReaderPageID,
+        page: BookPage?
+      ) -> PlatformImage? {
+        guard let image else { return nil }
+        if let pixelSize = webtoonPixelSize(from: image) {
+          _ = heightCache.updateHeight(for: pageID, pixelSize: pixelSize, pageWidth: pageWidth)
+        }
+        return hasKnownHeight(for: pageID, page: page) ? image : nil
       }
 
       func scheduleInitialScroll() {
@@ -334,6 +407,9 @@
         let pageCount = self.pageCount
         if lastPagesCount != pageCount {
           heightCache.reset()
+          sizeProbeTasks.values.forEach { $0.cancel() }
+          sizeProbeTasks.removeAll()
+          pendingMeasuredPageIDs.removeAll()
         }
         lastPagesCount = pageCount
 
@@ -443,6 +519,9 @@
         singleTapWorkItem?.cancel()
         singleTapWorkItem = nil
         cancelDeferredMaintenance()
+        sizeProbeTasks.values.forEach { $0.cancel() }
+        sizeProbeTasks.removeAll()
+        pendingMeasuredPageIDs.removeAll()
       }
 
       private func scheduleDeferredPendingReloadIfNeeded() {
@@ -567,6 +646,9 @@
           )
           return cell
         case .page(let pageID):
+          let page = viewModel?.page(for: pageID)
+          ensureMeasuredHeightProbe(for: pageID, page: page)
+
           let item = collectionView.dequeueReusableCell(
             withReuseIdentifier: "WebtoonPageCell",
             for: indexPath
@@ -577,12 +659,16 @@
           }
           cell.readerBackground = readerBackground
 
-          let preloadedImage = viewModel?.preloadedImage(for: pageID)
+          let displayImage = displayImageIfReady(
+            viewModel?.preloadedImage(for: pageID),
+            for: pageID,
+            page: page
+          )
           let pageLabel =
             viewModel?.displayPageNumber(for: pageID).map(String.init)
             ?? String(pageID.pageNumber)
 
-          if preloadedImage == nil {
+          if displayImage == nil, hasKnownHeight(for: pageID, page: page) {
             Task { @MainActor [weak self] in
               guard let self = self else { return }
               await self.loadImage(for: pageID)
@@ -591,7 +677,7 @@
 
           cell.configure(
             pageLabel: pageLabel,
-            image: preloadedImage,
+            image: displayImage,
             showPageNumber: showPageNumber
           )
 
@@ -614,7 +700,15 @@
           return CGSize(width: pageWidth, height: WebtoonConstants.footerHeight)
         case .page(let pageID):
           guard let page = viewModel?.page(for: pageID) else {
-            return CGSize(width: pageWidth, height: pageWidth * 3)
+            return CGSize(width: pageWidth, height: WebtoonConstants.measuringPlaceholderHeight)
+          }
+          if let preloadedImage = viewModel?.preloadedImage(for: pageID),
+            let pixelSize = webtoonPixelSize(from: preloadedImage)
+          {
+            _ = heightCache.updateHeight(for: pageID, pixelSize: pixelSize, pageWidth: pageWidth)
+          }
+          if !hasKnownHeight(for: pageID, page: page) {
+            return CGSize(width: pageWidth, height: WebtoonConstants.measuringPlaceholderHeight)
           }
           let height = heightCache.height(for: pageID, page: page, pageWidth: pageWidth)
           let scale = collectionView.traitCollection.displayScale
@@ -654,6 +748,7 @@
 
       private func finalizeScrollInteraction() {
         isUserScrolling = false
+        applyPendingMeasuredLayoutUpdatesIfNeeded()
         updateCurrentPage()
         scheduleDeferredPendingReloadIfNeeded()
         scheduleDeferredCleanupIfNeeded()
@@ -702,12 +797,26 @@
         }
 
         if let preloadedImage = viewModel.preloadedImage(for: pageID) {
-          pageCell(for: pageID)?.setImage(preloadedImage)
+          if let pixelSize = webtoonPixelSize(from: preloadedImage) {
+            applyMeasuredHeightIfNeeded(for: pageID, pixelSize: pixelSize)
+          }
+          if let page = viewModel.page(for: pageID),
+            hasKnownHeight(for: pageID, page: page)
+          {
+            pageCell(for: pageID)?.setImage(preloadedImage)
+          }
           return
         }
 
         if let image = await viewModel.preloadImage(for: pageID) {
-          pageCell(for: pageID)?.setImage(image)
+          if let pixelSize = webtoonPixelSize(from: image) {
+            applyMeasuredHeightIfNeeded(for: pageID, pixelSize: pixelSize)
+          }
+          if let page = viewModel.page(for: pageID),
+            hasKnownHeight(for: pageID, page: page)
+          {
+            pageCell(for: pageID)?.setImage(image)
+          }
         } else {
           showImageError(for: pageID)
         }

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
@@ -147,6 +147,8 @@
       var hasTriggeredZoomGesture: Bool = false
       private var deferredReloadWorkItem: DispatchWorkItem?
       private var deferredCleanupWorkItem: DispatchWorkItem?
+      private var sizeProbeTasks: [ReaderPageID: Task<Void, Never>] = [:]
+      private var pendingMeasuredPageIDs: Set<ReaderPageID> = []
 
       init(_ parent: WebtoonReaderView) {
         self.scrollEngine = WebtoonScrollEngine(
@@ -178,6 +180,9 @@
 
       func teardown() {
         cancelDeferredMaintenance()
+        sizeProbeTasks.values.forEach { $0.cancel() }
+        sizeProbeTasks.removeAll()
+        pendingMeasuredPageIDs.removeAll()
         NotificationCenter.default.removeObserver(self)
         if let monitor = keyMonitor {
           NSEvent.removeMonitor(monitor)
@@ -210,6 +215,79 @@
 
       private func itemIndex(forPageID pageID: ReaderPageID?) -> Int? {
         scrollEngine.itemIndex(forPageID: pageID)
+      }
+
+      private func indexPath(forPageID pageID: ReaderPageID?) -> IndexPath? {
+        guard let itemIndex = itemIndex(forPageID: pageID) else { return nil }
+        return IndexPath(item: itemIndex, section: 0)
+      }
+
+      private func hasKnownHeight(for pageID: ReaderPageID, page: BookPage?) -> Bool {
+        if heightCache.hasHeight(for: pageID) {
+          return true
+        }
+
+        guard let page else { return false }
+        return (page.width ?? 0) > 0 && (page.height ?? 0) > 0
+      }
+
+      private func applyMeasuredHeightIfNeeded(for pageID: ReaderPageID, pixelSize: CGSize) {
+        guard heightCache.updateHeight(for: pageID, pixelSize: pixelSize, pageWidth: pageWidth) else {
+          return
+        }
+        if isScrollInteractionActive {
+          pendingMeasuredPageIDs.insert(pageID)
+        } else {
+          invalidateLayout(for: pageID)
+        }
+      }
+
+      private func invalidateLayout(for pageID: ReaderPageID) {
+        guard let collectionView, let indexPath = indexPath(forPageID: pageID) else { return }
+        NSAnimationContext.runAnimationGroup { context in
+          context.duration = 0
+          collectionView.reloadItems(at: Set([indexPath]))
+        }
+      }
+
+      private func applyPendingMeasuredLayoutUpdatesIfNeeded() {
+        guard !pendingMeasuredPageIDs.isEmpty else { return }
+        guard let collectionView else { return }
+
+        let indexPaths = pendingMeasuredPageIDs.compactMap { indexPath(forPageID: $0) }
+        pendingMeasuredPageIDs.removeAll()
+        guard !indexPaths.isEmpty else { return }
+
+        NSAnimationContext.runAnimationGroup { context in
+          context.duration = 0
+          collectionView.reloadItems(at: Set(indexPaths))
+        }
+      }
+
+      private func ensureMeasuredHeightProbe(for pageID: ReaderPageID, page: BookPage?) {
+        guard !hasKnownHeight(for: pageID, page: page) else { return }
+        guard sizeProbeTasks[pageID] == nil else { return }
+        guard let viewModel else { return }
+
+        sizeProbeTasks[pageID] = Task { @MainActor [weak self, weak viewModel] in
+          defer { self?.sizeProbeTasks[pageID] = nil }
+          guard let self, let viewModel else { return }
+          guard let fileURL = await viewModel.getPageImageFileURL(pageID: pageID) else { return }
+          guard let pixelSize = webtoonProbePixelSize(at: fileURL) else { return }
+          self.applyMeasuredHeightIfNeeded(for: pageID, pixelSize: pixelSize)
+        }
+      }
+
+      private func displayImageIfReady(
+        _ image: PlatformImage?,
+        for pageID: ReaderPageID,
+        page: BookPage?
+      ) -> PlatformImage? {
+        guard let image else { return nil }
+        if let pixelSize = webtoonPixelSize(from: image) {
+          _ = heightCache.updateHeight(for: pageID, pixelSize: pixelSize, pageWidth: pageWidth)
+        }
+        return hasKnownHeight(for: pageID, page: page) ? image : nil
       }
 
       func scheduleInitialScroll() {
@@ -336,6 +414,9 @@
         let pageCount = self.pageCount
         if lastPagesCount != pageCount {
           heightCache.reset()
+          sizeProbeTasks.values.forEach { $0.cancel() }
+          sizeProbeTasks.removeAll()
+          pendingMeasuredPageIDs.removeAll()
         }
         lastPagesCount = pageCount
 
@@ -464,12 +545,14 @@
 
       private func finalizeProgrammaticScroll() {
         isProgrammaticScrolling = false
+        applyPendingMeasuredLayoutUpdatesIfNeeded()
         scheduleDeferredPendingReloadIfNeeded()
         scheduleDeferredCleanupIfNeeded()
       }
 
       private func finalizeScrollInteraction() {
         isUserScrolling = false
+        applyPendingMeasuredLayoutUpdatesIfNeeded()
         updateCurrentPage()
         scheduleDeferredPendingReloadIfNeeded()
         scheduleDeferredCleanupIfNeeded()
@@ -557,6 +640,9 @@
           )
           return cell
         case .page(let pageID):
+          let page = viewModel?.page(for: pageID)
+          ensureMeasuredHeightProbe(for: pageID, page: page)
+
           let item = collectionView.makeItem(
             withIdentifier: NSUserInterfaceItemIdentifier("WebtoonPageCell"),
             for: indexPath
@@ -566,18 +652,22 @@
             return item
           }
           cell.readerBackground = readerBackground
-          let preloadedImage = viewModel?.preloadedImage(for: pageID)
+          let displayImage = displayImageIfReady(
+            viewModel?.preloadedImage(for: pageID),
+            for: pageID,
+            page: page
+          )
           let pageLabel =
             viewModel?.displayPageNumber(for: pageID).map(String.init)
             ?? String(pageID.pageNumber)
 
           cell.configure(
             pageLabel: pageLabel,
-            image: preloadedImage,
+            image: displayImage,
             showPageNumber: showPageNumber
           )
 
-          if preloadedImage == nil {
+          if displayImage == nil, hasKnownHeight(for: pageID, page: page) {
             Task { @MainActor [weak self] in
               await self?.loadImage(for: pageID)
             }
@@ -600,7 +690,15 @@
           return NSSize(width: pageWidth, height: WebtoonConstants.footerHeight)
         case .page(let pageID):
           guard let page = viewModel?.page(for: pageID) else {
-            return NSSize(width: pageWidth, height: pageWidth * 3)
+            return NSSize(width: pageWidth, height: WebtoonConstants.measuringPlaceholderHeight)
+          }
+          if let preloadedImage = viewModel?.preloadedImage(for: pageID),
+            let pixelSize = webtoonPixelSize(from: preloadedImage)
+          {
+            _ = heightCache.updateHeight(for: pageID, pixelSize: pixelSize, pageWidth: pageWidth)
+          }
+          if !hasKnownHeight(for: pageID, page: page) {
+            return NSSize(width: pageWidth, height: WebtoonConstants.measuringPlaceholderHeight)
           }
           let height = heightCache.height(for: pageID, page: page, pageWidth: pageWidth)
           let scale = collectionView.window?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 1.0
@@ -667,12 +765,26 @@
         guard let vm = viewModel else { return }
 
         if let preloadedImage = vm.preloadedImage(for: pageID) {
-          pageCell(for: pageID)?.setImage(preloadedImage)
+          if let pixelSize = webtoonPixelSize(from: preloadedImage) {
+            applyMeasuredHeightIfNeeded(for: pageID, pixelSize: pixelSize)
+          }
+          if let page = vm.page(for: pageID),
+            hasKnownHeight(for: pageID, page: page)
+          {
+            pageCell(for: pageID)?.setImage(preloadedImage)
+          }
           return
         }
 
         if let image = await vm.preloadImage(for: pageID) {
-          pageCell(for: pageID)?.setImage(image)
+          if let pixelSize = webtoonPixelSize(from: image) {
+            applyMeasuredHeightIfNeeded(for: pageID, pixelSize: pixelSize)
+          }
+          if let page = vm.page(for: pageID),
+            hasKnownHeight(for: pageID, page: page)
+          {
+            pageCell(for: pageID)?.setImage(image)
+          }
         }
       }
 


### PR DESCRIPTION
## Problem
Webtoon pages without metadata dimensions could either render with an incorrect guessed height or require on-the-fly layout changes while the user was actively scrolling. That produced distorted rendering in the missing-metadata case and visible stutter during manual swipe scrolling.

## Approach
Treat missing page dimensions as a measurement state instead of a renderable state. Webtoon now probes image metadata to obtain real pixel sizes, only displays page content once a valid size is known, and caches the resulting heights. When new measurements arrive during scrolling, layout updates are deferred until the scroll interaction finishes so drag gestures are not interrupted by item reloads.

## Scope
- Add shared helpers to probe image pixel sizes and update cached webtoon page heights
- Gate webtoon page rendering on known dimensions for both iOS and macOS
- Batch deferred layout refreshes after scroll completion to reduce scroll jank

## Validation
- [x] `make build-macos`
- [x] `make build-ios`
