### PR TITLE
docs: refresh product docs and changelog

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,15 +1,13 @@
 Reader Improvements
-- EPUB on macOS now feels much closer to the iOS experience, with better settings, preview behavior, overlays, and keyboard shortcuts.
-- EPUB reading has been improved across the app with better pagination, typography controls, dark theme behavior, link colors, and image rendering.
-- Reader navigation is more reliable, including smoother DIVINA scrolling, better page position restoration, and more accurate next and previous book handling.
-- Live Text interactions in the reader are more precise, reducing accidental page turns or missed control toggles.
+- EPUB adds richer reading controls, including text alignment, more consistent font-weight behavior, better overlay options, and improved progress display on iPhone, iPad, and Mac.
+- macOS EPUB paged reading now supports cover-style page turns, bringing it closer to the native feel available elsewhere in KMReader.
+- Reader navigation is steadier across DIVINA, EPUB, and Webtoon, with better position recovery after rotation, reloads, and end-of-chapter preloading.
+- Live Text interactions are more precise, reducing accidental page turns near text selection.
 
-Browsing and Library Updates
-- Added a faster single-library picker mode for quicker filtering, including easier access on Apple TV.
-- Book, series, and one-shot detail pages now support native share actions.
-- Detail pages are easier to scan with collapsible metadata and link sections, plus clearer combined tag display.
+Offline and Sync
+- Offline EPUB handling is more reliable, with safer download finalization and better recovery when reopening downloaded books.
+- Reading history now syncs automatically on app launch and resume, so recent activity stays current with less manual refresh.
 
-Polish and Fixes
-- Improved reader overlay animations and control behavior, especially for EPUB on iPhone, iPad, and Mac.
-- Fixed several iPad layout issues related to closing the reader and restoring the main interface correctly.
-- Refined end-of-book screens and close button styling for a cleaner, more consistent finish across platforms.
+Polish and Quality
+- Reader and download Live Activities are cleaner and easier to read, especially in Dynamic Island.
+- Completed books now show more useful last-read details, and several reader overlays and picker views have been refined for a more consistent experience.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -6,14 +6,14 @@ IMPORTANT FEATURES
 
 - Native readers for every format
 DIVINA on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl (iOS), cover-style transitions on all platforms, optional page shadows, clearer page-turn animation controls, and steadier scroll reading with better RTL and wide-page handling.
-EPUB on iOS and macOS with paged, scrolled, or cover layouts, custom fonts, themes, and per-book preferences.
+EPUB on iOS and macOS with paged, scrolled, or cover layouts, custom fonts, themes, text alignment and font-weight controls, and configurable overlay/footer visibility.
 Animated GIF and WebP pages start immediately, stay smooth while you zoom or scroll, and remain reliable when you revisit pages.
 PDF on iOS and macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality, and clearer offline preparation progress.
 Incognito mode, optional reader Live Activities with progress or incognito status, and iOS Live Text support let you read your way.
 
 - Dashboard, discovery, and shortcuts
 Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists keep important items close.
-Browse Series, Books, Collections, and Read Lists with advanced metadata filters, saved filters, and optional unread-cover blur.
+Browse Series, Books, Collections, and Read Lists with advanced metadata filters, saved filters, optional unread-cover blur, and automatically synced reading history.
 Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions, help you jump back into reading faster.
 KMReader UI is localized in English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ### Native Reading Experience
 
 - DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, customizable tap zones, page curl (iOS), cover-style page transitions on all platforms, optional page shadows, clearer page-turn animation controls, and steadier scroll and cover navigation with better RTL, wide-page, and interruption handling.
-- EPUB reader on iOS/macOS with paged, scrolled, and cover layouts, custom font importing (`.ttf`/`.otf`), theme presets, multi-column reading, and nested table of contents.
+- EPUB reader on iOS/macOS with paged, scrolled, and cover layouts, custom font importing (`.ttf`/`.otf`), theme presets, text alignment and font-weight controls, optional status/footer overlays, multi-column reading, and nested table of contents.
 - Animated GIF and WebP pages start immediately, stay smooth while you zoom or scroll, and remain reliable when reopening or revisiting pages.
 - PDF reading on iOS/macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality tiers for offline preparation, and clearer progress feedback.
 - Per-book preferences save reading direction, page layout, and theme settings.
@@ -35,7 +35,7 @@
 - Browse Series, Books, Collections, and Read Lists with metadata filters for publishers, authors, genres, tags, and languages using all/any logic.
 - Save and reuse filters across browse surfaces.
 - Optional unread-cover blur helps hide spoiler-heavy artwork until you start reading.
-- Reading history and stats help surface recent activity from synced local data.
+- Reading history and stats stay fresh with automatic sync and help surface recent activity from synced local data.
 - Spotlight integration for downloaded content on iOS/macOS, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
 - UI localization includes English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
 

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
         <title>KMReader · Native Komga Client for iOS, macOS & tvOS</title>
         <meta
             name="description"
-            content="KMReader is a native SwiftUI Komga client with DIVINA, EPUB, and PDF readers, reliable offline downloads, advanced filtering, admin tools, and multi-server support."
+            content="KMReader is a native SwiftUI Komga client with DIVINA, EPUB, and PDF readers, richer EPUB typography controls, reliable offline downloads, advanced filtering, admin tools, and multi-server support."
         />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -27,8 +27,9 @@
                 <h1>KMReader</h1>
                 <p class="tagline">
                     Read, download, browse, and manage your Komga library with
-                    native readers, smooth animated page playback, reliable
-                    offline sync, advanced filtering, multi-server support,
+                    native readers, richer EPUB typography and overlay
+                    controls, smooth animated page playback, reliable offline
+                    sync, advanced filtering, multi-server support,
                     and practical Apple-platform extras like widgets,
                     Spotlight, Dynamic Island updates, and keyboard-first
                     controls on iPhone, iPad, Mac, and Apple TV.
@@ -88,12 +89,14 @@
                             controls, and steadier scroll reading with better
                             RTL, wide-page, and interruption handling.
                             EPUB on iOS/macOS adds custom fonts, paged,
-                            scrolled, or cover layouts. Animated pages play
-                            immediately, stay smooth while you zoom or scroll,
-                            and remain reliable when you revisit pages, while
-                            PDF on iOS/macOS offers a native reader or DIVINA
-                            mode with search, TOC, and configurable render
-                            quality.
+                            scrolled, or cover layouts, text alignment and
+                            font-weight controls, configurable status/footer
+                            overlays, and nested table of contents. Animated
+                            pages play immediately, stay smooth while you zoom
+                            or scroll, and remain reliable when you revisit
+                            pages, while PDF on iOS/macOS offers a native
+                            reader or DIVINA mode with search, TOC, and
+                            configurable render quality.
                         </p>
                     </article>
                     <article class="card">
@@ -101,9 +104,10 @@
                         <h3>Keep reading, recent updates, and favorites</h3>
                         <p>
                             Keep Reading, On Deck, Recently Added, Recently
-                            Updated, pinned collections/read lists, saved
-                            filters, and optional unread-cover blur keep the
-                            most useful parts of your library close.
+                            Updated, reading history and stats, pinned
+                            collections/read lists, saved filters, and
+                            optional unread-cover blur keep the most useful
+                            parts of your library close.
                         </p>
                     </article>
                     <article class="card">
@@ -123,9 +127,10 @@
                         <p>
                             Live Activities keep current reading sessions and
                             download progress visible, can be turned off for
-                            the reader, and show reading progress or an
-                            incognito indicator with Dynamic Island support on
-                            iPhone.
+                            the reader, show reading progress or an incognito
+                            indicator with Dynamic Island support on iPhone,
+                            while EPUB overlay controls can stay minimal or
+                            more informative.
                         </p>
                     </article>
                     <article class="card">
@@ -217,9 +222,10 @@
                         <p>
                             DIVINA is available on iOS, macOS, and tvOS. EPUB
                             and PDF are available on iOS and macOS, with EPUB
-                            supporting cover mode and PDF offering a native
-                            reader or DIVINA mode, while animated GIF and WebP
-                            pages play inline with the reader. Reader settings
+                            supporting cover mode, richer typography and
+                            overlay controls, and PDF offering a native reader
+                            or DIVINA mode, while animated GIF and WebP pages
+                            play inline with the reader. Reader settings
                             include page shadows and page-turn animation
                             controls.
                         </p>


### PR DESCRIPTION
## Problem
Recent reader and sync improvements changed the product story, but the evergreen docs and App Store release notes no longer reflected the current feature set clearly.

## Approach
Refresh the README, App Store description, and landing page around the latest reader, EPUB, offline, and sync capabilities, then rewrite the App Store changelog into a user-facing summary for the commits since `v4.4`.

## Scope
- update the README product overview
- update the App Store description copy
- align the landing page messaging
- rewrite `APP_STORE_CHANGELOG.txt` for the latest release range

## Validation
- [x] Reviewed the updated copy for cross-file consistency
- [ ] Build/tests not run (docs-only changes)
