### PR TITLE
fix: stabilize epub reader opening and localize ordering

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 391;
+				CURRENT_PROJECT_VERSION = 392;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 391;
+				CURRENT_PROJECT_VERSION = 392;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 391;
+				CURRENT_PROJECT_VERSION = 392;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 391;
+				CURRENT_PROJECT_VERSION = 392;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -350,31 +350,68 @@
             closeReader()
           }
         )
-      } else if viewModel.isLoading {
-        ReaderLoadingView(
-          title: loadingTitle,
-          detail: loadingDetail,
-          progress: (viewModel.downloadBytesReceived > 0 || viewModel.downloadProgress > 0)
-            ? viewModel.downloadProgress : nil
-        )
-      } else if let error = viewModel.errorMessage {
-        VStack(spacing: 12) {
-          Image(systemName: "exclamationmark.triangle")
-            .font(.largeTitle)
-          Text(error)
-            .multilineTextAlignment(.center)
-          Button("Retry") {
-            Task {
-              await loadBook()
-            }
-          }
-        }
-        .padding()
-      } else if viewModel.hasContent {
-        readerContent
       } else {
-        Text("No content available.")
-          .foregroundStyle(.secondary)
+        #if os(iOS)
+          readerContent
+            .opacity(viewModel.hasContent && !viewModel.isLoading && viewModel.errorMessage == nil ? 1 : 0)
+            .animation(nil, value: viewModel.isLoading)
+            .animation(nil, value: viewModel.hasContent)
+            .animation(nil, value: viewModel.errorMessage)
+            .allowsHitTesting(viewModel.hasContent && !viewModel.isLoading && viewModel.errorMessage == nil)
+            .overlay {
+              if viewModel.isLoading {
+                ReaderLoadingView(
+                  title: loadingTitle,
+                  detail: loadingDetail,
+                  progress: (viewModel.downloadBytesReceived > 0 || viewModel.downloadProgress > 0)
+                    ? viewModel.downloadProgress : nil
+                )
+              } else if let error = viewModel.errorMessage {
+                VStack(spacing: 12) {
+                  Image(systemName: "exclamationmark.triangle")
+                    .font(.largeTitle)
+                  Text(error)
+                    .multilineTextAlignment(.center)
+                  Button("Retry") {
+                    Task {
+                      await loadBook()
+                    }
+                  }
+                }
+                .padding()
+              } else if !viewModel.hasContent {
+                Text("No content available.")
+                  .foregroundStyle(.secondary)
+              }
+            }
+        #else
+          if viewModel.isLoading {
+            ReaderLoadingView(
+              title: loadingTitle,
+              detail: loadingDetail,
+              progress: (viewModel.downloadBytesReceived > 0 || viewModel.downloadProgress > 0)
+                ? viewModel.downloadProgress : nil
+            )
+          } else if let error = viewModel.errorMessage {
+            VStack(spacing: 12) {
+              Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+              Text(error)
+                .multilineTextAlignment(.center)
+              Button("Retry") {
+                Task {
+                  await loadBook()
+                }
+              }
+            }
+            .padding()
+          } else if viewModel.hasContent {
+            readerContent
+          } else {
+            Text("No content available.")
+              .foregroundStyle(.secondary)
+          }
+        #endif
       }
     }
 

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -20894,18 +20894,17 @@
       }
     },
     "epub.text_alignment.justify" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Justify"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Blocksatz"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Justify"
           }
         },
         "es" : {
@@ -20959,18 +20958,17 @@
       }
     },
     "epub.text_alignment.justify.description" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Justify automatically enables hyphenation."
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Blocksatz aktiviert automatisch die Silbentrennung."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Justify automatically enables hyphenation."
           }
         },
         "es" : {
@@ -21024,18 +21022,17 @@
       }
     },
     "epub.text_alignment.publisher_default" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Publisher Default"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verlagsstandard"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Publisher Default"
           }
         },
         "es" : {
@@ -21089,18 +21086,17 @@
       }
     },
     "epub.text_alignment.start" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Am Anfang ausrichten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start"
           }
         },
         "es" : {
@@ -21154,18 +21150,17 @@
       }
     },
     "epub.text_alignment.title" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text Alignment"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Textausrichtung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Text Alignment"
           }
         },
         "es" : {

--- a/misc/localize.py
+++ b/misc/localize.py
@@ -10,6 +10,18 @@ from pathlib import Path
 from localize_sort import sort_entries, sort_keys
 
 REQUIRED_PLATFORMS = ("ios", "macos", "tvos")
+LOCALIZATION_KEY_ORDER = (
+    "de",
+    "en",
+    "es",
+    "fr",
+    "it",
+    "ja",
+    "ko",
+    "ru",
+    "zh-Hans",
+    "zh-Hant",
+)
 
 
 def eprint(message: str) -> None:
@@ -145,13 +157,40 @@ def load_stringsdata_entries(paths: list[Path]) -> dict:
     }
 
 
-def sort_xcstrings_keys(path: Path) -> None:
+def sort_localizations(localizations: dict) -> dict:
+    ordered = {}
+    seen = set()
+
+    for key in LOCALIZATION_KEY_ORDER:
+        if key in localizations:
+            ordered[key] = localizations[key]
+            seen.add(key)
+
+    for key in sort_keys(k for k in localizations.keys() if k not in seen):
+        ordered[key] = localizations[key]
+
+    return ordered
+
+
+def sort_xcstrings_keys(path: Path, existing_keys: set[str]) -> None:
     with path.open("r", encoding="utf-8") as f:
         data = json.load(f)
 
     strings = data.get("strings")
     if not isinstance(strings, dict):
         return
+
+    new_keys = set(strings.keys()) - existing_keys
+    for key in new_keys:
+        entry = strings.get(key)
+        if not isinstance(entry, dict):
+            continue
+
+        localizations = entry.get("localizations")
+        if not isinstance(localizations, dict):
+            continue
+
+        entry["localizations"] = sort_localizations(localizations)
 
     data["strings"] = {key: strings[key] for key in sort_keys(strings.keys())}
 
@@ -166,6 +205,11 @@ def main() -> int:
     if not xcstrings_path.exists():
         eprint(f"Error: xcstrings not found at {xcstrings_path}")
         return 1
+
+    with xcstrings_path.open("r", encoding="utf-8") as f:
+        existing_data = json.load(f)
+    existing_strings = existing_data.get("strings")
+    existing_keys = set(existing_strings.keys()) if isinstance(existing_strings, dict) else set()
 
     derived_root = Path(
         os.environ.get(
@@ -265,7 +309,7 @@ def main() -> int:
         ]
         code = os.spawnvp(os.P_WAIT, args[0], args)
         if code == 0:
-            sort_xcstrings_keys(xcstrings_path)
+            sort_xcstrings_keys(xcstrings_path, existing_keys)
         return code
     finally:
         try:


### PR DESCRIPTION
## Summary
- keep the iOS EPUB reader content mounted behind the loading state to avoid the extra open animation
- preserve deterministic locale ordering only when `make localize` introduces brand-new xcstrings keys
- bump the build number to 392

## Validation
- `python3 -m py_compile misc/localize.py misc/translate.py misc/localize_sort.py`
- `make build-ios`