### PR TITLE
fix: narrow selectable detail text

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 393;
+				CURRENT_PROJECT_VERSION = 394;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 393;
+				CURRENT_PROJECT_VERSION = 394;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 393;
+				CURRENT_PROJECT_VERSION = 394;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 393;
+				CURRENT_PROJECT_VERSION = 394;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Views/BookDetailContentView.swift
+++ b/KMReader/Features/Book/Views/BookDetailContentView.swift
@@ -27,10 +27,12 @@ struct BookDetailContentView: View {
         .font(.subheadline)
         .foregroundColor(.secondary)
         .fixedSize(horizontal: false, vertical: true)
+        .textSelectionIfAvailable()
 
       Text(book.metadata.title)
         .font(.title2)
         .fixedSize(horizontal: false, vertical: true)
+        .textSelectionIfAvailable()
 
       HStack(alignment: .top) {
         ThumbnailImage(
@@ -220,6 +222,7 @@ struct BookDetailContentView: View {
               .frame(minWidth: 16)
             Text(book.media.mediaType.uppercased())
               .font(.caption)
+              .textSelectionIfAvailable()
             Spacer()
           }
 
@@ -230,6 +233,7 @@ struct BookDetailContentView: View {
               .frame(minWidth: 16)
             Text(book.size)
               .font(.caption)
+              .textSelectionIfAvailable()
             Spacer()
           }
 
@@ -240,6 +244,7 @@ struct BookDetailContentView: View {
               .frame(minWidth: 16)
             Text(book.url)
               .font(.caption)
+              .textSelectionIfAvailable()
             Spacer()
           }
 
@@ -251,6 +256,7 @@ struct BookDetailContentView: View {
               Text(comment)
                 .font(.caption)
                 .foregroundColor(.red)
+                .textSelectionIfAvailable()
             }
           }
         }

--- a/KMReader/Features/Collection/Views/CollectionDetailContentView.swift
+++ b/KMReader/Features/Collection/Views/CollectionDetailContentView.swift
@@ -13,6 +13,7 @@ struct CollectionDetailContentView: View {
     VStack(alignment: .leading) {
       Text(collection.name)
         .font(.title2)
+        .textSelectionIfAvailable()
 
       HStack(alignment: .top) {
         ThumbnailImage(

--- a/KMReader/Features/OneShot/OneShotDetailContentView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailContentView.swift
@@ -38,6 +38,7 @@ struct OneShotDetailContentView: View {
         Text(book.metadata.title)
           .font(.title2)
           .fixedSize(horizontal: false, vertical: true)
+          .textSelectionIfAvailable()
         if let ageRating = series.metadata.ageRating, ageRating > 0 {
           AgeRatingBadge(ageRating: ageRating)
         }
@@ -267,6 +268,7 @@ struct OneShotDetailContentView: View {
                 Text(altTitle.title)
                   .font(.caption)
                   .foregroundColor(.primary)
+                  .textSelectionIfAvailable()
               }
             }
           }
@@ -298,6 +300,7 @@ struct OneShotDetailContentView: View {
               .frame(minWidth: 16)
             Text(book.media.mediaType.uppercased())
               .font(.caption)
+              .textSelectionIfAvailable()
             Spacer()
           }
 
@@ -308,6 +311,7 @@ struct OneShotDetailContentView: View {
               .frame(minWidth: 16)
             Text(book.size)
               .font(.caption)
+              .textSelectionIfAvailable()
             Spacer()
           }
 
@@ -318,6 +322,7 @@ struct OneShotDetailContentView: View {
               .frame(minWidth: 16)
             Text(book.url)
               .font(.caption)
+              .textSelectionIfAvailable()
             Spacer()
           }
 
@@ -329,6 +334,7 @@ struct OneShotDetailContentView: View {
               Text(comment)
                 .font(.caption)
                 .foregroundColor(.red)
+                .textSelectionIfAvailable()
             }
           }
         }

--- a/KMReader/Features/ReadList/Views/ReadListDetailContentView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListDetailContentView.swift
@@ -13,6 +13,7 @@ struct ReadListDetailContentView: View {
     VStack(alignment: .leading) {
       Text(readList.name)
         .font(.title2)
+        .textSelectionIfAvailable()
 
       HStack(alignment: .top) {
         ThumbnailImage(
@@ -52,6 +53,7 @@ struct ReadListDetailContentView: View {
               .font(.subheadline)
               .foregroundColor(.secondary)
               .padding(.top, 4)
+              .textSelectionIfAvailable()
           }
 
           // Info chips

--- a/KMReader/Features/Series/Views/SeriesDetailContentView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailContentView.swift
@@ -24,6 +24,7 @@ struct SeriesDetailContentView: View {
       HStack(alignment: .bottom) {
         Text(series.metadata.title)
           .font(.title2)
+          .textSelectionIfAvailable()
         if let ageRating = series.metadata.ageRating, ageRating > 0 {
           AgeRatingBadge(ageRating: ageRating)
         }
@@ -225,6 +226,7 @@ struct SeriesDetailContentView: View {
                 Text(altTitle.title)
                   .font(.caption)
                   .foregroundColor(.primary)
+                  .textSelectionIfAvailable()
               }
             }
           }

--- a/KMReader/Shared/UI/ExpandableSummaryView.swift
+++ b/KMReader/Shared/UI/ExpandableSummaryView.swift
@@ -84,6 +84,7 @@ struct ExpandableSummaryView: View {
         .foregroundColor(.primary)
         .lineLimit(isExpanded ? nil : collapsedLineLimit)
         .animation(.easeInOut(duration: 0.2), value: isExpanded)
+        .textSelectionIfAvailable()
         .background(
           GeometryReader { geometry in
             VStack(spacing: 0) {

--- a/KMReader/Shared/UI/InfoRow.swift
+++ b/KMReader/Shared/UI/InfoRow.swift
@@ -31,6 +31,7 @@ struct InfoRow: View {
         .foregroundColor(.primary)
         .multilineTextAlignment(.trailing)
         .lineLimit(2)
+        .textSelectionIfAvailable()
     }
   }
 }


### PR DESCRIPTION
## Problem
Detail views had no consistent way to copy useful text such as titles, summaries, alternate titles, and media metadata values. The first pass also made some structural labels selectable, which added noise without helping copy workflows.

## Approach
Limit text selection to the values users are likely to copy and keep section headings and field labels as normal UI text. This keeps the interaction focused on real content instead of exposing selection affordances on decorative labels.

## Scope
- Enable selection for copyable detail values in book, series, oneshot, collection, and read list detail views
- Keep section titles and label text non-selectable
- Bump the build version to 394

## Validation
- [x] `make format`
- [x] `make build`
