### PR TITLE
feat: add detail title copy button

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 394;
+				CURRENT_PROJECT_VERSION = 395;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 394;
+				CURRENT_PROJECT_VERSION = 395;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 394;
+				CURRENT_PROJECT_VERSION = 395;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 394;
+				CURRENT_PROJECT_VERSION = 395;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Views/BookDetailContentView.swift
+++ b/KMReader/Features/Book/Views/BookDetailContentView.swift
@@ -29,10 +29,7 @@ struct BookDetailContentView: View {
         .fixedSize(horizontal: false, vertical: true)
         .textSelectionIfAvailable()
 
-      Text(book.metadata.title)
-        .font(.title2)
-        .fixedSize(horizontal: false, vertical: true)
-        .textSelectionIfAvailable()
+      DetailTitleView(title: book.metadata.title)
 
       HStack(alignment: .top) {
         ThumbnailImage(

--- a/KMReader/Features/Collection/Views/CollectionDetailContentView.swift
+++ b/KMReader/Features/Collection/Views/CollectionDetailContentView.swift
@@ -11,9 +11,7 @@ struct CollectionDetailContentView: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      Text(collection.name)
-        .font(.title2)
-        .textSelectionIfAvailable()
+      DetailTitleView(title: collection.name)
 
       HStack(alignment: .top) {
         ThumbnailImage(

--- a/KMReader/Features/OneShot/OneShotDetailContentView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailContentView.swift
@@ -34,15 +34,12 @@ struct OneShotDetailContentView: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      HStack(alignment: .bottom) {
-        Text(book.metadata.title)
-          .font(.title2)
-          .fixedSize(horizontal: false, vertical: true)
-          .textSelectionIfAvailable()
+      HStack(alignment: .bottom, spacing: 8) {
+        DetailTitleView(title: book.metadata.title)
         if let ageRating = series.metadata.ageRating, ageRating > 0 {
           AgeRatingBadge(ageRating: ageRating)
         }
-        Spacer()
+        Spacer(minLength: 0)
       }
 
       HStack(alignment: .top) {

--- a/KMReader/Features/ReadList/Views/ReadListDetailContentView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListDetailContentView.swift
@@ -11,9 +11,7 @@ struct ReadListDetailContentView: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      Text(readList.name)
-        .font(.title2)
-        .textSelectionIfAvailable()
+      DetailTitleView(title: readList.name)
 
       HStack(alignment: .top) {
         ThumbnailImage(

--- a/KMReader/Features/Series/Views/SeriesDetailContentView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailContentView.swift
@@ -21,14 +21,12 @@ struct SeriesDetailContentView: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      HStack(alignment: .bottom) {
-        Text(series.metadata.title)
-          .font(.title2)
-          .textSelectionIfAvailable()
+      HStack(alignment: .bottom, spacing: 8) {
+        DetailTitleView(title: series.metadata.title)
         if let ageRating = series.metadata.ageRating, ageRating > 0 {
           AgeRatingBadge(ageRating: ageRating)
         }
-        Spacer()
+        Spacer(minLength: 0)
       }
 
       HStack(alignment: .top) {

--- a/KMReader/Shared/UI/DetailTitleView.swift
+++ b/KMReader/Shared/UI/DetailTitleView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct DetailTitleView: View {
+  let title: String
+
+  var body: some View {
+    HStack(alignment: .center, spacing: 8) {
+      Text(title)
+        .font(.title2)
+        .fixedSize(horizontal: false, vertical: true)
+        .textSelectionIfAvailable()
+        .layoutPriority(1)
+
+      #if os(iOS) || os(macOS)
+        Button {
+          copyTitle()
+        } label: {
+          Image(systemName: "doc.on.doc")
+            .font(.subheadline)
+        }
+        .adaptiveButtonStyle(.plain)
+        .foregroundStyle(.secondary)
+      #endif
+    }
+  }
+
+  private func copyTitle() {
+    #if os(iOS) || os(macOS)
+      PlatformHelper.generalPasteboard.string = title
+      ErrorManager.shared.notify(message: String(localized: "notification.copied"))
+    #endif
+  }
+}


### PR DESCRIPTION
## Problem
Detail pages show the title text prominently, but there is no direct way to copy it from the header itself.

## Approach
Add a shared `DetailTitleView` that keeps the title rendering in one place and adds a lightweight copy action on iOS and macOS. Update the book, series, oneshot, collection, and read list detail content views to use the shared title row while preserving existing badges and layout.

## Scope
- add a reusable copy action for detail titles
- adopt the shared title row across detail content views
- bump the build version to 395 via the repo automation

## Testing
- [x] `make build`
