### PR TITLE
fix: improve legacy glass readability

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 396;
+				CURRENT_PROJECT_VERSION = 395;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 396;
+				CURRENT_PROJECT_VERSION = 395;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 396;
+				CURRENT_PROJECT_VERSION = 395;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 396;
+				CURRENT_PROJECT_VERSION = 395;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 395;
+				CURRENT_PROJECT_VERSION = 396;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 395;
+				CURRENT_PROJECT_VERSION = 396;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 395;
+				CURRENT_PROJECT_VERSION = 396;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 395;
+				CURRENT_PROJECT_VERSION = 396;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/EndPageCloseButtonStyle.swift
+++ b/KMReader/Features/Reader/Views/EndPageCloseButtonStyle.swift
@@ -25,7 +25,27 @@
           return .glass()
         }
       #endif
-      return .bordered()
+      var configuration = UIButton.Configuration.bordered()
+      var background = UIBackgroundConfiguration.clear()
+
+      #if os(iOS)
+        if UIAccessibility.isReduceTransparencyEnabled {
+          background.backgroundColor = .systemBackground.withAlphaComponent(0.96)
+        } else {
+          background.visualEffect = UIBlurEffect(style: .systemThickMaterial)
+          background.backgroundColor = .systemBackground.withAlphaComponent(0.12)
+        }
+        background.strokeColor = UIColor.label.withAlphaComponent(0.12)
+      #elseif os(tvOS)
+        background.backgroundColor = UIColor.black.withAlphaComponent(
+          UIAccessibility.isReduceTransparencyEnabled ? 0.92 : 0.82
+        )
+        background.strokeColor = UIColor.white.withAlphaComponent(0.24)
+      #endif
+
+      background.strokeWidth = 1
+      configuration.background = background
+      return configuration
     }
 
     private static var buttonSymbolConfiguration: UIImage.SymbolConfiguration {

--- a/KMReader/Features/Reader/Views/EndPageCloseButtonStyle.swift
+++ b/KMReader/Features/Reader/Views/EndPageCloseButtonStyle.swift
@@ -12,6 +12,11 @@
       configuration.cornerStyle = .capsule
       button.configuration = configuration
       button.tintColor = textColor
+      button.layer.shadowColor = UIColor.black.withAlphaComponent(0.35).cgColor
+      button.layer.shadowOpacity = 1
+      button.layer.shadowRadius = 4
+      button.layer.shadowOffset = CGSize(width: 0, height: 2)
+      button.layer.masksToBounds = false
     }
 
     private static func borderedButtonConfiguration() -> UIButton.Configuration {
@@ -20,27 +25,7 @@
           return .glass()
         }
       #endif
-      var configuration = UIButton.Configuration.bordered()
-      var background = UIBackgroundConfiguration.clear()
-      #if os(iOS)
-        if UIAccessibility.isReduceTransparencyEnabled {
-          background.backgroundColor = .systemBackground.withAlphaComponent(0.96)
-          background.strokeColor = UIColor.label.withAlphaComponent(0.12)
-        } else {
-          background.visualEffect = UIBlurEffect(style: .systemMaterial)
-          background.strokeColor = UIColor.white.withAlphaComponent(0.24)
-        }
-      #elseif os(tvOS)
-        background.backgroundColor = UIColor.black.withAlphaComponent(
-          UIAccessibility.isReduceTransparencyEnabled ? 0.92 : 0.76
-        )
-        background.strokeColor = UIColor.white.withAlphaComponent(
-          UIAccessibility.isReduceTransparencyEnabled ? 0.18 : 0.24
-        )
-      #endif
-      background.strokeWidth = 1
-      configuration.background = background
-      return configuration
+      return .bordered()
     }
 
     private static var buttonSymbolConfiguration: UIImage.SymbolConfiguration {

--- a/KMReader/Features/Reader/Views/EndPageCloseButtonStyle.swift
+++ b/KMReader/Features/Reader/Views/EndPageCloseButtonStyle.swift
@@ -20,7 +20,27 @@
           return .glass()
         }
       #endif
-      return .bordered()
+      var configuration = UIButton.Configuration.bordered()
+      var background = UIBackgroundConfiguration.clear()
+      #if os(iOS)
+        if UIAccessibility.isReduceTransparencyEnabled {
+          background.backgroundColor = .systemBackground.withAlphaComponent(0.96)
+          background.strokeColor = UIColor.label.withAlphaComponent(0.12)
+        } else {
+          background.visualEffect = UIBlurEffect(style: .systemMaterial)
+          background.strokeColor = UIColor.white.withAlphaComponent(0.24)
+        }
+      #elseif os(tvOS)
+        background.backgroundColor = UIColor.black.withAlphaComponent(
+          UIAccessibility.isReduceTransparencyEnabled ? 0.92 : 0.76
+        )
+        background.strokeColor = UIColor.white.withAlphaComponent(
+          UIAccessibility.isReduceTransparencyEnabled ? 0.18 : 0.24
+        )
+      #endif
+      background.strokeWidth = 1
+      configuration.background = background
+      return configuration
     }
 
     private static var buttonSymbolConfiguration: UIImage.SymbolConfiguration {

--- a/KMReader/Shared/Extensions/View+ButtonStyle.swift
+++ b/KMReader/Shared/Extensions/View+ButtonStyle.swift
@@ -17,16 +17,15 @@ enum GlassEffectType {
   case regular
 }
 
-private struct LegacyGlassButtonChromeModifier: ViewModifier {
+private struct LegacyGlassButtonStyle: ButtonStyle {
   @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
   @Environment(\.controlSize) private var controlSize
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.colorScheme) private var colorScheme
 
-  func body(content: Content) -> some View {
-    content
-      .padding(.horizontal, horizontalPadding)
-      .padding(.vertical, verticalPadding)
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .padding(buttonPadding)
       .background {
         ButtonBorderShape.buttonBorder
           .fill(backgroundStyle)
@@ -40,16 +39,18 @@ private struct LegacyGlassButtonChromeModifier: ViewModifier {
         ButtonBorderShape.buttonBorder
           .stroke(borderColor, lineWidth: 0.8)
       }
+      .contentShape(ButtonBorderShape.buttonBorder)
       .shadow(
         color: reduceTransparency ? .clear : .black.opacity(0.14),
         radius: 8,
         x: 0,
         y: 2
       )
-      .opacity(isEnabled ? 1 : 0.55)
+      .opacity(isEnabled ? (configuration.isPressed ? 0.92 : 1) : 0.55)
+      .scaleEffect(configuration.isPressed ? 0.98 : 1)
   }
 
-  private var horizontalPadding: CGFloat {
+  private var buttonPadding: CGFloat {
     switch controlSize {
     case .mini:
       return 8
@@ -63,23 +64,6 @@ private struct LegacyGlassButtonChromeModifier: ViewModifier {
       return 20
     @unknown default:
       return 12
-    }
-  }
-
-  private var verticalPadding: CGFloat {
-    switch controlSize {
-    case .mini:
-      return 4
-    case .small:
-      return 5
-    case .regular:
-      return 7
-    case .large:
-      return 9
-    case .extraLarge:
-      return 11
-    @unknown default:
-      return 7
     }
   }
 
@@ -221,13 +205,9 @@ extension View {
       case .borderedProminent:
         self.buttonStyle(.borderedProminent)
       case .bordered:
-        self
-          .buttonStyle(.plain)
-          .legacyGlassButtonChrome()
+        self.buttonStyle(LegacyGlassButtonStyle())
       case .borderless:
-        self
-          .buttonStyle(.plain)
-          .legacyGlassButtonChrome()
+        self.buttonStyle(LegacyGlassButtonStyle())
       case .plain:
         #if os(tvOS)
           self.buttonStyle(.card)
@@ -278,9 +258,5 @@ extension View {
 
   private func legacyGlassSurface<S: Shape>(_ type: GlassEffectType, in shape: S) -> some View {
     modifier(LegacyGlassSurfaceModifier(type: type, shape: shape))
-  }
-
-  private func legacyGlassButtonChrome() -> some View {
-    modifier(LegacyGlassButtonChromeModifier())
   }
 }

--- a/KMReader/Shared/Extensions/View+ButtonStyle.swift
+++ b/KMReader/Shared/Extensions/View+ButtonStyle.swift
@@ -17,6 +17,66 @@ enum GlassEffectType {
   case regular
 }
 
+private struct LegacyGlassSurfaceModifier<SurfaceShape: Shape>: ViewModifier {
+  @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+  let type: GlassEffectType
+  let shape: SurfaceShape
+
+  func body(content: Content) -> some View {
+    content
+      .background(backgroundStyle, in: shape)
+      .overlay {
+        shape
+          .stroke(borderColor, lineWidth: reduceTransparency ? 1 : 0.8)
+      }
+      .shadow(
+        color: reduceTransparency ? .clear : .black.opacity(type == .clear ? 0.08 : 0.14),
+        radius: type == .clear ? 4 : 8,
+        x: 0,
+        y: 2
+      )
+  }
+
+  private var backgroundStyle: AnyShapeStyle {
+    if reduceTransparency {
+      return AnyShapeStyle(reducedTransparencyColor)
+    }
+
+    switch type {
+    case .clear:
+      return AnyShapeStyle(.ultraThinMaterial)
+    case .regular:
+      return AnyShapeStyle(.regularMaterial)
+    }
+  }
+
+  private var borderColor: Color {
+    if reduceTransparency {
+      return .primary.opacity(0.12)
+    }
+
+    switch type {
+    case .clear:
+      return .white.opacity(0.18)
+    case .regular:
+      return .white.opacity(0.24)
+    }
+  }
+
+  private var reducedTransparencyColor: Color {
+    #if os(iOS)
+      return type == .clear ? Color(.secondarySystemBackground) : Color(.systemBackground)
+    #elseif os(tvOS)
+      return type == .clear ? Color.black.opacity(0.84) : Color.black.opacity(0.92)
+    #elseif os(macOS)
+      return type == .clear ? Color(NSColor.windowBackgroundColor) : Color(NSColor.controlBackgroundColor)
+    #else
+      return .gray
+    #endif
+  }
+}
+
 extension View {
   @ViewBuilder
   func adaptiveButtonStyle(_ style: AdaptiveButtonStyleType) -> some View {
@@ -48,9 +108,13 @@ extension View {
       case .borderedProminent:
         self.buttonStyle(.borderedProminent)
       case .bordered:
-        self.buttonStyle(.bordered)
+        self
+          .buttonStyle(.bordered)
+          .legacyGlassSurface(.regular, in: ButtonBorderShape.buttonBorder)
       case .borderless:
-        self.buttonStyle(.borderless)
+        self
+          .buttonStyle(.borderless)
+          .legacyGlassSurface(.regular, in: ButtonBorderShape.buttonBorder)
       case .plain:
         #if os(tvOS)
           self.buttonStyle(.card)
@@ -74,7 +138,7 @@ extension View {
         case .regular: self.glassEffect(.regular)
         }
       } else {
-        self
+        self.legacyGlassSurface(type, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
       }
     } else {
       self
@@ -92,10 +156,14 @@ extension View {
         case .regular: self.glassEffect(.regular, in: shape)
         }
       } else {
-        self
+        self.legacyGlassSurface(type, in: shape)
       }
     } else {
       self
     }
+  }
+
+  private func legacyGlassSurface<S: Shape>(_ type: GlassEffectType, in shape: S) -> some View {
+    modifier(LegacyGlassSurfaceModifier(type: type, shape: shape))
   }
 }

--- a/KMReader/Shared/Extensions/View+ButtonStyle.swift
+++ b/KMReader/Shared/Extensions/View+ButtonStyle.swift
@@ -19,13 +19,11 @@ enum GlassEffectType {
 
 private struct LegacyGlassButtonStyle: ButtonStyle {
   @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
-  @Environment(\.controlSize) private var controlSize
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.colorScheme) private var colorScheme
 
   func makeBody(configuration: Configuration) -> some View {
     configuration.label
-      .padding(buttonPadding)
       .background {
         ButtonBorderShape.buttonBorder
           .fill(backgroundStyle)
@@ -48,23 +46,6 @@ private struct LegacyGlassButtonStyle: ButtonStyle {
       )
       .opacity(isEnabled ? (configuration.isPressed ? 0.92 : 1) : 0.55)
       .scaleEffect(configuration.isPressed ? 0.98 : 1)
-  }
-
-  private var buttonPadding: CGFloat {
-    switch controlSize {
-    case .mini:
-      return 8
-    case .small:
-      return 10
-    case .regular:
-      return 12
-    case .large:
-      return 16
-    case .extraLarge:
-      return 20
-    @unknown default:
-      return 12
-    }
   }
 
   private var backgroundStyle: AnyShapeStyle {

--- a/KMReader/Shared/Extensions/View+ButtonStyle.swift
+++ b/KMReader/Shared/Extensions/View+ButtonStyle.swift
@@ -17,6 +17,26 @@ enum GlassEffectType {
   case regular
 }
 
+private struct LegacyGlassReadabilityModifier: ViewModifier {
+  @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+  func body(content: Content) -> some View {
+    content
+      .shadow(
+        color: .black.opacity(reduceTransparency ? 0.45 : 0.35),
+        radius: reduceTransparency ? 6 : 4,
+        x: 0,
+        y: 2
+      )
+      .shadow(
+        color: .white.opacity(reduceTransparency ? 0.18 : 0.12),
+        radius: 1,
+        x: 0,
+        y: 0
+      )
+  }
+}
+
 private struct LegacyGlassSurfaceModifier<SurfaceShape: Shape>: ViewModifier {
   @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
@@ -110,11 +130,11 @@ extension View {
       case .bordered:
         self
           .buttonStyle(.bordered)
-          .legacyGlassSurface(.regular, in: ButtonBorderShape.buttonBorder)
+          .legacyGlassReadabilityIfNeeded()
       case .borderless:
         self
           .buttonStyle(.borderless)
-          .legacyGlassSurface(.regular, in: ButtonBorderShape.buttonBorder)
+          .legacyGlassReadabilityIfNeeded()
       case .plain:
         #if os(tvOS)
           self.buttonStyle(.card)
@@ -165,5 +185,9 @@ extension View {
 
   private func legacyGlassSurface<S: Shape>(_ type: GlassEffectType, in shape: S) -> some View {
     modifier(LegacyGlassSurfaceModifier(type: type, shape: shape))
+  }
+
+  private func legacyGlassReadabilityIfNeeded() -> some View {
+    modifier(LegacyGlassReadabilityModifier())
   }
 }

--- a/KMReader/Shared/Extensions/View+ButtonStyle.swift
+++ b/KMReader/Shared/Extensions/View+ButtonStyle.swift
@@ -19,11 +19,13 @@ enum GlassEffectType {
 
 private struct LegacyGlassButtonStyle: ButtonStyle {
   @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+  @Environment(\.controlSize) private var controlSize
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.colorScheme) private var colorScheme
 
   func makeBody(configuration: Configuration) -> some View {
     configuration.label
+      .padding(buttonPadding)
       .background {
         ButtonBorderShape.buttonBorder
           .fill(backgroundStyle)
@@ -46,6 +48,23 @@ private struct LegacyGlassButtonStyle: ButtonStyle {
       )
       .opacity(isEnabled ? (configuration.isPressed ? 0.92 : 1) : 0.55)
       .scaleEffect(configuration.isPressed ? 0.98 : 1)
+  }
+
+  private var buttonPadding: CGFloat {
+    switch controlSize {
+    case .mini:
+      return 6
+    case .small:
+      return 8
+    case .regular:
+      return 10
+    case .large:
+      return 12
+    case .extraLarge:
+      return 14
+    @unknown default:
+      return 10
+    }
   }
 
   private var backgroundStyle: AnyShapeStyle {

--- a/KMReader/Shared/Extensions/View+ButtonStyle.swift
+++ b/KMReader/Shared/Extensions/View+ButtonStyle.swift
@@ -17,23 +17,116 @@ enum GlassEffectType {
   case regular
 }
 
-private struct LegacyGlassReadabilityModifier: ViewModifier {
+private struct LegacyGlassButtonChromeModifier: ViewModifier {
   @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+  @Environment(\.controlSize) private var controlSize
+  @Environment(\.isEnabled) private var isEnabled
+  @Environment(\.colorScheme) private var colorScheme
 
   func body(content: Content) -> some View {
     content
+      .padding(.horizontal, horizontalPadding)
+      .padding(.vertical, verticalPadding)
+      .background {
+        ButtonBorderShape.buttonBorder
+          .fill(backgroundStyle)
+
+        if !reduceTransparency {
+          ButtonBorderShape.buttonBorder
+            .fill(tintOverlayColor)
+        }
+      }
+      .overlay {
+        ButtonBorderShape.buttonBorder
+          .stroke(borderColor, lineWidth: 0.8)
+      }
       .shadow(
-        color: .black.opacity(reduceTransparency ? 0.45 : 0.35),
-        radius: reduceTransparency ? 6 : 4,
+        color: reduceTransparency ? .clear : .black.opacity(0.14),
+        radius: 8,
         x: 0,
         y: 2
       )
-      .shadow(
-        color: .white.opacity(reduceTransparency ? 0.18 : 0.12),
-        radius: 1,
-        x: 0,
-        y: 0
-      )
+      .opacity(isEnabled ? 1 : 0.55)
+  }
+
+  private var horizontalPadding: CGFloat {
+    switch controlSize {
+    case .mini:
+      return 8
+    case .small:
+      return 10
+    case .regular:
+      return 12
+    case .large:
+      return 16
+    case .extraLarge:
+      return 20
+    @unknown default:
+      return 12
+    }
+  }
+
+  private var verticalPadding: CGFloat {
+    switch controlSize {
+    case .mini:
+      return 4
+    case .small:
+      return 5
+    case .regular:
+      return 7
+    case .large:
+      return 9
+    case .extraLarge:
+      return 11
+    @unknown default:
+      return 7
+    }
+  }
+
+  private var backgroundStyle: AnyShapeStyle {
+    if reduceTransparency {
+      return AnyShapeStyle(reducedTransparencyColor)
+    }
+
+    return AnyShapeStyle(.thickMaterial)
+  }
+
+  private var tintOverlayColor: Color {
+    switch colorScheme {
+    case .dark:
+      return .black.opacity(0.22)
+    case .light:
+      return .white.opacity(0.18)
+    @unknown default:
+      return .white.opacity(0.18)
+    }
+  }
+
+  private var borderColor: Color {
+    if reduceTransparency {
+      return .primary.opacity(0.12)
+    }
+
+    switch colorScheme {
+    case .dark:
+      return .white.opacity(0.24)
+    case .light:
+      return .black.opacity(0.10)
+    @unknown default:
+      return .primary.opacity(0.16)
+    }
+  }
+
+  private var reducedTransparencyColor: Color {
+    #if os(iOS)
+      return Color(.systemBackground)
+    #elseif os(tvOS)
+      return Color.black.opacity(0.92)
+    #elseif os(macOS)
+      return Color(NSColor.controlBackgroundColor)
+    #else
+      return .gray
+    #endif
   }
 }
 
@@ -129,12 +222,12 @@ extension View {
         self.buttonStyle(.borderedProminent)
       case .bordered:
         self
-          .buttonStyle(.bordered)
-          .legacyGlassReadabilityIfNeeded()
+          .buttonStyle(.plain)
+          .legacyGlassButtonChrome()
       case .borderless:
         self
-          .buttonStyle(.borderless)
-          .legacyGlassReadabilityIfNeeded()
+          .buttonStyle(.plain)
+          .legacyGlassButtonChrome()
       case .plain:
         #if os(tvOS)
           self.buttonStyle(.card)
@@ -187,7 +280,7 @@ extension View {
     modifier(LegacyGlassSurfaceModifier(type: type, shape: shape))
   }
 
-  private func legacyGlassReadabilityIfNeeded() -> some View {
-    modifier(LegacyGlassReadabilityModifier())
+  private func legacyGlassButtonChrome() -> some View {
+    modifier(LegacyGlassButtonChromeModifier())
   }
 }


### PR DESCRIPTION
## Problem
Reader controls that rely on glass styling become hard to read on pre-26 systems because the older fallback path remains too transparent against bright or dark content. The PDF overlay reported in #721 is the clearest example, but the same issue affects shared glass-style buttons more broadly on older OS versions.

## Approach
Keep the fix in the shared `adaptiveButtonStyle` entry point so old systems get a consistent fallback everywhere. Instead of relying on the system bordered style, pre-26 bordered and borderless buttons now use custom chrome with a thicker material background, a light tint overlay, and a matching border shape, while non-button `glassEffect` usages keep their separate surface fallback. The UIKit reader end-page close button was updated to use the same old-system background treatment.

## Scope
- Replace the pre-26 `.bordered` and `.borderless` fallback with custom button chrome in `adaptiveButtonStyle`
- Preserve `buttonBorderShape(.circle/.capsule)` while increasing contrast with thicker background surfaces
- Keep non-button `glassEffect` fallback behavior unchanged
- Update the UIKit reader end-page close button to match the old-system background strategy
- Bump the build version to 396

## Validation
- [x] `make format`
- [x] `make build`
