### PR TITLE
fix: trigger initial divina scroll preload on iOS

### DIFF
--- a/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
@@ -300,6 +300,10 @@
         if parent.viewModel.navigationTarget == nil {
           scheduleViewModelCommit(for: committedItem)
         }
+        Task { @MainActor [weak self] in
+          guard let self, self.engine.committedItem == committedItem else { return }
+          await self.parent.viewModel.preloadPages(bypassThrottle: true)
+        }
         return true
       }
 


### PR DESCRIPTION
## Problem
On iOS, opening the DIVINA reader in scroll mode on the first page could leave the second page outside the initial preload window. The first manual page turn then had to fetch and decode that page on demand, which showed a brief loading state.

## Approach
Trigger the regular page preload pass immediately after the initial scroll position is synchronized in the iOS scroll reader. This keeps the fix on the existing preload architecture and aligns the iOS initialization path with the macOS path that already warms adjacent pages at first presentation.

## Scope
- Update the iOS `ScrollPageView` initial-position sync path to force the first preload pass once the committed item is known
- Leave visible-page prioritization and later page-change maintenance behavior unchanged

## Validation
- [x] `make format`
- [x] `make build-ios`
