### PR TITLE
fix: unify macOS reader keyboard shortcuts

### DIFF
--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -514,6 +514,27 @@ enum AppConfig {
     }
   }
 
+  static nonisolated var pdfShowKeyboardHelpOverlay: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "pdfShowKeyboardHelpOverlay") != nil {
+        return UserDefaults.standard.bool(forKey: "pdfShowKeyboardHelpOverlay")
+      }
+
+      let migratedValue: Bool
+      if UserDefaults.standard.object(forKey: "showKeyboardHelpOverlay") != nil {
+        migratedValue = UserDefaults.standard.bool(forKey: "showKeyboardHelpOverlay")
+      } else {
+        migratedValue = true
+      }
+
+      UserDefaults.standard.set(migratedValue, forKey: "pdfShowKeyboardHelpOverlay")
+      return migratedValue
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: "pdfShowKeyboardHelpOverlay")
+    }
+  }
+
   static nonisolated var enableReaderLiveActivity: Bool {
     get {
       if UserDefaults.standard.object(forKey: "enableReaderLiveActivity") != nil {

--- a/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
@@ -13,9 +13,9 @@
   @MainActor
   @Observable
   class PdfReaderViewModel {
-    var isLoading: Bool = false
+    var isLoading: Bool = true
     var errorMessage: String?
-    var loadingStage: PdfLoadingStage = .idle
+    var loadingStage: PdfLoadingStage = .fetchingMetadata
 
     var downloadProgress: Double = 0.0
     var downloadBytesReceived: Int64 = 0

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -865,14 +865,6 @@ struct DivinaReaderView: View {
       // Ignore if modifier keys are pressed (except for system shortcuts)
       guard flags.intersection([.command, .option, .control]).isEmpty else { return false }
 
-      // Handle F key for fullscreen toggle
-      if keyCode == 3 {  // F key
-        if let window = NSApplication.shared.keyWindow {
-          window.toggleFullScreen(nil)
-        }
-        return true
-      }
-
       // Handle H key for keyboard help
       if keyCode == 4 {  // H key
         showKeyboardHelp.toggle()

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -924,13 +924,6 @@
 
         guard flags.intersection([.command, .option, .control]).isEmpty else { return false }
 
-        if keyCode == 3 {
-          if let window = NSApplication.shared.keyWindow {
-            window.toggleFullScreen(nil)
-          }
-          return true
-        }
-
         if keyCode == 4 {
           showKeyboardHelp.toggle()
           return true

--- a/KMReader/Features/Reader/Views/KeyboardHelpOverlay.swift
+++ b/KMReader/Features/Reader/Views/KeyboardHelpOverlay.swift
@@ -14,9 +14,30 @@ import SwiftUI
     let hasTOC: Bool
     let supportsLiveText: Bool
     let supportsJumpToPage: Bool
+    let supportsSearch: Bool
     let supportsToggleControls: Bool
     let hasNextBook: Bool
     let onDismiss: () -> Void
+
+    init(
+      readingDirection: ReadingDirection,
+      hasTOC: Bool,
+      supportsLiveText: Bool,
+      supportsJumpToPage: Bool,
+      supportsSearch: Bool = false,
+      supportsToggleControls: Bool,
+      hasNextBook: Bool,
+      onDismiss: @escaping () -> Void
+    ) {
+      self.readingDirection = readingDirection
+      self.hasTOC = hasTOC
+      self.supportsLiveText = supportsLiveText
+      self.supportsJumpToPage = supportsJumpToPage
+      self.supportsSearch = supportsSearch
+      self.supportsToggleControls = supportsToggleControls
+      self.hasNextBook = hasNextBook
+      self.onDismiss = onDismiss
+    }
 
     var body: some View {
       ZStack {
@@ -42,7 +63,7 @@ import SwiftUI
             Divider()
               .background(Color.white.opacity(0.3))
 
-            HelpRow(key: "F / Return", description: "Toggle fullscreen")
+            HelpRow(key: "Return", description: "Toggle fullscreen")
             if supportsToggleControls {
               HelpRow(key: "C / Space", description: "Toggle controls")
             }
@@ -54,6 +75,9 @@ import SwiftUI
             }
             if supportsJumpToPage {
               HelpRow(key: "J", description: "Jump to page")
+            }
+            if supportsSearch {
+              HelpRow(key: "F", description: "Search")
             }
             if hasNextBook {
               HelpRow(key: "N", description: "Next book")

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -20,6 +20,10 @@
     private var forceDefaultReadingDirection: Bool = false
     @AppStorage("pdfPageLayout") private var pageLayout: PageLayout = .auto
     @AppStorage("pdfIsolateCoverPage") private var isolateCoverPage: Bool = true
+    #if os(macOS)
+      @AppStorage("pdfShowKeyboardHelpOverlay")
+      private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
+    #endif
 
     @State private var viewModel: PdfReaderViewModel
     @State private var readingDirection: ReadingDirection
@@ -34,6 +38,10 @@
     @State private var searchQuery = ""
     @State private var targetPageNumber: Int?
     @State private var navigationToken = UUID()
+    #if os(macOS)
+      @State private var showKeyboardHelp = false
+      @State private var keyboardHelpTimer: Timer?
+    #endif
 
     private let logger = AppLogger(.reader)
 
@@ -61,6 +69,10 @@
         contentView
 
         controlsOverlay
+
+        #if os(macOS)
+          keyboardHelpOverlay
+        #endif
       }
       #if os(iOS)
         .statusBarHidden(!shouldShowControls)
@@ -164,6 +176,7 @@
         showingControls = false
         readerPresentation.clearFlushHandler(for: sessionID)
         #if os(macOS)
+          hideKeyboardHelp()
           readerPresentation.clearMacReaderCommands()
         #endif
       }
@@ -171,9 +184,24 @@
         handleScenePhaseChange(newPhase)
       }
       #if os(macOS)
+        .onChange(of: viewModel.pageCount) { oldCount, newCount in
+          if oldCount == 0 && newCount > 0 {
+            triggerKeyboardHelp(timeout: 1.5)
+          }
+        }
+        .onChange(of: readingDirection) { _, _ in
+          triggerKeyboardHelp(timeout: 2)
+        }
         .onChange(of: macReaderCommandState) { _, newState in
           readerPresentation.updateMacReaderCommandState(newState)
         }
+        .background(
+          KeyboardEventHandler(
+            onKeyPress: { keyCode, flags in
+              handleKeyCode(keyCode, flags: flags)
+            }
+          )
+        )
       #endif
       #if os(iOS)
         .readerDismissGesture(readingDirection: readingDirection)
@@ -454,6 +482,14 @@
     }
 
     #if os(macOS)
+      private var isPresentingModalSheet: Bool {
+        showingPageJumpSheet
+          || showingSearchSheet
+          || showingTOCSheet
+          || showingPreferencesSheet
+          || showingDetailSheet
+      }
+
       private var macReaderCommandState: ReaderPresentationManager.MacReaderCommandState {
         ReaderPresentationManager.MacReaderCommandState(
           isActive: true,
@@ -478,6 +514,24 @@
           supportsDualPageOptions: pageLayout.supportsDualPageOptions,
           supportsSplitWidePageMode: false
         )
+      }
+
+      private var keyboardHelpOverlay: some View {
+        KeyboardHelpOverlay(
+          readingDirection: readingDirection,
+          hasTOC: !viewModel.tableOfContents.isEmpty,
+          supportsLiveText: false,
+          supportsJumpToPage: viewModel.pageCount > 0,
+          supportsSearch: viewModel.documentURL != nil,
+          supportsToggleControls: true,
+          hasNextBook: false,
+          onDismiss: {
+            hideKeyboardHelp()
+          }
+        )
+        .opacity(showKeyboardHelp ? 1.0 : 0.0)
+        .allowsHitTesting(showKeyboardHelp)
+        .animation(.default, value: showKeyboardHelp)
       }
 
       private func configureMacReaderCommands() {
@@ -522,6 +576,133 @@
             setSplitWidePageMode: { _ in }
           )
         )
+      }
+
+      private func handleKeyCode(_ keyCode: UInt16, flags: NSEvent.ModifierFlags) -> Bool {
+        guard !isPresentingModalSheet else { return false }
+
+        if keyCode == 53 {
+          closeReader()
+          return true
+        }
+
+        if keyCode == 44 {
+          showKeyboardHelp.toggle()
+          return true
+        }
+
+        if keyCode == 36 {
+          toggleFullscreen()
+          return true
+        }
+
+        if keyCode == 49 {
+          toggleControls()
+          return true
+        }
+
+        let modifierFlags = flags.intersection([.command, .option, .control])
+        guard modifierFlags.isEmpty else { return false }
+
+        if keyCode == 3 {
+          guard viewModel.documentURL != nil else { return false }
+          showingSearchSheet = true
+          return true
+        }
+
+        if keyCode == 4 {
+          showKeyboardHelp.toggle()
+          return true
+        }
+
+        if keyCode == 8 {
+          toggleControls()
+          return true
+        }
+
+        if keyCode == 17 {
+          guard !viewModel.tableOfContents.isEmpty else { return false }
+          showingTOCSheet = true
+          return true
+        }
+
+        if keyCode == 38 {
+          guard viewModel.pageCount > 0 else { return false }
+          showingPageJumpSheet = true
+          return true
+        }
+
+        guard viewModel.pageCount > 0 else { return false }
+
+        switch readingDirection {
+        case .ltr:
+          switch keyCode {
+          case 124:
+            goToNextPage()
+            return true
+          case 123:
+            goToPreviousPage()
+            return true
+          default:
+            return false
+          }
+        case .rtl:
+          switch keyCode {
+          case 123:
+            goToNextPage()
+            return true
+          case 124:
+            goToPreviousPage()
+            return true
+          default:
+            return false
+          }
+        case .vertical, .webtoon:
+          switch keyCode {
+          case 125:
+            goToNextPage()
+            return true
+          case 126:
+            goToPreviousPage()
+            return true
+          default:
+            return false
+          }
+        }
+      }
+
+      private func goToNextPage() {
+        requestPageNavigation(to: viewModel.currentPageNumber + 1)
+      }
+
+      private func goToPreviousPage() {
+        requestPageNavigation(to: viewModel.currentPageNumber - 1)
+      }
+
+      private func toggleFullscreen() {
+        if let window = NSApplication.shared.keyWindow {
+          window.toggleFullScreen(nil)
+        }
+      }
+
+      private func hideKeyboardHelp() {
+        keyboardHelpTimer?.invalidate()
+        keyboardHelpTimer = nil
+        showKeyboardHelp = false
+      }
+
+      private func triggerKeyboardHelp(timeout: TimeInterval) {
+        keyboardHelpTimer?.invalidate()
+        guard showKeyboardHelpOverlay, viewModel.pageCount > 0 else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
+          self.showKeyboardHelp = true
+          self.keyboardHelpTimer = Timer.scheduledTimer(withTimeInterval: 2.5, repeats: false) { _ in
+            Task { @MainActor in
+              self.hideKeyboardHelp()
+            }
+          }
+        }
       }
     #endif
   }

--- a/KMReader/Features/Settings/PdfPreferencesView.swift
+++ b/KMReader/Features/Settings/PdfPreferencesView.swift
@@ -16,6 +16,10 @@
     private var pageLayout: PageLayout = .auto
     @AppStorage("pdfIsolateCoverPage")
     private var isolateCoverPage: Bool = true
+    #if os(macOS)
+      @AppStorage("pdfShowKeyboardHelpOverlay")
+      private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
+    #endif
     @AppStorage("pdfOfflineRenderQuality")
     private var pdfOfflineRenderQuality: PdfOfflineRenderQuality = AppConfig.pdfOfflineRenderQuality
 
@@ -127,6 +131,19 @@
               Text("Controls Gradient Background")
             }
           }
+
+          #if os(macOS)
+            Section(header: Text("Reader Overlay")) {
+              Toggle(isOn: $showKeyboardHelpOverlay) {
+                VStack(alignment: .leading, spacing: 4) {
+                  Text("Show Keyboard Help Overlay")
+                  Text("Briefly show keyboard shortcuts when opening the reader")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                }
+              }
+            }
+          #endif
         }
 
         if !useNativePdfReader {


### PR DESCRIPTION
## Problem
The macOS readers handled keyboard shortcuts inconsistently. The native PDF reader was missing the keyboard help overlay and window-level shortcuts that the other readers already exposed, the fullscreen shortcut behavior drifted between readers, and the native PDF reader could briefly flash an unavailable placeholder before its async loading state started.

## Approach
Add the missing macOS keyboard event handling and help overlay to the native PDF reader, give PDF its own keyboard-help preference, align fullscreen handling across readers so Return is the only fullscreen shortcut while PDF uses `F` for search, and start the PDF reader view model in a loading state so the first render no longer falls through to the unavailable branch.

## Scope
- add native PDF reader keyboard help overlay, shortcut handling, and search/page-jump/TOC actions on macOS
- split the PDF keyboard help overlay preference from the DIVINA reader with a one-time migration of the existing value
- update the shared keyboard help overlay copy and remove `F` fullscreen handling from DIVINA and EPUB
- prevent the native PDF reader from flashing `PDF file unavailable` before async loading begins

## Related
- https://github.com/everpcpc/KMReader/issues/718
