### PR TITLE
feat: add divina image context menus

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 396;
+				CURRENT_PROJECT_VERSION = 397;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 396;
+				CURRENT_PROJECT_VERSION = 397;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 396;
+				CURRENT_PROJECT_VERSION = 397;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 396;
+				CURRENT_PROJECT_VERSION = 397;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -117,6 +117,16 @@ enum AppConfig {
     set { UserDefaults.standard.set(newValue.rawValue, forKey: "splitWidePageMode") }
   }
 
+  static nonisolated var enableDivinaImageContextMenu: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "enableDivinaImageContextMenu") != nil {
+        return UserDefaults.standard.bool(forKey: "enableDivinaImageContextMenu")
+      }
+      return false
+    }
+    set { UserDefaults.standard.set(newValue, forKey: "enableDivinaImageContextMenu") }
+  }
+
   static nonisolated var pdfOfflineRenderQuality: PdfOfflineRenderQuality {
     get {
       if let stored = UserDefaults.standard.string(forKey: "pdfOfflineRenderQuality"),

--- a/KMReader/Features/Reader/Models/ReaderRenderConfig.swift
+++ b/KMReader/Features/Reader/Models/ReaderRenderConfig.swift
@@ -12,6 +12,8 @@ struct ReaderRenderConfig: Equatable {
   let showPageShadow: Bool
   let readerBackground: ReaderBackground
   let enableLiveText: Bool
+  let enableImageContextMenu: Bool
+  let supportsPageIsolationActions: Bool
   let doubleTapZoomScale: Double
   let doubleTapZoomMode: DoubleTapZoomMode
 }

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -94,6 +94,11 @@ class ReaderViewModel {
     return isolatePagesByBookId[currentReaderPage.bookId]?.contains(isolatePosition.localIndex) == true
   }
 
+  func isPageIsolated(_ pageID: ReaderPageID) -> Bool {
+    guard let isolatePosition = isolatePosition(for: pageID) else { return false }
+    return isolatePagesByBookId[isolatePosition.bookId]?.contains(isolatePosition.localIndex) == true
+  }
+
   /// Whether the current page is a wide (non-portrait) image, which cannot be isolated.
   var isCurrentPageWide: Bool {
     guard let currentReaderPage else { return false }

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -28,6 +28,8 @@ struct DivinaReaderView: View {
   @AppStorage("showPageShadow") private var showPageShadow: Bool = AppConfig.showPageShadow
   @AppStorage("showKeyboardHelpOverlay") private var showKeyboardHelpOverlay: Bool = true
   @AppStorage("enableLiveText") private var enableLiveText: Bool = false
+  @AppStorage("enableDivinaImageContextMenu")
+  private var enableDivinaImageContextMenu: Bool = AppConfig.enableDivinaImageContextMenu
   @AppStorage("doubleTapZoomScale") private var doubleTapZoomScale: Double = 3.0
   @AppStorage("doubleTapZoomMode") private var doubleTapZoomMode: DoubleTapZoomMode = .fast
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
@@ -116,6 +118,10 @@ struct DivinaReaderView: View {
       showPageShadow: showPageShadow,
       readerBackground: readerBackground,
       enableLiveText: enableLiveText,
+      enableImageContextMenu: enableDivinaImageContextMenu,
+      supportsPageIsolationActions: readingDirection != .webtoon
+        && readingDirection != .vertical
+        && pageLayout.supportsDualPageOptions,
       doubleTapZoomScale: doubleTapZoomScale,
       doubleTapZoomMode: doubleTapZoomMode
     )

--- a/KMReader/Features/Reader/Views/NativeCoverSlotView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverSlotView_iOS.swift
@@ -32,6 +32,8 @@
       showPageShadow: true,
       readerBackground: .system,
       enableLiveText: false,
+      enableImageContextMenu: false,
+      supportsPageIsolationActions: false,
       doubleTapZoomScale: 3.0,
       doubleTapZoomMode: .fast
     )

--- a/KMReader/Features/Reader/Views/NativeCoverSlotView_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverSlotView_macOS.swift
@@ -32,6 +32,8 @@
       showPageShadow: true,
       readerBackground: .system,
       enableLiveText: false,
+      enableImageContextMenu: false,
+      supportsPageIsolationActions: false,
       doubleTapZoomScale: 3.0,
       doubleTapZoomMode: .fast
     )

--- a/KMReader/Features/Reader/Views/NativeEndPageContentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeEndPageContentView_iOS.swift
@@ -16,6 +16,8 @@
       showPageShadow: true,
       readerBackground: .system,
       enableLiveText: false,
+      enableImageContextMenu: false,
+      supportsPageIsolationActions: false,
       doubleTapZoomScale: 3.0,
       doubleTapZoomMode: .fast
     )

--- a/KMReader/Features/Reader/Views/NativeEndPageContentView_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativeEndPageContentView_macOS.swift
@@ -16,6 +16,8 @@
       showPageShadow: true,
       readerBackground: .system,
       enableLiveText: false,
+      enableImageContextMenu: false,
+      supportsPageIsolationActions: false,
       doubleTapZoomScale: 3.0,
       doubleTapZoomMode: .fast
     )

--- a/KMReader/Features/Reader/Views/NativeImagePageViewController.swift
+++ b/KMReader/Features/Reader/Views/NativeImagePageViewController.swift
@@ -23,6 +23,8 @@
       showPageShadow: true,
       readerBackground: .system,
       enableLiveText: false,
+      enableImageContextMenu: false,
+      supportsPageIsolationActions: false,
       doubleTapZoomScale: 3.0,
       doubleTapZoomMode: .fast
     )
@@ -173,6 +175,9 @@
         showPageNumber: renderConfig.showPageNumber,
         showPageShadow: renderConfig.showPageShadow,
         enableLiveText: renderConfig.enableLiveText,
+        enableImageContextMenu: renderConfig.enableImageContextMenu,
+        supportsPageIsolationActions: renderConfig.supportsPageIsolationActions,
+        canIsolatePageFromCurrentPresentation: false,
         background: renderConfig.readerBackground,
         readingDirection: readingDirection,
         displayMode: .fit,

--- a/KMReader/Features/Reader/Views/NativePagedEndCell_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativePagedEndCell_iOS.swift
@@ -65,6 +65,8 @@
         showPageShadow: true,
         readerBackground: .system,
         enableLiveText: false,
+        enableImageContextMenu: false,
+        supportsPageIsolationActions: false,
         doubleTapZoomScale: 3.0,
         doubleTapZoomMode: .fast
       )

--- a/KMReader/Features/Reader/Views/NativePagedEndCell_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativePagedEndCell_macOS.swift
@@ -60,6 +60,8 @@
         showPageShadow: true,
         readerBackground: .system,
         enableLiveText: false,
+        enableImageContextMenu: false,
+        supportsPageIsolationActions: false,
         doubleTapZoomScale: 3.0,
         doubleTapZoomMode: .fast
       )

--- a/KMReader/Features/Reader/Views/NativePagedPageContentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativePagedPageContentView_iOS.swift
@@ -19,6 +19,8 @@
       showPageShadow: true,
       readerBackground: .system,
       enableLiveText: false,
+      enableImageContextMenu: false,
+      supportsPageIsolationActions: false,
       doubleTapZoomScale: 3.0,
       doubleTapZoomMode: .fast
     )
@@ -157,6 +159,10 @@
     private func updatePages() {
       guard let viewModel else { return }
       let pages = currentPageData
+      let canIsolatePageFromCurrentPresentation =
+        renderConfig.supportsPageIsolationActions
+        && pages.count == 2
+        && Set(pages.map(\.pageID)).count == 2
 
       if pageViews.count != pages.count {
         pageViews.forEach { view in
@@ -178,6 +184,9 @@
           showPageNumber: renderConfig.showPageNumber,
           showPageShadow: renderConfig.showPageShadow,
           enableLiveText: renderConfig.enableLiveText,
+          enableImageContextMenu: renderConfig.enableImageContextMenu,
+          supportsPageIsolationActions: renderConfig.supportsPageIsolationActions,
+          canIsolatePageFromCurrentPresentation: canIsolatePageFromCurrentPresentation,
           background: renderConfig.readerBackground,
           readingDirection: readingDirection,
           displayMode: .fit,

--- a/KMReader/Features/Reader/Views/NativePagedPageContentView_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativePagedPageContentView_macOS.swift
@@ -19,6 +19,8 @@
       showPageShadow: true,
       readerBackground: .system,
       enableLiveText: false,
+      enableImageContextMenu: false,
+      supportsPageIsolationActions: false,
       doubleTapZoomScale: 3.0,
       doubleTapZoomMode: .fast
     )
@@ -154,6 +156,10 @@
     private func updatePages() {
       guard let viewModel else { return }
       let pages = currentPageData
+      let canIsolatePageFromCurrentPresentation =
+        renderConfig.supportsPageIsolationActions
+        && pages.count == 2
+        && Set(pages.map(\.pageID)).count == 2
 
       if pageViews.count != pages.count {
         pageViews.forEach { view in
@@ -175,6 +181,9 @@
           showPageNumber: renderConfig.showPageNumber,
           showPageShadow: renderConfig.showPageShadow,
           enableLiveText: renderConfig.enableLiveText,
+          enableImageContextMenu: renderConfig.enableImageContextMenu,
+          supportsPageIsolationActions: renderConfig.supportsPageIsolationActions,
+          canIsolatePageFromCurrentPresentation: canIsolatePageFromCurrentPresentation,
           background: renderConfig.readerBackground,
           readingDirection: readingDirection,
           displayMode: .fit,

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
@@ -21,6 +21,9 @@
     private var readerBackground: ReaderBackground = .system
     private var showPageShadow = true
     private var enableLiveText = false
+    private var enableImageContextMenu = false
+    private var supportsPageIsolationActions = false
+    private var canIsolatePageFromCurrentPresentation = false
     private let logger = AppLogger(.reader)
 
     #if !os(tvOS)
@@ -29,6 +32,10 @@
       private var analyzedImage: UIImage?
       private var analysisSourceImage: UIImage?
       private var analysisRequestID: UInt64 = 0
+    #endif
+
+    #if os(iOS)
+      private lazy var contextMenuInteraction = UIContextMenuInteraction(delegate: self)
     #endif
 
     private var heightConstraint: NSLayoutConstraint?
@@ -54,6 +61,9 @@
         clearAnalysis()
         analyzedImage = nil
         analysisSourceImage = nil
+      #endif
+      #if os(iOS)
+        removeContextMenuInteractionIfNeeded()
       #endif
       updateAnimatedPlayback(sourceFileURL: nil)
       imageView.isHidden = false
@@ -84,6 +94,9 @@
           if enableLiveText {
             analyzeImage()
           }
+        #endif
+        #if os(iOS)
+          updateContextMenuInteraction()
         #endif
       }
     }
@@ -150,6 +163,9 @@
       showPageNumber: Bool,
       showPageShadow: Bool,
       enableLiveText: Bool,
+      enableImageContextMenu: Bool,
+      supportsPageIsolationActions: Bool,
+      canIsolatePageFromCurrentPresentation: Bool,
       background: ReaderBackground,
       readingDirection: ReadingDirection,
       displayMode: PageDisplayMode,
@@ -163,6 +179,9 @@
       self.showPageShadow = showPageShadow
       let shouldEnableLiveText = enableLiveText && !viewModel.isAnimatedPage(for: data.pageID)
       self.enableLiveText = shouldEnableLiveText
+      self.enableImageContextMenu = enableImageContextMenu
+      self.supportsPageIsolationActions = supportsPageIsolationActions
+      self.canIsolatePageFromCurrentPresentation = canIsolatePageFromCurrentPresentation
 
       let pageSourceImage: PlatformImage?
       if let image = image, data.splitMode != .none {
@@ -221,6 +240,10 @@
           }
           clearAnalysis()
         }
+      #endif
+
+      #if os(iOS)
+        updateContextMenuInteraction()
       #endif
 
       updateShadowAppearance()
@@ -406,6 +429,10 @@
           analyzeImage()
         }
       #endif
+
+      #if os(iOS)
+        updateContextMenuInteraction()
+      #endif
     }
 
     private func updateOverlaysPosition() {
@@ -484,5 +511,123 @@
 
       return combinedRect
     }
+
+    #if os(iOS)
+      private var shouldEnableContextMenuInteraction: Bool {
+        enableImageContextMenu && !enableLiveText && imageView.image != nil
+      }
+
+      private func updateContextMenuInteraction() {
+        guard shouldEnableContextMenuInteraction else {
+          removeContextMenuInteractionIfNeeded()
+          return
+        }
+
+        if !imageView.interactions.contains(where: { $0 === contextMenuInteraction }) {
+          imageView.addInteraction(contextMenuInteraction)
+        }
+      }
+
+      private func removeContextMenuInteractionIfNeeded() {
+        if imageView.interactions.contains(where: { $0 === contextMenuInteraction }) {
+          imageView.removeInteraction(contextMenuInteraction)
+        }
+      }
+
+      private func makeContextMenu() -> UIMenu? {
+        guard let currentData, imageView.image != nil else { return nil }
+
+        var actions: [UIMenuElement] = [makeShareAction(for: currentData.pageID)]
+        if let isolateAction = makePageIsolationAction(for: currentData.pageID) {
+          actions.append(isolateAction)
+        }
+
+        return UIMenu(children: actions)
+      }
+
+      private func makeShareAction(for pageID: ReaderPageID) -> UIAction {
+        let displayPageNumber = viewModel?.displayPageNumber(for: pageID) ?? pageID.pageNumber + 1
+        let title = String.localizedStringWithFormat(
+          String(localized: "Share Page %d"),
+          displayPageNumber
+        )
+        return UIAction(title: title, image: UIImage(systemName: "square.and.arrow.up")) {
+          [weak self] _ in
+          self?.shareCurrentImage(for: pageID)
+        }
+      }
+
+      private func makePageIsolationAction(for pageID: ReaderPageID) -> UIAction? {
+        guard supportsPageIsolationActions, let viewModel else { return nil }
+        guard let readerPage = viewModel.readerPage(for: pageID), readerPage.page.isPortrait else {
+          return nil
+        }
+
+        if viewModel.isPageIsolated(pageID) {
+          return UIAction(
+            title: String(localized: "Cancel Isolation"),
+            image: UIImage(systemName: "rectangle.portrait.slash")
+          ) { [weak self] _ in
+            self?.viewModel?.toggleIsolatePage(pageID)
+          }
+        }
+
+        guard canIsolatePageFromCurrentPresentation else { return nil }
+        let displayPageNumber = viewModel.displayPageNumber(for: pageID) ?? pageID.pageNumber + 1
+        let title = String.localizedStringWithFormat(
+          String(localized: "Isolate Page %d"),
+          displayPageNumber
+        )
+        return UIAction(
+          title: title,
+          image: UIImage(systemName: "rectangle.portrait")
+        ) { [weak self] _ in
+          self?.viewModel?.toggleIsolatePage(pageID)
+        }
+      }
+
+      private func shareCurrentImage(for pageID: ReaderPageID) {
+        guard let image = imageView.image else { return }
+        let fileName = viewModel?.page(for: pageID)?.fileName
+        ImageShareHelper.share(image: image, fileName: fileName)
+      }
+
+      private func makePreview() -> UITargetedPreview? {
+        guard !imageView.bounds.isEmpty else { return nil }
+        let parameters = UIPreviewParameters()
+        parameters.backgroundColor = .clear
+        parameters.visiblePath = UIBezierPath(rect: imageView.bounds)
+        return UITargetedPreview(view: imageView, parameters: parameters)
+      }
+    #endif
   }
+
+  #if os(iOS)
+    extension NativePageItem: UIContextMenuInteractionDelegate {
+      func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        configurationForMenuAtLocation location: CGPoint
+      ) -> UIContextMenuConfiguration? {
+        guard imageView.bounds.contains(location) else { return nil }
+        guard makeContextMenu() != nil else { return nil }
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+          self?.makeContextMenu()
+        }
+      }
+
+      func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        previewForHighlightingMenuWithConfiguration configuration: UIContextMenuConfiguration
+      ) -> UITargetedPreview? {
+        makePreview()
+      }
+
+      func contextMenuInteraction(
+        _ interaction: UIContextMenuInteraction,
+        previewForDismissingMenuWithConfiguration configuration: UIContextMenuConfiguration
+      ) -> UITargetedPreview? {
+        makePreview()
+      }
+    }
+  #endif
 #endif

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_macOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_macOS.swift
@@ -23,6 +23,9 @@
     private var readerBackground: ReaderBackground = .system
     private var showPageShadow = true
     private var enableLiveText = false
+    private var enableImageContextMenu = false
+    private var supportsPageIsolationActions = false
+    private var canIsolatePageFromCurrentPresentation = false
     private weak var readerViewModel: ReaderViewModel?
     private let logger = AppLogger(.reader)
     private var analysisSourceImage: NSImage?
@@ -49,6 +52,7 @@
 
     func prepareForDismantle() {
       clearAnalysis()
+      updateContextMenu(menu: nil)
       updateAnimatedPlayback(sourceFileURL: nil)
       imageView.isHidden = false
       imageView.image = nil
@@ -79,6 +83,7 @@
             analyzeImage(image)
           }
         }
+        updateContextMenu()
       }
     }
 
@@ -195,6 +200,9 @@
       showPageNumber: Bool,
       showPageShadow: Bool,
       enableLiveText: Bool,
+      enableImageContextMenu: Bool,
+      supportsPageIsolationActions: Bool,
+      canIsolatePageFromCurrentPresentation: Bool,
       background: ReaderBackground,
       readingDirection: ReadingDirection,
       displayMode: PageDisplayMode,
@@ -208,6 +216,9 @@
       self.showPageShadow = showPageShadow
       let shouldEnableLiveText = enableLiveText && !viewModel.isAnimatedPage(for: data.pageID)
       self.enableLiveText = shouldEnableLiveText
+      self.enableImageContextMenu = enableImageContextMenu
+      self.supportsPageIsolationActions = supportsPageIsolationActions
+      self.canIsolatePageFromCurrentPresentation = canIsolatePageFromCurrentPresentation
 
       let pageSourceImage: PlatformImage?
       if let image = image, data.splitMode != .none {
@@ -256,6 +267,7 @@
       }
 
       updateShadowAppearance()
+      updateContextMenu()
       updateOverlaysPosition()
     }
 
@@ -496,6 +508,101 @@
       {
         analyzeImage(image)
       }
+
+      updateContextMenu()
+    }
+
+    private var contextMenuTargetViews: [NSView] {
+      [
+        imageView,
+        sepiaOverlayView,
+        animatedInlineContainer,
+        overlayView,
+        pageNumberContainer,
+        pageNumberLabel,
+      ]
+    }
+
+    private var shouldEnableContextMenu: Bool {
+      enableImageContextMenu && imageView.image != nil
+    }
+
+    private func updateContextMenu() {
+      let menu = shouldEnableContextMenu ? buildContextMenu() : nil
+      updateContextMenu(menu: menu)
+    }
+
+    private func updateContextMenu(menu: NSMenu?) {
+      for view in contextMenuTargetViews {
+        view.menu = menu
+      }
+    }
+
+    private func buildContextMenu() -> NSMenu? {
+      guard let currentData, imageView.image != nil else { return nil }
+
+      let menu = NSMenu()
+      menu.addItem(makeShareMenuItem(for: currentData.pageID))
+
+      if let isolationItem = makePageIsolationMenuItem(for: currentData.pageID) {
+        menu.addItem(isolationItem)
+      }
+
+      return menu.items.isEmpty ? nil : menu
+    }
+
+    private func makeShareMenuItem(for pageID: ReaderPageID) -> NSMenuItem {
+      let displayPageNumber = readerViewModel?.displayPageNumber(for: pageID) ?? pageID.pageNumber + 1
+      let title = String.localizedStringWithFormat(
+        String(localized: "Share Page %d"),
+        displayPageNumber
+      )
+      let item = NSMenuItem(title: title, action: #selector(handleShareContextMenuAction), keyEquivalent: "")
+      item.target = self
+      return item
+    }
+
+    private func makePageIsolationMenuItem(for pageID: ReaderPageID) -> NSMenuItem? {
+      guard supportsPageIsolationActions, let readerViewModel else { return nil }
+      guard let readerPage = readerViewModel.readerPage(for: pageID), readerPage.page.isPortrait else {
+        return nil
+      }
+
+      if readerViewModel.isPageIsolated(pageID) {
+        let item = NSMenuItem(
+          title: String(localized: "Cancel Isolation"),
+          action: #selector(handleTogglePageIsolationContextMenuAction),
+          keyEquivalent: ""
+        )
+        item.target = self
+        return item
+      }
+
+      guard canIsolatePageFromCurrentPresentation else { return nil }
+      let displayPageNumber = readerViewModel.displayPageNumber(for: pageID) ?? pageID.pageNumber + 1
+      let title = String.localizedStringWithFormat(
+        String(localized: "Isolate Page %d"),
+        displayPageNumber
+      )
+      let item = NSMenuItem(
+        title: title,
+        action: #selector(handleTogglePageIsolationContextMenuAction),
+        keyEquivalent: ""
+      )
+      item.target = self
+      return item
+    }
+
+    @objc private func handleShareContextMenuAction() {
+      guard let pageID = currentData?.pageID, let image = imageView.image else { return }
+      let fileName = readerViewModel?.page(for: pageID)?.fileName
+      ImageShareHelper.share(image: image, fileName: fileName)
+    }
+
+    @objc private func handleTogglePageIsolationContextMenuAction() {
+      guard let pageID = currentData?.pageID else { return }
+      readerViewModel?.toggleIsolatePage(pageID)
+      updateContextMenu()
     }
   }
 #endif

--- a/KMReader/Features/Reader/Views/PageImage/PageScrollView_iOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/PageScrollView_iOS.swift
@@ -153,6 +153,10 @@
       func updatePages() {
         guard let stack = contentStack else { return }
         let pages = parent.pages
+        let canIsolatePageFromCurrentPresentation =
+          parent.renderConfig.supportsPageIsolationActions
+          && pages.count == 2
+          && Set(pages.map(\.pageID)).count == 2
 
         if pageViews.count != pages.count {
           pageViews.forEach { view in
@@ -175,6 +179,9 @@
             showPageNumber: parent.renderConfig.showPageNumber,
             showPageShadow: parent.renderConfig.showPageShadow,
             enableLiveText: parent.renderConfig.enableLiveText,
+            enableImageContextMenu: parent.renderConfig.enableImageContextMenu,
+            supportsPageIsolationActions: parent.renderConfig.supportsPageIsolationActions,
+            canIsolatePageFromCurrentPresentation: canIsolatePageFromCurrentPresentation,
             background: parent.renderConfig.readerBackground,
             readingDirection: parent.readingDirection,
             displayMode: parent.displayMode,

--- a/KMReader/Features/Reader/Views/PageImage/PageScrollView_macOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/PageScrollView_macOS.swift
@@ -194,6 +194,10 @@
       func updatePages() {
         guard let stack = contentStack else { return }
         let pages = parent.pages
+        let canIsolatePageFromCurrentPresentation =
+          parent.renderConfig.supportsPageIsolationActions
+          && pages.count == 2
+          && Set(pages.map(\.pageID)).count == 2
 
         if pageViews.count != pages.count {
           pageViews.forEach { view in
@@ -213,6 +217,9 @@
             showPageNumber: parent.renderConfig.showPageNumber,
             showPageShadow: parent.renderConfig.showPageShadow,
             enableLiveText: parent.renderConfig.enableLiveText,
+            enableImageContextMenu: parent.renderConfig.enableImageContextMenu,
+            supportsPageIsolationActions: parent.renderConfig.supportsPageIsolationActions,
+            canIsolatePageFromCurrentPresentation: canIsolatePageFromCurrentPresentation,
             background: parent.renderConfig.readerBackground,
             readingDirection: parent.readingDirection,
             displayMode: parent.displayMode,

--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -33,6 +33,8 @@ struct ReaderSettingsSheet: View {
   private var imageUpscaleAlwaysMaxScreenScale: Double =
     AppConfig.imageUpscaleAlwaysMaxScreenScale
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
+  @AppStorage("enableDivinaImageContextMenu")
+  private var enableDivinaImageContextMenu: Bool = AppConfig.enableDivinaImageContextMenu
   @AppStorage("readerControlsGradientBackground") private var readerControlsGradientBackground: Bool = false
 
   private var isWebtoonDirection: Bool {
@@ -219,6 +221,14 @@ struct ReaderSettingsSheet: View {
                 }
               }
             #endif
+          }
+        #endif
+
+        #if os(iOS) || os(macOS)
+          Section(header: Text("Context Menu")) {
+            Toggle(isOn: $enableDivinaImageContextMenu) {
+              Text("Enable Image Context Menu")
+            }
           }
         #endif
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonZoomOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonZoomOverlayView.swift
@@ -24,6 +24,8 @@
         showPageShadow: renderConfig.showPageShadow,
         readerBackground: renderConfig.readerBackground,
         enableLiveText: renderConfig.enableLiveText,
+        enableImageContextMenu: renderConfig.enableImageContextMenu,
+        supportsPageIsolationActions: false,
         doubleTapZoomScale: renderConfig.doubleTapZoomScale,
         doubleTapZoomMode: renderConfig.doubleTapZoomMode
       )

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -33,6 +33,8 @@ struct DivinaPreferencesView: View {
   private var imageUpscaleAlwaysMaxScreenScale: Double =
     AppConfig.imageUpscaleAlwaysMaxScreenScale
   @AppStorage("enableLiveText") private var enableLiveText: Bool = false
+  @AppStorage("enableDivinaImageContextMenu")
+  private var enableDivinaImageContextMenu: Bool = AppConfig.enableDivinaImageContextMenu
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
   @AppStorage("readerControlsGradientBackground") private var readerControlsGradientBackground: Bool = false
 
@@ -322,6 +324,21 @@ struct DivinaPreferencesView: View {
               }
             }
           #endif
+        }
+      #endif
+
+      #if os(iOS) || os(macOS)
+        Section(header: Text("Context Menu")) {
+          Toggle(isOn: $enableDivinaImageContextMenu) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Enable Image Context Menu")
+              Text(
+                "Show a context menu on page images for quick actions like share or isolate page. On iOS, Live Text keeps the long-press gesture while it is enabled."
+              )
+              .font(.caption)
+              .foregroundColor(.secondary)
+            }
+          }
         }
       #endif
 

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -13341,6 +13341,70 @@
         }
       }
     },
+    "Context Menu" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontextmenü"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Context Menu"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menú contextual"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menu contextuel"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menu contestuale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コンテキストメニュー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "컨텍스트 메뉴"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Контекстное меню"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上下文菜单"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上下文選單"
+          }
+        }
+      }
+    },
     "Controls Gradient Background" : {
       "localizations" : {
         "de" : {
@@ -19289,6 +19353,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "清空所有圖書館的回收桶"
+          }
+        }
+      }
+    },
+    "Enable Image Context Menu" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bild-Kontextmenü aktivieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enable Image Context Menu"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar menú contextual de imagen"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer le menu contextuel des images"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abilita menu contestuale immagine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像のコンテキストメニューを有効にする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미지 컨텍스트 메뉴 활성화"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включить контекстное меню изображения"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用图片上下文菜单"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用圖片上下文選單"
           }
         }
       }
@@ -66139,6 +66267,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文字和線稿更清晰，推薦用於 iPad 和 Mac。"
+          }
+        }
+      }
+    },
+    "Show a context menu on page images for quick actions like share or isolate page. On iOS, Live Text keeps the long-press gesture while it is enabled." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeigt auf Seitenbildern ein Kontextmenü für Schnellaktionen wie Teilen oder Seite isolieren an. Auf iOS bleibt die Geste für langes Drücken bei aktiviertem Live Text reserviert."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show a context menu on page images for quick actions like share or isolate page. On iOS, Live Text keeps the long-press gesture while it is enabled."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra un menú contextual en las imágenes de las páginas para acciones rápidas como compartir o aislar la página. En iOS, Live Text conserva el gesto de pulsación prolongada mientras está activado."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Affiche un menu contextuel sur les images des pages pour des actions rapides comme partager ou isoler la page. Sur iOS, Live Text conserve le geste d'appui long lorsqu'il est activé."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra un menu contestuale sulle immagini delle pagine per azioni rapide come condividere o isolare la pagina. Su iOS, Live Text mantiene il gesto di pressione prolungata quando è attivo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページ画像に共有やページの分離などのクイックアクション用コンテキストメニューを表示します。iOS では、Live Text が有効な間は長押しジェスチャは Live Text に割り当てられます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 이미지에 공유나 페이지 분리 같은 빠른 작업용 컨텍스트 메뉴를 표시합니다. iOS에서는 Live Text가 활성화되어 있는 동안 길게 누르기 제스처가 Live Text에 유지됩니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывает контекстное меню на изображениях страниц для быстрых действий, таких как отправка или изоляция страницы. На iOS при включенном Live Text жест долгого нажатия остается за Live Text."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在页面图片上显示上下文菜单，用于分享、隔离页面等快捷操作。在 iOS 上，启用 Live Text 后，长按手势仍会保留给 Live Text。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在頁面圖片上顯示上下文選單，用於分享、隔離頁面等快捷操作。在 iOS 上，啟用 Live Text 後，長按手勢仍會保留給 Live Text。"
           }
         }
       }


### PR DESCRIPTION
## Problem
DIVINA reader page images had no image-scoped context menu, so actions like sharing a page or isolating a page in a spread were only available through broader reader controls. The requested interaction also needed strict bounds: the long-press target and preview should match the rendered image area, and Live Text should keep owning the long-press gesture on iOS when enabled.

## Approach
Attach the context menu at the native image view layer instead of the outer SwiftUI container. This keeps the menu trigger and preview aligned with the actual rendered image frame, works for cropped split-page presentations, and allows the iOS implementation to disable the menu whenever Live Text is active so the long-press gesture remains reserved for text analysis.

## Scope
- Add an opt-in DIVINA image context menu setting, defaulting to off
- Surface the same toggle in both DIVINA preferences and the in-reader settings sheet
- Add native iOS and macOS page-image menus with share and isolate page actions
- Extend reader render config and page state helpers needed by the menu flow
- Bump the build version to 397

## Validation
- [x] `make format`
- [x] `make build`
- [x] `make localize`
- [x] `./misc/translate.py list`
