### PR TITLE
docs: refresh changelog and product docs

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,13 +1,13 @@
 Reader Improvements
-- EPUB adds richer reading controls, including text alignment, more consistent font-weight behavior, better overlay options, and improved progress display on iPhone, iPad, and Mac.
-- macOS EPUB paged reading now supports cover-style page turns, bringing it closer to the native feel available elsewhere in KMReader.
-- Reader navigation is steadier across DIVINA, EPUB, and Webtoon, with better position recovery after rotation, reloads, and end-of-chapter preloading.
-- Live Text interactions are more precise, reducing accidental page turns near text selection.
+- DIVINA cover reading feels smoother and more reliable on iPhone, iPad, and Mac, with steadier transitions and less stale loading state.
+- Scroll-mode DIVINA now preloads the next page earlier on iPhone and iPad, so the first page turn is less likely to pause.
+- Optional page image context menus on iPhone, iPad, and Mac let you share a page or isolate a single page from a spread more quickly.
+- Detail views now make it easier to copy titles and other useful library text.
 
-Offline and Sync
-- Offline EPUB handling is more reliable, with safer download finalization and better recovery when reopening downloaded books.
-- Reading history now syncs automatically on app launch and resume, so recent activity stays current with less manual refresh.
+Mac Experience
+- PDF reading on Mac now includes keyboard help, better shortcut coverage, and faster access to search, page jump, and table of contents actions.
+- Reader command menus are more consistent across DIVINA and PDF, including current-page isolation where supported.
 
-Polish and Quality
-- Reader and download Live Activities are cleaner and easier to read, especially in Dynamic Island.
-- Completed books now show more useful last-read details, and several reader overlays and picker views have been refined for a more consistent experience.
+Polish and Reliability
+- Reader controls are easier to read on older system versions.
+- EPUB opening is steadier, with fewer distracting transitions when a book first loads.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -1,26 +1,26 @@
 KMReader - Native Komga Client for iPhone, iPad, Mac, and Apple TV
 
-KMReader helps you read, browse, download, and manage your Komga library with a fast native experience across Apple platforms.
+KMReader helps you read, browse, download, and manage your Komga library with fast native readers and practical offline workflows across Apple platforms.
 
 IMPORTANT FEATURES
 
 - Native readers for every format
-DIVINA on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl (iOS), cover-style transitions on all platforms, optional page shadows, clearer page-turn animation controls, and steadier scroll reading with better RTL and wide-page handling.
-EPUB on iOS and macOS with paged, scrolled, or cover layouts, custom fonts, themes, text alignment and font-weight controls, and configurable overlay/footer visibility.
-Animated GIF and WebP pages start immediately, stay smooth while you zoom or scroll, and remain reliable when you revisit pages.
-PDF on iOS and macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality, and clearer offline preparation progress.
+DIVINA on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl (iOS), cover-style transitions, optional page shadows, customizable tap zones, and optional page image actions on iOS/macOS for sharing or isolating a page.
+EPUB on iOS and macOS with paged, scrolled, or cover layouts, custom fonts, themes, text alignment and font-weight controls, configurable overlays, and nested table of contents.
+Animated GIF and WebP pages play inline and stay smooth while you zoom or scroll.
+PDF on iOS and macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality, and strong keyboard support on macOS.
 Incognito mode, optional reader Live Activities with progress or incognito status, and iOS Live Text support let you read your way.
 
 - Dashboard, discovery, and shortcuts
-Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists keep important items close.
-Browse Series, Books, Collections, and Read Lists with advanced metadata filters, saved filters, optional unread-cover blur, and automatically synced reading history.
+Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/read lists, and saved filters keep the right parts of your library close.
+Browse Series, Books, Collections, and Read Lists with advanced metadata filters, optional unread-cover blur, synced reading history, and copy-friendly detail views for titles and metadata.
 Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions, help you jump back into reading faster.
 KMReader UI is localized in English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
 
 - Offline that actually works
-Download books for offline reading.
+Download books for offline reading across DIVINA, EPUB, and PDF workflows.
 EPUB downloads use a single-file workflow with local extraction for faster, more reliable saves.
-Use manual offline mode controls and more predictable iOS background downloads.
+Use manual offline mode controls and predictable iOS background downloads.
 Get Live Activities for both active reading sessions and downloads.
 Set per-series policies: Manual, Unread only, Unread + cleanup, or All books.
 Sync progress and offline changes when you reconnect, with safer conflict handling.
@@ -29,7 +29,7 @@ Sync progress and offline changes when you reconnect, with safer conflict handli
 Save multiple Komga servers and switch instantly.
 Sign in with password or API key, and manage API keys in the app.
 Edit metadata, manage libraries and media (analysis, missing posters, duplicate files, duplicate pages, and page-hash matches), monitor tasks, and view logs.
-On macOS, reader actions also live in the system menu bar for faster keyboard-first control.
+On macOS, reader actions also live in the menu bar and Reader menu for faster keyboard-first control.
 
 KMReader targets Komga 1.19.0+ and supports API v1/v2.
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@
 
 ### Native Reading Experience
 
-- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, customizable tap zones, page curl (iOS), cover-style page transitions on all platforms, optional page shadows, clearer page-turn animation controls, and steadier scroll and cover navigation with better RTL, wide-page, and interruption handling.
+- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, customizable tap zones, page curl (iOS), cover-style page transitions on all platforms, optional page shadows, optional page-image context menus on iOS/macOS for share and isolate actions, clearer page-turn animation controls, and steadier scroll and cover navigation with better RTL, wide-page, and interruption handling.
 - EPUB reader on iOS/macOS with paged, scrolled, and cover layouts, custom font importing (`.ttf`/`.otf`), theme presets, text alignment and font-weight controls, optional status/footer overlays, multi-column reading, and nested table of contents.
 - Animated GIF and WebP pages start immediately, stay smooth while you zoom or scroll, and remain reliable when reopening or revisiting pages.
-- PDF reading on iOS/macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality tiers for offline preparation, and clearer progress feedback.
+- PDF reading on iOS/macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality tiers for offline preparation, clearer progress feedback, and full keyboard help and command coverage on macOS.
 - Per-book preferences save reading direction, page layout, and theme settings.
 - Incognito mode and iOS Live Text support, including optional shake-to-toggle.
 
@@ -36,6 +36,7 @@
 - Save and reuse filters across browse surfaces.
 - Optional unread-cover blur helps hide spoiler-heavy artwork until you start reading.
 - Reading history and stats stay fresh with automatic sync and help surface recent activity from synced local data.
+- Detail views make titles and metadata easy to copy when you need to search, share, or organize library data.
 - Spotlight integration for downloaded content on iOS/macOS, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
 - UI localization includes English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
 
@@ -59,7 +60,7 @@
 ### Platform Highlights
 
 - iOS/iPadOS: widgets, quick actions, Spotlight search, Dynamic Island Live Activities for reader/downloads, background downloads, Live Text, and page curl/cover transitions.
-- macOS: dedicated reader windows, reader actions in the system menu bar, Spotlight search for downloaded content, keyboard shortcuts, and keyboard help overlay.
+- macOS: dedicated reader windows, reader actions in the system menu bar and Reader menu, Spotlight search for downloaded content, keyboard shortcuts, and keyboard help overlay.
 - tvOS: remote-first DIVINA reading with cover transitions and a TV-optimized browsing experience.
 
 ## Getting Started

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
         <title>KMReader · Native Komga Client for iOS, macOS & tvOS</title>
         <meta
             name="description"
-            content="KMReader is a native SwiftUI Komga client with DIVINA, EPUB, and PDF readers, richer EPUB typography controls, reliable offline downloads, advanced filtering, admin tools, and multi-server support."
+            content="KMReader is a native SwiftUI Komga client with DIVINA, EPUB, and PDF readers, page-level reader actions, reliable offline downloads, advanced filtering, admin tools, and multi-server support."
         />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -27,10 +27,10 @@
                 <h1>KMReader</h1>
                 <p class="tagline">
                     Read, download, browse, and manage your Komga library with
-                    native readers, richer EPUB typography and overlay
-                    controls, smooth animated page playback, reliable offline
-                    sync, advanced filtering, multi-server support,
-                    and practical Apple-platform extras like widgets,
+                    native readers, page-level reader actions, richer EPUB
+                    typography controls, smooth animated page playback,
+                    reliable offline sync, advanced filtering, multi-server
+                    support, and practical Apple-platform extras like widgets,
                     Spotlight, Dynamic Island updates, and keyboard-first
                     controls on iPhone, iPad, Mac, and Apple TV.
                 </p>
@@ -85,7 +85,9 @@
                             DIVINA on iOS/macOS/tvOS with LTR, RTL, vertical,
                             Webtoon, spreads, zoom, tap zones, page curl
                             (iOS), cover transitions on all platforms,
-                            optional page shadows, clearer page-turn animation
+                            optional page shadows, optional page image
+                            context menus on iOS/macOS for sharing or
+                            isolating a page, clearer page-turn animation
                             controls, and steadier scroll reading with better
                             RTL, wide-page, and interruption handling.
                             EPUB on iOS/macOS adds custom fonts, paged,
@@ -95,8 +97,9 @@
                             pages play immediately, stay smooth while you zoom
                             or scroll, and remain reliable when you revisit
                             pages, while PDF on iOS/macOS offers a native
-                            reader or DIVINA mode with search, TOC, and
-                            configurable render quality.
+                            reader or DIVINA mode with search, TOC,
+                            configurable render quality, and strong keyboard
+                            support on macOS.
                         </p>
                     </article>
                     <article class="card">
@@ -107,7 +110,9 @@
                             Updated, reading history and stats, pinned
                             collections/read lists, saved filters, and
                             optional unread-cover blur keep the most useful
-                            parts of your library close.
+                            parts of your library close, while copy-friendly
+                            detail views make titles and metadata easier to
+                            reuse.
                         </p>
                     </article>
                     <article class="card">
@@ -192,9 +197,10 @@
                         <h3>macOS</h3>
                         <p>
                             DIVINA, EPUB, and PDF with dedicated reader
-                            windows, reader actions in the system menu bar,
-                            Spotlight search for downloaded content,
-                            keyboard-first controls, and keyboard help.
+                            windows, reader actions in the system menu bar and
+                            Reader menu, Spotlight search for downloaded
+                            content, keyboard-first controls, and keyboard
+                            help.
                         </p>
                     </article>
                     <article class="card">
@@ -226,8 +232,9 @@
                             overlay controls, and PDF offering a native reader
                             or DIVINA mode, while animated GIF and WebP pages
                             play inline with the reader. Reader settings
-                            include page shadows and page-turn animation
-                            controls.
+                            include page shadows, page-turn animation
+                            controls, optional page image actions on
+                            iOS/macOS, and strong keyboard support on Mac.
                         </p>
                     </article>
                     <article class="faq-item">


### PR DESCRIPTION
## Problem
The release notes and product-facing docs had drifted apart. Recent reader improvements and quality-of-life changes were not reflected consistently across the App Store changelog, README, store description, and landing page.

## Approach
Rewrite the release changelog from the commits since `v4.5` in user-facing language, then realign the evergreen product docs around the current stable feature set instead of release-specific fragments.

## Scope
- refresh `APP_STORE_CHANGELOG.txt` for the `v4.5..HEAD` release window
- update `README.md`, `APP_STORE_DESCRIPTION.txt`, and `static/index.html`
- add current messaging for DIVINA page actions, macOS keyboard workflows, and copy-friendly detail views

## Validation
- [x] Reviewed git diff for the four updated docs
- [x] Checked messaging consistency across changelog, README, App Store description, and landing page
