### PR TITLE
feat: add reader keyboard support on iOS and tvOS

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 398;
+				CURRENT_PROJECT_VERSION = 399;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 398;
+				CURRENT_PROJECT_VERSION = 399;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 398;
+				CURRENT_PROJECT_VERSION = 399;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 398;
+				CURRENT_PROJECT_VERSION = 399;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -545,6 +545,18 @@ enum AppConfig {
     }
   }
 
+  static nonisolated var epubShowKeyboardHelpOverlay: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "epubShowKeyboardHelpOverlay") != nil {
+        return UserDefaults.standard.bool(forKey: "epubShowKeyboardHelpOverlay")
+      }
+      return true
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: "epubShowKeyboardHelpOverlay")
+    }
+  }
+
   static nonisolated var enableReaderLiveActivity: Bool {
     get {
       if UserDefaults.standard.object(forKey: "enableReaderLiveActivity") != nil {

--- a/KMReader/Core/Storage/LiveTextManager.swift
+++ b/KMReader/Core/Storage/LiveTextManager.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-#if !os(tvOS)
+#if os(iOS) || os(macOS)
   import VisionKit
 #endif
 
@@ -13,7 +13,7 @@ import Foundation
 class LiveTextManager {
   static let shared = LiveTextManager()
 
-  #if !os(tvOS)
+  #if os(iOS) || os(macOS)
     let analyzer = ImageAnalyzer()
   #endif
 

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -297,7 +297,7 @@ class AuthViewModel {
     await SSEService.shared.connect()
 
     WidgetDataService.refreshWidgetData()
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       SpotlightIndexService.removeAllItems()
       SpotlightIndexService.indexAllDownloadedBooks(instanceId: finalInstanceId)
     #endif

--- a/KMReader/Features/Auth/Views/LoginView.swift
+++ b/KMReader/Features/Auth/Views/LoginView.swift
@@ -209,7 +209,7 @@ struct LoginView: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 10)
       }
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         .frame(maxWidth: 360)
       #endif
       .frame(maxWidth: .infinity, alignment: .center)

--- a/KMReader/Features/Book/Views/BookDetailView.swift
+++ b/KMReader/Features/Book/Views/BookDetailView.swift
@@ -88,7 +88,7 @@ struct BookDetailView: View {
       url: KomgaWebLinkBuilder.book(serverURL: current.serverURL, bookId: bookId),
       scope: .browse
     )
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       .toolbar {
         ToolbarItem(placement: .automatic) {
           bookToolbarContent
@@ -239,7 +239,7 @@ struct BookDetailView: View {
   @ViewBuilder
   private var bookToolbarContent: some View {
     HStack {
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         if let shareURL {
           ShareLink(item: shareURL, subject: Text(navigationTitle)) {
             Image(systemName: "square.and.arrow.up")

--- a/KMReader/Features/Browse/Views/BrowseView.swift
+++ b/KMReader/Features/Browse/Views/BrowseView.swift
@@ -148,7 +148,7 @@ struct BrowseView: View {
     .inlineNavigationBarTitle(title)
     .animation(.default, value: librarySelection)
     .searchable(text: $searchQuery)
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       .toolbar {
         if librarySelection == nil {
           #if os(macOS)

--- a/KMReader/Features/Browse/Views/SavedFiltersView.swift
+++ b/KMReader/Features/Browse/Views/SavedFiltersView.swift
@@ -83,7 +83,7 @@ struct SavedFiltersView: View {
       }
       .adaptiveButtonStyle(.plain)
     }
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       .swipeActions(edge: .trailing, allowsFullSwipe: false) {
         Button(role: .destructive) {
           deleteFilter(filter)

--- a/KMReader/Features/Collection/Views/CollectionDetailView.swift
+++ b/KMReader/Features/Collection/Views/CollectionDetailView.swift
@@ -90,7 +90,7 @@ struct CollectionDetailView: View {
     } message: {
       Text("This will permanently delete \(collection?.name ?? "this collection") from Komga.")
     }
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       .toolbar {
         ToolbarItem(placement: .automatic) {
           collectionToolbarContent

--- a/KMReader/Features/Dashboard/Views/DashboardView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardView.swift
@@ -321,7 +321,7 @@ struct DashboardView: View {
         }
       }
     }
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       .toolbar {
         #if os(macOS)
           ToolbarItem(placement: .navigation) {

--- a/KMReader/Features/History/Views/ServerReadingStatsView.swift
+++ b/KMReader/Features/History/Views/ServerReadingStatsView.swift
@@ -259,7 +259,7 @@ struct ServerReadingStatsView: View {
             }
           }
         }
-        #if !os(tvOS)
+        #if os(iOS) || os(macOS)
           .chartOverlay { proxy in
             GeometryReader { geometry in
               Color.clear
@@ -314,7 +314,7 @@ struct ServerReadingStatsView: View {
           .font(.caption)
           .foregroundStyle(.secondary)
 
-        #if !os(tvOS)
+        #if os(iOS) || os(macOS)
           Text(String(localized: "Tip: Tap or drag a point to view details."))
             .font(.caption)
             .foregroundStyle(.secondary)

--- a/KMReader/Features/Offline/Services/BackgroundDownloadManager.swift
+++ b/KMReader/Features/Offline/Services/BackgroundDownloadManager.swift
@@ -6,7 +6,7 @@
 import Foundation
 import OSLog
 
-#if !os(tvOS)
+#if os(iOS) || os(macOS)
 
   /// Information about a download task, persisted to UserDefaults for session reconnection
   struct BackgroundDownloadTaskInfo: Codable {

--- a/KMReader/Features/Offline/Views/OfflineTasksView.swift
+++ b/KMReader/Features/Offline/Views/OfflineTasksView.swift
@@ -266,7 +266,7 @@ struct OfflineTaskRow: View {
 
       Spacer()
 
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         HStack(spacing: 16) {
           if case .failed = book.downloadStatus {
             Button {

--- a/KMReader/Features/Offline/Views/OfflineView.swift
+++ b/KMReader/Features/Offline/Views/OfflineView.swift
@@ -145,7 +145,7 @@ struct OfflineView: View {
     }
     .inlineNavigationBarTitle(title)
     .searchable(text: $searchQuery)
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       .toolbar {
         if librarySelection == nil {
           #if os(macOS)

--- a/KMReader/Features/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailView.swift
@@ -107,7 +107,7 @@ struct OneshotDetailView: View {
       url: KomgaWebLinkBuilder.oneshot(serverURL: current.serverURL, seriesId: seriesId),
       scope: .browse
     )
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       .toolbar {
         ToolbarItem(placement: .automatic) {
           oneshotToolbarContent
@@ -293,7 +293,7 @@ struct OneshotDetailView: View {
   @ViewBuilder
   private var oneshotToolbarContent: some View {
     HStack {
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         if let shareURL {
           ShareLink(item: shareURL, subject: Text(navigationTitle)) {
             Image(systemName: "square.and.arrow.up")

--- a/KMReader/Features/ReadList/Views/ReadListDetailView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListDetailView.swift
@@ -98,7 +98,7 @@ struct ReadListDetailView: View {
     } message: {
       Text("This will permanently delete \(readList?.name ?? "this read list") from Komga.")
     }
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       .toolbar {
         ToolbarItem(placement: .automatic) {
           readListToolbarContent

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -183,6 +183,17 @@ struct DivinaReaderView: View {
     max(tapPageTransitionDuration, 0)
   }
 
+  private var isPresentingModalSheet: Bool {
+    showingPageJumpSheet
+      || showingTOCSheet
+      || showingReaderSettingsSheet
+      || showingDetailSheet
+  }
+
+  private var isKeyboardCaptureEnabled: Bool {
+    !isPresentingModalSheet
+  }
+
   private func shouldUseDualPage(screenSize: CGSize) -> Bool {
     guard screenSize.width > screenSize.height else { return false }  // Only in landscape
     guard pageLayout != .single else { return false }
@@ -450,9 +461,7 @@ struct DivinaReaderView: View {
 
         controlsOverlay(useDualPage: useDualPage)
 
-        #if os(macOS)
-          keyboardHelpOverlay
-        #endif
+        keyboardHelpOverlay
       }
       .onChange(of: useDualPage, initial: true) { _, newValue in
         usesDualPagePresentation = newValue
@@ -468,23 +477,16 @@ struct DivinaReaderView: View {
         }
         .onExitCommand {
           logger.debug("📺 onExitCommand: showingControls=\(showingControls)")
-          if showingControls {
-            toggleControls()
-          } else {
-            closeReader()
-          }
+          handleReaderExitCommand()
         }
       #endif
-      #if os(macOS)
-        .background(
-          // Window-level keyboard event handler
-          KeyboardEventHandler(
-            onKeyPress: { keyCode, flags in
-              handleKeyCode(keyCode, flags: flags)
-            }
-          )
+      .background(
+        KeyboardEventHandler(
+          isEnabled: isKeyboardCaptureEnabled,
+          commands: keyboardCommands,
+          onKeyPress: handleKeyboardEvent
         )
-      #endif
+      )
     }
     .iPadIgnoresSafeArea()
     #if os(iOS)
@@ -529,7 +531,7 @@ struct DivinaReaderView: View {
       viewModel.updateDualPageSettings(noCover: !isolateCoverPage)
       updateHandoff()
       #if os(macOS)
-        configureMacReaderCommands()
+        configureReaderCommands()
       #endif
     }
     .onChange(of: isolateCoverPage) { _, newValue in
@@ -570,7 +572,6 @@ struct DivinaReaderView: View {
       readerPresentation.updatePresentedBook(sessionID: sessionID, book: newBook)
     }
     .onChange(of: viewModel.pageCount) { oldCount, newCount in
-      // Show helper overlay when pages are first loaded (iOS and macOS)
       if oldCount == 0 && newCount > 0 {
         triggerTapZoneOverlay(timeout: 1)
         triggerKeyboardHelp(timeout: 1.5)
@@ -591,7 +592,7 @@ struct DivinaReaderView: View {
       viewModel.clearPreloadedImages()
       readerPresentation.clearFlushHandler(for: sessionID)
       #if os(macOS)
-        readerPresentation.clearMacReaderCommands()
+        readerPresentation.clearReaderCommands()
       #endif
     }
     .onChange(of: scenePhase) { _, newPhase in
@@ -604,9 +605,7 @@ struct DivinaReaderView: View {
     }
     .onChange(of: readingDirection) { _, _ in
       #if os(iOS) || os(macOS)
-        // When switching read mode via settings, briefly show overlays again
         triggerTapZoneOverlay(timeout: 1)
-        triggerKeyboardHelp(timeout: 2)
       #endif
     }
     #if os(tvOS)
@@ -618,8 +617,8 @@ struct DivinaReaderView: View {
       }
     #endif
     #if os(macOS)
-      .onChange(of: macReaderCommandState) { _, newState in
-        readerPresentation.updateMacReaderCommandState(newState)
+      .onChange(of: readerCommandState) { _, newState in
+        readerPresentation.updateReaderCommandState(newState)
       }
     #endif
     #if os(iOS)
@@ -823,139 +822,167 @@ struct DivinaReaderView: View {
     )
   }
 
-  #if os(macOS)
-    private var keyboardHelpOverlay: some View {
-      KeyboardHelpOverlay(
-        readingDirection: readingDirection,
-        hasTOC: !viewModel.tableOfContents.isEmpty,
-        supportsLiveText: true,
-        supportsJumpToPage: true,
-        supportsToggleControls: true,
-        hasNextBook: currentSegmentNextBook != nil,
-        onDismiss: {
-          hideKeyboardHelp()
-        }
+  private var keyboardCommands: [ReaderKeyboardCommand] {
+    var commands = [
+      ReaderKeyboardCommand(
+        title: "Keyboard Shortcuts",
+        event: ReaderKeyboardEvent(key: .slash, modifiers: [.command])
       )
-      .opacity(showKeyboardHelp ? 1.0 : 0.0)
-      .allowsHitTesting(showKeyboardHelp)
-      .animation(.default, value: showKeyboardHelp)
+    ]
+
+    if !viewModel.tableOfContents.isEmpty {
+      commands.append(
+        ReaderKeyboardCommand(
+          title: "Table of Contents",
+          event: ReaderKeyboardEvent(key: .t, modifiers: [.command])
+        )
+      )
     }
 
-    private func handleKeyCode(_ keyCode: UInt16, flags: NSEvent.ModifierFlags) -> Bool {
-      // Handle ESC key to close window
-      if keyCode == 53 {  // ESC key
-        closeReader()
-        return true
+    if viewModel.hasPages {
+      commands.append(
+        ReaderKeyboardCommand(
+          title: "Jump to Page",
+          event: ReaderKeyboardEvent(key: .j, modifiers: [.command])
+        )
+      )
+    }
+
+    return commands
+  }
+
+  private var keyboardHelpOverlay: some View {
+    KeyboardHelpOverlay(
+      readingDirection: readingDirection,
+      hasTOC: !viewModel.tableOfContents.isEmpty,
+      supportsFullscreenToggle: supportsFullscreenToggle,
+      supportsLiveText: supportsLiveTextKeyboardShortcut,
+      supportsJumpToPage: true,
+      supportsToggleControls: true,
+      hasNextBook: currentSegmentNextBook != nil,
+      onDismiss: {
+        hideKeyboardHelp()
       }
+    )
+    .opacity(showKeyboardHelp ? 1.0 : 0.0)
+    .allowsHitTesting(showKeyboardHelp)
+    .animation(.default, value: showKeyboardHelp)
+  }
 
-      // Handle ? key and H key for keyboard help
-      if keyCode == 44 {  // ? key (Shift + /)
-        showKeyboardHelp.toggle()
-        return true
+  private func handleKeyboardEvent(_ event: ReaderKeyboardEvent) -> Bool {
+    if event.matches(.escape) {
+      handleReaderExitCommand()
+      return true
+    }
+
+    if event.matches(.slash, modifiers: [.shift])
+      || event.matches(.slash, modifiers: [.command])
+      || event.matches(.h)
+    {
+      toggleKeyboardHelpManually()
+      return true
+    }
+
+    if event.matches(.returnOrEnter) {
+      return toggleFullscreenIfSupported()
+    }
+
+    if event.matches(.space) {
+      toggleControls()
+      return true
+    }
+
+    if event.matches(.t, modifiers: [.command]) {
+      if !viewModel.tableOfContents.isEmpty {
+        showingTOCSheet = true
       }
+      return true
+    }
 
-      // Handle Return/Enter key for fullscreen toggle
-      if keyCode == 36 {  // Return/Enter key
-        if let window = NSApplication.shared.keyWindow {
-          window.toggleFullScreen(nil)
-        }
-        return true
+    if event.matches(.j, modifiers: [.command]) {
+      if viewModel.hasPages {
+        showingPageJumpSheet = true
       }
+      return true
+    }
 
-      // Handle Space key for toggle controls
-      if keyCode == 49 {  // Space key
-        toggleControls()
-        return true
-      }
+    guard !event.hasSystemModifiers else { return false }
 
-      // Ignore if modifier keys are pressed (except for system shortcuts)
-      guard flags.intersection([.command, .option, .control]).isEmpty else { return false }
+    if event.matches(.c) {
+      toggleControls()
+      return true
+    }
 
-      // Handle H key for keyboard help
-      if keyCode == 4 {  // H key
-        showKeyboardHelp.toggle()
-        return true
-      }
-
-      // Handle C key for toggle controls
-      if keyCode == 8 {  // C key
-        toggleControls()
-        return true
-      }
-
-      if keyCode == 37 {  // L key
+    #if os(iOS) || os(macOS)
+      if event.matches(.l) {
         enableLiveText.toggle()
         let message = enableLiveText ? String(localized: "Live Text: ON") : String(localized: "Live Text: OFF")
         ErrorManager.shared.notify(message: message)
         return true
       }
+    #endif
 
-      // Handle T key for TOC
-      if keyCode == 17 {  // T key
-        if !viewModel.tableOfContents.isEmpty {
-          showingTOCSheet = true
-        }
-        return true
+    if event.matches(.t) {
+      if !viewModel.tableOfContents.isEmpty {
+        showingTOCSheet = true
       }
+      return true
+    }
 
-      // Handle J key for jump to page
-      if keyCode == 38 {  // J key
-        if viewModel.hasPages {
-          showingPageJumpSheet = true
-        }
-        return true
+    if event.matches(.j) {
+      if viewModel.hasPages {
+        showingPageJumpSheet = true
       }
+      return true
+    }
 
-      // Handle N key for next book
-      if keyCode == 45 {  // N key
-        if let nextBook = currentSegmentNextBook {
-          openNextBook(nextBookId: nextBook.id)
-        }
-        return true
+    if event.matches(.n) {
+      if let nextBook = currentSegmentNextBook {
+        openNextBook(nextBookId: nextBook.id)
       }
+      return true
+    }
 
-      guard viewModel.hasPages else { return false }
+    guard viewModel.hasPages else { return false }
 
-      switch readingDirection {
-      case .ltr:
-        switch keyCode {
-        case 124:  // Right arrow
-          goToNextPage()
-          return true
-        case 123:  // Left arrow
-          goToPreviousPage()
-          return true
-        default:
-          return false
-        }
-      case .rtl:
-        switch keyCode {
-        case 123:  // Left arrow
-          goToNextPage()
-          return true
-        case 124:  // Right arrow
-          goToPreviousPage()
-          return true
-        default:
-          return false
-        }
-      case .vertical:
-        switch keyCode {
-        case 125:  // Down arrow
-          goToNextPage()
-          return true
-        case 126:  // Up arrow
-          goToPreviousPage()
-          return true
-        default:
-          return false
-        }
-      case .webtoon:
-        // Webtoon scrolling is handled by WebtoonReaderView's own keyboard monitor
+    switch readingDirection {
+    case .ltr:
+      switch event.key {
+      case .rightArrow:
+        goToNextPage()
+        return true
+      case .leftArrow:
+        goToPreviousPage()
+        return true
+      default:
         return false
       }
+    case .rtl:
+      switch event.key {
+      case .leftArrow:
+        goToNextPage()
+        return true
+      case .rightArrow:
+        goToPreviousPage()
+        return true
+      default:
+        return false
+      }
+    case .vertical:
+      switch event.key {
+      case .downArrow:
+        goToNextPage()
+        return true
+      case .upArrow:
+        goToPreviousPage()
+        return true
+      default:
+        return false
+      }
+    case .webtoon:
+      return false
     }
-  #endif
+  }
 
   private func loadBook(bookId: String, preserveReaderOptions: Bool) async {
     // Mark that loading has started
@@ -1364,7 +1391,7 @@ struct DivinaReaderView: View {
       )
     }
 
-    private var macReaderCommandState: ReaderPresentationManager.MacReaderCommandState {
+    private var readerCommandState: ReaderCommandState {
       let supportsDualPageOptions =
         readingDirection != .webtoon
         && readingDirection != .vertical
@@ -1373,7 +1400,7 @@ struct DivinaReaderView: View {
       let supportsSplitWidePageMode =
         readingDirection != .webtoon
 
-      return ReaderPresentationManager.MacReaderCommandState(
+      return ReaderCommandState(
         isActive: true,
         supportsReaderSettings: true,
         supportsBookDetails: currentSegmentBook != nil,
@@ -1398,10 +1425,10 @@ struct DivinaReaderView: View {
       )
     }
 
-    private func configureMacReaderCommands() {
-      readerPresentation.configureMacReaderCommands(
-        state: macReaderCommandState,
-        handlers: ReaderPresentationManager.MacReaderCommandHandlers(
+    private func configureReaderCommands() {
+      readerPresentation.configureReaderCommands(
+        state: readerCommandState,
+        handlers: ReaderCommandHandlers(
           showReaderSettings: {
             showingReaderSettingsSheet = true
           },
@@ -1513,6 +1540,42 @@ struct DivinaReaderView: View {
     }
   #endif
 
+  private func toggleFullscreenIfSupported() -> Bool {
+    #if os(macOS)
+      if let window = NSApplication.shared.keyWindow {
+        window.toggleFullScreen(nil)
+        return true
+      }
+    #endif
+    return false
+  }
+
+  private var supportsFullscreenToggle: Bool {
+    #if os(macOS)
+      true
+    #else
+      false
+    #endif
+  }
+
+  private var supportsLiveTextKeyboardShortcut: Bool {
+    #if os(iOS) || os(macOS)
+      true
+    #else
+      false
+    #endif
+  }
+
+  private func handleReaderExitCommand() {
+    #if os(tvOS)
+      if showingControls {
+        toggleControls()
+        return
+      }
+    #endif
+    closeReader()
+  }
+
   /// Hide helper overlay and cancel timer
   private func hideTapZoneOverlay() {
     tapZoneOverlayTimer?.invalidate()
@@ -1547,8 +1610,17 @@ struct DivinaReaderView: View {
   /// Hide keyboard help overlay and cancel timer
   private func hideKeyboardHelp() {
     keyboardHelpTimer?.invalidate()
+    keyboardHelpTimer = nil
     withAnimation {
       showKeyboardHelp = false
+    }
+  }
+
+  private func toggleKeyboardHelpManually() {
+    keyboardHelpTimer?.invalidate()
+    keyboardHelpTimer = nil
+    withAnimation {
+      showKeyboardHelp.toggle()
     }
   }
 
@@ -1556,6 +1628,7 @@ struct DivinaReaderView: View {
   private func triggerKeyboardHelp(timeout: TimeInterval) {
     // Respect user preference and ensure we have content
     guard showKeyboardHelpOverlay, viewModel.hasPages else { return }
+    guard ReaderKeyboardAvailability.shouldAutoShowKeyboardHelp else { return }
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
       withAnimation {

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -23,6 +23,8 @@
     @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
     @AppStorage("epubShowsStatusBarWhileReading") private var epubShowsStatusBarWhileReading: Bool = false
     @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.3
+    @AppStorage("epubShowKeyboardHelpOverlay")
+    private var showKeyboardHelpOverlay: Bool = AppConfig.epubShowKeyboardHelpOverlay
 
     @State private var viewModel: EpubReaderViewModel
     @State private var activePreferences: EpubReaderPreferences
@@ -35,11 +37,8 @@
     @State private var showingDetailSheet = false
     @State private var showingQuickActions = false
     @State private var showingEndPage = false
-    #if os(macOS)
-      @AppStorage("showKeyboardHelpOverlay") private var showKeyboardHelpOverlay: Bool = true
-      @State private var showKeyboardHelp = false
-      @State private var keyboardHelpTimer: Timer?
-    #endif
+    @State private var keyboardHelpTimer: Timer?
+    @State private var showKeyboardHelp = false
 
     private let logger = AppLogger(.reader)
 
@@ -87,6 +86,16 @@
 
     private var shouldShowStatusBar: Bool {
       shouldShowControls || epubShowsStatusBarWhileReading
+    }
+
+    private var isPresentingModalSheet: Bool {
+      showingChapterSheet
+        || showingPreferencesSheet
+        || showingDetailSheet
+    }
+
+    private var isKeyboardCaptureEnabled: Bool {
+      !isPresentingModalSheet
     }
 
     private var handoffBookId: String {
@@ -172,7 +181,7 @@
           updateHandoff()
           viewModel.applyPreferences(activePreferences, colorScheme: colorScheme)
           #if os(macOS)
-            configureMacReaderCommands()
+            configureReaderCommands()
           #endif
         }
         .onChange(of: currentBook) { _, newBook in
@@ -182,20 +191,18 @@
           updateHandoff()
         }
         #if os(macOS)
-          .onChange(of: macReaderCommandState) { _, newState in
-            readerPresentation.updateMacReaderCommandState(newState)
+          .onChange(of: readerCommandState) { _, newState in
+            readerPresentation.updateReaderCommandState(newState)
           }
         #endif
         .onChange(of: viewModel.currentLocation) { _, _ in
           updateReaderLiveActivityProgress()
         }
-        #if os(macOS)
-          .onChange(of: viewModel.hasContent) { oldValue, newValue in
-            if !oldValue && newValue {
-              triggerKeyboardHelp(timeout: 1.5)
-            }
+        .onChange(of: viewModel.hasContent) { oldValue, newValue in
+          if !oldValue && newValue {
+            triggerKeyboardHelp(timeout: 1.5)
           }
-        #endif
+        }
         .onChange(of: showingEndPage) { _, newValue in
           guard newValue else { return }
           #if os(iOS)
@@ -224,7 +231,7 @@
           readerPresentation.clearFlushHandler(for: sessionID)
           #if os(macOS)
             keyboardHelpTimer?.invalidate()
-            readerPresentation.clearMacReaderCommands()
+            readerPresentation.clearReaderCommands()
           #endif
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -233,15 +240,13 @@
         #if os(iOS)
           .readerDismissGesture(readingDirection: dismissGestureReadingDirection)
         #endif
-        #if os(macOS)
-          .background(
-            KeyboardEventHandler(
-              onKeyPress: { keyCode, flags in
-                handleKeyCode(keyCode, flags: flags)
-              }
-            )
+        .background(
+          KeyboardEventHandler(
+            isEnabled: isKeyboardCaptureEnabled,
+            commands: keyboardCommands,
+            onKeyPress: handleKeyboardEvent
           )
-        #endif
+        )
     }
 
     private func loadBook() async {
@@ -312,9 +317,7 @@
 
           controlsOverlay
 
-          #if os(macOS)
-            keyboardHelpOverlay
-          #endif
+          keyboardHelpOverlay
         }
         .onAppear {
           viewModel.updateViewport(size: geometry.size)
@@ -789,6 +792,24 @@
       }
     }
 
+    private func toggleFullscreenIfSupported() -> Bool {
+      #if os(macOS)
+        if let window = NSApplication.shared.keyWindow {
+          window.toggleFullScreen(nil)
+          return true
+        }
+      #endif
+      return false
+    }
+
+    private var supportsFullscreenToggle: Bool {
+      #if os(macOS)
+        true
+      #else
+        false
+      #endif
+    }
+
     private var currentChapterLink: WebPubLink? {
       guard let currentLocation = viewModel.currentLocation else {
         return nil
@@ -808,26 +829,46 @@
       return nil
     }
 
-    #if os(macOS)
-      private var isAtLastEpubPage: Bool {
-        guard let lastPosition = viewModel.lastPagePosition() else { return false }
-        return viewModel.currentChapterIndex == lastPosition.chapterIndex
-          && viewModel.currentPageIndex >= lastPosition.pageIndex
-      }
+    private var isAtLastEpubPage: Bool {
+      guard let lastPosition = viewModel.lastPagePosition() else { return false }
+      return viewModel.currentChapterIndex == lastPosition.chapterIndex
+        && viewModel.currentPageIndex >= lastPosition.pageIndex
+    }
 
-      private func goToNextEpubPage() {
-        if isAtLastEpubPage {
-          if !showingEndPage {
-            viewModel.syncEndProgression()
-            showingEndPage = true
-          }
-          return
+    private func goToNextEpubPage() {
+      if isAtLastEpubPage {
+        if !showingEndPage {
+          viewModel.syncEndProgression()
+          showingEndPage = true
         }
-        viewModel.goToNextPage()
+        return
+      }
+      viewModel.goToNextPage()
+    }
+
+    private var keyboardCommands: [ReaderKeyboardCommand] {
+      var commands = [
+        ReaderKeyboardCommand(
+          title: "Keyboard Shortcuts",
+          event: ReaderKeyboardEvent(key: .slash, modifiers: [.command])
+        )
+      ]
+
+      if !viewModel.tableOfContents.isEmpty {
+        commands.append(
+          ReaderKeyboardCommand(
+            title: "Table of Contents",
+            event: ReaderKeyboardEvent(key: .t, modifiers: [.command])
+          )
+        )
       }
 
-      private var macReaderCommandState: ReaderPresentationManager.MacReaderCommandState {
-        ReaderPresentationManager.MacReaderCommandState(
+      return commands
+    }
+
+    #if os(macOS)
+      private var readerCommandState: ReaderCommandState {
+        ReaderCommandState(
           isActive: true,
           supportsReaderSettings: true,
           supportsBookDetails: currentBook != nil && currentSeries != nil,
@@ -851,28 +892,31 @@
           supportsSplitWidePageMode: false
         )
       }
+    #endif
 
-      private var keyboardHelpOverlay: some View {
-        KeyboardHelpOverlay(
-          readingDirection: dismissGestureReadingDirection,
-          hasTOC: !viewModel.tableOfContents.isEmpty,
-          supportsLiveText: false,
-          supportsJumpToPage: false,
-          supportsToggleControls: supportsKeyboardOverlayToggle,
-          hasNextBook: false,
-          onDismiss: {
-            hideKeyboardHelp()
-          }
-        )
-        .opacity(showKeyboardHelp ? 1.0 : 0.0)
-        .allowsHitTesting(showKeyboardHelp)
-        .animation(.default, value: showKeyboardHelp)
-      }
+    private var keyboardHelpOverlay: some View {
+      KeyboardHelpOverlay(
+        readingDirection: dismissGestureReadingDirection,
+        hasTOC: !viewModel.tableOfContents.isEmpty,
+        supportsFullscreenToggle: supportsFullscreenToggle,
+        supportsLiveText: false,
+        supportsJumpToPage: false,
+        supportsToggleControls: supportsKeyboardOverlayToggle,
+        hasNextBook: false,
+        onDismiss: {
+          hideKeyboardHelp()
+        }
+      )
+      .opacity(showKeyboardHelp ? 1.0 : 0.0)
+      .allowsHitTesting(showKeyboardHelp)
+      .animation(.default, value: showKeyboardHelp)
+    }
 
-      private func configureMacReaderCommands() {
-        readerPresentation.configureMacReaderCommands(
-          state: macReaderCommandState,
-          handlers: ReaderPresentationManager.MacReaderCommandHandlers(
+    #if os(macOS)
+      private func configureReaderCommands() {
+        readerPresentation.configureReaderCommands(
+          state: readerCommandState,
+          handlers: ReaderCommandHandlers(
             showReaderSettings: {
               showingPreferencesSheet = true
             },
@@ -898,106 +942,115 @@
           )
         )
       }
-
-      private func handleKeyCode(_ keyCode: UInt16, flags: NSEvent.ModifierFlags) -> Bool {
-        if keyCode == 53 {
-          closeReader()
-          return true
-        }
-
-        if keyCode == 44 {
-          showKeyboardHelp.toggle()
-          return true
-        }
-
-        if keyCode == 36 {
-          if let window = NSApplication.shared.keyWindow {
-            window.toggleFullScreen(nil)
-          }
-          return true
-        }
-
-        if keyCode == 49 {
-          toggleControls()
-          return true
-        }
-
-        guard flags.intersection([.command, .option, .control]).isEmpty else { return false }
-
-        if keyCode == 4 {
-          showKeyboardHelp.toggle()
-          return true
-        }
-
-        if keyCode == 8 {
-          toggleControls()
-          return true
-        }
-
-        if keyCode == 17 {
-          if !viewModel.tableOfContents.isEmpty {
-            showingChapterSheet = true
-          }
-          return true
-        }
-
-        guard viewModel.hasContent else { return false }
-
-        switch dismissGestureReadingDirection {
-        case .ltr:
-          switch keyCode {
-          case 124:
-            goToNextEpubPage()
-            return true
-          case 123:
-            viewModel.goToPreviousPage()
-            return true
-          default:
-            return false
-          }
-        case .rtl:
-          switch keyCode {
-          case 123:
-            goToNextEpubPage()
-            return true
-          case 124:
-            viewModel.goToPreviousPage()
-            return true
-          default:
-            return false
-          }
-        case .vertical, .webtoon:
-          switch keyCode {
-          case 125:
-            goToNextEpubPage()
-            return true
-          case 126:
-            viewModel.goToPreviousPage()
-            return true
-          default:
-            return false
-          }
-        }
-      }
-
-      private func hideKeyboardHelp() {
-        keyboardHelpTimer?.invalidate()
-        keyboardHelpTimer = nil
-        showKeyboardHelp = false
-      }
-
-      private func triggerKeyboardHelp(timeout: TimeInterval) {
-        keyboardHelpTimer?.invalidate()
-        guard showKeyboardHelpOverlay, viewModel.hasContent else { return }
-        DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
-          self.showKeyboardHelp = true
-          self.keyboardHelpTimer = Timer.scheduledTimer(withTimeInterval: 2.5, repeats: false) { _ in
-            Task { @MainActor in
-              self.hideKeyboardHelp()
-            }
-          }
-        }
-      }
     #endif
+
+    private func handleKeyboardEvent(_ event: ReaderKeyboardEvent) -> Bool {
+      if event.matches(.escape) {
+        closeReader()
+        return true
+      }
+
+      if event.matches(.slash, modifiers: [.shift])
+        || event.matches(.slash, modifiers: [.command])
+        || event.matches(.h)
+      {
+        toggleKeyboardHelpManually()
+        return true
+      }
+
+      if event.matches(.returnOrEnter) {
+        return toggleFullscreenIfSupported()
+      }
+
+      if event.matches(.space) {
+        toggleControls()
+        return true
+      }
+
+      if event.matches(.t, modifiers: [.command]) {
+        if !viewModel.tableOfContents.isEmpty {
+          showingChapterSheet = true
+        }
+        return true
+      }
+
+      guard !event.hasSystemModifiers else { return false }
+
+      if event.matches(.c) {
+        toggleControls()
+        return true
+      }
+
+      if event.matches(.t) {
+        if !viewModel.tableOfContents.isEmpty {
+          showingChapterSheet = true
+        }
+        return true
+      }
+
+      guard viewModel.hasContent else { return false }
+
+      switch dismissGestureReadingDirection {
+      case .ltr:
+        switch event.key {
+        case .rightArrow:
+          goToNextEpubPage()
+          return true
+        case .leftArrow:
+          viewModel.goToPreviousPage()
+          return true
+        default:
+          return false
+        }
+      case .rtl:
+        switch event.key {
+        case .leftArrow:
+          goToNextEpubPage()
+          return true
+        case .rightArrow:
+          viewModel.goToPreviousPage()
+          return true
+        default:
+          return false
+        }
+      case .vertical, .webtoon:
+        switch event.key {
+        case .downArrow:
+          goToNextEpubPage()
+          return true
+        case .upArrow:
+          viewModel.goToPreviousPage()
+          return true
+        default:
+          return false
+        }
+      }
+    }
+
+    private func hideKeyboardHelp() {
+      keyboardHelpTimer?.invalidate()
+      keyboardHelpTimer = nil
+      showKeyboardHelp = false
+    }
+
+    private func toggleKeyboardHelpManually() {
+      keyboardHelpTimer?.invalidate()
+      keyboardHelpTimer = nil
+      showKeyboardHelp.toggle()
+    }
+
+    private func triggerKeyboardHelp(timeout: TimeInterval) {
+      keyboardHelpTimer?.invalidate()
+      guard showKeyboardHelpOverlay, viewModel.hasContent else { return }
+      guard ReaderKeyboardAvailability.shouldAutoShowKeyboardHelp else { return }
+      DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
+        self.showKeyboardHelp = true
+        self.keyboardHelpTimer = Timer.scheduledTimer(withTimeInterval: 2.5, repeats: false) { _ in
+          Task { @MainActor in
+            self.hideKeyboardHelp()
+          }
+        }
+      }
+    }
   }
 #endif

--- a/KMReader/Features/Reader/Views/KeyboardEventHandler.swift
+++ b/KMReader/Features/Reader/Views/KeyboardEventHandler.swift
@@ -8,35 +8,55 @@ import SwiftUI
 #if os(macOS)
   import AppKit
 
-  // Window-level keyboard event handler
   struct KeyboardEventHandler: NSViewRepresentable {
-    let onKeyPress: (UInt16, NSEvent.ModifierFlags) -> Bool
+    let isEnabled: Bool
+    let commands: [ReaderKeyboardCommand]
+    let onKeyPress: (ReaderKeyboardEvent) -> Bool
+
+    init(
+      isEnabled: Bool = true,
+      commands: [ReaderKeyboardCommand] = [],
+      onKeyPress: @escaping (ReaderKeyboardEvent) -> Bool
+    ) {
+      self.isEnabled = isEnabled
+      self.commands = commands
+      self.onKeyPress = onKeyPress
+    }
 
     func makeNSView(context: Context) -> KeyboardHandlerView {
       let view = KeyboardHandlerView()
+      view.isCaptureEnabled = isEnabled
       view.onKeyPress = onKeyPress
       return view
     }
 
     func updateNSView(_ nsView: KeyboardHandlerView, context: Context) {
+      nsView.isCaptureEnabled = isEnabled
       nsView.onKeyPress = onKeyPress
+      nsView.ensureResponderState()
     }
   }
 
   class KeyboardHandlerView: NSView {
-    var onKeyPress: ((UInt16, NSEvent.ModifierFlags) -> Bool)?
+    var isCaptureEnabled = true
+    var onKeyPress: ((ReaderKeyboardEvent) -> Bool)?
     private var keyMonitor: Any?
 
     override var acceptsFirstResponder: Bool {
-      return true
+      isCaptureEnabled
     }
 
     override func becomeFirstResponder() -> Bool {
-      return true
+      isCaptureEnabled
     }
 
     override func keyDown(with event: NSEvent) {
-      let handled = onKeyPress?(event.keyCode, event.modifierFlags) ?? false
+      guard let keyboardEvent = ReaderKeyboardEvent(event: event) else {
+        super.keyDown(with: event)
+        return
+      }
+
+      let handled = isCaptureEnabled && (onKeyPress?(keyboardEvent) ?? false)
       if !handled {
         super.keyDown(with: event)
       }
@@ -44,10 +64,7 @@ import SwiftUI
 
     override func viewDidMoveToWindow() {
       super.viewDidMoveToWindow()
-      // Make this view the first responder when added to window
-      DispatchQueue.main.async { [weak self] in
-        self?.window?.makeFirstResponder(self)
-      }
+      ensureResponderState()
       installMonitorIfNeeded()
     }
 
@@ -61,11 +78,25 @@ import SwiftUI
       return nil
     }
 
+    func ensureResponderState() {
+      DispatchQueue.main.async { [weak self] in
+        guard let self else { return }
+        if isCaptureEnabled {
+          window?.makeFirstResponder(self)
+        } else if window?.firstResponder === self {
+          window?.makeFirstResponder(nil)
+        }
+      }
+    }
+
     private func installMonitorIfNeeded() {
       guard keyMonitor == nil else { return }
       keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
         guard let self, let window = self.window, window.isKeyWindow else { return event }
-        let handled = self.onKeyPress?(event.keyCode, event.modifierFlags) ?? false
+        guard self.isCaptureEnabled, let keyboardEvent = ReaderKeyboardEvent(event: event) else {
+          return event
+        }
+        let handled = self.onKeyPress?(keyboardEvent) ?? false
         return handled ? nil : event
       }
     }
@@ -74,6 +105,367 @@ import SwiftUI
       guard let keyMonitor else { return }
       NSEvent.removeMonitor(keyMonitor)
       self.keyMonitor = nil
+    }
+  }
+
+  extension ReaderKeyboardEvent {
+    fileprivate init?(event: NSEvent) {
+      guard let key = ReaderKeyboardKey(keyCode: event.keyCode) else { return nil }
+      self.init(key: key, modifiers: ReaderKeyboardModifiers(event.modifierFlags))
+    }
+  }
+
+  extension ReaderKeyboardKey {
+    fileprivate init?(keyCode: UInt16) {
+      switch keyCode {
+      case 53:
+        self = .escape
+      case 36:
+        self = .returnOrEnter
+      case 49:
+        self = .space
+      case 44:
+        self = .slash
+      case 43:
+        self = .comma
+      case 4:
+        self = .h
+      case 8:
+        self = .c
+      case 37:
+        self = .l
+      case 17:
+        self = .t
+      case 38:
+        self = .j
+      case 45:
+        self = .n
+      case 3:
+        self = .f
+      case 123:
+        self = .leftArrow
+      case 124:
+        self = .rightArrow
+      case 126:
+        self = .upArrow
+      case 125:
+        self = .downArrow
+      default:
+        return nil
+      }
+    }
+  }
+
+  extension ReaderKeyboardModifiers {
+    fileprivate init(_ flags: NSEvent.ModifierFlags) {
+      self = []
+      if flags.contains(.shift) {
+        insert(.shift)
+      }
+      if flags.contains(.control) {
+        insert(.control)
+      }
+      if flags.contains(.option) {
+        insert(.option)
+      }
+      if flags.contains(.command) {
+        insert(.command)
+      }
+    }
+  }
+#elseif os(iOS) || os(tvOS)
+  import UIKit
+
+  struct KeyboardEventHandler: UIViewRepresentable {
+    let isEnabled: Bool
+    let commands: [ReaderKeyboardCommand]
+    let onKeyPress: (ReaderKeyboardEvent) -> Bool
+
+    init(
+      isEnabled: Bool = true,
+      commands: [ReaderKeyboardCommand] = [],
+      onKeyPress: @escaping (ReaderKeyboardEvent) -> Bool
+    ) {
+      self.isEnabled = isEnabled
+      self.commands = commands
+      self.onKeyPress = onKeyPress
+    }
+
+    func makeUIView(context: Context) -> KeyboardHandlerView {
+      let view = KeyboardHandlerView()
+      view.isCaptureEnabled = isEnabled
+      view.commands = commands
+      view.onKeyPress = onKeyPress
+      return view
+    }
+
+    func updateUIView(_ uiView: KeyboardHandlerView, context: Context) {
+      uiView.isCaptureEnabled = isEnabled
+      uiView.commands = commands
+      uiView.onKeyPress = onKeyPress
+    }
+  }
+
+  class KeyboardHandlerView: UIView {
+    var isCaptureEnabled = true {
+      didSet {
+        guard isCaptureEnabled != oldValue else { return }
+        scheduleResponderStateUpdate()
+      }
+    }
+    var commands: [ReaderKeyboardCommand] = []
+    var onKeyPress: ((ReaderKeyboardEvent) -> Bool)?
+    private var responderRetryWorkItem: DispatchWorkItem?
+    private var responderStateWorkItem: DispatchWorkItem?
+
+    override var canBecomeFirstResponder: Bool {
+      isCaptureEnabled
+    }
+
+    override var keyCommands: [UIKeyCommand]? {
+      guard isCaptureEnabled else { return nil }
+      return commands.compactMap(makeKeyCommand)
+    }
+
+    override func didMoveToWindow() {
+      super.didMoveToWindow()
+      scheduleResponderStateUpdate()
+    }
+
+    override func didMoveToSuperview() {
+      super.didMoveToSuperview()
+      scheduleResponderStateUpdate()
+    }
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+      nil
+    }
+
+    func ensureResponderState() {
+      scheduleResponderStateUpdate()
+    }
+
+    override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+      if action == #selector(handleKeyCommand(_:)) {
+        return isCaptureEnabled
+      }
+      return super.canPerformAction(action, withSender: sender)
+    }
+
+    override func pressesBegan(_ presses: Set<UIPress>, with event: UIPressesEvent?) {
+      guard isCaptureEnabled else {
+        super.pressesBegan(presses, with: event)
+        return
+      }
+
+      let unhandledPresses = Set(presses.filter { !handlePress($0) })
+      if !unhandledPresses.isEmpty {
+        super.pressesBegan(unhandledPresses, with: event)
+      }
+    }
+
+    private func makeKeyCommand(_ command: ReaderKeyboardCommand) -> UIKeyCommand? {
+      guard command.event.modifiers.contains(.command) else { return nil }
+      guard let input = command.event.key.uiKeyCommandInput else { return nil }
+
+      let keyCommand = UIKeyCommand(
+        input: input,
+        modifierFlags: UIKeyModifierFlags(command.event.modifiers),
+        action: #selector(handleKeyCommand(_:))
+      )
+      keyCommand.discoverabilityTitle = command.title
+      return keyCommand
+    }
+
+    @objc
+    private func handleKeyCommand(_ sender: UIKeyCommand) {
+      guard isCaptureEnabled else { return }
+      guard let command = commands.first(where: { $0.matches(sender) }) else { return }
+      _ = onKeyPress?(command.event)
+    }
+
+    private func handlePress(_ press: UIPress) -> Bool {
+      guard let key = press.key else { return false }
+      guard let keyboardEvent = ReaderKeyboardEvent(key: key) else { return false }
+
+      guard !keyboardEvent.modifiers.contains(.command) else {
+        return false
+      }
+
+      return onKeyPress?(keyboardEvent) ?? false
+    }
+
+    private func cancelResponderRetry() {
+      responderRetryWorkItem?.cancel()
+      responderRetryWorkItem = nil
+    }
+
+    private func cancelResponderStateUpdate() {
+      responderStateWorkItem?.cancel()
+      responderStateWorkItem = nil
+    }
+
+    private func scheduleResponderStateUpdate() {
+      cancelResponderRetry()
+      cancelResponderStateUpdate()
+
+      let workItem = DispatchWorkItem { [weak self] in
+        guard let self, self.window != nil else { return }
+
+        if self.isCaptureEnabled {
+          self.attemptBecomeFirstResponder()
+        } else if self.isFirstResponder {
+          self.resignFirstResponder()
+        }
+      }
+
+      responderStateWorkItem = workItem
+      DispatchQueue.main.async(execute: workItem)
+    }
+
+    private func attemptBecomeFirstResponder(attemptsLeft: Int = 8) {
+      guard window != nil, isCaptureEnabled else { return }
+
+      if !isFirstResponder {
+        becomeFirstResponder()
+      }
+
+      guard !isFirstResponder, attemptsLeft > 0 else { return }
+
+      cancelResponderRetry()
+      let workItem = DispatchWorkItem { [weak self] in
+        self?.attemptBecomeFirstResponder(attemptsLeft: attemptsLeft - 1)
+      }
+      responderRetryWorkItem = workItem
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.04, execute: workItem)
+    }
+  }
+
+  extension ReaderKeyboardCommand {
+    fileprivate func matches(_ command: UIKeyCommand) -> Bool {
+      command.input == event.key.uiKeyCommandInput
+        && command.modifierFlags == UIKeyModifierFlags(event.modifiers)
+    }
+  }
+
+  extension ReaderKeyboardEvent {
+    fileprivate init?(key: UIKey) {
+      guard let readerKey = ReaderKeyboardKey(keyCode: key.keyCode) else { return nil }
+      self.init(key: readerKey, modifiers: ReaderKeyboardModifiers(key.modifierFlags))
+    }
+  }
+
+  extension ReaderKeyboardKey {
+    fileprivate init?(keyCode: UIKeyboardHIDUsage) {
+      switch keyCode {
+      case .keyboardEscape:
+        self = .escape
+      case .keyboardReturnOrEnter:
+        self = .returnOrEnter
+      case .keyboardSpacebar:
+        self = .space
+      case .keyboardSlash:
+        self = .slash
+      case .keyboardComma:
+        self = .comma
+      case .keyboardH:
+        self = .h
+      case .keyboardC:
+        self = .c
+      case .keyboardL:
+        self = .l
+      case .keyboardT:
+        self = .t
+      case .keyboardJ:
+        self = .j
+      case .keyboardN:
+        self = .n
+      case .keyboardF:
+        self = .f
+      case .keyboardLeftArrow:
+        self = .leftArrow
+      case .keyboardRightArrow:
+        self = .rightArrow
+      case .keyboardUpArrow:
+        self = .upArrow
+      case .keyboardDownArrow:
+        self = .downArrow
+      default:
+        return nil
+      }
+    }
+
+    fileprivate var uiKeyCommandInput: String? {
+      switch self {
+      case .escape:
+        return UIKeyCommand.inputEscape
+      case .returnOrEnter:
+        return "\r"
+      case .space:
+        return " "
+      case .slash:
+        return "/"
+      case .comma:
+        return ","
+      case .h:
+        return "h"
+      case .c:
+        return "c"
+      case .l:
+        return "l"
+      case .t:
+        return "t"
+      case .j:
+        return "j"
+      case .n:
+        return "n"
+      case .f:
+        return "f"
+      case .leftArrow:
+        return UIKeyCommand.inputLeftArrow
+      case .rightArrow:
+        return UIKeyCommand.inputRightArrow
+      case .upArrow:
+        return UIKeyCommand.inputUpArrow
+      case .downArrow:
+        return UIKeyCommand.inputDownArrow
+      }
+    }
+  }
+
+  extension ReaderKeyboardModifiers {
+    fileprivate init(_ flags: UIKeyModifierFlags) {
+      self = []
+      if flags.contains(.shift) {
+        insert(.shift)
+      }
+      if flags.contains(.control) {
+        insert(.control)
+      }
+      if flags.contains(.alternate) {
+        insert(.option)
+      }
+      if flags.contains(.command) {
+        insert(.command)
+      }
+    }
+  }
+
+  extension UIKeyModifierFlags {
+    fileprivate init(_ modifiers: ReaderKeyboardModifiers) {
+      self = []
+      if modifiers.contains(.shift) {
+        insert(.shift)
+      }
+      if modifiers.contains(.control) {
+        insert(.control)
+      }
+      if modifiers.contains(.option) {
+        insert(.alternate)
+      }
+      if modifiers.contains(.command) {
+        insert(.command)
+      }
     }
   }
 #endif

--- a/KMReader/Features/Reader/Views/KeyboardEventHandler.swift
+++ b/KMReader/Features/Reader/Views/KeyboardEventHandler.swift
@@ -203,6 +203,7 @@ import SwiftUI
       uiView.isCaptureEnabled = isEnabled
       uiView.commands = commands
       uiView.onKeyPress = onKeyPress
+      uiView.ensureResponderState()
     }
   }
 

--- a/KMReader/Features/Reader/Views/KeyboardHelpOverlay.swift
+++ b/KMReader/Features/Reader/Views/KeyboardHelpOverlay.swift
@@ -5,151 +5,152 @@
 
 import SwiftUI
 
-#if os(macOS)
-  import AppKit
+struct KeyboardHelpOverlay: View {
+  let readingDirection: ReadingDirection
+  let hasTOC: Bool
+  let supportsFullscreenToggle: Bool
+  let supportsLiveText: Bool
+  let supportsJumpToPage: Bool
+  let supportsSearch: Bool
+  let supportsToggleControls: Bool
+  let hasNextBook: Bool
+  let onDismiss: () -> Void
 
-  // Keyboard shortcuts help overlay
-  struct KeyboardHelpOverlay: View {
-    let readingDirection: ReadingDirection
-    let hasTOC: Bool
-    let supportsLiveText: Bool
-    let supportsJumpToPage: Bool
-    let supportsSearch: Bool
-    let supportsToggleControls: Bool
-    let hasNextBook: Bool
-    let onDismiss: () -> Void
+  init(
+    readingDirection: ReadingDirection,
+    hasTOC: Bool,
+    supportsFullscreenToggle: Bool,
+    supportsLiveText: Bool,
+    supportsJumpToPage: Bool,
+    supportsSearch: Bool = false,
+    supportsToggleControls: Bool,
+    hasNextBook: Bool,
+    onDismiss: @escaping () -> Void
+  ) {
+    self.readingDirection = readingDirection
+    self.hasTOC = hasTOC
+    self.supportsFullscreenToggle = supportsFullscreenToggle
+    self.supportsLiveText = supportsLiveText
+    self.supportsJumpToPage = supportsJumpToPage
+    self.supportsSearch = supportsSearch
+    self.supportsToggleControls = supportsToggleControls
+    self.hasNextBook = hasNextBook
+    self.onDismiss = onDismiss
+  }
 
-    init(
-      readingDirection: ReadingDirection,
-      hasTOC: Bool,
-      supportsLiveText: Bool,
-      supportsJumpToPage: Bool,
-      supportsSearch: Bool = false,
-      supportsToggleControls: Bool,
-      hasNextBook: Bool,
-      onDismiss: @escaping () -> Void
-    ) {
-      self.readingDirection = readingDirection
-      self.hasTOC = hasTOC
-      self.supportsLiveText = supportsLiveText
-      self.supportsJumpToPage = supportsJumpToPage
-      self.supportsSearch = supportsSearch
-      self.supportsToggleControls = supportsToggleControls
-      self.hasNextBook = hasNextBook
-      self.onDismiss = onDismiss
-    }
+  var body: some View {
+    ZStack {
+      // Semi-transparent background
+      Button {
+        onDismiss()
+      } label: {
+        Color.black.opacity(0.5)
+      }
+      .adaptiveButtonStyle(.plain)
 
-    var body: some View {
-      ZStack {
-        // Semi-transparent background
+      // Help content
+      VStack(spacing: 20) {
+        Text("Keyboard Shortcuts")
+          .font(.title2)
+          .fontWeight(.bold)
+          .foregroundColor(.white)
+
+        VStack(alignment: .leading, spacing: 12) {
+          HelpRow(key: "ESC", description: "Close reader")
+          HelpRow(key: "? / H", description: "Show this help")
+
+          Divider()
+            .background(Color.white.opacity(0.3))
+
+          if supportsFullscreenToggle {
+            HelpRow(key: "Return", description: "Toggle fullscreen")
+          }
+          if supportsToggleControls {
+            HelpRow(key: "C / Space", description: "Toggle controls")
+          }
+          if supportsLiveText {
+            HelpRow(key: "L", description: "Toggle Live Text")
+          }
+          if hasTOC {
+            HelpRow(key: "T", description: "Table of Contents")
+          }
+          if supportsJumpToPage {
+            HelpRow(key: "J", description: "Jump to page")
+          }
+          if supportsSearch {
+            HelpRow(key: "F", description: "Search")
+          }
+          if hasNextBook {
+            HelpRow(key: "N", description: "Next book")
+          }
+
+          Divider()
+            .background(Color.white.opacity(0.3))
+
+          // Navigation keys based on reading direction
+          Group {
+            switch readingDirection {
+            case .ltr:
+              HelpRow(key: "→", description: "Next page")
+              HelpRow(key: "←", description: "Previous page")
+            case .rtl:
+              HelpRow(key: "←", description: "Next page")
+              HelpRow(key: "→", description: "Previous page")
+            case .vertical:
+              HelpRow(key: "↓", description: "Next page")
+              HelpRow(key: "↑", description: "Previous page")
+            case .webtoon:
+              HelpRow(key: "↓", description: "Scroll down")
+              HelpRow(key: "↑", description: "Scroll up")
+            }
+          }
+        }
+        .padding()
+        .background(Color.black.opacity(0.8))
+        .cornerRadius(12)
+        .overlay(
+          RoundedRectangle(cornerRadius: 12)
+            .stroke(Color.white.opacity(0.3), lineWidth: 1)
+        )
+
         Button {
           onDismiss()
         } label: {
-          Color.black.opacity(0.5)
+          Text("Close")
+            .foregroundColor(.white)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 8)
+            .background(Color.accentColor.opacity(0.9))
+            .cornerRadius(8)
         }
         .adaptiveButtonStyle(.plain)
-
-        // Help content
-        VStack(spacing: 20) {
-          Text("Keyboard Shortcuts")
-            .font(.title2)
-            .fontWeight(.bold)
-            .foregroundColor(.white)
-
-          VStack(alignment: .leading, spacing: 12) {
-            HelpRow(key: "ESC", description: "Close reader")
-            HelpRow(key: "? / H", description: "Show this help")
-
-            Divider()
-              .background(Color.white.opacity(0.3))
-
-            HelpRow(key: "Return", description: "Toggle fullscreen")
-            if supportsToggleControls {
-              HelpRow(key: "C / Space", description: "Toggle controls")
-            }
-            if supportsLiveText {
-              HelpRow(key: "L", description: "Toggle Live Text")
-            }
-            if hasTOC {
-              HelpRow(key: "T", description: "Table of Contents")
-            }
-            if supportsJumpToPage {
-              HelpRow(key: "J", description: "Jump to page")
-            }
-            if supportsSearch {
-              HelpRow(key: "F", description: "Search")
-            }
-            if hasNextBook {
-              HelpRow(key: "N", description: "Next book")
-            }
-
-            Divider()
-              .background(Color.white.opacity(0.3))
-
-            // Navigation keys based on reading direction
-            Group {
-              switch readingDirection {
-              case .ltr:
-                HelpRow(key: "→", description: "Next page")
-                HelpRow(key: "←", description: "Previous page")
-              case .rtl:
-                HelpRow(key: "←", description: "Next page")
-                HelpRow(key: "→", description: "Previous page")
-              case .vertical:
-                HelpRow(key: "↓", description: "Next page")
-                HelpRow(key: "↑", description: "Previous page")
-              case .webtoon:
-                HelpRow(key: "↓", description: "Scroll down")
-                HelpRow(key: "↑", description: "Scroll up")
-              }
-            }
-          }
-          .padding()
-          .background(Color.black.opacity(0.8))
-          .cornerRadius(12)
-          .overlay(
-            RoundedRectangle(cornerRadius: 12)
-              .stroke(Color.white.opacity(0.3), lineWidth: 1)
-          )
-
-          Button {
-            onDismiss()
-          } label: {
-            Text("Close")
-              .foregroundColor(.white)
-              .padding(.horizontal, 24)
-              .padding(.vertical, 8)
-              .background(Color.accentColor.opacity(0.9))
-              .cornerRadius(8)
-          }
-          .adaptiveButtonStyle(.plain)
-        }
-        .padding(40)
-        .frame(maxWidth: 500)
       }
+      .padding(40)
+      .frame(maxWidth: 500)
+    }
+    .readerIgnoresSafeArea()
+  }
+}
+
+private struct HelpRow: View {
+  let key: String
+  let description: String
+
+  var body: some View {
+    HStack {
+      Text(key)
+        .font(.system(.body, design: .monospaced))
+        .fontWeight(.semibold)
+        .foregroundColor(.white)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(Color.white.opacity(0.2))
+        .cornerRadius(6)
+        .frame(width: 130, alignment: .leading)
+
+      Text(description)
+        .foregroundColor(.white.opacity(0.9))
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
   }
-
-  private struct HelpRow: View {
-    let key: String
-    let description: String
-
-    var body: some View {
-      HStack {
-        Text(key)
-          .font(.system(.body, design: .monospaced))
-          .fontWeight(.semibold)
-          .foregroundColor(.white)
-          .padding(.horizontal, 12)
-          .padding(.vertical, 6)
-          .background(Color.white.opacity(0.2))
-          .cornerRadius(6)
-          .frame(width: 130, alignment: .leading)
-
-        Text(description)
-          .foregroundColor(.white.opacity(0.9))
-          .frame(maxWidth: .infinity, alignment: .leading)
-      }
-    }
-  }
-#endif
+}

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
@@ -181,7 +181,7 @@
       }
 
       private func attachPanRecognizerIfNeeded(to containerView: NativeCoverContainerView) {
-        #if !os(tvOS)
+        #if os(iOS) || os(macOS)
           if panRecognizer?.view === containerView {
             return
           }
@@ -201,7 +201,7 @@
       }
 
       private func applyPanRecognizerState() {
-        #if !os(tvOS)
+        #if os(iOS) || os(macOS)
           guard let panRecognizer else { return }
           let wasEnabled = panRecognizer.isEnabled
           let shouldEnable = !parent.viewModel.isZoomed && !isAnimatingTransition

--- a/KMReader/Features/Reader/Views/NativePagedPageContentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativePagedPageContentView_iOS.swift
@@ -220,7 +220,7 @@
       }
     }
 
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       @objc private func handleDoubleTap(_ gesture: UITapGestureRecognizer) {
         guard renderConfig.doubleTapZoomMode != .disabled else { return }
 

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
@@ -2,7 +2,7 @@
   import SwiftUI
   import UIKit
 
-  #if !os(tvOS)
+  #if os(iOS) || os(macOS)
     import VisionKit
   #endif
 
@@ -26,7 +26,7 @@
     private var canIsolatePageFromCurrentPresentation = false
     private let logger = AppLogger(.reader)
 
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       private let interaction = ImageAnalysisInteraction()
       private var analysisTask: Task<Void, Never>?
       private var analyzedImage: UIImage?
@@ -48,13 +48,13 @@
     required init?(coder: NSCoder) { fatalError() }
 
     deinit {
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         analysisTask?.cancel()
       #endif
     }
 
     func prepareForDismantle() {
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         if imageView.interactions.contains(where: { $0 === interaction }) {
           imageView.removeInteraction(interaction)
         }
@@ -84,13 +84,13 @@
           } else {
             pageSourceImage = viewModel?.preloadedImage(for: data.pageID)
           }
-          #if !os(tvOS)
+          #if os(iOS) || os(macOS)
             analysisSourceImage = pageSourceImage
           #endif
           imageView.image = pageSourceImage
         }
         updateAnimatedPlayback(sourceFileURL: currentData?.animatedSourceFileURL)
-        #if !os(tvOS)
+        #if os(iOS) || os(macOS)
           if enableLiveText {
             analyzeImage()
           }
@@ -190,7 +190,7 @@
         pageSourceImage = image
       }
 
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         analysisSourceImage = shouldEnableLiveText ? pageSourceImage : nil
       #endif
 
@@ -226,7 +226,7 @@
         loadingIndicator.stopAnimating()
       }
 
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         if shouldEnableLiveText {
           if window != nil && !isHidden {
             if !imageView.interactions.contains(where: { $0 === interaction }) {
@@ -341,7 +341,7 @@
       }
     }
 
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       private func analyzeImage() {
         guard let image = analysisSourceImage ?? imageView.image else { return }
 
@@ -419,7 +419,7 @@
         imageView.layer.shadowPath = nil
       }
 
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         if enableLiveText, imageView.image != nil,
           window != nil, !isHidden, interaction.analysis == nil, analysisTask == nil
         {

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -20,10 +20,8 @@
     private var forceDefaultReadingDirection: Bool = false
     @AppStorage("pdfPageLayout") private var pageLayout: PageLayout = .auto
     @AppStorage("pdfIsolateCoverPage") private var isolateCoverPage: Bool = true
-    #if os(macOS)
-      @AppStorage("pdfShowKeyboardHelpOverlay")
-      private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
-    #endif
+    @AppStorage("pdfShowKeyboardHelpOverlay")
+    private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
 
     @State private var viewModel: PdfReaderViewModel
     @State private var readingDirection: ReadingDirection
@@ -38,10 +36,8 @@
     @State private var searchQuery = ""
     @State private var targetPageNumber: Int?
     @State private var navigationToken = UUID()
-    #if os(macOS)
-      @State private var showKeyboardHelp = false
-      @State private var keyboardHelpTimer: Timer?
-    #endif
+    @State private var keyboardHelpTimer: Timer?
+    @State private var showKeyboardHelp = false
 
     private let logger = AppLogger(.reader)
 
@@ -62,6 +58,18 @@
       _currentBook = State(initialValue: book)
     }
 
+    private var isPresentingModalSheet: Bool {
+      showingPageJumpSheet
+        || showingSearchSheet
+        || showingTOCSheet
+        || showingPreferencesSheet
+        || showingDetailSheet
+    }
+
+    private var isKeyboardCaptureEnabled: Bool {
+      !isPresentingModalSheet
+    }
+
     var body: some View {
       ZStack {
         readerBackground.color.readerIgnoresSafeArea()
@@ -70,9 +78,7 @@
 
         controlsOverlay
 
-        #if os(macOS)
-          keyboardHelpOverlay
-        #endif
+        keyboardHelpOverlay
       }
       #if os(iOS)
         .statusBarHidden(!shouldShowControls)
@@ -132,7 +138,7 @@
       .onAppear {
         updateHandoff()
         #if os(macOS)
-          configureMacReaderCommands()
+          configureReaderCommands()
         #endif
       }
       .onChange(of: defaultReadingDirection) { _, newDirection in
@@ -177,31 +183,28 @@
         readerPresentation.clearFlushHandler(for: sessionID)
         #if os(macOS)
           hideKeyboardHelp()
-          readerPresentation.clearMacReaderCommands()
+          readerPresentation.clearReaderCommands()
         #endif
       }
       .onChange(of: scenePhase) { _, newPhase in
         handleScenePhaseChange(newPhase)
       }
-      #if os(macOS)
-        .onChange(of: viewModel.pageCount) { oldCount, newCount in
-          if oldCount == 0 && newCount > 0 {
-            triggerKeyboardHelp(timeout: 1.5)
-          }
-        }
-        .onChange(of: readingDirection) { _, _ in
-          triggerKeyboardHelp(timeout: 2)
-        }
-        .onChange(of: macReaderCommandState) { _, newState in
-          readerPresentation.updateMacReaderCommandState(newState)
-        }
-        .background(
-          KeyboardEventHandler(
-            onKeyPress: { keyCode, flags in
-              handleKeyCode(keyCode, flags: flags)
-            }
-          )
+      .background(
+        KeyboardEventHandler(
+          isEnabled: isKeyboardCaptureEnabled,
+          commands: keyboardCommands,
+          onKeyPress: handleKeyboardEvent
         )
+      )
+      .onChange(of: viewModel.pageCount) { oldCount, newCount in
+        if oldCount == 0 && newCount > 0 {
+          triggerKeyboardHelp(timeout: 1.5)
+        }
+      }
+      #if os(macOS)
+        .onChange(of: readerCommandState) { _, newState in
+          readerPresentation.updateReaderCommandState(newState)
+        }
       #endif
       #if os(iOS)
         .readerDismissGesture(readingDirection: readingDirection)
@@ -481,17 +484,47 @@
       return title
     }
 
-    #if os(macOS)
-      private var isPresentingModalSheet: Bool {
-        showingPageJumpSheet
-          || showingSearchSheet
-          || showingTOCSheet
-          || showingPreferencesSheet
-          || showingDetailSheet
+    private var keyboardCommands: [ReaderKeyboardCommand] {
+      var commands = [
+        ReaderKeyboardCommand(
+          title: "Keyboard Shortcuts",
+          event: ReaderKeyboardEvent(key: .slash, modifiers: [.command])
+        )
+      ]
+
+      if viewModel.documentURL != nil {
+        commands.append(
+          ReaderKeyboardCommand(
+            title: "Search",
+            event: ReaderKeyboardEvent(key: .f, modifiers: [.command])
+          )
+        )
       }
 
-      private var macReaderCommandState: ReaderPresentationManager.MacReaderCommandState {
-        ReaderPresentationManager.MacReaderCommandState(
+      if !viewModel.tableOfContents.isEmpty {
+        commands.append(
+          ReaderKeyboardCommand(
+            title: "Table of Contents",
+            event: ReaderKeyboardEvent(key: .t, modifiers: [.command])
+          )
+        )
+      }
+
+      if viewModel.pageCount > 0 {
+        commands.append(
+          ReaderKeyboardCommand(
+            title: "Jump to Page",
+            event: ReaderKeyboardEvent(key: .j, modifiers: [.command])
+          )
+        )
+      }
+
+      return commands
+    }
+
+    #if os(macOS)
+      private var readerCommandState: ReaderCommandState {
+        ReaderCommandState(
           isActive: true,
           supportsReaderSettings: true,
           supportsBookDetails: currentBook != nil && currentSeries != nil,
@@ -515,29 +548,32 @@
           supportsSplitWidePageMode: false
         )
       }
+    #endif
 
-      private var keyboardHelpOverlay: some View {
-        KeyboardHelpOverlay(
-          readingDirection: readingDirection,
-          hasTOC: !viewModel.tableOfContents.isEmpty,
-          supportsLiveText: false,
-          supportsJumpToPage: viewModel.pageCount > 0,
-          supportsSearch: viewModel.documentURL != nil,
-          supportsToggleControls: true,
-          hasNextBook: false,
-          onDismiss: {
-            hideKeyboardHelp()
-          }
-        )
-        .opacity(showKeyboardHelp ? 1.0 : 0.0)
-        .allowsHitTesting(showKeyboardHelp)
-        .animation(.default, value: showKeyboardHelp)
-      }
+    private var keyboardHelpOverlay: some View {
+      KeyboardHelpOverlay(
+        readingDirection: readingDirection,
+        hasTOC: !viewModel.tableOfContents.isEmpty,
+        supportsFullscreenToggle: supportsFullscreenToggle,
+        supportsLiveText: false,
+        supportsJumpToPage: viewModel.pageCount > 0,
+        supportsSearch: viewModel.documentURL != nil,
+        supportsToggleControls: true,
+        hasNextBook: false,
+        onDismiss: {
+          hideKeyboardHelp()
+        }
+      )
+      .opacity(showKeyboardHelp ? 1.0 : 0.0)
+      .allowsHitTesting(showKeyboardHelp)
+      .animation(.default, value: showKeyboardHelp)
+    }
 
-      private func configureMacReaderCommands() {
-        readerPresentation.configureMacReaderCommands(
-          state: macReaderCommandState,
-          handlers: ReaderPresentationManager.MacReaderCommandHandlers(
+    #if os(macOS)
+      private func configureReaderCommands() {
+        readerPresentation.configureReaderCommands(
+          state: readerCommandState,
+          handlers: ReaderCommandHandlers(
             showReaderSettings: {
               showingPreferencesSheet = true
             },
@@ -577,133 +613,166 @@
           )
         )
       }
+    #endif
 
-      private func handleKeyCode(_ keyCode: UInt16, flags: NSEvent.ModifierFlags) -> Bool {
-        guard !isPresentingModalSheet else { return false }
+    private func handleKeyboardEvent(_ event: ReaderKeyboardEvent) -> Bool {
+      guard !isPresentingModalSheet else { return false }
 
-        if keyCode == 53 {
-          closeReader()
-          return true
-        }
+      if event.matches(.escape) {
+        closeReader()
+        return true
+      }
 
-        if keyCode == 44 {
-          showKeyboardHelp.toggle()
-          return true
-        }
+      if event.matches(.slash, modifiers: [.shift])
+        || event.matches(.slash, modifiers: [.command])
+        || event.matches(.h)
+      {
+        toggleKeyboardHelpManually()
+        return true
+      }
 
-        if keyCode == 36 {
-          toggleFullscreen()
-          return true
-        }
+      if event.matches(.returnOrEnter) {
+        return toggleFullscreenIfSupported()
+      }
 
-        if keyCode == 49 {
-          toggleControls()
-          return true
-        }
+      if event.matches(.space) {
+        toggleControls()
+        return true
+      }
 
-        let modifierFlags = flags.intersection([.command, .option, .control])
-        guard modifierFlags.isEmpty else { return false }
+      if event.matches(.f, modifiers: [.command]) {
+        guard viewModel.documentURL != nil else { return false }
+        showingSearchSheet = true
+        return true
+      }
 
-        if keyCode == 3 {
-          guard viewModel.documentURL != nil else { return false }
-          showingSearchSheet = true
-          return true
-        }
+      if event.matches(.t, modifiers: [.command]) {
+        guard !viewModel.tableOfContents.isEmpty else { return false }
+        showingTOCSheet = true
+        return true
+      }
 
-        if keyCode == 4 {
-          showKeyboardHelp.toggle()
-          return true
-        }
-
-        if keyCode == 8 {
-          toggleControls()
-          return true
-        }
-
-        if keyCode == 17 {
-          guard !viewModel.tableOfContents.isEmpty else { return false }
-          showingTOCSheet = true
-          return true
-        }
-
-        if keyCode == 38 {
-          guard viewModel.pageCount > 0 else { return false }
-          showingPageJumpSheet = true
-          return true
-        }
-
+      if event.matches(.j, modifiers: [.command]) {
         guard viewModel.pageCount > 0 else { return false }
+        showingPageJumpSheet = true
+        return true
+      }
 
-        switch readingDirection {
-        case .ltr:
-          switch keyCode {
-          case 124:
-            goToNextPage()
-            return true
-          case 123:
-            goToPreviousPage()
-            return true
-          default:
-            return false
-          }
-        case .rtl:
-          switch keyCode {
-          case 123:
-            goToNextPage()
-            return true
-          case 124:
-            goToPreviousPage()
-            return true
-          default:
-            return false
-          }
-        case .vertical, .webtoon:
-          switch keyCode {
-          case 125:
-            goToNextPage()
-            return true
-          case 126:
-            goToPreviousPage()
-            return true
-          default:
-            return false
-          }
+      guard !event.hasSystemModifiers else { return false }
+
+      if event.matches(.f) {
+        guard viewModel.documentURL != nil else { return false }
+        showingSearchSheet = true
+        return true
+      }
+
+      if event.matches(.c) {
+        toggleControls()
+        return true
+      }
+
+      if event.matches(.t) {
+        guard !viewModel.tableOfContents.isEmpty else { return false }
+        showingTOCSheet = true
+        return true
+      }
+
+      if event.matches(.j) {
+        guard viewModel.pageCount > 0 else { return false }
+        showingPageJumpSheet = true
+        return true
+      }
+
+      guard viewModel.pageCount > 0 else { return false }
+
+      switch readingDirection {
+      case .ltr:
+        switch event.key {
+        case .rightArrow:
+          goToNextPage()
+          return true
+        case .leftArrow:
+          goToPreviousPage()
+          return true
+        default:
+          return false
+        }
+      case .rtl:
+        switch event.key {
+        case .leftArrow:
+          goToNextPage()
+          return true
+        case .rightArrow:
+          goToPreviousPage()
+          return true
+        default:
+          return false
+        }
+      case .vertical, .webtoon:
+        switch event.key {
+        case .downArrow:
+          goToNextPage()
+          return true
+        case .upArrow:
+          goToPreviousPage()
+          return true
+        default:
+          return false
         }
       }
+    }
 
-      private func goToNextPage() {
-        requestPageNavigation(to: viewModel.currentPageNumber + 1)
-      }
+    private func goToNextPage() {
+      requestPageNavigation(to: viewModel.currentPageNumber + 1)
+    }
 
-      private func goToPreviousPage() {
-        requestPageNavigation(to: viewModel.currentPageNumber - 1)
-      }
+    private func goToPreviousPage() {
+      requestPageNavigation(to: viewModel.currentPageNumber - 1)
+    }
 
-      private func toggleFullscreen() {
+    private func toggleFullscreenIfSupported() -> Bool {
+      #if os(macOS)
         if let window = NSApplication.shared.keyWindow {
           window.toggleFullScreen(nil)
+          return true
         }
-      }
+      #endif
+      return false
+    }
 
-      private func hideKeyboardHelp() {
-        keyboardHelpTimer?.invalidate()
-        keyboardHelpTimer = nil
-        showKeyboardHelp = false
-      }
+    private var supportsFullscreenToggle: Bool {
+      #if os(macOS)
+        true
+      #else
+        false
+      #endif
+    }
 
-      private func triggerKeyboardHelp(timeout: TimeInterval) {
-        keyboardHelpTimer?.invalidate()
-        guard showKeyboardHelpOverlay, viewModel.pageCount > 0 else { return }
+    private func hideKeyboardHelp() {
+      keyboardHelpTimer?.invalidate()
+      keyboardHelpTimer = nil
+      showKeyboardHelp = false
+    }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
-          self.showKeyboardHelp = true
-          self.keyboardHelpTimer = Timer.scheduledTimer(withTimeInterval: 2.5, repeats: false) { _ in
-            Task { @MainActor in
-              self.hideKeyboardHelp()
-            }
+    private func toggleKeyboardHelpManually() {
+      keyboardHelpTimer?.invalidate()
+      keyboardHelpTimer = nil
+      showKeyboardHelp.toggle()
+    }
+
+    private func triggerKeyboardHelp(timeout: TimeInterval) {
+      keyboardHelpTimer?.invalidate()
+      guard showKeyboardHelpOverlay, viewModel.pageCount > 0 else { return }
+      guard ReaderKeyboardAvailability.shouldAutoShowKeyboardHelp else { return }
+
+      DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
+        self.showKeyboardHelp = true
+        self.keyboardHelpTimer = Timer.scheduledTimer(withTimeInterval: 2.5, repeats: false) { _ in
+          Task { @MainActor in
+            self.hideKeyboardHelp()
           }
         }
       }
-    #endif
+    }
   }
 #endif

--- a/KMReader/Features/Reader/Views/ReaderCommandHandlers.swift
+++ b/KMReader/Features/Reader/Views/ReaderCommandHandlers.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct ReaderCommandHandlers {
+  let showReaderSettings: () -> Void
+  let showBookDetails: () -> Void
+  let showTableOfContents: () -> Void
+  let showPageJump: () -> Void
+  let showSearch: () -> Void
+  let openPreviousBook: () -> Void
+  let openNextBook: () -> Void
+  let setReadingDirection: (ReadingDirection) -> Void
+  let setPageLayout: (PageLayout) -> Void
+  let toggleIsolateCoverPage: () -> Void
+  let toggleIsolatePage: (ReaderPageID) -> Void
+  let setSplitWidePageMode: (SplitWidePageMode) -> Void
+}

--- a/KMReader/Features/Reader/Views/ReaderCommandState.swift
+++ b/KMReader/Features/Reader/Views/ReaderCommandState.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct ReaderCommandState: Equatable {
+  var isActive: Bool = false
+  var supportsReaderSettings: Bool = false
+  var supportsBookDetails: Bool = false
+  var hasPages: Bool = false
+  var hasTableOfContents: Bool = false
+  var supportsPageJump: Bool = false
+  var supportsBookNavigation: Bool = false
+  var canOpenPreviousBook: Bool = false
+  var canOpenNextBook: Bool = false
+  var readingDirection: ReadingDirection = .ltr
+  var availableReadingDirections: [ReadingDirection] = ReadingDirection.availableCases
+  var pageLayout: PageLayout = .auto
+  var isolateCoverPage: Bool = true
+  var pageIsolationActions: [ReaderPageIsolationActions.Action] = []
+  var splitWidePageMode: SplitWidePageMode = .none
+  var supportsSearch: Bool = false
+  var canSearch: Bool = false
+  var supportsReadingDirectionSelection: Bool = false
+  var supportsPageLayoutSelection: Bool = false
+  var supportsDualPageOptions: Bool = false
+  var supportsSplitWidePageMode: Bool = false
+}

--- a/KMReader/Features/Reader/Views/ReaderKeyboardAvailability.swift
+++ b/KMReader/Features/Reader/Views/ReaderKeyboardAvailability.swift
@@ -1,0 +1,14 @@
+import Foundation
+import GameController
+
+enum ReaderKeyboardAvailability {
+  static var shouldAutoShowKeyboardHelp: Bool {
+    #if os(macOS)
+      true
+    #elseif os(iOS) || os(tvOS)
+      GCKeyboard.coalesced != nil
+    #else
+      false
+    #endif
+  }
+}

--- a/KMReader/Features/Reader/Views/ReaderKeyboardCommand.swift
+++ b/KMReader/Features/Reader/Views/ReaderKeyboardCommand.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct ReaderKeyboardCommand: Equatable {
+  let title: String
+  let event: ReaderKeyboardEvent
+}

--- a/KMReader/Features/Reader/Views/ReaderKeyboardEvent.swift
+++ b/KMReader/Features/Reader/Views/ReaderKeyboardEvent.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum ReaderKeyboardKey: String, Sendable {
+  case escape
+  case returnOrEnter
+  case space
+  case slash
+  case comma
+  case h
+  case c
+  case l
+  case t
+  case j
+  case n
+  case f
+  case leftArrow
+  case rightArrow
+  case upArrow
+  case downArrow
+}
+
+struct ReaderKeyboardEvent: Equatable, Hashable, Sendable {
+  let key: ReaderKeyboardKey
+  let modifiers: ReaderKeyboardModifiers
+
+  init(key: ReaderKeyboardKey, modifiers: ReaderKeyboardModifiers = []) {
+    self.key = key
+    self.modifiers = modifiers
+  }
+
+  var hasSystemModifiers: Bool {
+    modifiers.intersection(.system).isEmpty == false
+  }
+
+  func matches(_ key: ReaderKeyboardKey, modifiers expectedModifiers: ReaderKeyboardModifiers = []) -> Bool {
+    self.key == key && modifiers == expectedModifiers
+  }
+}

--- a/KMReader/Features/Reader/Views/ReaderKeyboardModifiers.swift
+++ b/KMReader/Features/Reader/Views/ReaderKeyboardModifiers.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct ReaderKeyboardModifiers: OptionSet, Hashable, Sendable {
+  let rawValue: Int
+
+  static let shift = ReaderKeyboardModifiers(rawValue: 1 << 0)
+  static let control = ReaderKeyboardModifiers(rawValue: 1 << 1)
+  static let option = ReaderKeyboardModifiers(rawValue: 1 << 2)
+  static let command = ReaderKeyboardModifiers(rawValue: 1 << 3)
+  static let system: ReaderKeyboardModifiers = [.command, .option, .control]
+}

--- a/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
+++ b/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
@@ -27,50 +27,12 @@ final class ReaderPresentationManager {
     currentSession?.sourceBookId
   }
 
+  private(set) var readerCommandState = ReaderCommandState()
+  private var readerCommandHandlers: ReaderCommandHandlers?
+
   #if os(macOS)
-    struct MacReaderCommandState: Equatable {
-      var isActive: Bool = false
-      var supportsReaderSettings: Bool = false
-      var supportsBookDetails: Bool = false
-      var hasPages: Bool = false
-      var hasTableOfContents: Bool = false
-      var supportsPageJump: Bool = false
-      var supportsBookNavigation: Bool = false
-      var canOpenPreviousBook: Bool = false
-      var canOpenNextBook: Bool = false
-      var readingDirection: ReadingDirection = .ltr
-      var availableReadingDirections: [ReadingDirection] = ReadingDirection.availableCases
-      var pageLayout: PageLayout = .auto
-      var isolateCoverPage: Bool = true
-      var pageIsolationActions: [ReaderPageIsolationActions.Action] = []
-      var splitWidePageMode: SplitWidePageMode = .none
-      var supportsSearch: Bool = false
-      var canSearch: Bool = false
-      var supportsReadingDirectionSelection: Bool = false
-      var supportsPageLayoutSelection: Bool = false
-      var supportsDualPageOptions: Bool = false
-      var supportsSplitWidePageMode: Bool = false
-    }
-
-    struct MacReaderCommandHandlers {
-      let showReaderSettings: () -> Void
-      let showBookDetails: () -> Void
-      let showTableOfContents: () -> Void
-      let showPageJump: () -> Void
-      let showSearch: () -> Void
-      let openPreviousBook: () -> Void
-      let openNextBook: () -> Void
-      let setReadingDirection: (ReadingDirection) -> Void
-      let setPageLayout: (PageLayout) -> Void
-      let toggleIsolateCoverPage: () -> Void
-      let toggleIsolatePage: (ReaderPageID) -> Void
-      let setSplitWidePageMode: (SplitWidePageMode) -> Void
-    }
-
     private var openWindowHandler: (() -> Void)?
     private var isReaderWindowVisible = false
-    private(set) var macReaderCommandState = MacReaderCommandState()
-    private var macReaderCommandHandlers: MacReaderCommandHandlers?
   #endif
 
   func present(
@@ -81,7 +43,7 @@ final class ReaderPresentationManager {
     #if os(macOS)
       if let currentSession {
         finishSession(currentSession, syncVisited: true)
-        clearMacReaderCommands()
+        clearReaderCommands()
       }
     #else
       if currentSession != nil {
@@ -157,7 +119,7 @@ final class ReaderPresentationManager {
     #endif
 
     #if os(macOS)
-      clearMacReaderCommands()
+      clearReaderCommands()
     #endif
 
     self.currentSession = nil
@@ -178,69 +140,69 @@ final class ReaderPresentationManager {
       closeReader()
     }
 
-    func configureMacReaderCommands(
-      state: MacReaderCommandState,
-      handlers: MacReaderCommandHandlers
+    func configureReaderCommands(
+      state: ReaderCommandState,
+      handlers: ReaderCommandHandlers
     ) {
-      macReaderCommandState = state
-      macReaderCommandHandlers = handlers
+      readerCommandState = state
+      readerCommandHandlers = handlers
     }
 
-    func updateMacReaderCommandState(_ state: MacReaderCommandState) {
-      macReaderCommandState = state
+    func updateReaderCommandState(_ state: ReaderCommandState) {
+      readerCommandState = state
     }
 
-    func clearMacReaderCommands() {
-      macReaderCommandState = MacReaderCommandState()
-      macReaderCommandHandlers = nil
+    func clearReaderCommands() {
+      readerCommandState = ReaderCommandState()
+      readerCommandHandlers = nil
     }
 
     func showReaderSettingsFromCommand() {
-      macReaderCommandHandlers?.showReaderSettings()
+      readerCommandHandlers?.showReaderSettings()
     }
 
     func showBookDetailsFromCommand() {
-      macReaderCommandHandlers?.showBookDetails()
+      readerCommandHandlers?.showBookDetails()
     }
 
     func showTableOfContentsFromCommand() {
-      macReaderCommandHandlers?.showTableOfContents()
+      readerCommandHandlers?.showTableOfContents()
     }
 
     func showPageJumpFromCommand() {
-      macReaderCommandHandlers?.showPageJump()
+      readerCommandHandlers?.showPageJump()
     }
 
     func showSearchFromCommand() {
-      macReaderCommandHandlers?.showSearch()
+      readerCommandHandlers?.showSearch()
     }
 
     func openPreviousBookFromCommand() {
-      macReaderCommandHandlers?.openPreviousBook()
+      readerCommandHandlers?.openPreviousBook()
     }
 
     func openNextBookFromCommand() {
-      macReaderCommandHandlers?.openNextBook()
+      readerCommandHandlers?.openNextBook()
     }
 
     func setReadingDirectionFromCommand(_ direction: ReadingDirection) {
-      macReaderCommandHandlers?.setReadingDirection(direction)
+      readerCommandHandlers?.setReadingDirection(direction)
     }
 
     func setPageLayoutFromCommand(_ layout: PageLayout) {
-      macReaderCommandHandlers?.setPageLayout(layout)
+      readerCommandHandlers?.setPageLayout(layout)
     }
 
     func toggleIsolateCoverPageFromCommand() {
-      macReaderCommandHandlers?.toggleIsolateCoverPage()
+      readerCommandHandlers?.toggleIsolateCoverPage()
     }
 
     func toggleIsolatePageFromCommand(_ pageID: ReaderPageID) {
-      macReaderCommandHandlers?.toggleIsolatePage(pageID)
+      readerCommandHandlers?.toggleIsolatePage(pageID)
     }
 
     func setSplitWidePageModeFromCommand(_ mode: SplitWidePageMode) {
-      macReaderCommandHandlers?.setSplitWidePageMode(mode)
+      readerCommandHandlers?.setSplitWidePageMode(mode)
     }
   #endif
 

--- a/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
@@ -67,7 +67,7 @@
       collectionView.isPrefetchingEnabled = false
       collectionView.semanticContentAttribute = .forceLeftToRight
 
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         collectionView.isPagingEnabled = true
         collectionView.scrollsToTop = false
       #endif

--- a/KMReader/Features/Reader/Views/Sheets/EpubPreferencesView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubPreferencesView_macOS.swift
@@ -18,6 +18,8 @@
     @State private var showSystemFontPicker: Bool = false
     @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
     @AppStorage("epubShowsProgressFooter") private var epubShowsProgressFooter: Bool = false
+    @AppStorage("epubShowKeyboardHelpOverlay")
+    private var showKeyboardHelpOverlay: Bool = AppConfig.epubShowKeyboardHelpOverlay
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
@@ -196,6 +198,15 @@
                 VStack(alignment: .leading, spacing: 4) {
                   Text(String(localized: "Show Progress Footer"))
                   Text(String(localized: "Show book progress at the bottom while reading."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+              }
+
+              Toggle(isOn: $showKeyboardHelpOverlay) {
+                VStack(alignment: .leading, spacing: 4) {
+                  Text("Auto-Show Keyboard Help")
+                  Text("Briefly show keyboard shortcuts when opening the reader")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 }

--- a/KMReader/Features/Reader/Views/Sheets/EpubThemePresetsView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubThemePresetsView.swift
@@ -86,7 +86,7 @@ struct EpubThemePresetsView: View {
       }
       .adaptiveButtonStyle(.plain)
     }
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       .swipeActions(edge: .trailing, allowsFullSwipe: false) {
         Button(role: .destructive) {
           deletePreset(preset)

--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -201,7 +201,7 @@ struct ReaderSettingsSheet: View {
           }
         #endif
 
-        #if !os(tvOS)
+        #if os(iOS) || os(macOS)
           Section(header: Text("Live Text")) {
             Toggle(isOn: $enableLiveText) {
               VStack(alignment: .leading, spacing: 4) {
@@ -270,11 +270,9 @@ struct ReaderSettingsSheet: View {
             #endif
           }
 
-          #if os(macOS)
-            Toggle(isOn: $showKeyboardHelpOverlay) {
-              Text("Show Keyboard Help Overlay")
-            }
-          #endif
+          Toggle(isOn: $showKeyboardHelpOverlay) {
+            Text("Auto-Show Keyboard Help")
+          }
 
           #if os(iOS) || os(macOS)
             Picker("Tap Zone Mode", selection: $tapZoneMode) {

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -133,7 +133,7 @@ struct SeriesDetailView: View {
       url: KomgaWebLinkBuilder.series(serverURL: current.serverURL, seriesId: seriesId),
       scope: .browse
     )
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       .toolbar {
         ToolbarItem(placement: .automatic) {
           seriesToolbarContent
@@ -286,7 +286,7 @@ extension SeriesDetailView {
   @ViewBuilder
   private var seriesToolbarContent: some View {
     HStack {
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         if let shareURL {
           ShareLink(item: shareURL, subject: Text(navigationTitle)) {
             Image(systemName: "square.and.arrow.up")

--- a/KMReader/Features/Server/LibraryAddSheet.swift
+++ b/KMReader/Features/Server/LibraryAddSheet.swift
@@ -80,7 +80,7 @@ struct LibraryAddSheet: View {
           String(localized: "library.add.field.root", defaultValue: "Root Folder"),
           text: $libraryCreation.root
         )
-        #if !os(tvOS)
+        #if os(iOS) || os(macOS)
           Button {
             showDirectoryBrowser = true
           } label: {

--- a/KMReader/Features/Server/LibraryEditSheet.swift
+++ b/KMReader/Features/Server/LibraryEditSheet.swift
@@ -86,7 +86,7 @@ struct LibraryEditSheet: View {
           String(localized: "library.add.field.root", defaultValue: "Root Folder"),
           text: $libraryUpdate.root
         )
-        #if !os(tvOS)
+        #if os(iOS) || os(macOS)
           Button {
             showDirectoryBrowser = true
           } label: {

--- a/KMReader/Features/Settings/Components/SettingsSection.swift
+++ b/KMReader/Features/Settings/Components/SettingsSection.swift
@@ -18,7 +18,7 @@ enum SettingsSection: String, CaseIterable {
     case epubReader
   #endif
   case sse
-  #if !os(tvOS)
+  #if os(iOS) || os(macOS)
     case spotlight
   #endif
   case network
@@ -46,7 +46,7 @@ enum SettingsSection: String, CaseIterable {
     #endif
     case .sse:
       return "antenna.radiowaves.left.and.right"
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       case .spotlight:
         return "magnifyingglass.circle"
     #endif
@@ -79,7 +79,7 @@ enum SettingsSection: String, CaseIterable {
     #endif
     case .sse:
       return String(localized: "Real-time Updates")
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       case .spotlight:
         return String(localized: "Spotlight")
     #endif

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -304,7 +304,7 @@ struct DivinaPreferencesView: View {
         }
       #endif
 
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         Section(header: Text("Live Text")) {
           Toggle(isOn: $enableLiveText) {
             VStack(alignment: .leading, spacing: 4) {
@@ -378,16 +378,14 @@ struct DivinaPreferencesView: View {
           #endif
         }
 
-        #if os(macOS)
-          Toggle(isOn: $showKeyboardHelpOverlay) {
-            VStack(alignment: .leading, spacing: 4) {
-              Text("Show Keyboard Help Overlay")
-              Text("Briefly show keyboard shortcuts when opening the reader")
-                .font(.caption)
-                .foregroundColor(.secondary)
-            }
+        Toggle(isOn: $showKeyboardHelpOverlay) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Auto-Show Keyboard Help")
+            Text("Briefly show keyboard shortcuts when opening the reader")
+              .font(.caption)
+              .foregroundColor(.secondary)
           }
-        #endif
+        }
 
         #if os(iOS) || os(macOS)
           VStack(alignment: .leading, spacing: 8) {

--- a/KMReader/Features/Settings/EpubPreferencesView.swift
+++ b/KMReader/Features/Settings/EpubPreferencesView.swift
@@ -25,6 +25,8 @@
     @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
     @AppStorage("epubShowsStatusBarWhileReading") private var epubShowsStatusBarWhileReading: Bool = false
     @AppStorage("epubShowsProgressFooter") private var epubShowsProgressFooter: Bool = false
+    @AppStorage("epubShowKeyboardHelpOverlay")
+    private var showKeyboardHelpOverlay: Bool = AppConfig.epubShowKeyboardHelpOverlay
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) var colorScheme
@@ -189,6 +191,15 @@
             VStack(alignment: .leading, spacing: 4) {
               Text(String(localized: "Show Progress Footer"))
               Text(String(localized: "Show book progress at the bottom while reading."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+          }
+
+          Toggle(isOn: $showKeyboardHelpOverlay) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Auto-Show Keyboard Help")
+              Text("Briefly show keyboard shortcuts when opening the reader")
                 .font(.caption)
                 .foregroundStyle(.secondary)
             }

--- a/KMReader/Features/Settings/PdfPreferencesView.swift
+++ b/KMReader/Features/Settings/PdfPreferencesView.swift
@@ -16,10 +16,8 @@
     private var pageLayout: PageLayout = .auto
     @AppStorage("pdfIsolateCoverPage")
     private var isolateCoverPage: Bool = true
-    #if os(macOS)
-      @AppStorage("pdfShowKeyboardHelpOverlay")
-      private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
-    #endif
+    @AppStorage("pdfShowKeyboardHelpOverlay")
+    private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
     @AppStorage("pdfOfflineRenderQuality")
     private var pdfOfflineRenderQuality: PdfOfflineRenderQuality = AppConfig.pdfOfflineRenderQuality
 
@@ -132,18 +130,16 @@
             }
           }
 
-          #if os(macOS)
-            Section(header: Text("Reader Overlay")) {
-              Toggle(isOn: $showKeyboardHelpOverlay) {
-                VStack(alignment: .leading, spacing: 4) {
-                  Text("Show Keyboard Help Overlay")
-                  Text("Briefly show keyboard shortcuts when opening the reader")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                }
+          Section(header: Text("Reader Overlay")) {
+            Toggle(isOn: $showKeyboardHelpOverlay) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Auto-Show Keyboard Help")
+                Text("Briefly show keyboard shortcuts when opening the reader")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
               }
             }
-          #endif
+          }
         }
 
         if !useNativePdfReader {

--- a/KMReader/Features/Settings/SettingsLogsView.swift
+++ b/KMReader/Features/Settings/SettingsLogsView.swift
@@ -36,7 +36,7 @@ struct SettingsLogsView: View {
           ForEach(logEntries) { entry in
             LogEntryRow(entry: entry)
               .tvFocusableHighlight()
-              #if !os(tvOS)
+              #if os(iOS) || os(macOS)
                 .contextMenu {
                   Button {
                     copyToClipboard(formatEntry(entry))
@@ -133,7 +133,7 @@ struct SettingsLogsView: View {
     .refreshable {
       await loadLogs()
     }
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       .toolbar {
         ToolbarItem(placement: .primaryAction) {
           ShareLink(item: exportLogs()) {

--- a/KMReader/Features/Settings/SettingsSpotlightView.swift
+++ b/KMReader/Features/Settings/SettingsSpotlightView.swift
@@ -5,7 +5,7 @@
 
 import SwiftUI
 
-#if !os(tvOS)
+#if os(iOS) || os(macOS)
   struct SettingsSpotlightView: View {
     @AppStorage("enableSpotlightIndexing") private var enableSpotlightIndexing: Bool = true
     @AppStorage("enableSpotlightBookIndexing") private var enableSpotlightBookIndexing: Bool = true

--- a/KMReader/Features/Settings/SettingsView.swift
+++ b/KMReader/Features/Settings/SettingsView.swift
@@ -40,12 +40,12 @@ struct SettingsView: View {
         NavigationLink(value: NavDestination.settingsSSE) {
           SettingsSectionRow(section: .sse)
         }
-        #if !os(tvOS)
+        #if os(iOS) || os(macOS)
           NavigationLink(value: NavDestination.settingsSpotlight) {
             SettingsSectionRow(section: .spotlight)
           }
         #endif
-        #if !os(tvOS)
+        #if os(iOS) || os(macOS)
           NavigationLink(value: NavDestination.settingsNetwork) {
             SettingsSectionRow(section: .network)
           }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -6941,6 +6941,70 @@
         }
       }
     },
+    "Auto-Show Keyboard Help" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tastaturhilfe automatisch anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-Show Keyboard Help"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar ayuda del teclado automáticamente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher automatiquement l’aide clavier"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra automaticamente l’aiuto da tastiera"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キーボードヘルプを自動表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "키보드 도움말 자동 표시"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически показывать справку по клавиатуре"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动显示键盘帮助"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動顯示鍵盤說明"
+          }
+        }
+      }
+    },
     "Automatically enable Live Text for all images." : {
       "localizations" : {
         "de" : {
@@ -66459,70 +66523,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示連線狀態與任務完成提示"
-          }
-        }
-      }
-    },
-    "Show Keyboard Help Overlay" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tastaturhilfe anzeigen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Keyboard Help Overlay"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar superposicion de ayuda de teclado"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher l'aide des raccourcis clavier"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra overlay aiuto tastiera"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キーボードヘルプオーバーレイを表示"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "키보드 도움말 오버레이 표시"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показывать оверлей помощи по клавиатуре"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示键盘帮助叠层"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示鍵盤輔助疊層"
           }
         }
       }

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -6,7 +6,7 @@
 import SwiftData
 import SwiftUI
 
-#if !os(tvOS)
+#if os(iOS) || os(macOS)
   import CoreSpotlight
 #endif
 
@@ -159,7 +159,7 @@ struct MainApp: App {
     @CommandsBuilder
     private var readerCommands: some Commands {
       CommandMenu("Reader") {
-        let state = readerPresentation.macReaderCommandState
+        let state = readerPresentation.readerCommandState
 
         if state.supportsReaderSettings {
           Button("Reader Settings") {
@@ -308,7 +308,7 @@ struct MainApp: App {
       .onOpenURL { url in
         deepLinkRouter.handle(url: url)
       }
-      #if !os(tvOS)
+      #if os(iOS) || os(macOS)
         .onContinueUserActivity(CSSearchableItemActionType) { activity in
           if let identifier = activity.userInfo?[CSSearchableItemActivityIdentifier] as? String {
             if let deepLink = SpotlightIndexService.deepLink(for: identifier) {

--- a/KMReader/Shared/Foundation/Models/NavDestination.swift
+++ b/KMReader/Shared/Foundation/Models/NavDestination.swift
@@ -45,7 +45,7 @@ enum NavDestination: Hashable {
     case settingsEpubReader
   #endif
   case settingsSSE
-  #if !os(tvOS)
+  #if os(iOS) || os(macOS)
     case settingsSpotlight
   #endif
   case settingsNetwork
@@ -167,7 +167,7 @@ enum NavDestination: Hashable {
     #endif
     case .settingsSSE:
       SettingsSSEView()
-    #if !os(tvOS)
+    #if os(iOS) || os(macOS)
       case .settingsSpotlight:
         SettingsSpotlightView()
     #endif


### PR DESCRIPTION
## Problem
Reader keyboard support was limited to macOS even though iPad, iPhone, and Apple TV can all be used with external keyboards. The help overlay also shared settings across reader types, and the initial UIKit responder handling introduced two iOS regressions: sheet presentation could trigger AttributeGraph cycle warnings, and EPUB keyboard shortcuts could stop responding after toggling controls.

## Approach
This PR introduces shared reader keyboard command models and routes iOS and tvOS key events through a UIKit bridge while keeping the existing macOS command integration. The keyboard help overlay is available across supported reader platforms, auto-shows only when appropriate, and uses per-reader configuration where needed. On iOS, responder updates are deferred off the SwiftUI update path and then refreshed asynchronously so the reader can recover keyboard focus without reintroducing the cycle warning.

## Scope
- Add iOS and tvOS keyboard shortcut support for DIVINA reader navigation and controls
- Extend the keyboard help overlay and auto-show behavior across DIVINA, EPUB, and PDF readers
- Add independent EPUB and PDF keyboard help preferences while preserving DIVINA settings
- Refactor reader command state and handlers into platform-neutral types
- Avoid iOS AttributeGraph cycles by deferring UIKit first responder changes outside SwiftUI updates
- Restore EPUB keyboard shortcut responsiveness after toggling controls on iOS
- Bump build version to 399

## Related
- #717
