### PR TITLE
fix: remove heavy end page close shadow

### DIFF
--- a/KMReader/Features/Reader/Views/EndPageCloseButtonStyle.swift
+++ b/KMReader/Features/Reader/Views/EndPageCloseButtonStyle.swift
@@ -12,11 +12,9 @@
       configuration.cornerStyle = .capsule
       button.configuration = configuration
       button.tintColor = textColor
-      button.layer.shadowColor = UIColor.black.withAlphaComponent(0.35).cgColor
-      button.layer.shadowOpacity = 1
-      button.layer.shadowRadius = 4
-      button.layer.shadowOffset = CGSize(width: 0, height: 2)
-      button.layer.masksToBounds = false
+      button.layer.shadowOpacity = 0
+      button.layer.shadowRadius = 0
+      button.layer.shadowOffset = .zero
     }
 
     private static func borderedButtonConfiguration() -> UIButton.Configuration {


### PR DESCRIPTION
## Problem
The close button on the reader end page looked heavier than the surrounding controls because the shared end page button style added an extra manual shadow on top of the system bordered or glass appearance.

## Approach
Remove the explicit layer shadow from the shared end page close button style on iOS and tvOS and let the system button background provide the visual depth by itself.

## Scope
- Update the shared end page close button styling used by native end pages and webtoon end pages
- Keep the existing material, border, and capsule shape unchanged

## Validation
- [x] `make format`
- [x] `make build-ios`
