### PR TITLE
fix: restore DIVINA cover zoom dismissal

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 399;
+				CURRENT_PROJECT_VERSION = 400;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 399;
+				CURRENT_PROJECT_VERSION = 400;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 399;
+				CURRENT_PROJECT_VERSION = 400;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 399;
+				CURRENT_PROJECT_VERSION = 400;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
@@ -734,6 +734,29 @@
         return max(min(raw, start), 0)
       }
 
+      func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer === panRecognizer else { return true }
+        guard !parent.viewModel.isZoomed else { return false }
+        guard !isAnimatingTransition else { return false }
+        guard let currentItem else { return false }
+        guard let pan = gestureRecognizer as? UIPanGestureRecognizer else { return true }
+
+        let translation = pan.translation(in: containerView)
+        let velocity = pan.velocity(in: containerView)
+        let directionalSignal =
+          abs(primaryTranslation(from: translation)) > TransitionMetrics.minimumDragDistance
+          ? translation
+          : velocity
+
+        guard isPrimaryDirectionalDrag(directionalSignal) else { return false }
+
+        let primarySignal = primaryTranslation(from: directionalSignal)
+        guard abs(primarySignal) > TransitionMetrics.minimumDragDistance else { return false }
+
+        let directionOffset = adjacentOffset(for: primarySignal)
+        return parent.viewModel.adjacentViewItem(from: currentItem, offset: directionOffset) != nil
+      }
+
       func gestureRecognizer(
         _ gestureRecognizer: UIGestureRecognizer,
         shouldReceive touch: UITouch


### PR DESCRIPTION
## Problem
DIVINA cover mode installed a full-screen custom pan recognizer for cover-style page turns. Because that recognizer could begin for non-page-turn drags and did not allow simultaneous recognition, it blocked the system zoom dismissal gesture, while scroll and page curl modes continued to work.

## Approach
Gate the cover pan recognizer at `gestureRecognizerShouldBegin` so it only starts when the drag matches the reader's primary page-turn direction and there is an adjacent page to move to. Non-page-turn drags are left available for UIKit's system zoom/dismiss gestures instead of being swallowed by the cover engine.

## Scope
- Restore system zoom dismissal behavior for DIVINA cover mode.
- Preserve cover page-turn handling for valid forward/backward drags.
- Bump `CURRENT_PROJECT_VERSION` to 400.

## Validation
- [x] `make format`
- [x] `make build-ios`
