### PR TITLE
fix: restore DIVINA cover gesture behavior

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 400;
+				CURRENT_PROJECT_VERSION = 401;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 400;
+				CURRENT_PROJECT_VERSION = 401;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 400;
+				CURRENT_PROJECT_VERSION = 401;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 400;
+				CURRENT_PROJECT_VERSION = 401;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -694,6 +694,7 @@ struct DivinaReaderView: View {
                 mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
                 readingDirection: readingDirection,
                 splitWidePageMode: splitWidePageMode,
+                tapNavigationAnimationDuration: pageTurnAnimationDuration,
                 renderConfig: renderConfig,
                 viewModel: viewModel,
                 readListContext: readListContext,

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
@@ -26,6 +26,7 @@
       static let cancelThreshold: CGFloat = 0.5
       static let commitDistanceRatio: CGFloat = 0.18
       static let commitVelocityThreshold: CGFloat = 700
+      static let gestureAnimationDuration: Double = 0.3
       static let movingShadowOpacity: Double = 0.12
       static let idleShadowOpacity: Double = 0.05
       static let movingShadowRadius: CGFloat = 5
@@ -37,12 +38,11 @@
     let mode: PageViewMode
     let readingDirection: ReadingDirection
     let splitWidePageMode: SplitWidePageMode
+    let tapNavigationAnimationDuration: Double
     let renderConfig: ReaderRenderConfig
     @Bindable var viewModel: ReaderViewModel
     let readListContext: ReaderReadListContext?
     let onDismiss: () -> Void
-
-    @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.3
 
     func makeCoordinator() -> Coordinator {
       Coordinator(self)
@@ -70,6 +70,11 @@
 
     @MainActor
     final class Coordinator: NSObject, UIGestureRecognizerDelegate, NativePagedPagePresentationHost {
+      private enum TransitionAnimationKind {
+        case gesture
+        case tapNavigation
+      }
+
       private var parent: NativeCoverPageView
       private weak var containerView: NativeCoverContainerView?
       private let pagePresentationCoordinator = NativePagedPagePresentationCoordinator()
@@ -223,8 +228,12 @@
         return transitionDirection == 1 ? deckState.nextItem : deckState.previousItem
       }
 
-      private var transitionDuration: Double {
-        max(parent.tapPageTransitionDuration, 0)
+      private var tapNavigationTransitionDuration: Double {
+        max(parent.tapNavigationAnimationDuration, 0)
+      }
+
+      private var gestureTransitionDuration: Double {
+        TransitionMetrics.gestureAnimationDuration
       }
 
       private var primaryExtent: CGFloat {
@@ -320,7 +329,7 @@
 
         if abs(targetIndex - currentIndex) == 1 {
           dragOffset = 0
-          commitTransition(to: targetItem)
+          commitTransition(to: targetItem, animation: .tapNavigation)
         } else {
           deckState.rebuild(around: targetItem, viewModel: parent.viewModel)
           transitionDirection = nil
@@ -399,10 +408,13 @@
           cancelDragWithAnimation()
           return
         }
-        commitTransition(to: targetItem)
+        commitTransition(to: targetItem, animation: .gesture)
       }
 
-      private func commitTransition(to targetItem: ReaderViewItem) {
+      private func commitTransition(
+        to targetItem: ReaderViewItem,
+        animation: TransitionAnimationKind
+      ) {
         guard let currentItem,
           let currentIndex = parent.viewModel.viewItemIndex(for: currentItem),
           let targetIndex = parent.viewModel.viewItemIndex(for: targetItem)
@@ -422,9 +434,10 @@
         isAnimatingTransition = true
         transitionToken += 1
         let token = transitionToken
+        let duration = transitionDuration(for: animation)
 
         if targetIndex > currentIndex {
-          animateDragOffset(to: endOffset, token: token) {
+          animateDragOffset(to: endOffset, duration: duration, token: token) {
             self.completeTransition(to: targetItem)
           }
         } else {
@@ -432,7 +445,7 @@
             dragOffset = backwardStartOffset(for: directionSign)
             updateSlotLayout()
           }
-          animateDragOffset(to: 0, token: token) {
+          animateDragOffset(to: 0, duration: duration, token: token) {
             self.completeTransition(to: targetItem)
           }
         }
@@ -471,7 +484,7 @@
         }()
 
         isAnimatingTransition = true
-        animateDragOffset(to: cancelTargetOffset, token: token) {
+        animateDragOffset(to: cancelTargetOffset, duration: gestureTransitionDuration, token: token) {
           self.resetDragStateImmediately()
         }
       }
@@ -487,6 +500,7 @@
 
       private func animateDragOffset(
         to targetOffset: CGFloat,
+        duration: Double,
         token: Int,
         completion: @escaping () -> Void
       ) {
@@ -496,7 +510,7 @@
           return
         }
 
-        if transitionDuration <= 0 {
+        if duration <= 0 {
           dragOffset = targetOffset
           updateSlotLayout()
           guard token == transitionToken else { return }
@@ -505,7 +519,7 @@
         }
 
         UIView.animate(
-          withDuration: transitionDuration,
+          withDuration: duration,
           delay: 0,
           options: [.curveEaseOut, .beginFromCurrentState, .allowUserInteraction]
         ) {
@@ -515,6 +529,15 @@
         } completion: { _ in
           guard token == self.transitionToken else { return }
           completion()
+        }
+      }
+
+      private func transitionDuration(for animation: TransitionAnimationKind) -> Double {
+        switch animation {
+        case .gesture:
+          gestureTransitionDuration
+        case .tapNavigation:
+          tapNavigationTransitionDuration
         }
       }
 
@@ -738,23 +761,13 @@
         guard gestureRecognizer === panRecognizer else { return true }
         guard !parent.viewModel.isZoomed else { return false }
         guard !isAnimatingTransition else { return false }
-        guard let currentItem else { return false }
         guard let pan = gestureRecognizer as? UIPanGestureRecognizer else { return true }
 
-        let translation = pan.translation(in: containerView)
         let velocity = pan.velocity(in: containerView)
-        let directionalSignal =
-          abs(primaryTranslation(from: translation)) > TransitionMetrics.minimumDragDistance
-          ? translation
-          : velocity
-
-        guard isPrimaryDirectionalDrag(directionalSignal) else { return false }
-
-        let primarySignal = primaryTranslation(from: directionalSignal)
-        guard abs(primarySignal) > TransitionMetrics.minimumDragDistance else { return false }
-
-        let directionOffset = adjacentOffset(for: primarySignal)
-        return parent.viewModel.adjacentViewItem(from: currentItem, offset: directionOffset) != nil
+        if velocity == .zero {
+          return true
+        }
+        return isPrimaryDirectionalDrag(velocity)
       }
 
       func gestureRecognizer(
@@ -772,6 +785,19 @@
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
       ) -> Bool {
         false
+      }
+
+      func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer
+      ) -> Bool {
+        guard gestureRecognizer === panRecognizer else { return false }
+        let typeName = String(describing: type(of: otherGestureRecognizer))
+        return typeName.contains("Parallax")
+          || typeName.contains("ZoomTransition")
+          || typeName.contains("ScreenEdgePan")
+          || typeName.contains("FullPageSwipe")
+          || typeName == "_UIContentSwipeDismissGestureRecognizer"
       }
     }
   }

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_macOS.swift
@@ -26,6 +26,7 @@
       static let cancelThreshold: CGFloat = 0.5
       static let commitDistanceRatio: CGFloat = 0.18
       static let commitVelocityThreshold: CGFloat = 700
+      static let gestureAnimationDuration: Double = 0.3
       static let movingShadowOpacity: Double = 0.12
       static let idleShadowOpacity: Double = 0.05
       static let movingShadowRadius: CGFloat = 5
@@ -37,12 +38,11 @@
     let mode: PageViewMode
     let readingDirection: ReadingDirection
     let splitWidePageMode: SplitWidePageMode
+    let tapNavigationAnimationDuration: Double
     let renderConfig: ReaderRenderConfig
     @Bindable var viewModel: ReaderViewModel
     let readListContext: ReaderReadListContext?
     let onDismiss: () -> Void
-
-    @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.3
 
     func makeCoordinator() -> Coordinator {
       Coordinator(self)
@@ -70,6 +70,11 @@
 
     @MainActor
     final class Coordinator: NSObject, NSGestureRecognizerDelegate, NativePagedPagePresentationHost {
+      private enum TransitionAnimationKind {
+        case gesture
+        case tapNavigation
+      }
+
       private var parent: NativeCoverPageView
       private weak var containerView: NativeCoverContainerView?
       private let pagePresentationCoordinator = NativePagedPagePresentationCoordinator()
@@ -216,8 +221,12 @@
         return transitionDirection == 1 ? deckState.nextItem : deckState.previousItem
       }
 
-      private var transitionDuration: Double {
-        max(parent.tapPageTransitionDuration, 0)
+      private var tapNavigationTransitionDuration: Double {
+        max(parent.tapNavigationAnimationDuration, 0)
+      }
+
+      private var gestureTransitionDuration: Double {
+        TransitionMetrics.gestureAnimationDuration
       }
 
       private var primaryExtent: CGFloat {
@@ -313,7 +322,7 @@
 
         if abs(targetIndex - currentIndex) == 1 {
           dragOffset = 0
-          commitTransition(to: targetItem)
+          commitTransition(to: targetItem, animation: .tapNavigation)
         } else {
           deckState.rebuild(around: targetItem, viewModel: parent.viewModel)
           transitionDirection = nil
@@ -392,10 +401,13 @@
           cancelDragWithAnimation()
           return
         }
-        commitTransition(to: targetItem)
+        commitTransition(to: targetItem, animation: .gesture)
       }
 
-      private func commitTransition(to targetItem: ReaderViewItem) {
+      private func commitTransition(
+        to targetItem: ReaderViewItem,
+        animation: TransitionAnimationKind
+      ) {
         guard let currentItem,
           let currentIndex = parent.viewModel.viewItemIndex(for: currentItem),
           let targetIndex = parent.viewModel.viewItemIndex(for: targetItem)
@@ -415,14 +427,16 @@
         isAnimatingTransition = true
         transitionToken += 1
         let token = transitionToken
+        let duration = transitionDuration(for: animation)
 
         if targetIndex > currentIndex {
-          animateDragOffset(to: endOffset, token: token) {
+          animateDragOffset(to: endOffset, duration: duration, token: token) {
             self.completeTransition(to: targetItem)
           }
         } else {
           animateBackwardCommitWithPreparedStartStateIfNeeded(
             directionSign: directionSign,
+            duration: duration,
             token: token
           ) {
             self.completeTransition(to: targetItem)
@@ -463,7 +477,7 @@
         }()
 
         isAnimatingTransition = true
-        animateDragOffset(to: cancelTargetOffset, token: token) {
+        animateDragOffset(to: cancelTargetOffset, duration: gestureTransitionDuration, token: token) {
           self.resetDragStateImmediately()
         }
       }
@@ -479,11 +493,12 @@
 
       private func animateBackwardCommitWithPreparedStartStateIfNeeded(
         directionSign: CGFloat,
+        duration: Double,
         token: Int,
         completion: @escaping @MainActor () -> Void
       ) {
         guard abs(dragOffset) < TransitionMetrics.cancelThreshold else {
-          animateDragOffset(to: 0, token: token, completion: completion)
+          animateDragOffset(to: 0, duration: duration, token: token, completion: completion)
           return
         }
 
@@ -496,12 +511,13 @@
         Task { @MainActor in
           await Task.yield()
           guard token == self.transitionToken else { return }
-          self.animateDragOffset(to: 0, token: token, completion: completion)
+          self.animateDragOffset(to: 0, duration: duration, token: token, completion: completion)
         }
       }
 
       private func animateDragOffset(
         to targetOffset: CGFloat,
+        duration: Double,
         token: Int,
         completion: @escaping @MainActor () -> Void
       ) {
@@ -511,7 +527,7 @@
           return
         }
 
-        if transitionDuration <= 0 {
+        if duration <= 0 {
           dragOffset = targetOffset
           updateSlotLayout()
           guard token == transitionToken else { return }
@@ -520,7 +536,7 @@
         }
 
         NSAnimationContext.runAnimationGroup { context in
-          context.duration = transitionDuration
+          context.duration = duration
           context.timingFunction = CAMediaTimingFunction(name: .easeOut)
           self.dragOffset = targetOffset
           self.updateSlotLayout(animated: true)
@@ -530,6 +546,15 @@
             guard token == self.transitionToken else { return }
             completion()
           }
+        }
+      }
+
+      private func transitionDuration(for animation: TransitionAnimationKind) -> Double {
+        switch animation {
+        case .gesture:
+          gestureTransitionDuration
+        case .tapNavigation:
+          tapNavigationTransitionDuration
         }
       }
 


### PR DESCRIPTION
## Problem
DIVINA cover mode regressed in two ways after the recent zoom-dismiss recovery change. The stricter `shouldBegin` gate could reject valid page-turn drags too early, and the configurable tap page-turn duration also started affecting drag-driven page turns.

## Approach
Give system zoom and dismiss gestures priority over the cover pan recognizer on iOS, but relax the cover recognizer's own start gate so primary-axis page turns are not dropped at gesture start. Split cover transition timing into separate tap-navigation and drag-gesture paths so only tap-based navigation uses the configurable duration.

## Scope
- pass tap navigation duration into native DIVINA cover containers explicitly
- restore more reliable iOS cover drag recognition while preserving zoom-dismiss behavior
- keep drag commit and cancel animations on a fixed gesture timing on iOS and macOS
- bump `CURRENT_PROJECT_VERSION` from 400 to 401

## Validation
- [x] `make format`
- [x] `make build`
