### PR TITLE
fix: use system controls for legacy reader overlays

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 401;
+				CURRENT_PROJECT_VERSION = 402;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 401;
+				CURRENT_PROJECT_VERSION = 402;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 401;
+				CURRENT_PROJECT_VERSION = 402;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 401;
+				CURRENT_PROJECT_VERSION = 402;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -197,10 +197,10 @@ struct DivinaControlsOverlayView: View {
           onDismiss()
         } label: {
           Image(systemName: "xmark")
+            .contentShape(Circle())
         }
         .buttonBorderShape(.circle)
         .controlSize(.large)
-        .contentShape(Circle())
         .adaptiveButtonStyle(buttonStyle)
         #if os(tvOS)
           .focused($focusedControl, equals: .close)
@@ -235,9 +235,9 @@ struct DivinaControlsOverlayView: View {
           }
           .padding(.vertical, 2)
           .padding(.horizontal)
+          .contentShape(Capsule())
         }
         .optimizedControlSize()
-        .contentShape(Capsule())
         .adaptiveButtonStyle(buttonStyle)
         #if os(tvOS)
           .focused($focusedControl, equals: .title)
@@ -253,10 +253,10 @@ struct DivinaControlsOverlayView: View {
         } label: {
           Image(systemName: "ellipsis")
             .padding(4)
+            .contentShape(Circle())
         }
         .buttonBorderShape(.circle)
         .controlSize(.large)
-        .contentShape(Circle())
         .adaptiveButtonStyle(buttonStyle)
         #if os(tvOS)
           .focused($focusedControl, equals: .settings)
@@ -288,8 +288,8 @@ struct DivinaControlsOverlayView: View {
             Text("\(displayedCurrentPage) / \(currentSegmentPageCount)")
               .monospacedDigit()
           }
+          .contentShape(Capsule())
         }
-        .contentShape(Capsule())
         .adaptiveButtonStyle(buttonStyle)
         #if os(tvOS)
           .focused($focusedControl, equals: .pageNumber)

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -639,8 +639,8 @@
               closeReader()
             } label: {
               Image(systemName: "xmark")
+                .contentShape(Circle())
             }
-            .contentShape(Circle())
             .controlSize(.extraLarge)
             .buttonBorderShape(.circle)
             .adaptiveButtonStyle(buttonStyle)
@@ -674,8 +674,8 @@
                 Image(systemName: showingQuickActions ? "xmark" : "line.3.horizontal")
                   .padding(2)
                   .contentTransition(.symbolEffect(.replace, options: .nonRepeating))
+                  .contentShape(Circle())
               }
-              .contentShape(Circle())
               .controlSize(.extraLarge)
               .buttonBorderShape(.circle)
               .adaptiveButtonStyle(buttonStyle)
@@ -742,6 +742,7 @@
                 .font(.callout)
               Image(systemName: "list.bullet")
             }
+            .contentShape(Capsule())
           }
           .adaptiveButtonStyle(buttonStyle)
           .buttonBorderShape(.capsule)
@@ -757,6 +758,7 @@
               .font(.callout)
             Image(systemName: "textformat")
           }
+          .contentShape(Capsule())
         }
         .adaptiveButtonStyle(buttonStyle)
         .buttonBorderShape(.capsule)
@@ -770,6 +772,7 @@
               .font(.callout)
             Image(systemName: "info.circle")
           }
+          .contentShape(Capsule())
         }
         .adaptiveButtonStyle(buttonStyle)
         .buttonBorderShape(.capsule)

--- a/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
@@ -81,10 +81,10 @@
             onDismiss()
           } label: {
             Image(systemName: "xmark")
+              .contentShape(Circle())
           }
           .buttonBorderShape(.circle)
           .controlSize(.large)
-          .contentShape(Circle())
           .adaptiveButtonStyle(buttonStyle)
         #endif
 
@@ -117,9 +117,9 @@
             }
             .padding(.vertical, 2)
             .padding(.horizontal)
+            .contentShape(Capsule())
           }
           .optimizedControlSize()
-          .contentShape(Capsule())
           .adaptiveButtonStyle(buttonStyle)
         }
 
@@ -131,10 +131,10 @@
           } label: {
             Image(systemName: "ellipsis")
               .padding(4)
+              .contentShape(Circle())
           }
           .buttonBorderShape(.circle)
           .controlSize(.large)
-          .contentShape(Circle())
           .adaptiveButtonStyle(buttonStyle)
         #endif
       }
@@ -163,8 +163,8 @@
               Text("\(displayedCurrentPage) / \(pageCount)")
                 .monospacedDigit()
             }
+            .contentShape(Capsule())
           }
-          .contentShape(Capsule())
           .adaptiveButtonStyle(buttonStyle)
           .disabled(pageCount <= 0)
 

--- a/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_iOS.swift
@@ -340,10 +340,7 @@
       func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         lastTouchStartTime = Date()
         hadSelectionAtTouchStart = (observedPDFView?.currentSelection != nil)
-        if let view = touch.view, view is UIControl {
-          return false
-        }
-        return true
+        return !isInteractiveElement(touch.view)
       }
 
       func gestureRecognizer(
@@ -351,6 +348,42 @@
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
       ) -> Bool {
         true
+      }
+
+      private func isInteractiveElement(_ view: UIView?) -> Bool {
+        var current = view
+        while let candidate = current {
+          if candidate is UIControl {
+            return true
+          }
+
+          let className = NSStringFromClass(type(of: candidate))
+          if className.contains("Button")
+            || className.contains("Slider")
+            || className.contains("Switch")
+            || className.contains("TextField")
+            || className.contains("TextView")
+            || className.contains("Segmented")
+            || className.contains("NavigationBar")
+            || className.contains("Toolbar")
+            || className.contains("Menu")
+            || className.contains("ContextMenu")
+            || className.contains("Popover")
+          {
+            return true
+          }
+
+          if candidate.isAccessibilityElement {
+            let traits = candidate.accessibilityTraits
+            if traits.contains(.button) || traits.contains(.link) {
+              return true
+            }
+          }
+
+          current = candidate.superview
+        }
+
+        return false
       }
     }
   }

--- a/KMReader/Shared/Extensions/View+ButtonStyle.swift
+++ b/KMReader/Shared/Extensions/View+ButtonStyle.swift
@@ -12,168 +12,6 @@ enum AdaptiveButtonStyleType {
   case plain
 }
 
-enum GlassEffectType {
-  case clear
-  case regular
-}
-
-private struct LegacyGlassButtonStyle: ButtonStyle {
-  @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
-  @Environment(\.controlSize) private var controlSize
-  @Environment(\.isEnabled) private var isEnabled
-  @Environment(\.colorScheme) private var colorScheme
-
-  func makeBody(configuration: Configuration) -> some View {
-    configuration.label
-      .padding(buttonPadding)
-      .background {
-        ButtonBorderShape.buttonBorder
-          .fill(backgroundStyle)
-
-        if !reduceTransparency {
-          ButtonBorderShape.buttonBorder
-            .fill(tintOverlayColor)
-        }
-      }
-      .overlay {
-        ButtonBorderShape.buttonBorder
-          .stroke(borderColor, lineWidth: 0.8)
-      }
-      .contentShape(ButtonBorderShape.buttonBorder)
-      .shadow(
-        color: reduceTransparency ? .clear : .black.opacity(0.14),
-        radius: 8,
-        x: 0,
-        y: 2
-      )
-      .opacity(isEnabled ? (configuration.isPressed ? 0.92 : 1) : 0.55)
-      .scaleEffect(configuration.isPressed ? 0.98 : 1)
-  }
-
-  private var buttonPadding: CGFloat {
-    switch controlSize {
-    case .mini:
-      return 6
-    case .small:
-      return 8
-    case .regular:
-      return 10
-    case .large:
-      return 12
-    case .extraLarge:
-      return 14
-    @unknown default:
-      return 10
-    }
-  }
-
-  private var backgroundStyle: AnyShapeStyle {
-    if reduceTransparency {
-      return AnyShapeStyle(reducedTransparencyColor)
-    }
-
-    return AnyShapeStyle(.thickMaterial)
-  }
-
-  private var tintOverlayColor: Color {
-    switch colorScheme {
-    case .dark:
-      return .black.opacity(0.22)
-    case .light:
-      return .white.opacity(0.18)
-    @unknown default:
-      return .white.opacity(0.18)
-    }
-  }
-
-  private var borderColor: Color {
-    if reduceTransparency {
-      return .primary.opacity(0.12)
-    }
-
-    switch colorScheme {
-    case .dark:
-      return .white.opacity(0.24)
-    case .light:
-      return .black.opacity(0.10)
-    @unknown default:
-      return .primary.opacity(0.16)
-    }
-  }
-
-  private var reducedTransparencyColor: Color {
-    #if os(iOS)
-      return Color(.systemBackground)
-    #elseif os(tvOS)
-      return Color.black.opacity(0.92)
-    #elseif os(macOS)
-      return Color(NSColor.controlBackgroundColor)
-    #else
-      return .gray
-    #endif
-  }
-}
-
-private struct LegacyGlassSurfaceModifier<SurfaceShape: Shape>: ViewModifier {
-  @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
-
-  let type: GlassEffectType
-  let shape: SurfaceShape
-
-  func body(content: Content) -> some View {
-    content
-      .background(backgroundStyle, in: shape)
-      .overlay {
-        shape
-          .stroke(borderColor, lineWidth: reduceTransparency ? 1 : 0.8)
-      }
-      .shadow(
-        color: reduceTransparency ? .clear : .black.opacity(type == .clear ? 0.08 : 0.14),
-        radius: type == .clear ? 4 : 8,
-        x: 0,
-        y: 2
-      )
-  }
-
-  private var backgroundStyle: AnyShapeStyle {
-    if reduceTransparency {
-      return AnyShapeStyle(reducedTransparencyColor)
-    }
-
-    switch type {
-    case .clear:
-      return AnyShapeStyle(.ultraThinMaterial)
-    case .regular:
-      return AnyShapeStyle(.regularMaterial)
-    }
-  }
-
-  private var borderColor: Color {
-    if reduceTransparency {
-      return .primary.opacity(0.12)
-    }
-
-    switch type {
-    case .clear:
-      return .white.opacity(0.18)
-    case .regular:
-      return .white.opacity(0.24)
-    }
-  }
-
-  private var reducedTransparencyColor: Color {
-    #if os(iOS)
-      return type == .clear ? Color(.secondarySystemBackground) : Color(.systemBackground)
-    #elseif os(tvOS)
-      return type == .clear ? Color.black.opacity(0.84) : Color.black.opacity(0.92)
-    #elseif os(macOS)
-      return type == .clear ? Color(NSColor.windowBackgroundColor) : Color(NSColor.controlBackgroundColor)
-    #else
-      return .gray
-    #endif
-  }
-}
-
 extension View {
   @ViewBuilder
   func adaptiveButtonStyle(_ style: AdaptiveButtonStyleType) -> some View {
@@ -205,9 +43,9 @@ extension View {
       case .borderedProminent:
         self.buttonStyle(.borderedProminent)
       case .bordered:
-        self.buttonStyle(LegacyGlassButtonStyle())
+        self.buttonStyle(.borderedProminent)
       case .borderless:
-        self.buttonStyle(LegacyGlassButtonStyle())
+        self.buttonStyle(.borderedProminent)
       case .plain:
         #if os(tvOS)
           self.buttonStyle(.card)
@@ -220,43 +58,5 @@ extension View {
         #endif
       }
     }
-  }
-
-  @ViewBuilder
-  func glassEffectIfAvailable(_ type: GlassEffectType, enabled: Bool = true) -> some View {
-    if enabled {
-      if #available(iOS 26.0, macOS 26.0, tvOS 26.0, *) {
-        switch type {
-        case .clear: self.glassEffect(.clear)
-        case .regular: self.glassEffect(.regular)
-        }
-      } else {
-        self.legacyGlassSurface(type, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-      }
-    } else {
-      self
-    }
-  }
-
-  @ViewBuilder
-  func glassEffectIfAvailable<S: Shape>(_ type: GlassEffectType, enabled: Bool = true, in shape: S)
-    -> some View
-  {
-    if enabled {
-      if #available(iOS 26.0, macOS 26.0, tvOS 26.0, *) {
-        switch type {
-        case .clear: self.glassEffect(.clear, in: shape)
-        case .regular: self.glassEffect(.regular, in: shape)
-        }
-      } else {
-        self.legacyGlassSurface(type, in: shape)
-      }
-    } else {
-      self
-    }
-  }
-
-  private func legacyGlassSurface<S: Shape>(_ type: GlassEffectType, in shape: S) -> some View {
-    modifier(LegacyGlassSurfaceModifier(type: type, shape: shape))
   }
 }

--- a/KMReader/Shared/UI/ReadingProgressBar.swift
+++ b/KMReader/Shared/UI/ReadingProgressBar.swift
@@ -15,7 +15,6 @@ struct ReadingProgressBar: View {
   let height: CGFloat
   let color: Color
   let background: Color
-  let glass: Bool
 
   init(progress: Double, type: ReadingProgressBarType) {
     self.progress = progress
@@ -24,11 +23,9 @@ struct ReadingProgressBar: View {
     case .reader:
       self.color = .white
       self.background = .secondary.opacity(0.4)
-      self.glass = true
     case .card:
       self.color = .accentColor
       self.background = .accentColor.opacity(0.4)
-      self.glass = false
     }
   }
 
@@ -46,7 +43,6 @@ struct ReadingProgressBar: View {
             height: height
           )
       }
-      .glassEffectIfAvailable(.regular, enabled: glass, in: Capsule())
     }
     .frame(height: height)
     .padding(height)


### PR DESCRIPTION
## Problem
On older systems, the reader overlay fell back to a custom legacy button style that made controls harder to read and left the button hit-testing path inconsistent. In practice, overlay controls such as close and jump-to-page could compete with the reader tap bridge instead of behaving like normal system controls.

## Approach
Switch the legacy adaptive button fallback to system `borderedProminent` controls, remove the obsolete glass fallback tied to that path, and keep each overlay button's `contentShape` aligned with its label hierarchy. In the PDF reader, also treat interactive descendants as controls so the page tap bridge does not intercept touches that start inside overlay UI.

## Scope
- Update the shared adaptive button fallback used by legacy reader overlays
- Adjust DIVINA, PDF, and EPUB overlay buttons so their hit-testing modifiers live with the label content
- Tighten PDF tap-bridge filtering for interactive overlay elements

## Validation
- make format
- make build-ios
- make build-macos
- make build-tvos
