### PR TITLE
fix: tombstone books that 404 on download

### DIFF
--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -1234,6 +1234,36 @@ actor DatabaseOperator {
     }
   }
 
+  /// Tombstone a book that the server no longer serves (e.g. file replaced, yielding a new UUID).
+  /// Sets `isUnavailable = true` and resets download state so policy sweeps stop re-enqueueing it.
+  /// Mirrors the effect of a server-delivered `deleted: true` on the book DTO.
+  func markBookUnavailable(bookId: String, instanceId: String) {
+    let compositeId = CompositeID.generate(instanceId: instanceId, id: bookId)
+    let descriptor = FetchDescriptor<KomgaBook>(
+      predicate: #Predicate { $0.id == compositeId }
+    )
+    guard let book = try? modelContext.fetch(descriptor).first else { return }
+
+    book.isUnavailable = true
+    book.downloadStatusRaw = "notDownloaded"
+    book.downloadError = nil
+    book.downloadAt = nil
+    book.downloadedSize = 0
+    book.pagesRaw = nil
+    book.tocRaw = nil
+    book.webPubManifestRaw = nil
+
+    // Re-sync series download state so counters and policy picks skip this book.
+    let seriesId = book.seriesId
+    let compositeSeriesId = CompositeID.generate(instanceId: instanceId, id: seriesId)
+    let seriesDescriptor = FetchDescriptor<KomgaSeries>(
+      predicate: #Predicate { $0.id == compositeSeriesId }
+    )
+    if let series = try? modelContext.fetch(seriesDescriptor).first {
+      syncSeriesDownloadStatus(series: series)
+    }
+  }
+
   func updateReadingProgress(bookId: String, page: Int, completed: Bool) {
     let instanceId = AppConfig.current.instanceId
     let compositeId = CompositeID.generate(instanceId: instanceId, id: bookId)
@@ -1346,8 +1376,15 @@ actor DatabaseOperator {
     let policyLimit = max(0, series.offlinePolicyLimit)
     let policySupportsLimit = policy == .unreadOnly || policy == .unreadOnlyAndCleanupRead
 
-    // Sort books to ensure they are processed in order
-    let sortedBooks = books.sorted { $0.metaNumberSort < $1.metaNumberSort }
+    // Sort books to ensure they are processed in order.
+    // Books tombstoned as unavailable (server replaced/removed them) are excluded
+    // up front so they neither consume a slot in `allowedUnreadIds` nor get
+    // re-enqueued by the loop below. Otherwise a cancel → sync sweep would
+    // resurrect the phantom download indefinitely.
+    let sortedBooks =
+      books
+      .filter { !$0.isUnavailable }
+      .sorted { $0.metaNumberSort < $1.metaNumberSort }
     var allowedUnreadIds = Set<String>()
     if policyLimit > 0, policySupportsLimit {
       let unreadBooks = sortedBooks.filter { $0.progressCompleted != true }

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -801,6 +801,22 @@ actor OfflineManager {
           )
         }
       } catch {
+        if isPermanentNotFound(error) {
+          logger.info(
+            "🪦 Book \(info.bookId) no longer exists on server; marking unavailable"
+          )
+          await BackgroundDownloadManager.shared.cancelDownloads(forBookId: info.bookId)
+          clearBackgroundDownloadContext(bookId: info.bookId)
+          removeActiveTask(info.bookId)
+          try? await DatabaseOperator.database().markBookUnavailable(
+            bookId: info.bookId,
+            instanceId: instanceId
+          )
+          try? await DatabaseOperator.database().commit()
+          await refreshQueueStatus(instanceId: instanceId)
+          await syncDownloadQueue(instanceId: instanceId)
+          return
+        }
         logger.error("❌ Failed to start background download for \(info.bookId): \(error)")
         await BackgroundDownloadManager.shared.cancelDownloads(forBookId: info.bookId)
         clearBackgroundDownloadContext(bookId: info.bookId)
@@ -1085,6 +1101,17 @@ actor OfflineManager {
 
         if Task.isCancelled {
           logger.info("⛔ Download cancelled for book: \(info.bookId)")
+        } else if self.isPermanentNotFound(error) {
+          // Book has been replaced/removed server-side — tombstone, do not mark .failed.
+          logger.info(
+            "🪦 Book \(info.bookId) no longer exists on server; marking unavailable"
+          )
+          try? await DatabaseOperator.database().markBookUnavailable(
+            bookId: info.bookId,
+            instanceId: instanceId
+          )
+          try? await DatabaseOperator.database().commit()
+          await self.refreshQueueStatus(instanceId: instanceId)
         } else {
           let shouldKeepPending = await self.shouldKeepPendingAfterNetworkFailure(error)
           if shouldKeepPending {
@@ -1394,6 +1421,16 @@ actor OfflineManager {
     }
   #endif
 
+  /// Returns true when the server has confirmed the book no longer exists (HTTP 404).
+  /// This happens when a file is replaced server-side and Komga issues a new book UUID,
+  /// leaving the previously-cached UUID orphaned.
+  private nonisolated func isPermanentNotFound(_ error: Error) -> Bool {
+    if let apiError = error as? APIError, case .notFound = apiError {
+      return true
+    }
+    return false
+  }
+
   private nonisolated func isNetworkRelatedError(_ error: Error) -> Bool {
     if let apiError = error as? APIError {
       if case .networkError = apiError { return true }
@@ -1530,6 +1567,23 @@ actor OfflineManager {
       if isNetworkError && AppConfig.isOffline {
         // Network error caused offline mode switch - keep as pending for retry
         logger.info("⚠️ Background download paused due to network error: \(bookId)")
+        return
+      }
+
+      // A 404 means the book has been replaced/removed server-side. Tombstone instead
+      // of marking .failed, so policy sweeps don't resurrect the phantom download.
+      if isPermanentNotFound(error) {
+        logger.info("🪦 Book \(bookId) no longer exists on server; marking unavailable")
+        try? await DatabaseOperator.database().markBookUnavailable(
+          bookId: bookId,
+          instanceId: info.instanceId
+        )
+        try? await DatabaseOperator.database().commit()
+        await refreshQueueStatus(instanceId: info.instanceId)
+        await BackgroundDownloadManager.shared.cancelDownloads(forBookId: bookId)
+        clearBackgroundDownloadContext(bookId: bookId)
+        removeActiveTask(bookId)
+        await syncDownloadQueue(instanceId: info.instanceId)
         return
       }
 


### PR DESCRIPTION
## Summary

Fixes the user-visible symptom described in #737: when a Komga file is replaced server-side and a new book UUID is issued, the offline auto-download queue gets stuck in a 404 loop on the old (phantom) UUID that no in-app action can clear.

## Reproduction

1. In KMReader, enable an auto-download policy (e.g., "unread only, download 3") on a series.
2. On the Komga server, replace a book's file so Komga issues a new UUID (the old UUID is hard-deleted).
3. KMReader's policy tries to download the old UUID → `GET /api/v1/books/<old_id>/pages` returns 404.
4. The book is marked `.failed` in SwiftData and stays there. The next policy sweep sees it as "not downloaded" (cancel flips it back to `notDownloaded`) and re-enqueues it. Loop.

Reported in [#737](https://github.com/everpcpc/KMReader/issues/737) — the user confirmed that "Sync Now", "Force Full Sync", clearing caches, resetting the offline policy, and deleting downloads all fail to clear the stuck task. Only reinstalling the app clears it.

## What this PR does

Treats HTTP 404 from a download as a permanent "book is gone" signal instead of a transient failure, and makes the policy layer aware of that state.

Three small pieces:

### 1. `DatabaseOperator.markBookUnavailable(bookId:instanceId:)`

Tombstones a book that the server no longer serves. Mirrors the effect of a server-delivered `deleted: true` on the book DTO:

- `isUnavailable = true`
- `downloadStatusRaw = "notDownloaded"`, `downloadError = nil`, `downloadAt = nil`, `downloadedSize = 0`
- Clears cached `pagesRaw` / `tocRaw` / `webPubManifestRaw`
- Re-runs `syncSeriesDownloadStatus` so the series counters and policy sweep re-evaluate

No schema change — `isUnavailable` is already a first-class field on `KomgaBook` (schema line 44), already mirrored from `dto.deleted` in `applyBook` / `upsertBook` / `upsertBooks`, and already used as a filter by views (`BookCardView`, `BookRowView`) and stores (`KomgaBookStore.fetchBook` and friends).

### 2. `OfflineManager.isPermanentNotFound(_:)`

Helper that matches `APIError.notFound`. Parallels the existing `isNetworkRelatedError` pattern in the same file.

### 3. Three catch-site patches

- `startBackgroundDownload` (iOS background URLSession path) — on 404, call `markBookUnavailable` and return before the generic `.failed` handling.
- `handleBackgroundDownloadFailed` (iOS background URLSession failure callback) — same.
- `startForegroundDownload` (macOS/tvOS in-process path) — same, as an `else if` branch before the `shouldKeepPendingAfterNetworkFailure` check.

### 4. `handlePolicyActions` pre-filter

Exclude `isUnavailable` books from `sortedBooks` before computing `allowedUnreadIds` or iterating. Without this, the phantom would still count toward the N-unread-books limit and silently cap the effective download count. With this, the next real book is promoted into the phantom's slot, so `auto-download 3 unread` downloads 3 real books.

## Behavior after the fix

| Before | After |
| --- | --- |
| Phantom 404s, marked `.failed`, stuck permanently. User's auto-download limit is effectively reduced by one. | Phantom 404s once, tombstoned, hidden from policy. Next real book is promoted. Download limit honored. |
| Cancel-then-sync resurrects the phantom. | Phantom is excluded from policy sweeps; cancel paths can no longer resurrect it. |
| Only reinstall clears the state. | Self-heals silently on the next 404. |

## Scope (what this PR does not do)

This PR does not address the root cause of phantom accumulation. From static reading, there is a real and more fundamental bug worth the maintainer's attention:

**`DashboardView.swift:154` is the only consumer of `SSEEvent.bookDeleted`, and it merely triggers a dashboard refresh — it never deletes the book from SwiftData.** So when Komga emits `BookDeleted` for the old UUID (which it does every time a file is replaced), KMReader ignores it for persistence purposes and the phantom accumulates in the local DB.

A proper SSE-driven delete would prevent phantoms from existing in the first place. That change is more invasive (touches the SSE subscription pattern — per `AGENTS.md` "SSE callbacks are single-assignment closures; implement dispatchers if multiple components need the same event") and I didn't want to rewrite SSE dispatching as a drive-by contributor.

Additionally, the reporter in #737 confirmed that "Force Full Sync" (`syncData(forceFullSync: true)` → `reconcileBookDeletions` → `deleteBooksNotIn`) does not clear their stuck phantom, which suggests there's a second, distinct bug in the reconcile pipeline that I couldn't pinpoint from static reading. Suggested follow-up investigation areas:

- `DatabaseOperator.commit()` debounces `modelContext.save()` by 500ms (line 81-92); concurrent cancellations may drop the save.
- `deleteBooksNotIn` pagination interacts with marked-for-deletion models (line 255-295) — worth verifying that `page.last?.id` is meaningful when the tail was just deleted.
- `fetchAllBookIdsForDeletionReconcile` uses `unpaged: true` with a silent fallback; worth confirming the unpaged path returns a complete set on large libraries.

The tombstone fix in this PR is robust regardless of which of those turns out to be real — it catches the phantom on its first download attempt and stops the loop, whether reconcile works or not.

## Convention checks

- `AGENTS.md` section "SwiftData Migration Discipline": no schema change (reusing existing `isUnavailable`), no migration needed.
- "All logging goes through `AppLogger`": yes, the new log lines use the existing `logger` at `.info` level (these are expected events, not errors).
- "Replace the confused layer instead of adding compensating state": `isUnavailable` is not compensating state — it is the existing tombstone mechanism, already in the schema to mirror Komga's `deleted` flag. This PR gives the policy layer the missing awareness of that state.
- `xcrun swift-format -i` run against the project's `.swift-format` config; no complaints.

## Testing notes

- No XCTest targets exist in the repo (per AGENTS.md).
- I don't have Xcode locally so I haven't built or run the app. The change is small, localized, and strictly additive on the 404 path — worst case if it misbehaves is that phantoms remain stuck as they already do today.
- Manual test recommended by maintainer:
  1. With an unread-only policy (e.g., limit 3), replace a book file server-side so Komga rotates the UUID.
  2. Confirm the stale download attempt resolves silently, the book disappears from the offline view, and the next real unread book is downloaded to fill the slot.
  3. Confirm `handlePolicyActions` never re-enqueues the tombstoned book on subsequent sweeps.

## Diff size

2 files changed, 93 insertions(+), 2 deletions(-).