### PR TITLE
fix: refresh expired thumbnails

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 402;
+				CURRENT_PROJECT_VERSION = 403;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 402;
+				CURRENT_PROJECT_VERSION = 403;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 402;
+				CURRENT_PROJECT_VERSION = 403;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 402;
+				CURRENT_PROJECT_VERSION = 403;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/Cache/ThumbnailCache.swift
+++ b/KMReader/Core/Storage/Cache/ThumbnailCache.swift
@@ -12,14 +12,14 @@ extension Notification.Name {
   static let thumbnailDidRefresh = Notification.Name("thumbnailDidRefresh")
 }
 
-enum ThumbnailType: String, CaseIterable, Sendable {
+nonisolated enum ThumbnailType: String, CaseIterable, Sendable {
   case book
   case series
   case collection
   case readlist
   case page
 
-  nonisolated var pathSegment: String {
+  var pathSegment: String {
     switch self {
     case .book: return "books"
     case .series: return "series"

--- a/KMReader/Core/Storage/Cache/ThumbnailCache.swift
+++ b/KMReader/Core/Storage/Cache/ThumbnailCache.swift
@@ -12,7 +12,7 @@ extension Notification.Name {
   static let thumbnailDidRefresh = Notification.Name("thumbnailDidRefresh")
 }
 
-enum ThumbnailType: String, CaseIterable {
+enum ThumbnailType: String, CaseIterable, Sendable {
   case book
   case series
   case collection
@@ -44,6 +44,7 @@ actor ThumbnailCache {
   private static let cleanupHighWatermarkPercent: Int64 = 90
   private static let cleanupTargetPercent: Int64 = 80
   private static let cleanupThrottleInterval: TimeInterval = 5
+  private static let thumbnailExpirationInterval: TimeInterval = 7 * 24 * 60 * 60
 
   private static func getMaxDiskCacheSize() -> Int {
     AppConfig.maxCoverCacheSize
@@ -71,7 +72,7 @@ actor ThumbnailCache {
     let fileURL = Self.getThumbnailFileURL(id: id, type: type, page: page)
 
     if !force && fileManager.fileExists(atPath: fileURL.path) {
-      return fileURL
+      return await cachedThumbnailOrRefreshedURL(id: id, type: type, page: page, fileURL: fileURL)
     }
 
     // For page thumbnails, try to generate from offline downloaded pages first
@@ -83,9 +84,7 @@ actor ThumbnailCache {
       }
     }
 
-    let cacheKey =
-      page != nil
-      ? "\(type.rawValue)#\(id)#\(page!)#\(force)" : "\(type.rawValue)#\(id)#\(force)"
+    let cacheKey = Self.taskCacheKey(id: id, type: type, page: page, force: force)
     if let existingTask = downloadTasks[cacheKey] {
       return try await existingTask.value
     }
@@ -171,6 +170,54 @@ actor ThumbnailCache {
         "❌ Failed to download thumbnail for \(type.rawValue) \(id): \(error.localizedDescription)")
       throw error
     }
+  }
+
+  private static nonisolated func taskCacheKey(
+    id: String,
+    type: ThumbnailType,
+    page: Int?,
+    force: Bool
+  ) -> String {
+    page != nil
+      ? "\(type.rawValue)#\(id)#\(page!)#\(force)" : "\(type.rawValue)#\(id)#\(force)"
+  }
+
+  private func cachedThumbnailOrRefreshedURL(
+    id: String,
+    type: ThumbnailType,
+    page: Int?,
+    fileURL: URL
+  ) async -> URL {
+    guard isExpiredThumbnail(fileURL) else { return fileURL }
+
+    do {
+      return try await ensureThumbnail(id: id, type: type, page: page, force: true)
+    } catch {
+      logExpiredThumbnailRefreshFailure(id: id, type: type, page: page, error: error)
+      return fileURL
+    }
+  }
+
+  private func isExpiredThumbnail(_ fileURL: URL) -> Bool {
+    guard
+      let attributes = try? fileManager.attributesOfItem(atPath: fileURL.path),
+      let modificationDate = attributes[.modificationDate] as? Date
+    else {
+      return false
+    }
+
+    return Date().timeIntervalSince(modificationDate) > Self.thumbnailExpirationInterval
+  }
+
+  private func logExpiredThumbnailRefreshFailure(
+    id: String,
+    type: ThumbnailType,
+    page: Int?,
+    error: Error
+  ) {
+    let logSuffix = page != nil ? "page \(page!) of book \(id)" : "\(type.rawValue) \(id)"
+    logger.debug(
+      "⚠️ Failed to refresh expired thumbnail for \(logSuffix): \(error.localizedDescription)")
   }
 
   // MARK: - Offline Page Thumbnail Generation
@@ -398,6 +445,10 @@ actor ThumbnailCache {
   static func refreshThumbnail(id: String, type: ThumbnailType) async throws {
     _ = try await shared.ensureThumbnail(id: id, type: type, force: true)
 
+    await postThumbnailDidRefresh(id: id, type: type)
+  }
+
+  private static func postThumbnailDidRefresh(id: String, type: ThumbnailType) async {
     await MainActor.run {
       NotificationCenter.default.post(
         name: .thumbnailDidRefresh,

--- a/KMReader/Features/Book/Models/BookSortField.swift
+++ b/KMReader/Features/Book/Models/BookSortField.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 // Sort field enum for Books
-enum BookSortField: String, CaseIterable {
+enum BookSortField: String, CaseIterable, Sendable {
   case series = "series,metadata.numberSort"
   case name = "metadata.title"
   case dateAdded = "createdDate"

--- a/KMReader/Features/Book/ViewModels/BookBrowseOptions.swift
+++ b/KMReader/Features/Book/ViewModels/BookBrowseOptions.swift
@@ -6,7 +6,7 @@
 import Foundation
 import SwiftUI
 
-nonisolated struct BookBrowseOptions: Equatable, RawRepresentable {
+nonisolated struct BookBrowseOptions: Equatable, RawRepresentable, Sendable {
   typealias RawValue = String
 
   var includeReadStatuses: Set<ReadStatus> = []

--- a/KMReader/Features/Collection/ViewModels/CollectionSeriesBrowseOptions.swift
+++ b/KMReader/Features/Collection/ViewModels/CollectionSeriesBrowseOptions.swift
@@ -6,7 +6,7 @@
 import Foundation
 import SwiftUI
 
-nonisolated struct CollectionSeriesBrowseOptions: Equatable, RawRepresentable {
+nonisolated struct CollectionSeriesBrowseOptions: Equatable, RawRepresentable, Sendable {
   typealias RawValue = String
 
   var includeReadStatuses: Set<ReadStatus> = []

--- a/KMReader/Features/ReadList/ViewModels/ReadListBookBrowseOptions.swift
+++ b/KMReader/Features/ReadList/ViewModels/ReadListBookBrowseOptions.swift
@@ -6,7 +6,7 @@
 import Foundation
 import SwiftUI
 
-nonisolated struct ReadListBookBrowseOptions: Equatable, RawRepresentable {
+nonisolated struct ReadListBookBrowseOptions: Equatable, RawRepresentable, Sendable {
   typealias RawValue = String
 
   var includeReadStatuses: Set<ReadStatus> = []

--- a/KMReader/Features/Reader/Models/DoubleTapZoomMode.swift
+++ b/KMReader/Features/Reader/Models/DoubleTapZoomMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum DoubleTapZoomMode: String, CaseIterable, Identifiable {
+enum DoubleTapZoomMode: String, CaseIterable, Identifiable, Sendable {
   case disabled
   case fast
   case slow

--- a/KMReader/Features/Reader/Models/PageLayout.swift
+++ b/KMReader/Features/Reader/Models/PageLayout.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum PageLayout: String, CaseIterable, Hashable {
+enum PageLayout: String, CaseIterable, Hashable, Sendable {
   case single = "single"
   case auto = "auto"
   case dual = "dual-forced"

--- a/KMReader/Features/Reader/Models/PageTransitionStyle.swift
+++ b/KMReader/Features/Reader/Models/PageTransitionStyle.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum PageTransitionStyle: String, CaseIterable, Hashable {
+enum PageTransitionStyle: String, CaseIterable, Hashable, Sendable {
   case none = "none"
   case scroll = "scroll"
   case cover = "cover"

--- a/KMReader/Features/Reader/Models/PdfOfflineRenderQuality.swift
+++ b/KMReader/Features/Reader/Models/PdfOfflineRenderQuality.swift
@@ -6,7 +6,7 @@
 import CoreGraphics
 import Foundation
 
-enum PdfOfflineRenderQuality: String, CaseIterable, Hashable {
+enum PdfOfflineRenderQuality: String, CaseIterable, Hashable, Sendable {
   case compact
   case balanced
   case high

--- a/KMReader/Features/Reader/Models/ReaderBackground.swift
+++ b/KMReader/Features/Reader/Models/ReaderBackground.swift
@@ -6,7 +6,7 @@
 import Foundation
 import SwiftUI
 
-enum ReaderBackground: String, CaseIterable, Hashable {
+enum ReaderBackground: String, CaseIterable, Hashable, Sendable {
   case black = "black"
   case white = "white"
   case gray = "gray"

--- a/KMReader/Features/Reader/Models/ReaderImageUpscalingMode.swift
+++ b/KMReader/Features/Reader/Models/ReaderImageUpscalingMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum ReaderImageUpscalingMode: String, CaseIterable, Hashable {
+enum ReaderImageUpscalingMode: String, CaseIterable, Hashable, Sendable {
   case disabled
   case auto
   case always

--- a/KMReader/Features/Reader/Models/ReadingDirection.swift
+++ b/KMReader/Features/Reader/Models/ReadingDirection.swift
@@ -6,7 +6,7 @@
 import Foundation
 import SwiftUI
 
-enum ReadingDirection: String, CaseIterable, Hashable, Codable {
+enum ReadingDirection: String, CaseIterable, Hashable, Codable, Sendable {
   case ltr = "LEFT_TO_RIGHT"
   case rtl = "RIGHT_TO_LEFT"
   case vertical = "VERTICAL"

--- a/KMReader/Features/Reader/Models/SplitWidePageMode.swift
+++ b/KMReader/Features/Reader/Models/SplitWidePageMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum SplitWidePageMode: String, CaseIterable, Hashable {
+enum SplitWidePageMode: String, CaseIterable, Hashable, Sendable {
   case none = "none"
   case auto = "auto"
   case ltr = "ltr"

--- a/KMReader/Features/Reader/Models/TapZoneMode.swift
+++ b/KMReader/Features/Reader/Models/TapZoneMode.swift
@@ -5,7 +5,7 @@
 
 import SwiftUI
 
-enum TapZoneMode: String, CaseIterable, Hashable {
+enum TapZoneMode: String, CaseIterable, Hashable, Sendable {
   case none = "none"
   case auto = "auto"
   case ltr = "ltr"

--- a/KMReader/Features/Reader/Models/TapZoneSize.swift
+++ b/KMReader/Features/Reader/Models/TapZoneSize.swift
@@ -5,7 +5,7 @@
 
 import SwiftUI
 
-enum TapZoneSize: String, CaseIterable, Hashable {
+enum TapZoneSize: String, CaseIterable, Hashable, Sendable {
   case large = "large"
   case medium = "medium"
   case small = "small"

--- a/KMReader/Features/Reader/Services/Upscaling/ReaderUpscaleDecision.swift
+++ b/KMReader/Features/Reader/Services/Upscaling/ReaderUpscaleDecision.swift
@@ -7,7 +7,7 @@ import CoreGraphics
 #endif
 
 nonisolated struct ReaderUpscaleDecision: Sendable {
-  nonisolated enum SkipReason: Sendable {
+  enum SkipReason: Sendable {
     case disabled
     case belowAutoTriggerScale
     case exceedsAlwaysMaxScreenScale

--- a/KMReader/Features/Reader/Services/Upscaling/ReaderUpscaleDecision.swift
+++ b/KMReader/Features/Reader/Services/Upscaling/ReaderUpscaleDecision.swift
@@ -6,8 +6,8 @@ import CoreGraphics
   import AppKit
 #endif
 
-nonisolated struct ReaderUpscaleDecision {
-  nonisolated enum SkipReason {
+nonisolated struct ReaderUpscaleDecision: Sendable {
+  nonisolated enum SkipReason: Sendable {
     case disabled
     case belowAutoTriggerScale
     case exceedsAlwaysMaxScreenScale

--- a/KMReader/Features/Reader/Services/Upscaling/ReaderUpscaleModelDescriptor.swift
+++ b/KMReader/Features/Reader/Services/Upscaling/ReaderUpscaleModelDescriptor.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-nonisolated enum ReaderUpscaleModelType: String, Decodable {
+nonisolated enum ReaderUpscaleModelType: String, Decodable, Sendable {
   case multiarray
   case image
 }
 
-nonisolated struct ReaderUpscaleModelConfig: Decodable {
+nonisolated struct ReaderUpscaleModelConfig: Decodable, Sendable {
   let inputName: String?
   let outputName: String?
   let blockSize: Int?
@@ -14,7 +14,7 @@ nonisolated struct ReaderUpscaleModelConfig: Decodable {
   let shape: [Int]?
 }
 
-nonisolated struct ReaderUpscaleModelDescriptor: Decodable {
+nonisolated struct ReaderUpscaleModelDescriptor: Decodable, Sendable {
   let name: String?
   let type: String?
   let file: String

--- a/KMReader/Features/Reader/Views/Models/EpubColumnCount.swift
+++ b/KMReader/Features/Reader/Views/Models/EpubColumnCount.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-nonisolated enum EpubColumnCount: String, CaseIterable, Identifiable {
+nonisolated enum EpubColumnCount: String, CaseIterable, Identifiable, Sendable {
   case auto
   case one
   case two

--- a/KMReader/Features/Reader/Views/Models/EpubFlowStyle.swift
+++ b/KMReader/Features/Reader/Views/Models/EpubFlowStyle.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-nonisolated enum EpubFlowStyle: String, CaseIterable, Identifiable {
+nonisolated enum EpubFlowStyle: String, CaseIterable, Identifiable, Sendable {
   case paged = "paged"
   case scrolled = "scrolled"
 

--- a/KMReader/Features/Reader/Views/Models/EpubReaderPreferences.swift
+++ b/KMReader/Features/Reader/Views/Models/EpubReaderPreferences.swift
@@ -26,7 +26,7 @@ nonisolated enum EpubConstants {
   static let defaultTapScrollPercentage: Double = 80.0
 }
 
-nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable {
+nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable {
   typealias RawValue = String
 
   // Keep this list in sync with makeReadiumPayload.
@@ -441,7 +441,7 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable {
   }
 }
 
-nonisolated enum ThemeChoice: String, CaseIterable, Identifiable {
+nonisolated enum ThemeChoice: String, CaseIterable, Identifiable, Sendable {
   case system
   case quiet
   case sepia
@@ -460,7 +460,7 @@ nonisolated enum ThemeChoice: String, CaseIterable, Identifiable {
   }
 }
 
-nonisolated enum ReaderTheme: String, CaseIterable {
+nonisolated enum ReaderTheme: String, CaseIterable, Sendable {
   case white
   case black
   case lightQuiet
@@ -525,7 +525,7 @@ nonisolated enum ReaderTheme: String, CaseIterable {
   }
 }
 
-nonisolated enum FontFamilyChoice: Hashable, Identifiable {
+nonisolated enum FontFamilyChoice: Hashable, Identifiable, Sendable {
   case publisher
   case system(String)
 

--- a/KMReader/Features/Reader/Views/Models/EpubTextAlignment.swift
+++ b/KMReader/Features/Reader/Views/Models/EpubTextAlignment.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-nonisolated enum EpubTextAlignment: String, CaseIterable, Identifiable {
+nonisolated enum EpubTextAlignment: String, CaseIterable, Identifiable, Sendable {
   case publisherDefault = "publisherDefault"
   case start = "start"
   case justify = "justify"

--- a/KMReader/Features/Reader/Views/NativeBookCoverImageLoader.swift
+++ b/KMReader/Features/Reader/Views/NativeBookCoverImageLoader.swift
@@ -13,13 +13,7 @@ import Foundation
 
 func loadNativeBookCoverImage(for bookID: String) async -> PlatformImage? {
   await Task.detached(priority: .userInitiated) {
-    let fileURL = ThumbnailCache.getThumbnailFileURL(id: bookID, type: .book)
-    let targetURL: URL?
-    if FileManager.default.fileExists(atPath: fileURL.path) {
-      targetURL = fileURL
-    } else {
-      targetURL = try? await ThumbnailCache.shared.ensureThumbnail(id: bookID, type: .book)
-    }
+    let targetURL = try? await ThumbnailCache.shared.ensureThumbnail(id: bookID, type: .book)
 
     guard !Task.isCancelled, let targetURL else { return nil }
     guard let image = PlatformImage(contentsOfFile: targetURL.path) else { return nil }

--- a/KMReader/Features/Series/Models/Filters/SeriesSortField.swift
+++ b/KMReader/Features/Series/Models/Filters/SeriesSortField.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum SeriesSortField: String, CaseIterable {
+enum SeriesSortField: String, CaseIterable, Sendable {
   case name = "metadata.titleSort"
   case dateAdded = "created"
   case dateUpdated = "lastModified"

--- a/KMReader/Features/Series/Models/SeriesStatus.swift
+++ b/KMReader/Features/Series/Models/SeriesStatus.swift
@@ -12,16 +12,16 @@ nonisolated enum SeriesStatus: String, CaseIterable, Hashable, Codable, Sendable
   case hiatus = "HIATUS"
   case abandoned = "ABANDONED"
 
-  nonisolated static func fromString(_ status: String?) -> SeriesStatus {
+  static func fromString(_ status: String?) -> SeriesStatus {
     fromAPIValue(status) ?? .ongoing
   }
 
-  nonisolated static func fromAPIValue(_ status: String?) -> SeriesStatus? {
+  static func fromAPIValue(_ status: String?) -> SeriesStatus? {
     guard let status else { return nil }
     return SeriesStatus(rawValue: status.uppercased())
   }
 
-  nonisolated var displayName: String {
+  var displayName: String {
     switch self {
     case .ongoing:
       return String(localized: "series.status.ongoing")
@@ -34,7 +34,7 @@ nonisolated enum SeriesStatus: String, CaseIterable, Hashable, Codable, Sendable
     }
   }
 
-  nonisolated var icon: String {
+  var icon: String {
     switch self {
     case .ongoing:
       return "bolt.circle"
@@ -47,7 +47,7 @@ nonisolated enum SeriesStatus: String, CaseIterable, Hashable, Codable, Sendable
     }
   }
 
-  nonisolated var apiValue: String {
+  var apiValue: String {
     rawValue
   }
 }

--- a/KMReader/Features/Series/Models/SeriesStatus.swift
+++ b/KMReader/Features/Series/Models/SeriesStatus.swift
@@ -6,7 +6,7 @@
 import Foundation
 import SwiftUI
 
-nonisolated enum SeriesStatus: String, CaseIterable, Hashable, Codable {
+nonisolated enum SeriesStatus: String, CaseIterable, Hashable, Codable, Sendable {
   case ongoing = "ONGOING"
   case ended = "ENDED"
   case hiatus = "HIATUS"

--- a/KMReader/Features/Series/ViewModels/SeriesBrowseOptions.swift
+++ b/KMReader/Features/Series/ViewModels/SeriesBrowseOptions.swift
@@ -6,7 +6,7 @@
 import Foundation
 import SwiftUI
 
-nonisolated struct SeriesBrowseOptions: Equatable, RawRepresentable {
+nonisolated struct SeriesBrowseOptions: Equatable, RawRepresentable, Sendable {
   typealias RawValue = String
 
   var includeReadStatuses: Set<ReadStatus> = []

--- a/KMReader/Shared/Foundation/Models/BrowseLayoutMode.swift
+++ b/KMReader/Shared/Foundation/Models/BrowseLayoutMode.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum BrowseLayoutMode: String, CaseIterable, Identifiable {
+enum BrowseLayoutMode: String, CaseIterable, Identifiable, Sendable {
   case grid
   case list
 

--- a/KMReader/Shared/Foundation/Models/Common.swift
+++ b/KMReader/Shared/Foundation/Models/Common.swift
@@ -16,7 +16,7 @@ struct LibraryInfo: Identifiable, Codable, Equatable {
 }
 
 /// Sort direction for sorting operations
-enum SortDirection: String, CaseIterable {
+enum SortDirection: String, CaseIterable, Sendable {
   case ascending = "asc"
   case descending = "desc"
 

--- a/KMReader/Shared/Foundation/Models/MetadataFilterConfig.swift
+++ b/KMReader/Shared/Foundation/Models/MetadataFilterConfig.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Configuration for metadata-based filtering
-nonisolated struct MetadataFilterConfig: Equatable, RawRepresentable {
+nonisolated struct MetadataFilterConfig: Equatable, RawRepresentable, Sendable {
   typealias RawValue = String
 
   var publishers: [String]?

--- a/KMReader/Shared/Foundation/Models/ReadStatusSelectionHelper.swift
+++ b/KMReader/Shared/Foundation/Models/ReadStatusSelectionHelper.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum ReadStatus: String, Codable, CaseIterable {
+enum ReadStatus: String, Codable, CaseIterable, Sendable {
   case unread = "UNREAD"
   case inProgress = "IN_PROGRESS"
   case read = "READ"

--- a/KMReader/Shared/Foundation/Models/TriStateFilter.swift
+++ b/KMReader/Shared/Foundation/Models/TriStateFilter.swift
@@ -5,18 +5,18 @@
 
 import Foundation
 
-nonisolated enum TriStateSelection: String, Codable {
+nonisolated enum TriStateSelection: String, Codable, Sendable {
   case off
   case include
   case exclude
 }
 
-nonisolated enum FilterLogic: String, Codable {
+nonisolated enum FilterLogic: String, Codable, Sendable {
   case all = "ALL"
   case any = "ANY"
 }
 
-nonisolated enum BoolTriStateFlag: String {
+nonisolated enum BoolTriStateFlag: String, Sendable {
   case yes = "true"
 
   var boolValue: Bool {
@@ -24,7 +24,8 @@ nonisolated enum BoolTriStateFlag: String {
   }
 }
 
-nonisolated struct TriStateFilter<Value: RawRepresentable & Equatable>: Equatable
+nonisolated struct TriStateFilter<Value: RawRepresentable & Equatable & Sendable>: Equatable,
+  Sendable
 where Value.RawValue == String {
   var state: TriStateSelection
   var value: Value?

--- a/KMReader/Shared/UI/ThumbnailImage.swift
+++ b/KMReader/Shared/UI/ThumbnailImage.swift
@@ -124,13 +124,7 @@ struct ThumbnailImage<Overlay: View, Menu: View>: View {
 
   private func loadThumbnail(id: String, type: ThumbnailType) async -> PlatformImage? {
     await Task.detached(priority: .userInitiated) {
-      let fileURL = ThumbnailCache.getThumbnailFileURL(id: id, type: type)
-      let targetURL: URL?
-      if FileManager.default.fileExists(atPath: fileURL.path) {
-        targetURL = fileURL
-      } else {
-        targetURL = try? await ThumbnailCache.shared.ensureThumbnail(id: id, type: type)
-      }
+      let targetURL = try? await ThumbnailCache.shared.ensureThumbnail(id: id, type: type)
 
       guard !Task.isCancelled, let url = targetURL else { return nil }
       guard let image = PlatformImage(contentsOfFile: url.path) else { return nil }


### PR DESCRIPTION
## Problem
Cached thumbnails could remain stale indefinitely unless the user manually refreshed them. This made updated covers hard to pick up during normal browsing and reader cover loading.

## Approach
Thumbnail reads now go through `ThumbnailCache.ensureThumbnail`, including existing local files. When a cached thumbnail is older than seven days, the cache first attempts a forced refresh and returns the refreshed file on success. If the network refresh fails, it falls back to the existing local file so offline and transient failure paths keep working.

The follow-up concurrency audit keeps `nonisolated` for default MainActor isolation control, adds `Sendable` to related pure value types that are passed through browsing, reader preference, and upscaling async paths, and trims duplicate member-level `nonisolated` where the enclosing type already carries the isolation decision.

## Scope
- Add a seven-day thumbnail freshness check based on file modification time
- Reuse the existing forced thumbnail download path for expired cache entries
- Keep automatic expiry refresh silent; only explicit manual refresh posts `thumbnailDidRefresh`
- Mark related pure preference/filter/reader value models as `Sendable`
- Remove redundant `nonisolated` annotations from already nonisolated value types
- Bump `CURRENT_PROJECT_VERSION` to 403

## Validation
- [x] `make format`
- [x] `git diff --check`
- [x] `make build`
