### PR TITLE
fix: avoid SwiftData transformable reads during upserts

### DIFF
--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -211,7 +211,7 @@ actor DatabaseOperator {
           progressPage: existing.progressPage
         )
 
-        guard existing.readProgress != book.readProgress else { continue }
+        guard existing.hasDifferentReadProgressFields(book.readProgress) else { continue }
 
         existing.updateReadProgress(book.readProgress)
 
@@ -860,16 +860,21 @@ actor DatabaseOperator {
   }
 
   private func applyBook(dto: Book, to existing: KomgaBook) {
+    let shouldApplyContent =
+      existing.lastModified != dto.lastModified
+      || existing.hasDifferentContentFields(
+        media: dto.media,
+        metadata: dto.metadata,
+        readProgress: dto.readProgress
+      )
+
     if existing.name != dto.name { existing.name = dto.name }
     if existing.url != dto.url { existing.url = dto.url }
     if existing.number != dto.number { existing.number = dto.number }
     if existing.lastModified != dto.lastModified { existing.lastModified = dto.lastModified }
     if existing.sizeBytes != dto.sizeBytes { existing.sizeBytes = dto.sizeBytes }
     if existing.size != dto.size { existing.size = dto.size }
-    if existing.media != dto.media
-      || existing.metadata != dto.metadata
-      || existing.readProgress != dto.readProgress
-    {
+    if shouldApplyContent {
       existing.applyContent(media: dto.media, metadata: dto.metadata, readProgress: dto.readProgress)
     }
     if existing.isUnavailable != dto.deleted { existing.isUnavailable = dto.deleted }
@@ -878,6 +883,13 @@ actor DatabaseOperator {
   }
 
   private func applySeries(dto: Series, to existing: KomgaSeries) {
+    let shouldApplyContent =
+      existing.lastModified != dto.lastModified
+      || existing.hasDifferentContentFields(
+        metadata: dto.metadata,
+        booksMetadata: dto.booksMetadata
+      )
+
     if existing.name != dto.name { existing.name = dto.name }
     if existing.url != dto.url { existing.url = dto.url }
     if existing.lastModified != dto.lastModified { existing.lastModified = dto.lastModified }
@@ -891,7 +903,7 @@ actor DatabaseOperator {
     if existing.booksInProgressCount != dto.booksInProgressCount {
       existing.booksInProgressCount = dto.booksInProgressCount
     }
-    if existing.metadata != dto.metadata || existing.booksMetadata != dto.booksMetadata {
+    if shouldApplyContent {
       existing.applyContent(metadata: dto.metadata, booksMetadata: dto.booksMetadata)
     }
     if existing.isUnavailable != dto.deleted { existing.isUnavailable = dto.deleted }

--- a/KMReader/Features/Book/Models/KomgaBook.swift
+++ b/KMReader/Features/Book/Models/KomgaBook.swift
@@ -174,6 +174,8 @@ final class KomgaBook {
     self.progressPage = readProgress?.page
     self.progressCompleted = readProgress?.completed
     self.progressReadDate = readProgress?.readDate
+    self.metaAuthorsIndex = MetadataIndex.encode(values: metadata.authors?.map(\.name) ?? [])
+    self.metaTagsIndex = MetadataIndex.encode(values: metadata.tags ?? [])
 
     self.seriesTitle = seriesTitle
     self.isUnavailable = isUnavailable
@@ -183,26 +185,43 @@ final class KomgaBook {
     self.isolatePagesRaw = try? JSONEncoder().encode([] as [Int])
     self.epubPreferencesRaw = nil
     self.epubProgressionRaw = nil
-
-    rebuildQueryFields()
   }
 
   func applyContent(media: Media, metadata: BookMetadata, readProgress: ReadProgress?) {
     self.media = media
     self.metadata = metadata
     self.readProgress = readProgress
-    rebuildQueryFields()
+    syncQueryFields(media: media, metadata: metadata, readProgress: readProgress)
   }
 
   func updateReadProgress(_ readProgress: ReadProgress?) {
     self.readProgress = readProgress
-    syncReadProgressFields()
+    syncReadProgressFields(readProgress)
   }
 
-  func rebuildQueryFields() {
-    let media = media ?? Media.empty
-    let metadata = metadata ?? BookMetadata.empty
+  func hasDifferentContentFields(
+    media: Media,
+    metadata: BookMetadata,
+    readProgress: ReadProgress?
+  ) -> Bool {
+    return mediaPagesCount != media.pagesCount
+      || mediaProfile != media.mediaProfile
+      || metaTitle != metadata.title
+      || metaNumber != metadata.number
+      || metaNumberSort != metadata.numberSort
+      || metaReleaseDate != metadata.releaseDate
+      || metaAuthorsIndex != MetadataIndex.encode(values: metadata.authors?.map(\.name) ?? [])
+      || metaTagsIndex != MetadataIndex.encode(values: metadata.tags ?? [])
+      || hasDifferentReadProgressFields(readProgress)
+  }
 
+  func hasDifferentReadProgressFields(_ readProgress: ReadProgress?) -> Bool {
+    return progressPage != readProgress?.page
+      || progressCompleted != readProgress?.completed
+      || progressReadDate != readProgress?.readDate
+  }
+
+  private func syncQueryFields(media: Media, metadata: BookMetadata, readProgress: ReadProgress?) {
     mediaPagesCount = media.pagesCount
     mediaProfile = media.mediaProfile
 
@@ -213,10 +232,10 @@ final class KomgaBook {
     metaAuthorsIndex = MetadataIndex.encode(values: metadata.authors?.map(\.name) ?? [])
     metaTagsIndex = MetadataIndex.encode(values: metadata.tags ?? [])
 
-    syncReadProgressFields()
+    syncReadProgressFields(readProgress)
   }
 
-  private func syncReadProgressFields() {
+  private func syncReadProgressFields(_ readProgress: ReadProgress?) {
     progressPage = readProgress?.page
     progressCompleted = readProgress?.completed
     progressReadDate = readProgress?.readDate

--- a/KMReader/Features/Series/Models/KomgaSeries.swift
+++ b/KMReader/Features/Series/Models/KomgaSeries.swift
@@ -140,6 +140,11 @@ final class KomgaSeries {
     self.booksMetadata = booksMetadata
     self.metaTitle = metadata.title
     self.metaTitleSort = metadata.titleSort
+    self.metaPublisherIndex = MetadataIndex.encode(value: metadata.publisher)
+    self.metaAuthorsIndex = MetadataIndex.encode(values: booksMetadata.authors?.map(\.name) ?? [])
+    self.metaGenresIndex = MetadataIndex.encode(values: metadata.genres ?? [])
+    self.metaTagsIndex = MetadataIndex.encode(values: metadata.tags ?? [])
+    self.metaLanguageIndex = MetadataIndex.encode(value: metadata.language)
 
     self.isUnavailable = isUnavailable
     self.oneshot = oneshot
@@ -149,20 +154,28 @@ final class KomgaSeries {
     self.offlinePolicyRaw = offlinePolicy.rawValue
     self.offlinePolicyLimit = offlinePolicyLimit
     self.collectionIdsRaw = try? JSONEncoder().encode([] as [String])
-
-    rebuildQueryFields()
   }
 
   func applyContent(metadata: SeriesMetadata, booksMetadata: SeriesBooksMetadata) {
     self.metadata = metadata
     self.booksMetadata = booksMetadata
-    rebuildQueryFields()
+    syncQueryFields(metadata: metadata, booksMetadata: booksMetadata)
   }
 
-  func rebuildQueryFields() {
-    let metadata = metadata ?? SeriesMetadata.empty
-    let booksMetadata = booksMetadata ?? SeriesBooksMetadata.empty
+  func hasDifferentContentFields(
+    metadata: SeriesMetadata,
+    booksMetadata: SeriesBooksMetadata
+  ) -> Bool {
+    return metaTitle != metadata.title
+      || metaTitleSort != metadata.titleSort
+      || metaPublisherIndex != MetadataIndex.encode(value: metadata.publisher)
+      || metaAuthorsIndex != MetadataIndex.encode(values: booksMetadata.authors?.map(\.name) ?? [])
+      || metaGenresIndex != MetadataIndex.encode(values: metadata.genres ?? [])
+      || metaTagsIndex != MetadataIndex.encode(values: metadata.tags ?? [])
+      || metaLanguageIndex != MetadataIndex.encode(value: metadata.language)
+  }
 
+  private func syncQueryFields(metadata: SeriesMetadata, booksMetadata: SeriesBooksMetadata) {
     metaTitle = metadata.title
     metaTitleSort = metadata.titleSort
 


### PR DESCRIPTION
## Problem
On iOS 17, SwiftData can abort while decoding persisted Codable transformable properties during background dashboard or reading-progress sync. The crash report pointed at `KomgaBook.metadata` being read back during upsert-time query-field rebuilding.

## Approach
Avoid reading persisted transformable fields in the hot upsert path. Book and series query fields are now synchronized from incoming DTO values, and upsert change detection uses scalar query fields instead of comparing stored Codable payloads.

## Scope
- Update book upserts to avoid reading stored `media`, `metadata`, and `readProgress` for equality checks
- Update series upserts to avoid reading stored `metadata` and `booksMetadata` for equality checks
- Remove unused query-field rebuild helpers that could reintroduce transformable readback

## Validation
- [x] `make format`
- [x] `make build-ios`
