### PR TITLE
fix: remove phantom offline books on 404

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 403;
+				CURRENT_PROJECT_VERSION = 404;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 403;
+				CURRENT_PROJECT_VERSION = 404;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 403;
+				CURRENT_PROJECT_VERSION = 404;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 403;
+				CURRENT_PROJECT_VERSION = 404;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -1246,33 +1246,31 @@ actor DatabaseOperator {
     }
   }
 
-  /// Tombstone a book that the server no longer serves (e.g. file replaced, yielding a new UUID).
-  /// Sets `isUnavailable = true` and resets download state so policy sweeps stop re-enqueueing it.
-  /// Mirrors the effect of a server-delivered `deleted: true` on the book DTO.
-  func markBookUnavailable(bookId: String, instanceId: String) {
+  /// Removes a locally cached book after the server confirms the ID no longer exists.
+  /// `isUnavailable` is reserved for the server DTO's deleted state.
+  func deleteLocalBookAfterNotFound(bookId: String, instanceId: String) {
     let compositeId = CompositeID.generate(instanceId: instanceId, id: bookId)
     let descriptor = FetchDescriptor<KomgaBook>(
       predicate: #Predicate { $0.id == compositeId }
     )
     guard let book = try? modelContext.fetch(descriptor).first else { return }
 
-    book.isUnavailable = true
-    book.downloadStatusRaw = "notDownloaded"
-    book.downloadError = nil
-    book.downloadAt = nil
-    book.downloadedSize = 0
-    book.pagesRaw = nil
-    book.tocRaw = nil
-    book.webPubManifestRaw = nil
-
-    // Re-sync series download state so counters and policy picks skip this book.
     let seriesId = book.seriesId
-    let compositeSeriesId = CompositeID.generate(instanceId: instanceId, id: seriesId)
-    let seriesDescriptor = FetchDescriptor<KomgaSeries>(
-      predicate: #Predicate { $0.id == compositeSeriesId }
+    removeBookFromCachedReadLists(bookId: bookId, instanceId: instanceId)
+    modelContext.delete(book)
+
+    syncSeriesDownloadStatus(seriesId: seriesId, instanceId: instanceId)
+  }
+
+  private func removeBookFromCachedReadLists(bookId: String, instanceId: String) {
+    let descriptor = FetchDescriptor<KomgaReadList>(
+      predicate: #Predicate { $0.instanceId == instanceId }
     )
-    if let series = try? modelContext.fetch(seriesDescriptor).first {
-      syncSeriesDownloadStatus(series: series)
+    guard let readLists = try? modelContext.fetch(descriptor) else { return }
+
+    for readList in readLists where readList.bookIds.contains(bookId) {
+      readList.bookIds = readList.bookIds.filter { $0 != bookId }
+      syncReadListDownloadStatus(readList: readList)
     }
   }
 
@@ -1389,10 +1387,8 @@ actor DatabaseOperator {
     let policySupportsLimit = policy == .unreadOnly || policy == .unreadOnlyAndCleanupRead
 
     // Sort books to ensure they are processed in order.
-    // Books tombstoned as unavailable (server replaced/removed them) are excluded
-    // up front so they neither consume a slot in `allowedUnreadIds` nor get
-    // re-enqueued by the loop below. Otherwise a cancel → sync sweep would
-    // resurrect the phantom download indefinitely.
+    // Server-deleted books are excluded up front so they neither consume a slot
+    // in `allowedUnreadIds` nor get re-enqueued by the loop below.
     let sortedBooks =
       books
       .filter { !$0.isUnavailable }

--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -1246,6 +1246,36 @@ actor DatabaseOperator {
     }
   }
 
+  /// Tombstone a book that the server no longer serves (e.g. file replaced, yielding a new UUID).
+  /// Sets `isUnavailable = true` and resets download state so policy sweeps stop re-enqueueing it.
+  /// Mirrors the effect of a server-delivered `deleted: true` on the book DTO.
+  func markBookUnavailable(bookId: String, instanceId: String) {
+    let compositeId = CompositeID.generate(instanceId: instanceId, id: bookId)
+    let descriptor = FetchDescriptor<KomgaBook>(
+      predicate: #Predicate { $0.id == compositeId }
+    )
+    guard let book = try? modelContext.fetch(descriptor).first else { return }
+
+    book.isUnavailable = true
+    book.downloadStatusRaw = "notDownloaded"
+    book.downloadError = nil
+    book.downloadAt = nil
+    book.downloadedSize = 0
+    book.pagesRaw = nil
+    book.tocRaw = nil
+    book.webPubManifestRaw = nil
+
+    // Re-sync series download state so counters and policy picks skip this book.
+    let seriesId = book.seriesId
+    let compositeSeriesId = CompositeID.generate(instanceId: instanceId, id: seriesId)
+    let seriesDescriptor = FetchDescriptor<KomgaSeries>(
+      predicate: #Predicate { $0.id == compositeSeriesId }
+    )
+    if let series = try? modelContext.fetch(seriesDescriptor).first {
+      syncSeriesDownloadStatus(series: series)
+    }
+  }
+
   func updateReadingProgress(bookId: String, page: Int, completed: Bool) {
     let instanceId = AppConfig.current.instanceId
     let compositeId = CompositeID.generate(instanceId: instanceId, id: bookId)
@@ -1358,8 +1388,15 @@ actor DatabaseOperator {
     let policyLimit = max(0, series.offlinePolicyLimit)
     let policySupportsLimit = policy == .unreadOnly || policy == .unreadOnlyAndCleanupRead
 
-    // Sort books to ensure they are processed in order
-    let sortedBooks = books.sorted { $0.metaNumberSort < $1.metaNumberSort }
+    // Sort books to ensure they are processed in order.
+    // Books tombstoned as unavailable (server replaced/removed them) are excluded
+    // up front so they neither consume a slot in `allowedUnreadIds` nor get
+    // re-enqueued by the loop below. Otherwise a cancel → sync sweep would
+    // resurrect the phantom download indefinitely.
+    let sortedBooks =
+      books
+      .filter { !$0.isUnavailable }
+      .sorted { $0.metaNumberSort < $1.metaNumberSort }
     var allowedUnreadIds = Set<String>()
     if policyLimit > 0, policySupportsLimit {
       let unreadBooks = sortedBooks.filter { $0.progressCompleted != true }

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -801,6 +801,22 @@ actor OfflineManager {
           )
         }
       } catch {
+        if isPermanentNotFound(error) {
+          logger.info(
+            "🪦 Book \(info.bookId) no longer exists on server; marking unavailable"
+          )
+          await BackgroundDownloadManager.shared.cancelDownloads(forBookId: info.bookId)
+          clearBackgroundDownloadContext(bookId: info.bookId)
+          removeActiveTask(info.bookId)
+          try? await DatabaseOperator.database().markBookUnavailable(
+            bookId: info.bookId,
+            instanceId: instanceId
+          )
+          try? await DatabaseOperator.database().commit()
+          await refreshQueueStatus(instanceId: instanceId)
+          await syncDownloadQueue(instanceId: instanceId)
+          return
+        }
         logger.error("❌ Failed to start background download for \(info.bookId): \(error)")
         await BackgroundDownloadManager.shared.cancelDownloads(forBookId: info.bookId)
         clearBackgroundDownloadContext(bookId: info.bookId)
@@ -1085,6 +1101,17 @@ actor OfflineManager {
 
         if Task.isCancelled {
           logger.info("⛔ Download cancelled for book: \(info.bookId)")
+        } else if self.isPermanentNotFound(error) {
+          // Book has been replaced/removed server-side — tombstone, do not mark .failed.
+          logger.info(
+            "🪦 Book \(info.bookId) no longer exists on server; marking unavailable"
+          )
+          try? await DatabaseOperator.database().markBookUnavailable(
+            bookId: info.bookId,
+            instanceId: instanceId
+          )
+          try? await DatabaseOperator.database().commit()
+          await self.refreshQueueStatus(instanceId: instanceId)
         } else {
           let shouldKeepPending = await self.shouldKeepPendingAfterNetworkFailure(error)
           if shouldKeepPending {
@@ -1394,6 +1421,16 @@ actor OfflineManager {
     }
   #endif
 
+  /// Returns true when the server has confirmed the book no longer exists (HTTP 404).
+  /// This happens when a file is replaced server-side and Komga issues a new book UUID,
+  /// leaving the previously-cached UUID orphaned.
+  private nonisolated func isPermanentNotFound(_ error: Error) -> Bool {
+    if let apiError = error as? APIError, case .notFound = apiError {
+      return true
+    }
+    return false
+  }
+
   private nonisolated func isNetworkRelatedError(_ error: Error) -> Bool {
     if let apiError = error as? APIError {
       if case .networkError = apiError { return true }
@@ -1530,6 +1567,23 @@ actor OfflineManager {
       if isNetworkError && AppConfig.isOffline {
         // Network error caused offline mode switch - keep as pending for retry
         logger.info("⚠️ Background download paused due to network error: \(bookId)")
+        return
+      }
+
+      // A 404 means the book has been replaced/removed server-side. Tombstone instead
+      // of marking .failed, so policy sweeps don't resurrect the phantom download.
+      if isPermanentNotFound(error) {
+        logger.info("🪦 Book \(bookId) no longer exists on server; marking unavailable")
+        try? await DatabaseOperator.database().markBookUnavailable(
+          bookId: bookId,
+          instanceId: info.instanceId
+        )
+        try? await DatabaseOperator.database().commit()
+        await refreshQueueStatus(instanceId: info.instanceId)
+        await BackgroundDownloadManager.shared.cancelDownloads(forBookId: bookId)
+        clearBackgroundDownloadContext(bookId: bookId)
+        removeActiveTask(bookId)
+        await syncDownloadQueue(instanceId: info.instanceId)
         return
       }
 

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -803,17 +803,9 @@ actor OfflineManager {
       } catch {
         if isPermanentNotFound(error) {
           logger.info(
-            "🪦 Book \(info.bookId) no longer exists on server; marking unavailable"
+            "🧹 Book \(info.bookId) no longer exists on server; removing local record"
           )
-          await BackgroundDownloadManager.shared.cancelDownloads(forBookId: info.bookId)
-          clearBackgroundDownloadContext(bookId: info.bookId)
-          removeActiveTask(info.bookId)
-          try? await DatabaseOperator.database().markBookUnavailable(
-            bookId: info.bookId,
-            instanceId: instanceId
-          )
-          try? await DatabaseOperator.database().commit()
-          await refreshQueueStatus(instanceId: instanceId)
+          await removeBookAfterPermanentNotFound(bookId: info.bookId, instanceId: instanceId)
           await syncDownloadQueue(instanceId: instanceId)
           return
         }
@@ -1095,29 +1087,33 @@ actor OfflineManager {
         await syncDownloadQueue(instanceId: instanceId)
 
       } catch {
-        // Cleanup on failure
-        try? FileManager.default.removeItem(at: bookDir)
-        var shouldTriggerNextDownload = true
-
         if Task.isCancelled {
+          try? FileManager.default.removeItem(at: bookDir)
           logger.info("⛔ Download cancelled for book: \(info.bookId)")
         } else if self.isPermanentNotFound(error) {
-          // Book has been replaced/removed server-side — tombstone, do not mark .failed.
           logger.info(
-            "🪦 Book \(info.bookId) no longer exists on server; marking unavailable"
+            "🧹 Book \(info.bookId) no longer exists on server; removing local record"
           )
-          try? await DatabaseOperator.database().markBookUnavailable(
-            bookId: info.bookId,
-            instanceId: instanceId
-          )
-          try? await DatabaseOperator.database().commit()
-          await self.refreshQueueStatus(instanceId: instanceId)
+          await self.removeBookAfterPermanentNotFound(bookId: info.bookId, instanceId: instanceId)
+          #if os(iOS)
+            await self.finishForegroundLiveActivity(bookId: info.bookId, instanceId: instanceId)
+          #endif
+          await syncDownloadQueue(instanceId: instanceId)
+          return
         } else {
+          try? FileManager.default.removeItem(at: bookDir)
           let shouldKeepPending = await self.shouldKeepPendingAfterNetworkFailure(error)
           if shouldKeepPending {
             // Keep status as pending so foreground retry can continue later.
             logger.info("⚠️ Download paused due to transient network issue: \(info.bookId)")
-            shouldTriggerNextDownload = AppConfig.isOffline
+            await removeActiveTask(info.bookId)
+            #if os(iOS)
+              await self.finishForegroundLiveActivity(bookId: info.bookId, instanceId: instanceId)
+            #endif
+            if AppConfig.isOffline {
+              await syncDownloadQueue(instanceId: instanceId)
+            }
+            return
           } else {
             logger.error("❌ Download failed for book \(info.bookId): \(error)")
             try? await DatabaseOperator.database().updateBookDownloadStatus(
@@ -1135,9 +1131,7 @@ actor OfflineManager {
         #endif
 
         // Trigger next download even on failure or cancellation
-        if shouldTriggerNextDownload {
-          await syncDownloadQueue(instanceId: instanceId)
-        }
+        await syncDownloadQueue(instanceId: instanceId)
       }
     }
   }
@@ -1343,6 +1337,40 @@ actor OfflineManager {
         failed: summary.failedCount
       )
     }
+  }
+
+  private func removeBookAfterPermanentNotFound(bookId: String, instanceId: String) async {
+    #if os(iOS)
+      await BackgroundDownloadManager.shared.cancelDownloads(forBookId: bookId)
+      clearBackgroundDownloadContext(bookId: bookId)
+    #endif
+
+    removeActiveTask(bookId)
+    removeOfflineFiles(instanceId: instanceId, bookId: bookId)
+    try? await DatabaseOperator.database().deleteLocalBookAfterNotFound(
+      bookId: bookId,
+      instanceId: instanceId
+    )
+    try? await DatabaseOperator.database().commit()
+    await refreshQueueStatus(instanceId: instanceId)
+  }
+
+  private func removeOfflineFiles(instanceId: String, bookId: String) {
+    let dir = bookDirectory(instanceId: instanceId, bookId: bookId)
+    Task.detached { [logger] in
+      do {
+        if FileManager.default.fileExists(atPath: dir.path) {
+          try FileManager.default.removeItem(at: dir)
+        }
+        logger.info("🗑️ Deleted offline book files: \(bookId)")
+      } catch {
+        logger.error("❌ Failed to delete offline book files \(bookId): \(error)")
+      }
+    }
+
+    #if os(iOS) || os(macOS)
+      SpotlightIndexService.removeBook(bookId: bookId, instanceId: instanceId)
+    #endif
   }
 
   private func removeActiveTask(_ bookId: String) {
@@ -1570,19 +1598,9 @@ actor OfflineManager {
         return
       }
 
-      // A 404 means the book has been replaced/removed server-side. Tombstone instead
-      // of marking .failed, so policy sweeps don't resurrect the phantom download.
       if isPermanentNotFound(error) {
-        logger.info("🪦 Book \(bookId) no longer exists on server; marking unavailable")
-        try? await DatabaseOperator.database().markBookUnavailable(
-          bookId: bookId,
-          instanceId: info.instanceId
-        )
-        try? await DatabaseOperator.database().commit()
-        await refreshQueueStatus(instanceId: info.instanceId)
-        await BackgroundDownloadManager.shared.cancelDownloads(forBookId: bookId)
-        clearBackgroundDownloadContext(bookId: bookId)
-        removeActiveTask(bookId)
+        logger.info("🧹 Book \(bookId) no longer exists on server; removing local record")
+        await removeBookAfterPermanentNotFound(bookId: bookId, instanceId: info.instanceId)
         await syncDownloadQueue(instanceId: info.instanceId)
         return
       }


### PR DESCRIPTION
## Problem
Offline auto-downloads can keep retrying a stale Komga book ID after the server replaces or removes the original file and the old book endpoint starts returning 404. The retry loop needs to be broken without mixing a server-mirrored deleted state with a locally detected orphan.

## Approach
Handle confirmed 404 responses by removing the stale local SwiftData book record instead of setting `isUnavailable`. The removal path also clears offline files, updates Spotlight where supported, refreshes queue status, and re-syncs derived series/read-list download state.

## Scope
- Keep unavailable-book filtering in offline policy selection
- Replace local tombstoning with local deletion for confirmed book 404s
- Reuse one offline cleanup path across foreground download, background startup, and background failure callbacks

## Validation
- [x] `make format`
- [x] `make build`

Closes #737
Closes #738
