### PR TITLE
fix: stabilize webtoon end page layout

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 406;
+				CURRENT_PROJECT_VERSION = 407;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 406;
+				CURRENT_PROJECT_VERSION = 407;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 406;
+				CURRENT_PROJECT_VERSION = 407;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 406;
+				CURRENT_PROJECT_VERSION = 407;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_iOS.swift
@@ -17,7 +17,8 @@
     private var readListContext: ReaderReadListContext?
     private var onDismiss: (() -> Void)?
 
-    private let containerStack = UIStackView()
+    private let topRegionView = UIView()
+    private let bottomRegionView = UIView()
     private let previousBookStack = UIStackView()
     private let previousBadgeLabel = UILabel()
     private let previousTitleLabel = UILabel()
@@ -58,18 +59,18 @@
     }
 
     private func setupUI() {
-      contentView.addSubview(containerStack)
-      containerStack.translatesAutoresizingMaskIntoConstraints = false
-      containerStack.axis = .vertical
-      containerStack.alignment = .center
-      containerStack.spacing = 20
-      containerStack.isLayoutMarginsRelativeArrangement = true
-      containerStack.layoutMargins = UIEdgeInsets(top: 24, left: 20, bottom: 24, right: 20)
+      topRegionView.translatesAutoresizingMaskIntoConstraints = false
+      bottomRegionView.translatesAutoresizingMaskIntoConstraints = false
+      contentView.addSubview(topRegionView)
+      contentView.addSubview(bottomRegionView)
 
       previousBookStack.axis = .vertical
       previousBookStack.alignment = .center
       previousBookStack.spacing = 6
-      containerStack.addArrangedSubview(previousBookStack)
+      previousBookStack.translatesAutoresizingMaskIntoConstraints = false
+      previousBookStack.setContentHuggingPriority(.required, for: .vertical)
+      previousBookStack.setContentCompressionResistancePriority(.required, for: .vertical)
+      topRegionView.addSubview(previousBookStack)
 
       previousBadgeLabel.numberOfLines = 1
       previousBadgeLabel.textAlignment = .center
@@ -90,7 +91,8 @@
       dividerStack.axis = .horizontal
       dividerStack.alignment = .center
       dividerStack.spacing = 10
-      containerStack.addArrangedSubview(dividerStack)
+      dividerStack.translatesAutoresizingMaskIntoConstraints = false
+      contentView.addSubview(dividerStack)
 
       leadingDivider.translatesAutoresizingMaskIntoConstraints = false
       leadingDivider.heightAnchor.constraint(equalToConstant: 1).isActive = true
@@ -110,7 +112,10 @@
       nextBookStack.axis = .vertical
       nextBookStack.alignment = .center
       nextBookStack.spacing = 6
-      containerStack.addArrangedSubview(nextBookStack)
+      nextBookStack.translatesAutoresizingMaskIntoConstraints = false
+      nextBookStack.setContentHuggingPriority(.required, for: .vertical)
+      nextBookStack.setContentCompressionResistancePriority(.required, for: .vertical)
+      bottomRegionView.addSubview(nextBookStack)
 
       nextBadgeLabel.numberOfLines = 1
       nextBadgeLabel.textAlignment = .center
@@ -134,13 +139,34 @@
       nextBookStack.addArrangedSubview(caughtUpLabel)
 
       closeButton.addTarget(self, action: #selector(handleClose), for: .touchUpInside)
-      containerStack.addArrangedSubview(closeButton)
+      nextBookStack.addArrangedSubview(closeButton)
 
       NSLayoutConstraint.activate([
-        containerStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24),
-        containerStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -24),
-        containerStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 32),
-        containerStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -32),
+        dividerStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+        dividerStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 44),
+        dividerStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -44),
+
+        topRegionView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 32),
+        topRegionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 44),
+        topRegionView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -44),
+        topRegionView.bottomAnchor.constraint(equalTo: dividerStack.topAnchor, constant: -12),
+
+        bottomRegionView.topAnchor.constraint(equalTo: dividerStack.bottomAnchor, constant: 12),
+        bottomRegionView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 44),
+        bottomRegionView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -44),
+        bottomRegionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -32),
+
+        previousBookStack.centerXAnchor.constraint(equalTo: topRegionView.centerXAnchor),
+        previousBookStack.centerYAnchor.constraint(equalTo: topRegionView.centerYAnchor),
+        previousBookStack.leadingAnchor.constraint(
+          greaterThanOrEqualTo: topRegionView.leadingAnchor),
+        previousBookStack.trailingAnchor.constraint(
+          lessThanOrEqualTo: topRegionView.trailingAnchor),
+
+        nextBookStack.centerXAnchor.constraint(equalTo: bottomRegionView.centerXAnchor),
+        nextBookStack.centerYAnchor.constraint(equalTo: bottomRegionView.centerYAnchor),
+        nextBookStack.leadingAnchor.constraint(greaterThanOrEqualTo: bottomRegionView.leadingAnchor),
+        nextBookStack.trailingAnchor.constraint(lessThanOrEqualTo: bottomRegionView.trailingAnchor),
       ])
 
       applyBackground()

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_macOS.swift
@@ -17,7 +17,8 @@
     private var readListContext: ReaderReadListContext?
     private var onDismiss: (() -> Void)?
 
-    private let containerStack = NSStackView()
+    private let topRegionView = NSView()
+    private let bottomRegionView = NSView()
     private let previousBookStack = NSStackView()
     private let previousBadgeLabel = NSTextField(labelWithString: "")
     private let previousTitleLabel = NSTextField(labelWithString: "")
@@ -56,16 +57,18 @@
     }
 
     private func setupUI() {
-      containerStack.translatesAutoresizingMaskIntoConstraints = false
-      containerStack.orientation = .vertical
-      containerStack.alignment = .centerX
-      containerStack.spacing = 18
-      view.addSubview(containerStack)
+      topRegionView.translatesAutoresizingMaskIntoConstraints = false
+      bottomRegionView.translatesAutoresizingMaskIntoConstraints = false
+      view.addSubview(topRegionView)
+      view.addSubview(bottomRegionView)
 
       previousBookStack.orientation = .vertical
       previousBookStack.alignment = .centerX
       previousBookStack.spacing = 6
-      containerStack.addArrangedSubview(previousBookStack)
+      previousBookStack.translatesAutoresizingMaskIntoConstraints = false
+      previousBookStack.setContentHuggingPriority(.required, for: .vertical)
+      previousBookStack.setContentCompressionResistancePriority(.required, for: .vertical)
+      topRegionView.addSubview(previousBookStack)
 
       previousBadgeLabel.alignment = .center
       previousBadgeLabel.maximumNumberOfLines = 1
@@ -86,7 +89,8 @@
       dividerStack.orientation = .horizontal
       dividerStack.alignment = .centerY
       dividerStack.spacing = 10
-      containerStack.addArrangedSubview(dividerStack)
+      dividerStack.translatesAutoresizingMaskIntoConstraints = false
+      view.addSubview(dividerStack)
 
       leadingDivider.wantsLayer = true
       leadingDivider.translatesAutoresizingMaskIntoConstraints = false
@@ -108,7 +112,10 @@
       nextBookStack.orientation = .vertical
       nextBookStack.alignment = .centerX
       nextBookStack.spacing = 6
-      containerStack.addArrangedSubview(nextBookStack)
+      nextBookStack.translatesAutoresizingMaskIntoConstraints = false
+      nextBookStack.setContentHuggingPriority(.required, for: .vertical)
+      nextBookStack.setContentCompressionResistancePriority(.required, for: .vertical)
+      bottomRegionView.addSubview(nextBookStack)
 
       nextBadgeLabel.alignment = .center
       nextBadgeLabel.maximumNumberOfLines = 1
@@ -134,13 +141,34 @@
       closeButton.bezelStyle = .rounded
       closeButton.target = self
       closeButton.action = #selector(handleClose)
-      containerStack.addArrangedSubview(closeButton)
+      nextBookStack.addArrangedSubview(closeButton)
 
       NSLayoutConstraint.activate([
-        containerStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
-        containerStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
-        containerStack.topAnchor.constraint(equalTo: view.topAnchor, constant: 32),
-        containerStack.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -32),
+        dividerStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        dividerStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 44),
+        dividerStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -44),
+
+        topRegionView.topAnchor.constraint(equalTo: view.topAnchor, constant: 32),
+        topRegionView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 44),
+        topRegionView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -44),
+        topRegionView.bottomAnchor.constraint(equalTo: dividerStack.topAnchor, constant: -12),
+
+        bottomRegionView.topAnchor.constraint(equalTo: dividerStack.bottomAnchor, constant: 12),
+        bottomRegionView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 44),
+        bottomRegionView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -44),
+        bottomRegionView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -32),
+
+        previousBookStack.centerXAnchor.constraint(equalTo: topRegionView.centerXAnchor),
+        previousBookStack.centerYAnchor.constraint(equalTo: topRegionView.centerYAnchor),
+        previousBookStack.leadingAnchor.constraint(
+          greaterThanOrEqualTo: topRegionView.leadingAnchor),
+        previousBookStack.trailingAnchor.constraint(
+          lessThanOrEqualTo: topRegionView.trailingAnchor),
+
+        nextBookStack.centerXAnchor.constraint(equalTo: bottomRegionView.centerXAnchor),
+        nextBookStack.centerYAnchor.constraint(equalTo: bottomRegionView.centerYAnchor),
+        nextBookStack.leadingAnchor.constraint(greaterThanOrEqualTo: bottomRegionView.leadingAnchor),
+        nextBookStack.trailingAnchor.constraint(lessThanOrEqualTo: bottomRegionView.trailingAnchor),
       ])
 
       applyBackground()

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonLayout_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonLayout_iOS.swift
@@ -7,12 +7,19 @@
   import UIKit
 
   class WebtoonLayout: UICollectionViewFlowLayout {
+    var topContentPadding: CGFloat = 0 {
+      didSet {
+        guard abs(topContentPadding - oldValue) > WebtoonConstants.offsetEpsilon else { return }
+        invalidateLayout()
+      }
+    }
+
     override func prepare() {
       super.prepare()
       scrollDirection = .vertical
       minimumLineSpacing = 0
       minimumInteritemSpacing = 0
-      sectionInset = .zero
+      sectionInset = UIEdgeInsets(top: topContentPadding, left: 0, bottom: 0, right: 0)
     }
 
     override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -447,12 +447,18 @@
             collectionView.contentInset = .zero
             collectionView.scrollIndicatorInsets = .zero
           }
+          if let layout = collectionView.collectionViewLayout as? WebtoonLayout {
+            layout.topContentPadding = 0
+          }
           return
         }
 
         let safeInsets = collectionView.safeAreaInsets
+        if let layout = collectionView.collectionViewLayout as? WebtoonLayout {
+          layout.topContentPadding = safeInsets.top
+        }
         let newInsets = UIEdgeInsets(
-          top: safeInsets.top, left: 0, bottom: safeInsets.bottom, right: 0)
+          top: 0, left: 0, bottom: safeInsets.bottom, right: 0)
 
         if collectionView.contentInset != newInsets {
           collectionView.contentInset = newInsets


### PR DESCRIPTION
## Problem
Webtoon continuous reading on iOS could visually compress the first book end page while scrolling into the next book. The first page also still needs notch-safe top spacing, but using the scroll view top content inset makes that safe-area distance part of the scrollable offset behavior.

## Approach
Move the iOS top safe-area spacing into the webtoon collection layout as a stable section inset while keeping the scroll view top content inset at zero. Rework webtoon end page footer cells on iOS and macOS so the previous and next book regions are independently centered around a fixed divider instead of flowing through a stretched stack view.

## Scope
- Add layout-level top padding for iOS webtoon safe-area handling
- Keep iOS scroll view top content inset at zero and preserve bottom inset
- Rebuild iOS and macOS webtoon footer layout with direct top, divider, and bottom region constraints
- Bump build version to 407

## Validation
- [x] make format
- [x] make build-ios
- [x] make build-macos
