### PR TITLE
fix: align webtoon end page layout

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 407;
+				CURRENT_PROJECT_VERSION = 408;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 407;
+				CURRENT_PROJECT_VERSION = 408;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 407;
+				CURRENT_PROJECT_VERSION = 408;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 407;
+				CURRENT_PROJECT_VERSION = 408;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_iOS.swift
@@ -74,18 +74,20 @@
 
       previousBadgeLabel.numberOfLines = 1
       previousBadgeLabel.textAlignment = .center
-      previousBadgeLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
+      previousBadgeLabel.adjustsFontForContentSizeCategory = true
       previousBadgeLabel.text = String(localized: "reader.previousBook").uppercased()
       previousBookStack.addArrangedSubview(previousBadgeLabel)
 
       previousTitleLabel.numberOfLines = 2
       previousTitleLabel.textAlignment = .center
-      previousTitleLabel.font = UIFont.preferredFont(forTextStyle: .title3)
+      previousTitleLabel.adjustsFontForContentSizeCategory = true
+      previousTitleLabel.lineBreakMode = .byTruncatingTail
       previousBookStack.addArrangedSubview(previousTitleLabel)
 
       previousDetailLabel.numberOfLines = 1
       previousDetailLabel.textAlignment = .center
-      previousDetailLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
+      previousDetailLabel.adjustsFontForContentSizeCategory = true
+      previousDetailLabel.lineBreakMode = .byTruncatingTail
       previousBookStack.addArrangedSubview(previousDetailLabel)
 
       dividerStack.axis = .horizontal
@@ -101,7 +103,7 @@
 
       dividerTitleLabel.numberOfLines = 1
       dividerTitleLabel.textAlignment = .center
-      dividerTitleLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
+      dividerTitleLabel.adjustsFontForContentSizeCategory = true
       dividerStack.addArrangedSubview(dividerTitleLabel)
 
       trailingDivider.translatesAutoresizingMaskIntoConstraints = false
@@ -119,24 +121,27 @@
 
       nextBadgeLabel.numberOfLines = 1
       nextBadgeLabel.textAlignment = .center
-      nextBadgeLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
+      nextBadgeLabel.adjustsFontForContentSizeCategory = true
       nextBadgeLabel.text = String(localized: "reader.nextBook").uppercased()
       nextBookStack.addArrangedSubview(nextBadgeLabel)
 
       nextTitleLabel.numberOfLines = 2
       nextTitleLabel.textAlignment = .center
-      nextTitleLabel.font = UIFont.preferredFont(forTextStyle: .title3)
+      nextTitleLabel.adjustsFontForContentSizeCategory = true
+      nextTitleLabel.lineBreakMode = .byTruncatingTail
       nextBookStack.addArrangedSubview(nextTitleLabel)
 
       nextDetailLabel.numberOfLines = 1
       nextDetailLabel.textAlignment = .center
-      nextDetailLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
+      nextDetailLabel.adjustsFontForContentSizeCategory = true
+      nextDetailLabel.lineBreakMode = .byTruncatingTail
       nextBookStack.addArrangedSubview(nextDetailLabel)
 
       caughtUpLabel.numberOfLines = 0
       caughtUpLabel.textAlignment = .center
-      caughtUpLabel.font = UIFont.preferredFont(forTextStyle: .headline)
+      caughtUpLabel.adjustsFontForContentSizeCategory = true
       nextBookStack.addArrangedSubview(caughtUpLabel)
+      nextBookStack.setCustomSpacing(20, after: caughtUpLabel)
 
       closeButton.addTarget(self, action: #selector(handleClose), for: .touchUpInside)
       nextBookStack.addArrangedSubview(closeButton)
@@ -167,6 +172,7 @@
         nextBookStack.centerYAnchor.constraint(equalTo: bottomRegionView.centerYAnchor),
         nextBookStack.leadingAnchor.constraint(greaterThanOrEqualTo: bottomRegionView.leadingAnchor),
         nextBookStack.trailingAnchor.constraint(lessThanOrEqualTo: bottomRegionView.trailingAnchor),
+        leadingDivider.widthAnchor.constraint(equalTo: trailingDivider.widthAnchor),
       ])
 
       applyBackground()
@@ -176,6 +182,14 @@
     private func applyBackground() {
       contentView.backgroundColor = UIColor(readerBackground.color)
       let textColor = UIColor(readerBackground.contentColor)
+      previousBadgeLabel.font = preferredFont(textStyle: .caption1, weight: .semibold)
+      previousTitleLabel.font = preferredFont(textStyle: .title3, design: .serif, weight: .bold)
+      previousDetailLabel.font = .preferredFont(forTextStyle: .caption1)
+      dividerTitleLabel.font = .preferredFont(forTextStyle: .caption1)
+      nextBadgeLabel.font = preferredFont(textStyle: .caption1, weight: .semibold)
+      nextTitleLabel.font = preferredFont(textStyle: .title3, design: .serif, weight: .bold)
+      nextDetailLabel.font = .preferredFont(forTextStyle: .caption1)
+      caughtUpLabel.font = .preferredFont(forTextStyle: .headline)
       previousBadgeLabel.textColor = textColor.withAlphaComponent(0.55)
       previousTitleLabel.textColor = textColor
       previousDetailLabel.textColor = textColor.withAlphaComponent(0.6)
@@ -204,11 +218,15 @@
         closeButton.isHidden = true
         nextBadgeLabel.isHidden = false
         caughtUpLabel.isHidden = true
+        nextTitleLabel.isHidden = false
+        nextDetailLabel.isHidden = false
         nextTitleLabel.text = nextBook.readerChapterTitle
         nextDetailLabel.text = nextBook.readerChapterDetail
       } else {
         closeButton.isHidden = false
         nextBadgeLabel.isHidden = true
+        nextTitleLabel.isHidden = true
+        nextDetailLabel.isHidden = true
         nextTitleLabel.text = nil
         nextDetailLabel.text = nil
         caughtUpLabel.isHidden = false
@@ -220,6 +238,23 @@
 
     @objc private func handleClose() {
       onDismiss?()
+    }
+
+    private func preferredFont(
+      textStyle: UIFont.TextStyle,
+      design: UIFontDescriptor.SystemDesign? = nil,
+      weight: UIFont.Weight? = nil
+    ) -> UIFont {
+      var descriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: textStyle)
+      if let design, let designedDescriptor = descriptor.withDesign(design) {
+        descriptor = designedDescriptor
+      }
+      if let weight {
+        descriptor = descriptor.addingAttributes([
+          UIFontDescriptor.AttributeName.traits: [UIFontDescriptor.TraitKey.weight: weight]
+        ])
+      }
+      return UIFont(descriptor: descriptor, size: 0)
     }
   }
 #endif

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonFooterCell_macOS.swift
@@ -137,6 +137,7 @@
       caughtUpLabel.maximumNumberOfLines = 2
       caughtUpLabel.font = NSFont.preferredFont(forTextStyle: .headline)
       nextBookStack.addArrangedSubview(caughtUpLabel)
+      nextBookStack.setCustomSpacing(20, after: caughtUpLabel)
 
       closeButton.bezelStyle = .rounded
       closeButton.target = self
@@ -169,6 +170,7 @@
         nextBookStack.centerYAnchor.constraint(equalTo: bottomRegionView.centerYAnchor),
         nextBookStack.leadingAnchor.constraint(greaterThanOrEqualTo: bottomRegionView.leadingAnchor),
         nextBookStack.trailingAnchor.constraint(lessThanOrEqualTo: bottomRegionView.trailingAnchor),
+        leadingDivider.widthAnchor.constraint(equalTo: trailingDivider.widthAnchor),
       ])
 
       applyBackground()
@@ -207,11 +209,15 @@
         closeButton.isHidden = true
         nextBadgeLabel.isHidden = false
         caughtUpLabel.isHidden = true
+        nextTitleLabel.isHidden = false
+        nextDetailLabel.isHidden = false
         nextTitleLabel.stringValue = nextBook.readerChapterTitle
         nextDetailLabel.stringValue = nextBook.readerChapterDetail
       } else {
         closeButton.isHidden = false
         nextBadgeLabel.isHidden = true
+        nextTitleLabel.isHidden = true
+        nextDetailLabel.isHidden = true
         nextTitleLabel.stringValue = ""
         nextDetailLabel.stringValue = ""
         caughtUpLabel.isHidden = false

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonLayout_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonLayout_iOS.swift
@@ -7,19 +7,12 @@
   import UIKit
 
   class WebtoonLayout: UICollectionViewFlowLayout {
-    var topContentPadding: CGFloat = 0 {
-      didSet {
-        guard abs(topContentPadding - oldValue) > WebtoonConstants.offsetEpsilon else { return }
-        invalidateLayout()
-      }
-    }
-
     override func prepare() {
       super.prepare()
       scrollDirection = .vertical
       minimumLineSpacing = 0
       minimumInteritemSpacing = 0
-      sectionInset = UIEdgeInsets(top: topContentPadding, left: 0, bottom: 0, right: 0)
+      sectionInset = .zero
     }
 
     override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -447,18 +447,12 @@
             collectionView.contentInset = .zero
             collectionView.scrollIndicatorInsets = .zero
           }
-          if let layout = collectionView.collectionViewLayout as? WebtoonLayout {
-            layout.topContentPadding = 0
-          }
           return
         }
 
         let safeInsets = collectionView.safeAreaInsets
-        if let layout = collectionView.collectionViewLayout as? WebtoonLayout {
-          layout.topContentPadding = safeInsets.top
-        }
         let newInsets = UIEdgeInsets(
-          top: 0, left: 0, bottom: safeInsets.bottom, right: 0)
+          top: safeInsets.top, left: 0, bottom: safeInsets.bottom, right: 0)
 
         if collectionView.contentInset != newInsets {
           collectionView.contentInset = newInsets


### PR DESCRIPTION
## Problem
The previous webtoon end page layout change regressed the visual alignment: the relation title could appear off center, the caught-up close button sat too close to the message, and the iOS webtoon top safe-area handling moved away from the original scroll view inset behavior.

## Approach
Restore iOS webtoon safe-area spacing to the collection view content inset so scrolling uses the same model as before. Keep the footer layout stabilization, but align the footer typography and spacing with the native end page and make the divider rails equal width so the relation title stays centered.

## Scope
- Restore iOS webtoon top safe-area handling to `contentInset.top`
- Remove the layout-level top padding from `WebtoonLayout`
- Align webtoon footer fonts with native end page styling on iOS
- Add divider equal-width constraints and caught-up close button spacing on iOS and macOS
- Bump build version to 408

## Validation
- [x] `make format`
- [x] `git diff --check`
- [x] `make build-ios`
- [x] `make build-macos`
