### PR TITLE
feat: streamline settings controls

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 408;
+				CURRENT_PROJECT_VERSION = 409;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 408;
+				CURRENT_PROJECT_VERSION = 409;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 408;
+				CURRENT_PROJECT_VERSION = 409;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 408;
+				CURRENT_PROJECT_VERSION = 409;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -164,6 +164,20 @@ enum AppConfig {
     set { UserDefaults.standard.set(newValue, forKey: "maxCoverCacheSize") }
   }
 
+  static nonisolated var coverCacheExpirationDays: Int {
+    get {
+      if UserDefaults.standard.object(forKey: "coverCacheExpirationDays") != nil {
+        return max(1, UserDefaults.standard.integer(forKey: "coverCacheExpirationDays"))
+      }
+      return 7
+    }
+    set { UserDefaults.standard.set(max(1, newValue), forKey: "coverCacheExpirationDays") }
+  }
+
+  static nonisolated var coverCacheExpirationInterval: TimeInterval {
+    TimeInterval(coverCacheExpirationDays * 24 * 60 * 60)
+  }
+
   // MARK: - SSE (Server-Sent Events)
   static nonisolated var enableSSE: Bool {
     get {

--- a/KMReader/Core/Storage/Cache/ThumbnailCache.swift
+++ b/KMReader/Core/Storage/Cache/ThumbnailCache.swift
@@ -44,7 +44,6 @@ actor ThumbnailCache {
   private static let cleanupHighWatermarkPercent: Int64 = 90
   private static let cleanupTargetPercent: Int64 = 80
   private static let cleanupThrottleInterval: TimeInterval = 5
-  private static let thumbnailExpirationInterval: TimeInterval = 7 * 24 * 60 * 60
 
   private static func getMaxDiskCacheSize() -> Int {
     AppConfig.maxCoverCacheSize
@@ -206,7 +205,7 @@ actor ThumbnailCache {
       return false
     }
 
-    return Date().timeIntervalSince(modificationDate) > Self.thumbnailExpirationInterval
+    return Date().timeIntervalSince(modificationDate) > AppConfig.coverCacheExpirationInterval
   }
 
   private func logExpiredThumbnailRefreshFailure(

--- a/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
@@ -13,7 +13,6 @@ struct DashboardPinnedSectionView: View {
 
   @AppStorage("currentInstanceId") private var currentInstanceId: String = ""
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
-  @AppStorage("dashboardShowGradient") private var dashboardShowGradient: Bool = true
 
   @Query private var pinnedCollections: [KomgaCollection]
   @Query private var pinnedReadLists: [KomgaReadList]
@@ -122,13 +121,11 @@ struct DashboardPinnedSectionView: View {
     if isSupportedSection {
       ZStack {
         #if os(iOS) || os(macOS)
-          if dashboardShowGradient {
-            LinearGradient(
-              colors: backgroundColors,
-              startPoint: .top,
-              endPoint: .bottom
-            ).ignoresSafeArea()
-          }
+          LinearGradient(
+            colors: backgroundColors,
+            startPoint: .top,
+            endPoint: .bottom
+          ).ignoresSafeArea()
         #endif
 
         VStack(alignment: .leading, spacing: 0) {

--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -24,7 +24,6 @@ struct DashboardSectionView: View {
 
   @AppStorage("dashboard") private var dashboard: DashboardConfiguration = DashboardConfiguration()
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
-  @AppStorage("dashboardShowGradient") private var dashboardShowGradient: Bool = true
   @Environment(\.modelContext) private var modelContext
   @Environment(\.colorScheme) private var colorScheme
 
@@ -64,13 +63,11 @@ struct DashboardSectionView: View {
   var body: some View {
     ZStack {
       #if os(iOS) || os(macOS)
-        if dashboardShowGradient {
-          LinearGradient(
-            colors: backgroundColors,
-            startPoint: .top,
-            endPoint: .bottom
-          ).ignoresSafeArea()
-        }
+        LinearGradient(
+          colors: backgroundColors,
+          startPoint: .top,
+          endPoint: .bottom
+        ).ignoresSafeArea()
       #endif
 
       VStack(alignment: .leading, spacing: 0) {

--- a/KMReader/Features/Offline/Views/OfflineTasksView.swift
+++ b/KMReader/Features/Offline/Views/OfflineTasksView.swift
@@ -249,7 +249,10 @@ struct OfflineTaskRow: View {
               Text(
                 isProcessing
                   ? String(localized: "Processing offline files...")
-                  : "Downloading \(Int(progress * 100))%"
+                  : String(
+                    format: String(localized: "Downloading %lld%%"),
+                    Int64(progress * 100)
+                  )
               )
               .font(.caption)
               .foregroundColor(.secondary)

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -16,8 +16,6 @@ struct DivinaControlsOverlayView: View {
   @Binding var showingReaderSettingsSheet: Bool
   @Binding var showingDetailSheet: Bool
 
-  @AppStorage("readerControlsGradientBackground") private var readerControlsGradientBackground: Bool = false
-
   let viewModel: ReaderViewModel
   let currentBook: Book?
   let dualPage: Bool
@@ -267,10 +265,8 @@ struct DivinaControlsOverlayView: View {
     .padding()
     .iPadIgnoresSafeArea(paddingTop: 24)
     .background {
-      if readerControlsGradientBackground {
-        gradientBackground(startPoint: .top, endPoint: .bottom)
-          .ignoresSafeArea(edges: .top)
-      }
+      gradientBackground(startPoint: .top, endPoint: .bottom)
+        .ignoresSafeArea(edges: .top)
     }
   }
 
@@ -302,20 +298,12 @@ struct DivinaControlsOverlayView: View {
 
       ReadingProgressBar(progress: progress, type: .reader)
         .scaleEffect(x: readingDirection == .rtl ? -1 : 1, y: 1)
-        .shadow(
-          color: readerControlsGradientBackground ? .clear : .black.opacity(0.4),
-          radius: readerControlsGradientBackground ? 0 : 4,
-          x: 0,
-          y: readerControlsGradientBackground ? 0 : 2
-        )
     }
     .padding()
     .iPadIgnoresSafeArea(paddingTop: 24)
     .background {
-      if readerControlsGradientBackground {
-        gradientBackground(startPoint: .bottom, endPoint: .top)
-          .ignoresSafeArea(edges: .bottom)
-      }
+      gradientBackground(startPoint: .bottom, endPoint: .top)
+        .ignoresSafeArea(edges: .bottom)
     }
   }
 
@@ -404,8 +392,8 @@ struct DivinaControlsOverlayView: View {
   ) -> some View {
     LinearGradient(
       gradient: Gradient(colors: [
-        Color.black.opacity(0.6),
-        Color.black.opacity(0.3),
+        Color.black.opacity(0.72),
+        Color.black.opacity(0.44),
         Color.clear,
       ]),
       startPoint: startPoint,

--- a/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
@@ -12,9 +12,6 @@
     @Binding var showingReaderSettingsSheet: Bool
     @Binding var showingDetailSheet: Bool
 
-    @AppStorage("pdfReaderControlsGradientBackground")
-    private var readerControlsGradientBackground: Bool = false
-
     let currentBook: Book?
     let fallbackTitle: String
     let incognito: Bool
@@ -142,10 +139,8 @@
       .padding()
       .iPadIgnoresSafeArea(paddingTop: 24)
       .background {
-        if readerControlsGradientBackground {
-          gradientBackground(startPoint: .top, endPoint: .bottom)
-            .ignoresSafeArea(edges: .top)
-        }
+        gradientBackground(startPoint: .top, endPoint: .bottom)
+          .ignoresSafeArea(edges: .top)
       }
     }
 
@@ -175,20 +170,12 @@
 
         ReadingProgressBar(progress: progress, type: .reader)
           .scaleEffect(x: readingDirection == .rtl ? -1 : 1, y: 1)
-          .shadow(
-            color: readerControlsGradientBackground ? .clear : .black.opacity(0.4),
-            radius: readerControlsGradientBackground ? 0 : 4,
-            x: 0,
-            y: readerControlsGradientBackground ? 0 : 2
-          )
       }
       .padding()
       .iPadIgnoresSafeArea(paddingTop: 24)
       .background {
-        if readerControlsGradientBackground {
-          gradientBackground(startPoint: .bottom, endPoint: .top)
-            .ignoresSafeArea(edges: .bottom)
-        }
+        gradientBackground(startPoint: .bottom, endPoint: .top)
+          .ignoresSafeArea(edges: .bottom)
       }
     }
 
@@ -275,8 +262,8 @@
     ) -> some View {
       LinearGradient(
         gradient: Gradient(colors: [
-          Color.black.opacity(0.6),
-          Color.black.opacity(0.3),
+          Color.black.opacity(0.72),
+          Color.black.opacity(0.44),
           Color.clear,
         ]),
         startPoint: startPoint,

--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -35,7 +35,6 @@ struct ReaderSettingsSheet: View {
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
   @AppStorage("enableDivinaImageContextMenu")
   private var enableDivinaImageContextMenu: Bool = AppConfig.enableDivinaImageContextMenu
-  @AppStorage("readerControlsGradientBackground") private var readerControlsGradientBackground: Bool = false
 
   private var isWebtoonDirection: Bool {
     readingDirection == .webtoon
@@ -106,12 +105,6 @@ struct ReaderSettingsSheet: View {
           #if os(macOS)
             Toggle(isOn: $autoFullscreenOnOpen) {
               Text("Auto Full Screen on Open")
-            }
-          #endif
-
-          #if os(iOS)
-            Toggle(isOn: $readerControlsGradientBackground) {
-              Text("Controls Gradient Background")
             }
           #endif
 

--- a/KMReader/Features/Settings/Components/SettingsSection.swift
+++ b/KMReader/Features/Settings/Components/SettingsSection.swift
@@ -18,6 +18,7 @@ enum SettingsSection: String, CaseIterable {
     case epubReader
   #endif
   case sse
+  case sync
   #if os(iOS) || os(macOS)
     case spotlight
   #endif
@@ -46,6 +47,8 @@ enum SettingsSection: String, CaseIterable {
     #endif
     case .sse:
       return "antenna.radiowaves.left.and.right"
+    case .sync:
+      return "arrow.triangle.2.circlepath"
     #if os(iOS) || os(macOS)
       case .spotlight:
         return "magnifyingglass.circle"
@@ -79,6 +82,8 @@ enum SettingsSection: String, CaseIterable {
     #endif
     case .sse:
       return String(localized: "Real-time Updates")
+    case .sync:
+      return String(localized: "Sync & Handoff")
     #if os(iOS) || os(macOS)
       case .spotlight:
         return String(localized: "Spotlight")

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -36,7 +36,6 @@ struct DivinaPreferencesView: View {
   @AppStorage("enableDivinaImageContextMenu")
   private var enableDivinaImageContextMenu: Bool = AppConfig.enableDivinaImageContextMenu
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
-  @AppStorage("readerControlsGradientBackground") private var readerControlsGradientBackground: Bool = false
 
   private var forcedReadingDirection: ReadingDirection? {
     forceDefaultReadingDirection ? readDirection : nil
@@ -172,17 +171,6 @@ struct DivinaPreferencesView: View {
               .foregroundColor(.secondary)
           }
         }
-
-        #if os(iOS)
-          Toggle(isOn: $readerControlsGradientBackground) {
-            VStack(alignment: .leading, spacing: 4) {
-              Text("Controls Gradient Background")
-              Text("Add gradient background to improve button visibility")
-                .font(.caption)
-                .foregroundColor(.secondary)
-            }
-          }
-        #endif
 
         #if os(iOS) || os(macOS)
           if shouldShowWebtoonSpecificSettings {

--- a/KMReader/Features/Settings/PdfPreferencesView.swift
+++ b/KMReader/Features/Settings/PdfPreferencesView.swift
@@ -6,8 +6,6 @@
 
     @AppStorage("useNativePdfReader") private var useNativePdfReader: Bool = true
     @AppStorage("pdfReaderBackground") private var readerBackground: ReaderBackground = .system
-    @AppStorage("pdfReaderControlsGradientBackground")
-    private var readerControlsGradientBackground: Bool = false
     @AppStorage("pdfDefaultReadingDirection")
     private var defaultReadingDirection: ReadingDirection = .ltr
     @AppStorage("pdfForceDefaultReadingDirection")
@@ -124,10 +122,6 @@
               }
             }
             .pickerStyle(.menu)
-
-            Toggle(isOn: $readerControlsGradientBackground) {
-              Text("Controls Gradient Background")
-            }
           }
 
           Section(header: Text("Reader Overlay")) {

--- a/KMReader/Features/Settings/SettingsAppearanceView.swift
+++ b/KMReader/Features/Settings/SettingsAppearanceView.swift
@@ -10,7 +10,6 @@ struct SettingsAppearanceView: View {
   @AppStorage("themeColorHex") private var themeColor: ThemeColor = .orange
   @AppStorage("appColorScheme") private var appColorScheme: AppColorScheme = .system
   @AppStorage("privacyProtection") private var privacyProtection: Bool = false
-  @AppStorage("dashboardShowGradient") private var dashboardShowGradient: Bool = true
   #if os(iOS)
     @AppStorage("enableReaderLiveActivity") private var enableReaderLiveActivity: Bool = true
   #endif
@@ -101,14 +100,6 @@ struct SettingsAppearanceView: View {
             supportsOpacity: false)
         #endif
 
-        Toggle(isOn: $dashboardShowGradient) {
-          VStack(alignment: .leading, spacing: 4) {
-            Text(String(localized: "dashboard.gradient.title"))
-            Text(String(localized: "dashboard.gradient.caption"))
-              .font(.caption)
-              .foregroundColor(.secondary)
-          }
-        }
       }
 
       Section(header: Text(String(localized: "settings.appearance.privacy"))) {

--- a/KMReader/Features/Settings/SettingsCacheView.swift
+++ b/KMReader/Features/Settings/SettingsCacheView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct SettingsCacheView: View {
   @AppStorage("maxPageCacheSize") private var maxPageCacheSize: Int = 8
   @AppStorage("maxCoverCacheSize") private var maxCoverCacheSize: Int = 512
+  @AppStorage("coverCacheExpirationDays") private var coverCacheExpirationDays: Int = 7
   @State private var showClearImageCacheConfirmation = false
   @State private var showClearAllImageCacheConfirmation = false
   @State private var showClearCoverCacheConfirmation = false
@@ -35,9 +36,17 @@ struct SettingsCacheView: View {
         set: { maxCoverCacheSize = Int($0) }
       )
     }
+
+    private var coverCacheExpirationDaysBinding: Binding<Double> {
+      Binding(
+        get: { Double(max(1, coverCacheExpirationDays)) },
+        set: { coverCacheExpirationDays = max(1, Int($0)) }
+      )
+    }
   #else
     @State private var cacheSizeText: String = ""
     @State private var coverCacheSizeText: String = ""
+    @State private var coverCacheExpirationDaysText: String = ""
 
     private var cacheSizeTextFieldBinding: Binding<String> {
       Binding(
@@ -60,6 +69,21 @@ struct SettingsCacheView: View {
           coverCacheSizeText = newValue
           if let value = Int(newValue), value >= 128, value <= 2048 {
             maxCoverCacheSize = value
+          }
+        }
+      )
+    }
+
+    private var coverCacheExpirationDaysTextFieldBinding: Binding<String> {
+      Binding(
+        get: {
+          coverCacheExpirationDaysText.isEmpty
+            ? "\(coverCacheExpirationDays)" : coverCacheExpirationDaysText
+        },
+        set: { newValue in
+          coverCacheExpirationDaysText = newValue
+          if let value = Int(newValue), value >= 1, value <= 90 {
+            coverCacheExpirationDays = value
           }
         }
       )
@@ -187,6 +211,41 @@ struct SettingsCacheView: View {
           )
           .font(.caption)
           .foregroundColor(.secondary)
+        }
+
+        VStack(alignment: .leading, spacing: 8) {
+          #if os(iOS) || os(macOS)
+            HStack {
+              Text("Expiration")
+              Spacer()
+              Text("\(max(1, coverCacheExpirationDays)) days")
+                .foregroundColor(.secondary)
+            }
+            Slider(
+              value: coverCacheExpirationDaysBinding,
+              in: 1...90,
+              step: 1
+            )
+          #else
+            HStack {
+              Text("Expiration (days)")
+              Spacer()
+              TextField("Days", text: coverCacheExpirationDaysTextFieldBinding)
+                .frame(maxWidth: 240)
+                .multilineTextAlignment(.trailing)
+                .onAppear {
+                  coverCacheExpirationDaysText = "\(coverCacheExpirationDays)"
+                }
+                .onChange(of: coverCacheExpirationDays) { _, newValue in
+                  if coverCacheExpirationDaysText != "\(newValue)" {
+                    coverCacheExpirationDaysText = "\(newValue)"
+                  }
+                }
+            }
+          #endif
+          Text("Refresh cached covers after this many days.")
+            .font(.caption)
+            .foregroundColor(.secondary)
         }
 
         HStack {

--- a/KMReader/Features/Settings/SettingsNetworkView.swift
+++ b/KMReader/Features/Settings/SettingsNetworkView.swift
@@ -10,9 +10,6 @@ struct SettingsNetworkView: View {
   @AppStorage("downloadTimeout") private var downloadTimeout: Double = 60
   @AppStorage("authTimeout") private var authTimeout: Double = 5
   @AppStorage("apiRetryCount") private var apiRetryCount: Int = 0
-  @AppStorage("readingHistoryAutoSyncIntervalHours") private var readingHistoryAutoSyncIntervalHours: Int = 24
-  @AppStorage("enableBrowseHandoff") private var enableBrowseHandoff: Bool = true
-  @AppStorage("enableReaderHandoff") private var enableReaderHandoff: Bool = false
 
   var body: some View {
     Form {
@@ -62,73 +59,9 @@ struct SettingsNetworkView: View {
             .foregroundStyle(.secondary)
         }
       }
-
-      Section(header: Text(String(localized: "settings.network.read_history_sync"))) {
-        VStack(alignment: .leading, spacing: 8) {
-          #if os(tvOS)
-            HStack {
-              Label(
-                String(localized: "settings.network.read_history_sync.minimum_interval.label"),
-                systemImage: "book.circle"
-              )
-              Spacer()
-              Text(readingHistoryAutoSyncIntervalText)
-                .foregroundStyle(.secondary)
-            }
-          #else
-            Stepper(value: $readingHistoryAutoSyncIntervalHours, in: 0...168) {
-              HStack {
-                Label(
-                  String(localized: "settings.network.read_history_sync.minimum_interval.label"),
-                  systemImage: "book.circle"
-                )
-                Spacer()
-                Text(readingHistoryAutoSyncIntervalText)
-                  .foregroundStyle(.secondary)
-              }
-            }
-          #endif
-          Text(String(localized: "settings.network.read_history_sync.minimum_interval.description"))
-            .font(.caption)
-            .foregroundStyle(.secondary)
-        }
-      }
-
-      Section(header: Text(String(localized: "settings.network.handoff"))) {
-        Toggle(isOn: $enableBrowseHandoff) {
-          VStack(alignment: .leading, spacing: 4) {
-            Text(String(localized: "settings.network.handoff.browse.title"))
-            Text(String(localized: "settings.network.handoff.browse.caption"))
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-        }
-
-        Toggle(isOn: $enableReaderHandoff) {
-          VStack(alignment: .leading, spacing: 4) {
-            Text(String(localized: "settings.network.handoff.reader.title"))
-            Text(String(localized: "settings.network.handoff.reader.caption"))
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-        }
-      }
     }
     .formStyle(.grouped)
     .inlineNavigationBarTitle(SettingsSection.network.title)
-  }
-
-  private var readingHistoryAutoSyncIntervalText: String {
-    guard readingHistoryAutoSyncIntervalHours > 0 else {
-      return String(localized: "settings.sync_data.never")
-    }
-
-    let formatter = DateComponentsFormatter()
-    formatter.allowedUnits = [.hour]
-    formatter.unitsStyle = .full
-    formatter.maximumUnitCount = 1
-    return formatter.string(from: TimeInterval(readingHistoryAutoSyncIntervalHours * 60 * 60))
-      ?? "\(readingHistoryAutoSyncIntervalHours) h"
   }
 
   @ViewBuilder

--- a/KMReader/Features/Settings/SettingsSyncView.swift
+++ b/KMReader/Features/Settings/SettingsSyncView.swift
@@ -1,0 +1,82 @@
+//
+// SettingsSyncView.swift
+//
+//
+
+import SwiftUI
+
+struct SettingsSyncView: View {
+  @AppStorage("readingHistoryAutoSyncIntervalHours") private var readingHistoryAutoSyncIntervalHours: Int = 24
+  @AppStorage("enableBrowseHandoff") private var enableBrowseHandoff: Bool = true
+  @AppStorage("enableReaderHandoff") private var enableReaderHandoff: Bool = false
+
+  var body: some View {
+    Form {
+      Section(header: Text(String(localized: "settings.network.read_history_sync"))) {
+        VStack(alignment: .leading, spacing: 8) {
+          #if os(tvOS)
+            HStack {
+              Label(
+                String(localized: "settings.network.read_history_sync.minimum_interval.label"),
+                systemImage: "book.circle"
+              )
+              Spacer()
+              Text(readingHistoryAutoSyncIntervalText)
+                .foregroundStyle(.secondary)
+            }
+          #else
+            Stepper(value: $readingHistoryAutoSyncIntervalHours, in: 0...168) {
+              HStack {
+                Label(
+                  String(localized: "settings.network.read_history_sync.minimum_interval.label"),
+                  systemImage: "book.circle"
+                )
+                Spacer()
+                Text(readingHistoryAutoSyncIntervalText)
+                  .foregroundStyle(.secondary)
+              }
+            }
+          #endif
+          Text(String(localized: "settings.network.read_history_sync.minimum_interval.description"))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+      }
+
+      Section(header: Text(String(localized: "settings.network.handoff"))) {
+        Toggle(isOn: $enableBrowseHandoff) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text(String(localized: "settings.network.handoff.browse.title"))
+            Text(String(localized: "settings.network.handoff.browse.caption"))
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+
+        Toggle(isOn: $enableReaderHandoff) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text(String(localized: "settings.network.handoff.reader.title"))
+            Text(String(localized: "settings.network.handoff.reader.caption"))
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+    }
+    .formStyle(.grouped)
+    .inlineNavigationBarTitle(SettingsSection.sync.title)
+  }
+
+  private var readingHistoryAutoSyncIntervalText: String {
+    guard readingHistoryAutoSyncIntervalHours > 0 else {
+      return String(localized: "settings.sync_data.never")
+    }
+
+    let formatter = DateComponentsFormatter()
+    formatter.allowedUnits = [.hour]
+    formatter.unitsStyle = .full
+    formatter.maximumUnitCount = 1
+    return formatter.string(from: TimeInterval(readingHistoryAutoSyncIntervalHours * 60 * 60))
+      ?? "\(readingHistoryAutoSyncIntervalHours) h"
+  }
+}

--- a/KMReader/Features/Settings/SettingsView.swift
+++ b/KMReader/Features/Settings/SettingsView.swift
@@ -40,6 +40,9 @@ struct SettingsView: View {
         NavigationLink(value: NavDestination.settingsSSE) {
           SettingsSectionRow(section: .sse)
         }
+        NavigationLink(value: NavDestination.settingsSync) {
+          SettingsSectionRow(section: .sync)
+        }
         #if os(iOS) || os(macOS)
           NavigationLink(value: NavDestination.settingsSpotlight) {
             SettingsSectionRow(section: .spotlight)

--- a/KMReader/Features/Settings/SettingsView_macOS.swift
+++ b/KMReader/Features/Settings/SettingsView_macOS.swift
@@ -27,6 +27,7 @@ import SwiftUI
 
           Section(String(localized: "Behavior")) {
             SettingsSectionRow(section: .sse)
+            SettingsSectionRow(section: .sync)
             SettingsSectionRow(section: .spotlight)
             SettingsSectionRow(section: .network)
             SettingsSectionRow(section: .cache)
@@ -77,6 +78,8 @@ import SwiftUI
         EpubPreferencesView()
       case .sse:
         SettingsSSEView()
+      case .sync:
+        SettingsSyncView()
       case .spotlight:
         SettingsSpotlightView()
       case .network:

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -680,6 +680,70 @@
         }
       }
     },
+    "%lld days" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Tage"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld days"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld días"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld jours"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld giorni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld日"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld일"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld дн."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 天"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 天"
+          }
+        }
+      }
+    },
     "%lld failed" : {
       "localizations" : {
         "de" : {
@@ -3097,70 +3161,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "新增作者"
-          }
-        }
-      }
-    },
-    "Add gradient background to improve button visibility" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verlaufshintergrund hinzufügen, um die Sichtbarkeit der Schaltflächen zu verbessern"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Add gradient background to improve button visibility"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anadir fondo degradado para mejorar la visibilidad del boton"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter un arrière-plan dégradé pour améliorer la visibilité des boutons"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi uno sfondo sfumato per migliorare la visibilita del pulsante"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボタンの視認性を向上させるためにグラデーション背景を追加"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "버튼 가시성을 향상시키기 위해 그라데이션 배경 추가"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добавить градиентный фон для улучшения видимости кнопки"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "添加渐变背景以提高按钮可见度"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新增漸變背景以提高按鈕可見度"
           }
         }
       }
@@ -13469,70 +13469,6 @@
         }
       }
     },
-    "Controls Gradient Background" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Steuerungsleiste mit Verlaufshintergrund"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Controls Gradient Background"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fondo degradado de controles"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrière-plan dégradé des contrôles"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sfondo sfumato dei controlli"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コントロールのグラデーション背景"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "컨트롤 그라데이션 배경"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Градиентный фон элементов управления"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "控制栏渐变背景"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "控制列漸變背景"
-          }
-        }
-      }
-    },
     "Copy" : {
       "localizations" : {
         "de" : {
@@ -14749,134 +14685,6 @@
         }
       }
     },
-    "dashboard.gradient.caption" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einen Verlaufshintergrund auf Dashboard-Abschnitten anzeigen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Display a gradient background on dashboard sections"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar fondo degradado en las secciones del panel"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher un arrière-plan dégradé sur les sections du tableau de bord"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra uno sfondo sfumato nelle sezioni della dashboard"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダッシュボードセクションにグラデーション背景を表示"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "대시보드 섹션에 그라데이션 배경 표시"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показывать градиентный фон в разделах панели"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在主页区块上显示渐变背景"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在主頁區塊上顯示漸層背景"
-          }
-        }
-      }
-    },
-    "dashboard.gradient.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verlaufshintergrund anzeigen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Gradient Background"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar fondo degradado"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher l'arrière-plan dégradé"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra sfondo sfumato"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "グラデーション背景を表示"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "그라데이션 배경 표시"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показывать градиентный фон"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示渐变背景"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示漸層背景"
-          }
-        }
-      }
-    },
     "dashboard.hiddenSections" : {
       "localizations" : {
         "de" : {
@@ -15769,6 +15577,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇移動按鈕並使用遙控器重新排序區塊。"
+          }
+        }
+      }
+    },
+    "Days" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tage"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Days"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Días"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jours"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Giorni"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дни"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "天"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "天"
           }
         }
       }
@@ -18338,7 +18210,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wird heruntergeladen %lld%%"
+            "value" : "%lld %% heruntergeladen"
           }
         },
         "en" : {
@@ -18350,19 +18222,19 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Descargando %lld%%"
+            "value" : "Descargando %lld %%"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Téléchargement %lld%%"
+            "value" : "Téléchargement %lld %%"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Download %lld%%"
+            "value" : "Download %lld %%"
           }
         },
         "ja" : {
@@ -18380,19 +18252,19 @@
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Загрузка %lld%%"
+            "value" : "Загрузка %lld %%"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "下载中 %lld%%"
+            "value" : "正在下载 %lld%%"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "下載中 %lld%%"
+            "value" : "正在下載 %lld%%"
           }
         }
       }
@@ -25753,6 +25625,134 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "每12小時"
+          }
+        }
+      }
+    },
+    "Expiration" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ablauf"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expiration"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caducidad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expiration"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scadenza"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期限"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "만료"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Срок действия"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "过期时间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到期時間"
+          }
+        }
+      }
+    },
+    "Expiration (days)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ablauf (Tage)"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expiration (days)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Caducidad (días)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expiration (jours)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scadenza (giorni)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効期限（日）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "만료(일)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Срок действия (дни)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "过期时间（天）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到期時間（天）"
           }
         }
       }
@@ -54495,6 +54495,70 @@
         }
       }
     },
+    "Refresh cached covers after this many days." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktualisiert zwischengespeicherte Cover nach dieser Anzahl von Tagen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh cached covers after this many days."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualizar las portadas en caché después de esta cantidad de días."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualise les couvertures en cache après ce nombre de jours."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiorna le copertine memorizzate nella cache dopo questo numero di giorni."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この日数が経過したらキャッシュ済みの表紙を更新します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 일수가 지난 뒤 캐시된 표지를 새로 고칩니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновлять кэшированные обложки через указанное количество дней."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "超过这个天数后刷新已缓存的封面。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "超過這個天數後重新整理已快取的封面。"
+          }
+        }
+      }
+    },
     "Refresh Cover" : {
       "localizations" : {
         "de" : {
@@ -69659,6 +69723,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已切換到 %@"
+          }
+        }
+      }
+    },
+    "Sync & Handoff" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync & Handoff"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sync & Handoff"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronización y Handoff"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronisation et Handoff"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizzazione e Handoff"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同期とHandoff"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "동기화 및 Handoff"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронизация и Handoff"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步与接力"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同步與接力"
           }
         }
       }

--- a/KMReader/Shared/Foundation/Models/NavDestination.swift
+++ b/KMReader/Shared/Foundation/Models/NavDestination.swift
@@ -45,6 +45,7 @@ enum NavDestination: Hashable {
     case settingsEpubReader
   #endif
   case settingsSSE
+  case settingsSync
   #if os(iOS) || os(macOS)
     case settingsSpotlight
   #endif
@@ -167,6 +168,8 @@ enum NavDestination: Hashable {
     #endif
     case .settingsSSE:
       SettingsSSEView()
+    case .settingsSync:
+      SettingsSyncView()
     #if os(iOS) || os(macOS)
       case .settingsSpotlight:
         SettingsSpotlightView()


### PR DESCRIPTION
## Problem
Several appearance and reader controls exposed toggles for behavior that should now be fixed on, while sync-related settings were mixed into the network configuration page. Cover thumbnail refresh timing was also hard-coded to seven days, making cache staleness hard to tune.

## Approach
Remove the gradient toggles and render the dashboard and reader control gradients unconditionally. Move reading history sync and Handoff into a dedicated `Sync & Handoff` settings page under Behavior, leaving Network focused on request behavior. Add an AppConfig-backed cover cache expiration setting and use it in thumbnail refresh checks.

## Scope
- Always show dashboard and reader control gradients, with darker reader overlay gradients
- Add `SettingsSyncView` and route it from the Behavior settings section
- Add configurable cover cache expiration days with localization
- Localize the offline download progress string that was not extracted correctly
- Bump build version to 409

## Validation
- [x] `make format`
- [x] `make build`
- [x] `make localize`
- [x] `./misc/translate.py list`
- [x] `git diff --check`
