### PR TITLE
docs: update 4.7 release copy

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,13 +1,20 @@
 Reader Improvements
-- DIVINA cover reading feels smoother and more reliable on iPhone, iPad, and Mac, with steadier transitions and less stale loading state.
-- Scroll-mode DIVINA now preloads the next page earlier on iPhone and iPad, so the first page turn is less likely to pause.
-- Optional page image context menus on iPhone, iPad, and Mac let you share a page or isolate a single page from a spread more quickly.
-- Detail views now make it easier to copy titles and other useful library text.
+- External keyboard shortcuts now work in the reader on iPhone, iPad, and Apple TV, with expanded keyboard help across DIVINA, EPUB, and PDF readers.
+- DIVINA cover and scroll reading are more reliable, especially around drag gestures, tap navigation, zoom dismissal, split wide pages, and Webtoon end pages.
+- Split wide pages in scroll mode now line up more cleanly while swiping, reducing the visible gap between page halves.
+- Reader overlays and controls are easier to interact with on older system versions.
 
-Mac Experience
-- PDF reading on Mac now includes keyboard help, better shortcut coverage, and faster access to search, page jump, and table of contents actions.
-- Reader command menus are more consistent across DIVINA and PDF, including current-page isolation where supported.
+Offline and Downloads
+- Large original book downloads now stream directly to disk, reducing memory pressure for large CBR, EPUB, and PDF files.
+- Offline downloads for CBZ, CBR, and supported EPUB books now use a faster single-file workflow with local extraction.
+- Download progress updates are smoother, and offline tasks now show a processing state while extraction or finalization continues.
+- Stale offline books removed from the server are cleaned up more reliably instead of retrying forever.
 
-Polish and Reliability
-- Reader controls are easier to read on older system versions.
-- EPUB opening is steadier, with fewer distracting transitions when a book first loads.
+Browsing and Settings
+- Cover thumbnails can refresh automatically after a configurable expiration period, helping updated covers appear without manual refresh.
+- Sync and Handoff settings now have their own settings page, making network settings easier to scan.
+- Filter sheets are more stable on iOS 17.
+
+Reliability
+- Dashboard and reading-progress sync are more stable on iOS 17.
+- Thumbnail refreshes, cache fallbacks, and local offline state handling are more resilient during transient network failures.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -9,21 +9,22 @@ DIVINA on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, 
 EPUB on iOS and macOS with paged, scrolled, or cover layouts, custom fonts, themes, text alignment and font-weight controls, configurable overlays, and nested table of contents.
 Animated GIF and WebP pages play inline and stay smooth while you zoom or scroll.
 PDF on iOS and macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality, and strong keyboard support on macOS.
+External keyboard shortcuts and keyboard help are available across supported readers on iPhone, iPad, Mac, and Apple TV.
 Incognito mode, optional reader Live Activities with progress or incognito status, and iOS Live Text support let you read your way.
 
 - Dashboard, discovery, and shortcuts
 Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/read lists, and saved filters keep the right parts of your library close.
-Browse Series, Books, Collections, and Read Lists with advanced metadata filters, optional unread-cover blur, synced reading history, and copy-friendly detail views for titles and metadata.
+Browse Series, Books, Collections, and Read Lists with advanced metadata filters, optional unread-cover blur, synced reading history, configurable cover thumbnail freshness, and copy-friendly detail views for titles and metadata.
 Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions, help you jump back into reading faster.
 KMReader UI is localized in English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
 
 - Offline that actually works
 Download books for offline reading across DIVINA, EPUB, and PDF workflows.
-EPUB downloads use a single-file workflow with local extraction for faster, more reliable saves.
+Large original book downloads stream directly to disk to reduce memory pressure, while CBZ, CBR, PDF, and supported EPUB offline flows use single-file downloads with local extraction or storage.
 Use manual offline mode controls and predictable iOS background downloads.
-Get Live Activities for both active reading sessions and downloads.
+Get Live Activities for both active reading sessions and downloads, including processing status while extraction or finalization continues.
 Set per-series policies: Manual, Unread only, Unread + cleanup, or All books.
-Sync progress and offline changes when you reconnect, with safer conflict handling.
+Sync progress and offline changes when you reconnect, with safer conflict handling and cleanup for stale offline books.
 
 - Multi-server and admin tools
 Save multiple Komga servers and switch instantly.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@
 
 ### Native Reading Experience
 
-- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, customizable tap zones, page curl (iOS), cover-style page transitions on all platforms, optional page shadows, optional page-image context menus on iOS/macOS for share and isolate actions, clearer page-turn animation controls, and steadier scroll and cover navigation with better RTL, wide-page, and interruption handling.
+- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, customizable tap zones, page curl (iOS), cover-style page transitions on all platforms, optional page shadows, optional page-image context menus on iOS/macOS for share and isolate actions, clearer page-turn animation controls, and steadier scroll, cover, split-wide-page, and Webtoon end-page navigation with better RTL, gesture, and interruption handling.
 - EPUB reader on iOS/macOS with paged, scrolled, and cover layouts, custom font importing (`.ttf`/`.otf`), theme presets, text alignment and font-weight controls, optional status/footer overlays, multi-column reading, and nested table of contents.
 - Animated GIF and WebP pages start immediately, stay smooth while you zoom or scroll, and remain reliable when reopening or revisiting pages.
-- PDF reading on iOS/macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality tiers for offline preparation, clearer progress feedback, and full keyboard help and command coverage on macOS.
+- PDF reading on iOS/macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality tiers for offline preparation, clearer progress feedback, and full keyboard help and command coverage on supported platforms.
 - Per-book preferences save reading direction, page layout, and theme settings.
+- Reader keyboard shortcuts and keyboard help are available across DIVINA, EPUB, and PDF workflows on supported iPhone, iPad, Mac, and Apple TV devices.
 - Incognito mode and iOS Live Text support, including optional shake-to-toggle.
 
 ### Dashboard and Discovery
@@ -36,6 +37,7 @@
 - Save and reuse filters across browse surfaces.
 - Optional unread-cover blur helps hide spoiler-heavy artwork until you start reading.
 - Reading history and stats stay fresh with automatic sync and help surface recent activity from synced local data.
+- Configurable cover thumbnail freshness helps updated covers appear automatically without forcing every cached thumbnail to refresh at once.
 - Detail views make titles and metadata easy to copy when you need to search, share, or organize library data.
 - Spotlight integration for downloaded content on iOS/macOS, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
 - UI localization includes English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
@@ -43,12 +45,13 @@
 ### Offline and Sync
 
 - Download books for full offline reading across DIVINA, EPUB, and PDF workflows.
-- EPUB downloads use a single-file download plus local extraction for faster, more reliable offline saves.
+- Large original book downloads stream directly to disk to reduce memory pressure for CBR, EPUB, and PDF files.
+- CBZ, CBR, PDF, and supported EPUB offline flows use single-file downloads with local extraction or storage for faster, more reliable offline saves.
 - Manual offline mode controls and more predictable iOS background downloads for page files and extra resources.
-- Optional iOS Live Activities for both active reading sessions and downloads, including reader progress or incognito status on iPhone.
+- Optional iOS Live Activities for both active reading sessions and downloads, including reader progress, incognito status, and processing feedback while extraction or finalization continues.
 - Per-series download policies: Manual, Unread only, Unread + cleanup, and All books.
 - Offline mode includes dedicated downloaded-library browsing and metadata filters.
-- Progress and offline data sync automatically when reconnecting, including safer conflict handling.
+- Progress and offline data sync automatically when reconnecting, including safer conflict handling and cleanup for stale offline books that disappeared from the server.
 - Cache controls cover pages and thumbnails.
 
 ### Multi-Server and Management
@@ -59,9 +62,9 @@
 
 ### Platform Highlights
 
-- iOS/iPadOS: widgets, quick actions, Spotlight search, Dynamic Island Live Activities for reader/downloads, background downloads, Live Text, and page curl/cover transitions.
+- iOS/iPadOS: widgets, quick actions, Spotlight search, Dynamic Island Live Activities for reader/downloads, background downloads, Live Text, reader keyboard shortcuts, and page curl/cover transitions.
 - macOS: dedicated reader windows, reader actions in the system menu bar and Reader menu, Spotlight search for downloaded content, keyboard shortcuts, and keyboard help overlay.
-- tvOS: remote-first DIVINA reading with cover transitions and a TV-optimized browsing experience.
+- tvOS: remote-first DIVINA reading with cover transitions, external keyboard support, and a TV-optimized browsing experience.
 
 ## Getting Started
 

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
         <title>KMReader · Native Komga Client for iOS, macOS & tvOS</title>
         <meta
             name="description"
-            content="KMReader is a native SwiftUI Komga client with DIVINA, EPUB, and PDF readers, page-level reader actions, reliable offline downloads, advanced filtering, admin tools, and multi-server support."
+            content="KMReader is a native SwiftUI Komga client with DIVINA, EPUB, and PDF readers, keyboard support, page-level reader actions, reliable offline downloads, advanced filtering, admin tools, and multi-server support."
         />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -27,12 +27,13 @@
                 <h1>KMReader</h1>
                 <p class="tagline">
                     Read, download, browse, and manage your Komga library with
-                    native readers, page-level reader actions, richer EPUB
-                    typography controls, smooth animated page playback,
-                    reliable offline sync, advanced filtering, multi-server
-                    support, and practical Apple-platform extras like widgets,
-                    Spotlight, Dynamic Island updates, and keyboard-first
-                    controls on iPhone, iPad, Mac, and Apple TV.
+                    native readers, keyboard shortcuts, page-level reader
+                    actions, richer EPUB typography controls, smooth animated
+                    page playback, reliable large-file offline downloads,
+                    advanced filtering, multi-server support, and practical
+                    Apple-platform extras like widgets, Spotlight, Dynamic
+                    Island updates, and keyboard-first controls on iPhone,
+                    iPad, Mac, and Apple TV.
                 </p>
                 <div class="cta">
                     <a
@@ -85,11 +86,12 @@
                             DIVINA on iOS/macOS/tvOS with LTR, RTL, vertical,
                             Webtoon, spreads, zoom, tap zones, page curl
                             (iOS), cover transitions on all platforms,
-                            optional page shadows, optional page image
-                            context menus on iOS/macOS for sharing or
-                            isolating a page, clearer page-turn animation
-                            controls, and steadier scroll reading with better
-                            RTL, wide-page, and interruption handling.
+                            optional page shadows, optional page image context
+                            menus on iOS/macOS for sharing or isolating a page,
+                            clearer page-turn animation controls, keyboard
+                            help, and steadier scroll, cover, split-wide-page,
+                            and Webtoon end-page navigation with better RTL,
+                            gesture, and interruption handling.
                             EPUB on iOS/macOS adds custom fonts, paged,
                             scrolled, or cover layouts, text alignment and
                             font-weight controls, configurable status/footer
@@ -99,7 +101,7 @@
                             pages, while PDF on iOS/macOS offers a native
                             reader or DIVINA mode with search, TOC,
                             configurable render quality, and strong keyboard
-                            support on macOS.
+                            support on supported platforms.
                         </p>
                     </article>
                     <article class="card">
@@ -108,20 +110,22 @@
                         <p>
                             Keep Reading, On Deck, Recently Added, Recently
                             Updated, reading history and stats, pinned
-                            collections/read lists, saved filters, and
-                            optional unread-cover blur keep the most useful
-                            parts of your library close, while copy-friendly
-                            detail views make titles and metadata easier to
-                            reuse.
+                            collections/read lists, saved filters, configurable
+                            cover thumbnail freshness, and optional
+                            unread-cover blur keep the most useful parts of
+                            your library close, while copy-friendly detail
+                            views make titles and metadata easier to reuse.
                         </p>
                     </article>
                     <article class="card">
                         <span class="pill">Offline</span>
                         <h3>Download and keep reading anywhere</h3>
                         <p>
-                            Download books for offline reading, use single-file
-                            EPUB downloads with local extraction, run
-                            more predictable background downloads on iOS,
+                            Download books for offline reading, stream large
+                            original book files directly to disk, use
+                            single-file CBZ, CBR, PDF, and supported EPUB
+                            offline workflows with local extraction or storage,
+                            run more predictable background downloads on iOS,
                             switch Offline mode manually, and apply per-series
                             policies to automate what stays on device.
                         </p>
@@ -132,10 +136,11 @@
                         <p>
                             Live Activities keep current reading sessions and
                             download progress visible, can be turned off for
-                            the reader, show reading progress or an incognito
-                            indicator with Dynamic Island support on iPhone,
-                            while EPUB overlay controls can stay minimal or
-                            more informative.
+                            the reader, show reading progress, incognito state,
+                            or offline processing after transfers complete with
+                            Dynamic Island support on iPhone, while EPUB
+                            overlay controls can stay minimal or more
+                            informative.
                         </p>
                     </article>
                     <article class="card">
@@ -190,7 +195,8 @@
                         <p>
                             DIVINA, EPUB, and PDF readers with widgets, quick
                             actions, Spotlight search, background downloads,
-                            Dynamic Island Live Activities, and Live Text.
+                            Dynamic Island Live Activities, Live Text, and
+                            reader keyboard shortcuts.
                         </p>
                     </article>
                     <article class="card">
@@ -206,8 +212,9 @@
                     <article class="card">
                         <h3>tvOS</h3>
                         <p>
-                            Remote-first DIVINA reading with a focused TV
-                            browsing experience.
+                            Remote-first DIVINA reading with cover transitions,
+                            keyboard support, and a focused TV browsing
+                            experience.
                         </p>
                     </article>
                 </div>
@@ -234,7 +241,8 @@
                             play inline with the reader. Reader settings
                             include page shadows, page-turn animation
                             controls, optional page image actions on
-                            iOS/macOS, and strong keyboard support on Mac.
+                            iOS/macOS, and strong keyboard support across
+                            supported reader platforms.
                         </p>
                     </article>
                     <article class="faq-item">
@@ -248,10 +256,11 @@
                     <article class="faq-item">
                         <h4>How does offline mode work?</h4>
                         <p>
-                            Downloaded books stay readable offline, EPUB saves
-                            use a single-file workflow, filtering is available
-                            for offline items, and sync resumes when you
-                            reconnect.
+                            Downloaded books stay readable offline, large files
+                            stream to disk, CBZ, CBR, PDF, and supported EPUB
+                            saves use single-file workflows, filtering is
+                            available for offline items, and sync resumes when
+                            you reconnect.
                         </p>
                     </article>
                     <article class="faq-item">


### PR DESCRIPTION
## Problem
The 4.7 App Store release needs updated public-facing copy before submission. The previous release notes and evergreen docs did not cover the latest reader keyboard support, large-file offline download path, thumbnail freshness controls, and reliability improvements.

## Approach
Refresh the release-specific App Store changelog from the commits since `v4.6`, then align the App Store description, README, and static landing page around the same durable product capabilities. The App Store Connect 4.7 versions for iOS, macOS, and tvOS have also been created separately and updated with the same English description and release notes.

## Scope
- Update `APP_STORE_CHANGELOG.txt` for the 4.7 release
- Refresh `APP_STORE_DESCRIPTION.txt`
- Update README feature coverage
- Align `static/index.html` with the same product messaging

## Validation
- [x] Checked App Store description and changelog lengths are under App Store limits
- [x] Created 4.7 versions for iOS, macOS, and tvOS in App Store Connect
- [x] Verified `en-US` description and What's New were written to all three App Store Connect versions
- [ ] Build not run; docs and release metadata only
