### PR TITLE
refactor: use libarchive for offline extraction

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 410;
+				CURRENT_PROJECT_VERSION = 411;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 410;
+				CURRENT_PROJECT_VERSION = 411;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 410;
+				CURRENT_PROJECT_VERSION = 411;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 410;
+				CURRENT_PROJECT_VERSION = 411;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -15,8 +15,7 @@
 		1983B7332FF4000100A1B2C3 /* SDWebImageWebPCoder in Frameworks */ = {isa = PBXBuildFile; productRef = 1983B7322FF4000100A1B2C3 /* SDWebImageWebPCoder */; };
 		19AEC07F2EE714150073EB5F /* Flow in Frameworks */ = {isa = PBXBuildFile; productRef = 19AEC07E2EE714150073EB5F /* Flow */; };
 		19AEFE572EFC62E200EC7D3B /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19AEFE562EFC62E200EC7D3B /* StoreKit.framework */; };
-		19B0A1022F08A00000AB1234 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 19B0A1012F08A00000AB1234 /* ZIPFoundation */; };
-		19C0A1022F09000000C0A001 /* Unrar in Frameworks */ = {isa = PBXBuildFile; productRef = 19C0A1012F09000000C0A001 /* Unrar */; };
+		19D0A1022F0A000000D0A001 /* LibArchive in Frameworks */ = {isa = PBXBuildFile; productRef = 19D0A1012F0A000000D0A001 /* LibArchive */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -100,8 +99,7 @@
 				196028592ED9F7980066E8A4 /* SwiftSoup in Frameworks */,
 				1983B7312FF4000100A1B2C3 /* SDWebImage in Frameworks */,
 				1983B7332FF4000100A1B2C3 /* SDWebImageWebPCoder in Frameworks */,
-				19B0A1022F08A00000AB1234 /* ZIPFoundation in Frameworks */,
-				19C0A1022F09000000C0A001 /* Unrar in Frameworks */,
+				19D0A1022F0A000000D0A001 /* LibArchive in Frameworks */,
 				19AEFE572EFC62E200EC7D3B /* StoreKit.framework in Frameworks */,
 				19AEC07F2EE714150073EB5F /* Flow in Frameworks */,
 			);
@@ -176,8 +174,7 @@
 				1983B7302FF4000100A1B2C3 /* SDWebImage */,
 				1983B7322FF4000100A1B2C3 /* SDWebImageWebPCoder */,
 				19AEC07E2EE714150073EB5F /* Flow */,
-				19B0A1012F08A00000AB1234 /* ZIPFoundation */,
-				19C0A1012F09000000C0A001 /* Unrar */,
+				19D0A1012F0A000000D0A001 /* LibArchive */,
 			);
 			productName = KMReader;
 			productReference = 192E6F7D2EC4B4E20040D165 /* KMReader.app */;
@@ -247,8 +244,7 @@
 				1983B72E2FF4000100A1B2C3 /* XCRemoteSwiftPackageReference "SDWebImage" */,
 				1983B72F2FF4000100A1B2C3 /* XCRemoteSwiftPackageReference "SDWebImageWebPCoder" */,
 				19AEC07D2EE714150073EB5F /* XCRemoteSwiftPackageReference "SwiftUI-Flow" */,
-				19B0A1002F08A00000AB1234 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
-				19C0A1002F09000000C0A001 /* XCRemoteSwiftPackageReference "Unrar.swift" */,
+				19D0A1002F0A000000D0A001 /* XCRemoteSwiftPackageReference "libarchive-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 192E6F7E2EC4B4E20040D165 /* Products */;
@@ -687,20 +683,12 @@
 				minimumVersion = 3.1.1;
 			};
 		};
-		19B0A1002F08A00000AB1234 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
+		19D0A1002F0A000000D0A001 /* XCRemoteSwiftPackageReference "libarchive-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/weichsel/ZIPFoundation";
+			repositoryURL = "https://github.com/everpcpc/libarchive-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.9.19;
-			};
-		};
-		19C0A1002F09000000C0A001 /* XCRemoteSwiftPackageReference "Unrar.swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mtgto/Unrar.swift.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.2;
+				minimumVersion = 0.1.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -726,15 +714,10 @@
 			package = 19AEC07D2EE714150073EB5F /* XCRemoteSwiftPackageReference "SwiftUI-Flow" */;
 			productName = Flow;
 		};
-		19B0A1012F08A00000AB1234 /* ZIPFoundation */ = {
+		19D0A1012F0A000000D0A001 /* LibArchive */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 19B0A1002F08A00000AB1234 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
-			productName = ZIPFoundation;
-		};
-		19C0A1012F09000000C0A001 /* Unrar */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 19C0A1002F09000000C0A001 /* XCRemoteSwiftPackageReference "Unrar.swift" */;
-			productName = Unrar;
+			package = 19D0A1002F0A000000D0A001 /* XCRemoteSwiftPackageReference "libarchive-swift" */;
+			productName = LibArchive;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/KMReader/Features/Offline/Services/ArchiveExtractionService.swift
+++ b/KMReader/Features/Offline/Services/ArchiveExtractionService.swift
@@ -1,0 +1,96 @@
+//
+// ArchiveExtractionService.swift
+//
+//
+
+import Foundation
+import LibArchive
+
+nonisolated enum ArchiveExtractionService {
+  struct ExtractedFile: Sendable {
+    let archivePath: String
+    let destination: URL
+  }
+
+  static func extractFiles(
+    from archiveFile: URL,
+    destinationsByArchivePath: [String: URL],
+    normalizePath: (String) -> String?
+  ) throws -> [ExtractedFile] {
+    guard !destinationsByArchivePath.isEmpty else { return [] }
+
+    let stagingDirectory = try makeStagingDirectory()
+    defer {
+      try? FileManager.default.removeItem(at: stagingDirectory)
+    }
+
+    try ArchiveReader().extract(archiveFile, to: stagingDirectory)
+
+    let extractedFiles = try regularFiles(in: stagingDirectory)
+    var remainingDestinations = destinationsByArchivePath
+    var extracted: [ExtractedFile] = []
+
+    for fileURL in extractedFiles {
+      let relativePath = relativePath(for: fileURL, under: stagingDirectory)
+      guard
+        let archivePath = normalizePath(relativePath),
+        let destination = remainingDestinations.removeValue(forKey: archivePath)
+      else { continue }
+
+      try moveExtractedFile(from: fileURL, to: destination)
+      extracted.append(ExtractedFile(archivePath: archivePath, destination: destination))
+
+      if remainingDestinations.isEmpty {
+        break
+      }
+    }
+
+    return extracted
+  }
+
+  private static func makeStagingDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("KMReaderArchiveExtraction-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+  }
+
+  private static func regularFiles(in directory: URL) throws -> [URL] {
+    guard
+      let enumerator = FileManager.default.enumerator(
+        at: directory,
+        includingPropertiesForKeys: [.isRegularFileKey],
+        options: []
+      )
+    else { return [] }
+
+    var files: [URL] = []
+    for case let fileURL as URL in enumerator {
+      let values = try fileURL.resourceValues(forKeys: [.isRegularFileKey])
+      if values.isRegularFile == true {
+        files.append(fileURL)
+      }
+    }
+    return files
+  }
+
+  private static func relativePath(for fileURL: URL, under directory: URL) -> String {
+    let rootPath = directory.standardizedFileURL.path
+    let filePath = fileURL.standardizedFileURL.path
+    guard filePath.hasPrefix(rootPath + "/") else {
+      return fileURL.lastPathComponent
+    }
+    return String(filePath.dropFirst(rootPath.count + 1))
+  }
+
+  private static func moveExtractedFile(from source: URL, to destination: URL) throws {
+    let directory = destination.deletingLastPathComponent()
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    if FileManager.default.fileExists(atPath: destination.path) {
+      try FileManager.default.removeItem(at: destination)
+    }
+
+    try FileManager.default.moveItem(at: source, to: destination)
+  }
+}

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -7,8 +7,6 @@ import Combine
 import Foundation
 import OSLog
 import UniformTypeIdentifiers
-import Unrar
-import ZIPFoundation
 
 #if os(iOS)
   import UIKit
@@ -2200,8 +2198,6 @@ actor OfflineManager {
 
     guard !hrefs.isEmpty else { return }
 
-    let archive = try ZIPFoundation.Archive(url: epubFile, accessMode: .read)
-
     // Komga already normalizes EPUB hrefs to publication resource keys.
     var archivePathToDestination: [String: URL] = [:]
     for href in hrefs {
@@ -2212,22 +2208,15 @@ actor OfflineManager {
       archivePathToDestination[normalizedArchivePath] = destination
     }
 
-    for entry in archive where entry.type == .file {
-      guard
-        let normalizedEntryPath = Self.normalizeArchivePath(entry.path),
-        let destination = archivePathToDestination[normalizedEntryPath]
-      else { continue }
+    let extracted = try ArchiveExtractionService.extractFiles(
+      from: epubFile,
+      destinationsByArchivePath: archivePathToDestination,
+      normalizePath: Self.normalizeArchivePath
+    )
 
-      let directory = destination.deletingLastPathComponent()
-      Self.ensureDirectoryExists(at: directory)
-      Self.excludeFromBackupIfNeeded(at: directory)
-
-      if FileManager.default.fileExists(atPath: destination.path) {
-        try FileManager.default.removeItem(at: destination)
-      }
-
-      _ = try archive.extract(entry, to: destination)
-      Self.excludeFromBackupIfNeeded(at: destination)
+    for file in extracted {
+      Self.excludeFromBackupIfNeeded(at: file.destination.deletingLastPathComponent())
+      Self.excludeFromBackupIfNeeded(at: file.destination)
     }
   }
 
@@ -2236,7 +2225,6 @@ actor OfflineManager {
     pages: [BookPage],
     bookDir: URL
   ) throws {
-    let archive = try ZIPFoundation.Archive(url: epubFile, accessMode: .read)
     let targets = try Self.divinaImageTargets(from: pages, bookDir: bookDir)
 
     guard !targets.isEmpty else {
@@ -2247,30 +2235,24 @@ actor OfflineManager {
 
     try removePageImageFiles(in: bookDir)
 
-    var archivePathToTarget: [String: DivinaImageTarget] = [:]
+    var archivePathToDestination: [String: URL] = [:]
     for target in targets {
-      archivePathToTarget[target.archivePath] = target
-    }
-    var extractedCount = 0
-
-    for entry in archive where entry.type == .file {
-      guard
-        let normalizedEntryPath = Self.normalizeArchivePath(entry.path),
-        let target = archivePathToTarget.removeValue(forKey: normalizedEntryPath)
-      else { continue }
-
-      if FileManager.default.fileExists(atPath: target.destination.path) {
-        try FileManager.default.removeItem(at: target.destination)
-      }
-
-      _ = try archive.extract(entry, to: target.destination)
-      Self.excludeFromBackupIfNeeded(at: target.destination)
-      extractedCount += 1
+      archivePathToDestination[target.archivePath] = target.destination
     }
 
-    guard extractedCount == targets.count else {
+    let extracted = try ArchiveExtractionService.extractFiles(
+      from: epubFile,
+      destinationsByArchivePath: archivePathToDestination,
+      normalizePath: Self.normalizeArchivePath
+    )
+
+    for file in extracted {
+      Self.excludeFromBackupIfNeeded(at: file.destination)
+    }
+
+    guard extracted.count == targets.count else {
       throw AppErrorType.missingRequiredData(
-        message: "EPUB archive is missing \(targets.count - extractedCount) DIVINA image resources."
+        message: "EPUB archive is missing \(targets.count - extracted.count) DIVINA image resources."
       )
     }
   }
@@ -2302,29 +2284,7 @@ actor OfflineManager {
     pages: [BookPage],
     bookDir: URL
   ) throws {
-    let archive = try ZIPFoundation.Archive(url: archiveFile, accessMode: .read)
-    var entryByPath: [String: ZIPFoundation.Entry] = [:]
-    for entry in archive where entry.type == .file {
-      guard let normalizedPath = Self.normalizeArchivePath(entry.path) else { continue }
-      entryByPath[normalizedPath] = entry
-    }
-
-    for page in pages {
-      guard
-        let normalizedPath = Self.normalizeArchivePath(page.fileName),
-        let entry = entryByPath[normalizedPath]
-      else {
-        throw AppErrorType.missingRequiredData(
-          message: "Archive is missing page resource: \(page.fileName)."
-        )
-      }
-      let destination = imageArchivePageDestination(page: page, fallbackPath: page.fileName, bookDir: bookDir)
-      if FileManager.default.fileExists(atPath: destination.path) {
-        try FileManager.default.removeItem(at: destination)
-      }
-      _ = try archive.extract(entry, to: destination)
-      Self.excludeFromBackupIfNeeded(at: destination)
-    }
+    try extractCompressedImageArchive(archiveFile: archiveFile, pages: pages, bookDir: bookDir)
   }
 
   private func extractCBRArchive(
@@ -2332,33 +2292,47 @@ actor OfflineManager {
     pages: [BookPage],
     bookDir: URL
   ) throws {
-    let archive = try Unrar.Archive(fileURL: archiveFile)
-    var entryByPath: [String: Unrar.Entry] = [:]
-    for entry in try archive.entries() where !entry.directory {
-      guard let normalizedPath = Self.normalizeArchivePath(entry.fileName) else { continue }
-      entryByPath[normalizedPath] = entry
-    }
+    try extractCompressedImageArchive(archiveFile: archiveFile, pages: pages, bookDir: bookDir)
+  }
 
+  private func extractCompressedImageArchive(
+    archiveFile: URL,
+    pages: [BookPage],
+    bookDir: URL
+  ) throws {
+    var destinationsByArchivePath: [String: URL] = [:]
     for page in pages {
-      guard
-        let normalizedPath = Self.normalizeArchivePath(page.fileName),
-        let entry = entryByPath[normalizedPath]
-      else {
-        throw AppErrorType.missingRequiredData(
-          message: "Archive is missing page resource: \(page.fileName)."
-        )
+      guard let normalizedPath = Self.normalizeArchivePath(page.fileName) else {
+        throw AppErrorType.invalidFileURL(url: page.fileName)
       }
       let destination = imageArchivePageDestination(
         page: page,
         fallbackPath: page.fileName,
         bookDir: bookDir
       )
-      if FileManager.default.fileExists(atPath: destination.path) {
-        try FileManager.default.removeItem(at: destination)
+      destinationsByArchivePath[normalizedPath] = destination
+    }
+
+    let extracted = try ArchiveExtractionService.extractFiles(
+      from: archiveFile,
+      destinationsByArchivePath: destinationsByArchivePath,
+      normalizePath: Self.normalizeArchivePath
+    )
+
+    for file in extracted {
+      Self.excludeFromBackupIfNeeded(at: file.destination)
+    }
+
+    guard extracted.count == pages.count else {
+      let extractedPaths = Set(extracted.map(\.archivePath))
+      let missingPage = pages.first { page in
+        guard let normalizedPath = Self.normalizeArchivePath(page.fileName) else { return true }
+        return !extractedPaths.contains(normalizedPath)
       }
-      let data = try archive.extract(entry)
-      try data.write(to: destination, options: [.atomic])
-      Self.excludeFromBackupIfNeeded(at: destination)
+      let missingPath = missingPage?.fileName ?? "unknown"
+      throw AppErrorType.missingRequiredData(
+        message: "Archive is missing page resource: \(missingPath)."
+      )
     }
   }
 


### PR DESCRIPTION
## Problem
Offline archive extraction had two format-specific dependencies: ZIPFoundation for EPUB/CBZ and Unrar.swift for CBR. That kept the extraction path split even though the app now needs one consistent archive reader for ZIP and RAR-family inputs.

## Approach
Use libarchive-swift as the single archive backend. Archives are extracted into a temporary staging directory, then only the mapped WebPub resources or page files are moved into the existing offline book layout so reader paths and cache behavior stay unchanged.

## Scope
- Replace ZIPFoundation and Unrar.swift package references with LibArchive
- Add ArchiveExtractionService for staging-directory extraction and path-based file selection
- Route EPUB WebPub, EPUB DIVINA, CBZ, and CBR offline extraction through the shared service
- Bump build version to 411

## Validation
- [x] make format
- [x] git diff --check
- [x] make build-macos
