### PR TITLE
fix: smooth webtoon segment scrolling

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 413;
+				CURRENT_PROJECT_VERSION = 414;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 413;
+				CURRENT_PROJECT_VERSION = 414;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 413;
+				CURRENT_PROJECT_VERSION = 414;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 413;
+				CURRENT_PROJECT_VERSION = 414;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -283,6 +283,7 @@ struct DivinaControlsOverlayView: View {
             Image(systemName: "bookmark")
             Text("\(displayedCurrentPage) / \(currentSegmentPageCount)")
               .monospacedDigit()
+              .contentTransition(.numericText())
           }
           .contentShape(Capsule())
         }
@@ -299,6 +300,10 @@ struct DivinaControlsOverlayView: View {
       ReadingProgressBar(progress: progress, type: .reader)
         .scaleEffect(x: readingDirection == .rtl ? -1 : 1, y: 1)
     }
+    .animation(animation, value: currentBook?.id)
+    .animation(animation, value: displayedCurrentPage)
+    .animation(animation, value: currentSegmentPageCount)
+    .animation(animation, value: progress)
     .padding()
     .iPadIgnoresSafeArea(paddingTop: 24)
     .background {

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -789,7 +789,7 @@
 
       func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if isUserScrolling {
-          updateCurrentPage()
+          updateCurrentPage(commitToViewModel: false)
         }
       }
 
@@ -816,7 +816,7 @@
         scheduleDeferredCleanupIfNeeded()
       }
 
-      private func updateCurrentPage() {
+      private func updateCurrentPage(commitToViewModel: Bool = true) {
         guard let collectionView = collectionView else { return }
         let totalItems = scrollEngine.itemCount
         guard totalItems > 0 else { return }
@@ -846,6 +846,8 @@
 
         if scrollEngine.currentPageID != resolvedPageID {
           scrollEngine.currentPageID = resolvedPageID
+        }
+        if commitToViewModel, viewModel?.currentReaderPage?.id != resolvedPageID {
           viewModel?.updateCurrentPosition(pageID: resolvedPageID)
         }
       }

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
@@ -776,14 +776,14 @@
           isUserScrolling = true
         }
         lastScrollTime = Date().timeIntervalSinceReferenceDate
-        updateCurrentPage()
+        updateCurrentPage(commitToViewModel: false)
       }
 
       @objc func scrollViewDidEndScroll(_ notification: Notification) {
         finalizeScrollInteraction()
       }
 
-      private func updateCurrentPage() {
+      private func updateCurrentPage(commitToViewModel: Bool = true) {
         guard let cv = collectionView, let sv = scrollView else { return }
         let totalItems = scrollEngine.itemCount
         guard totalItems > 0 else { return }
@@ -813,6 +813,8 @@
 
         if scrollEngine.currentPageID != resolvedPageID {
           scrollEngine.currentPageID = resolvedPageID
+        }
+        if commitToViewModel, viewModel?.currentReaderPage?.id != resolvedPageID {
           viewModel?.updateCurrentPosition(pageID: resolvedPageID)
         }
       }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -69344,18 +69344,17 @@
       }
     },
     "startup.storageFailure.resetButton" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Local Data"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lokale Daten zurücksetzen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset Local Data"
           }
         },
         "es" : {
@@ -69409,18 +69408,17 @@
       }
     },
     "startup.storageFailure.resetConfirm" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zurücksetzen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset"
           }
         },
         "es" : {
@@ -69474,18 +69472,17 @@
       }
     },
     "startup.storageFailure.resetMessage" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This removes all local KMReader data on this device, including saved servers, preferences, offline books, custom fonts, logs, and caches. Server data in Komga is not changed. KMReader will start fresh after the reset."
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dadurch werden alle lokalen KMReader-Daten auf diesem Gerät entfernt, einschließlich gespeicherter Server, Einstellungen, Offline-Bücher, eigener Schriften, Protokolle und Caches. Daten auf dem Komga-Server werden nicht geändert. KMReader startet nach dem Zurücksetzen frisch."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This removes all local KMReader data on this device, including saved servers, preferences, offline books, custom fonts, logs, and caches. Server data in Komga is not changed. KMReader will start fresh after the reset."
           }
         },
         "es" : {
@@ -69539,18 +69536,17 @@
       }
     },
     "startup.storageFailure.resetTitle" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset Local Data?"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lokale Daten zurücksetzen?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset Local Data?"
           }
         },
         "es" : {

--- a/KMReader/Shared/UI/ReadingProgressBar.swift
+++ b/KMReader/Shared/UI/ReadingProgressBar.swift
@@ -42,6 +42,7 @@ struct ReadingProgressBar: View {
             width: max(geometry.size.width * progress, progress > 0 ? 4 : 0),
             height: height
           )
+          .animation(.easeInOut(duration: 0.2), value: progress)
       }
     }
     .frame(height: height)


### PR DESCRIPTION
## Problem
Webtoon scrolling could hitch when the viewport crossed into the next book because the scroll callback committed the new page into the global reader state while scrolling was still active. That global state update refreshed reader controls and related SwiftUI bindings on the scroll path.

## Approach
Keep Webtoon scroll position changes local to the platform scroll engine during active scrolling, then commit the resolved page back to `ReaderViewModel` when scrolling settles. Reader controls still update after the settled commit, with lightweight numeric/progress animations for the page indicator and progress bar.

## Scope
- Defer Webtoon current-page commits on iOS and macOS until scroll completion
- Animate reader page number and progress updates after the deferred commit
- Include pending Localizable.xcstrings synchronization changes
- Increment build number to 414 via `make bump`

## Validation
- [x] `make format`
- [x] `make build`
