### PR TITLE
fix: improve reader control contrast

### DIFF
--- a/KMReader/Assets.xcassets/readerTint.colorset/Contents.json
+++ b/KMReader/Assets.xcassets/readerTint.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x1C",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -38,10 +38,6 @@ struct DivinaControlsOverlayView: View {
     @FocusState private var focusedControl: ControlFocus?
   #endif
 
-  private var buttonStyle: AdaptiveButtonStyleType {
-    return .bordered
-  }
-
   private var animation: Animation {
     .easeInOut(duration: 0.2)
   }
@@ -199,7 +195,7 @@ struct DivinaControlsOverlayView: View {
         }
         .buttonBorderShape(.circle)
         .controlSize(.large)
-        .adaptiveButtonStyle(buttonStyle)
+        .readerControlButtonStyle()
         #if os(tvOS)
           .focused($focusedControl, equals: .close)
           .id("closeButton")
@@ -236,7 +232,7 @@ struct DivinaControlsOverlayView: View {
           .contentShape(Capsule())
         }
         .optimizedControlSize()
-        .adaptiveButtonStyle(buttonStyle)
+        .readerControlButtonStyle()
         #if os(tvOS)
           .focused($focusedControl, equals: .title)
           .id("titleLabel")
@@ -255,7 +251,7 @@ struct DivinaControlsOverlayView: View {
         }
         .buttonBorderShape(.circle)
         .controlSize(.large)
-        .adaptiveButtonStyle(buttonStyle)
+        .readerControlButtonStyle()
         #if os(tvOS)
           .focused($focusedControl, equals: .settings)
         #endif
@@ -287,7 +283,7 @@ struct DivinaControlsOverlayView: View {
           }
           .contentShape(Capsule())
         }
-        .adaptiveButtonStyle(buttonStyle)
+        .readerControlButtonStyle()
         #if os(tvOS)
           .focused($focusedControl, equals: .pageNumber)
         #endif

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -106,10 +106,6 @@
       currentBook?.metadata.title ?? book.metadata.title
     }
 
-    private var buttonStyle: AdaptiveButtonStyleType {
-      return .bordered
-    }
-
     private var animation: Animation {
       .default
     }
@@ -643,7 +639,7 @@
             }
             .controlSize(.extraLarge)
             .buttonBorderShape(.circle)
-            .adaptiveButtonStyle(buttonStyle)
+            .readerControlButtonStyle()
             .padding(.top, 24)
             .padding(.trailing, 12)
             .transition(
@@ -678,7 +674,7 @@
               }
               .controlSize(.extraLarge)
               .buttonBorderShape(.circle)
-              .adaptiveButtonStyle(buttonStyle)
+              .readerControlButtonStyle()
               .padding(.bottom, 24)
               .padding(.trailing, 12)
               .transition(
@@ -744,7 +740,7 @@
             }
             .contentShape(Capsule())
           }
-          .adaptiveButtonStyle(buttonStyle)
+          .readerControlButtonStyle()
           .buttonBorderShape(.capsule)
           .controlSize(.large)
           .disabled(viewModel.tableOfContents.isEmpty)
@@ -760,7 +756,7 @@
           }
           .contentShape(Capsule())
         }
-        .adaptiveButtonStyle(buttonStyle)
+        .readerControlButtonStyle()
         .buttonBorderShape(.capsule)
         .controlSize(.large)
 
@@ -774,7 +770,7 @@
           }
           .contentShape(Capsule())
         }
-        .adaptiveButtonStyle(buttonStyle)
+        .readerControlButtonStyle()
         .buttonBorderShape(.capsule)
         .controlSize(.large)
       }

--- a/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
@@ -22,10 +22,6 @@
     let controlsVisible: Bool
     let onDismiss: () -> Void
 
-    private var buttonStyle: AdaptiveButtonStyleType {
-      .bordered
-    }
-
     private var animation: Animation {
       .easeInOut(duration: 0.2)
     }
@@ -82,7 +78,7 @@
           }
           .buttonBorderShape(.circle)
           .controlSize(.large)
-          .adaptiveButtonStyle(buttonStyle)
+          .readerControlButtonStyle()
         #endif
 
         Spacer()
@@ -117,7 +113,7 @@
             .contentShape(Capsule())
           }
           .optimizedControlSize()
-          .adaptiveButtonStyle(buttonStyle)
+          .readerControlButtonStyle()
         }
 
         Spacer()
@@ -132,7 +128,7 @@
           }
           .buttonBorderShape(.circle)
           .controlSize(.large)
-          .adaptiveButtonStyle(buttonStyle)
+          .readerControlButtonStyle()
         #endif
       }
       .allowsHitTesting(true)
@@ -160,7 +156,7 @@
             }
             .contentShape(Capsule())
           }
-          .adaptiveButtonStyle(buttonStyle)
+          .readerControlButtonStyle()
           .disabled(pageCount <= 0)
 
           Spacer(minLength: 0)

--- a/KMReader/Features/Reader/Views/ReaderControlButtonStyle.swift
+++ b/KMReader/Features/Reader/Views/ReaderControlButtonStyle.swift
@@ -1,0 +1,24 @@
+//
+// ReaderControlButtonStyle.swift
+//
+//
+
+import SwiftUI
+
+extension View {
+  @ViewBuilder
+  func readerControlButtonStyle() -> some View {
+    #if os(iOS)
+      if #available(iOS 26.0, *) {
+        self.adaptiveButtonStyle(.bordered)
+      } else {
+        self
+          .buttonStyle(.borderedProminent)
+          .tint(.readerTint)
+          .foregroundStyle(.white)
+      }
+    #else
+      self.adaptiveButtonStyle(.bordered)
+    #endif
+  }
+}

--- a/KMReader/Shared/Extensions/View+ButtonStyle.swift
+++ b/KMReader/Shared/Extensions/View+ButtonStyle.swift
@@ -43,9 +43,9 @@ extension View {
       case .borderedProminent:
         self.buttonStyle(.borderedProminent)
       case .bordered:
-        self.buttonStyle(.borderedProminent)
+        self.buttonStyle(.bordered)
       case .borderless:
-        self.buttonStyle(.borderedProminent)
+        self.buttonStyle(.borderless)
       case .plain:
         #if os(tvOS)
           self.buttonStyle(.card)


### PR DESCRIPTION
## Problem
Reader overlay controls on pre-iOS 26 releases could become hard to read because the standard bordered button background is too transparent over page artwork and gradients. Light mode also made the button text dark, which reduced contrast over the reader control gradient.

## Approach
Add a reader-specific control button modifier that keeps the existing iOS 26 bordered glass behavior, while using a darker prominent fallback with white foreground on older iOS versions. The general adaptive bordered fallback remains available for non-reader controls.

## Scope
- Add a `readerTint` asset for the older iOS reader control background.
- Route DIVINA, PDF, and EPUB reader overlay buttons through `readerControlButtonStyle()`.
- Keep global adaptive bordered and borderless fallbacks mapped to their native styles.

## Related
- #759
