### PR TITLE
fix: stabilize cover page jumps

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 414;
+				CURRENT_PROJECT_VERSION = 415;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 414;
+				CURRENT_PROJECT_VERSION = 415;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 414;
+				CURRENT_PROJECT_VERSION = 415;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 414;
+				CURRENT_PROJECT_VERSION = 415;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
@@ -562,6 +562,7 @@
       private func applyCurrentItem(_ item: ReaderViewItem) {
         postTransitionTask?.cancel()
         let token = transitionToken
+        parent.viewModel.updateCurrentPosition(viewItem: item)
 
         postTransitionTask = Task(priority: .utility) {
           guard !Task.isCancelled else { return }
@@ -569,7 +570,6 @@
           let shouldContinue = await MainActor.run { () -> Bool in
             guard token == self.transitionToken else { return false }
             guard self.currentItem == item else { return false }
-            self.parent.viewModel.updateCurrentPosition(viewItem: item)
             return true
           }
           guard shouldContinue else { return }

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_macOS.swift
@@ -579,6 +579,7 @@
       private func applyCurrentItem(_ item: ReaderViewItem) {
         postTransitionTask?.cancel()
         let token = transitionToken
+        parent.viewModel.updateCurrentPosition(viewItem: item)
 
         postTransitionTask = Task(priority: .utility) {
           guard !Task.isCancelled else { return }
@@ -586,7 +587,6 @@
           let shouldContinue = await MainActor.run { () -> Bool in
             guard token == self.transitionToken else { return false }
             guard self.currentItem == item else { return false }
-            self.parent.viewModel.updateCurrentPosition(viewItem: item)
             return true
           }
           guard shouldContinue else { return }


### PR DESCRIPTION
## Problem
Cover-mode TOC and page-jump navigation could flash the requested page and then settle back on the previous page. The cover deck was applying the visual target before the reader view model had committed the new current item, so a SwiftUI update pass could rebuild from stale state.

## Approach
Commit the current cover item to the reader view model synchronously when the cover coordinator applies a new item. The deferred post-transition task now only verifies the transition token and performs preload work, so state ownership stays current before any later view update can resync the deck.

## Scope
- Update iOS cover reader current-position commit timing
- Update macOS cover reader current-position commit timing
- Bump build version to 415

## Validation
- [x] make format
- [x] make build-macos
- [x] make build-ios
