### PR TITLE
feat: simplify tap turn animation settings

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 415;
+				CURRENT_PROJECT_VERSION = 416;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 415;
+				CURRENT_PROJECT_VERSION = 416;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 415;
+				CURRENT_PROJECT_VERSION = 416;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 415;
+				CURRENT_PROJECT_VERSION = 416;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -712,15 +712,27 @@ enum AppConfig {
     }
   }
 
-  static nonisolated var tapPageTransitionDuration: Double {
+  static nonisolated var animateTapTurns: Bool {
     get {
-      if UserDefaults.standard.object(forKey: "tapPageTransitionDuration") != nil {
-        return UserDefaults.standard.double(forKey: "tapPageTransitionDuration")
+      if UserDefaults.standard.object(forKey: "animateTapTurns") != nil {
+        return UserDefaults.standard.bool(forKey: "animateTapTurns")
       }
-      return 0.3
+      return true
     }
     set {
-      UserDefaults.standard.set(newValue, forKey: "tapPageTransitionDuration")
+      UserDefaults.standard.set(newValue, forKey: "animateTapTurns")
+    }
+  }
+
+  static nonisolated var animateEpubTapTurns: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "animateEpubTapTurns") != nil {
+        return UserDefaults.standard.bool(forKey: "animateEpubTapTurns")
+      }
+      return true
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: "animateEpubTapTurns")
     }
   }
 

--- a/KMReader/Features/Reader/Models/PageTransitionStyle.swift
+++ b/KMReader/Features/Reader/Models/PageTransitionStyle.swift
@@ -6,7 +6,6 @@
 import Foundation
 
 enum PageTransitionStyle: String, CaseIterable, Hashable, Sendable {
-  case none = "none"
   case scroll = "scroll"
   case cover = "cover"
   case pageCurl = "pageCurl"
@@ -22,15 +21,14 @@ enum PageTransitionStyle: String, CaseIterable, Hashable, Sendable {
 
   static var epubAvailableCases: [PageTransitionStyle] {
     #if os(iOS)
-      return [.none, .scroll, .cover, .pageCurl]
+      return [.scroll, .cover, .pageCurl]
     #else
-      return [.none, .scroll, .cover]
+      return [.scroll, .cover]
     #endif
   }
 
   var displayName: String {
     switch self {
-    case .none: return String(localized: "reader.page_transition.none")
     case .scroll: return String(localized: "reader.page_transition.scroll")
     case .cover: return String(localized: "reader.page_transition.cover")
     case .pageCurl: return String(localized: "reader.page_transition.page_curl")
@@ -39,7 +37,6 @@ enum PageTransitionStyle: String, CaseIterable, Hashable, Sendable {
 
   var description: String {
     switch self {
-    case .none: return String(localized: "reader.page_transition.none.description")
     case .scroll: return String(localized: "reader.page_transition.scroll.description")
     case .cover: return String(localized: "reader.page_transition.cover.description")
     case .pageCurl: return String(localized: "reader.page_transition.page_curl.description")

--- a/KMReader/Features/Reader/Views/CurlDualPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlDualPageView.swift
@@ -11,6 +11,7 @@
     let mode: PageViewMode
     let readingDirection: ReadingDirection
     let splitWidePageMode: SplitWidePageMode
+    let animateTapTurns: Bool
     let renderConfig: ReaderRenderConfig
     let readListContext: ReaderReadListContext?
     let onDismiss: () -> Void
@@ -129,7 +130,7 @@
       }
 
       context.coordinator.isTransitioning = true
-      let shouldAnimateTransition = context.coordinator.hasCompletedInitialUpdate
+      let shouldAnimateTransition = context.coordinator.hasCompletedInitialUpdate && animateTapTurns
       PageCurlControllerPlanner.safeSetViewControllers(
         targetPair,
         on: pageVC,

--- a/KMReader/Features/Reader/Views/CurlPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlPageView.swift
@@ -11,6 +11,7 @@
     let mode: PageViewMode
     let readingDirection: ReadingDirection
     let splitWidePageMode: SplitWidePageMode
+    let animateTapTurns: Bool
     let renderConfig: ReaderRenderConfig
     let readListContext: ReaderReadListContext?
     let onDismiss: () -> Void
@@ -120,7 +121,7 @@
       }
 
       context.coordinator.isTransitioning = true
-      let shouldAnimateTransition = context.coordinator.hasCompletedInitialUpdate
+      let shouldAnimateTransition = context.coordinator.hasCompletedInitialUpdate && animateTapTurns
       let transitionControllers = pageCurlControllers(
         primary: targetVC,
         targetIndex: targetViewItemIndex,

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -20,7 +20,7 @@ struct DivinaReaderView: View {
   @AppStorage("readerBackground") private var readerBackground: ReaderBackground = .system
   @AppStorage("webtoonPageWidthPercentage") private var webtoonPageWidthPercentage: Double = 100.0
   @AppStorage("pageTransitionStyle") private var pageTransitionStyle: PageTransitionStyle = .cover
-  @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.3
+  @AppStorage("animateTapTurns") private var animateTapTurns: Bool = AppConfig.animateTapTurns
   @AppStorage("showTapZoneHints") private var showTapZoneHints: Bool = true
   @AppStorage("tapZoneSize") private var tapZoneSize: TapZoneSize = .large
   @AppStorage("tapZoneMode") private var tapZoneMode: TapZoneMode = .auto
@@ -180,7 +180,7 @@ struct DivinaReaderView: View {
   }
 
   private var pageTurnAnimationDuration: Double {
-    max(tapPageTransitionDuration, 0)
+    animateTapTurns ? 0.3 : 0
   }
 
   private var isPresentingModalSheet: Bool {
@@ -669,6 +669,7 @@ struct DivinaReaderView: View {
                     mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
                     readingDirection: readingDirection,
                     splitWidePageMode: splitWidePageMode,
+                    animateTapTurns: animateTapTurns,
                     renderConfig: renderConfig,
                     readListContext: readListContext,
                     onDismiss: { closeReader() }
@@ -679,6 +680,7 @@ struct DivinaReaderView: View {
                     mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
                     readingDirection: readingDirection,
                     splitWidePageMode: splitWidePageMode,
+                    animateTapTurns: animateTapTurns,
                     renderConfig: renderConfig,
                     readListContext: readListContext,
                     onDismiss: { closeReader() }
@@ -687,7 +689,7 @@ struct DivinaReaderView: View {
               #else
                 standardScrollPageView(useDualPage: useDualPage, screenSize: screenSize)
               #endif
-            case .none, .scroll:
+            case .scroll:
               standardScrollPageView(useDualPage: useDualPage, screenSize: screenSize)
             case .cover:
               NativeCoverPageView(

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -22,7 +22,7 @@
     @AppStorage("epubPreferences") private var globalPreferences: EpubReaderPreferences = .init()
     @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
     @AppStorage("epubShowsStatusBarWhileReading") private var epubShowsStatusBarWhileReading: Bool = false
-    @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.3
+    @AppStorage("animateEpubTapTurns") private var animateEpubTapTurns: Bool = AppConfig.animateEpubTapTurns
     @AppStorage("epubShowKeyboardHelpOverlay")
     private var showKeyboardHelpOverlay: Bool = AppConfig.epubShowKeyboardHelpOverlay
 
@@ -420,29 +420,12 @@
         switch activePreferences.flowStyle {
         case .paged:
           switch epubPageTransitionStyle {
-          case .none:
-            WebPubPagedScrollView(
-              viewModel: viewModel,
-              animatePageTransitions: false,
-              preferences: activePreferences,
-              colorScheme: colorScheme,
-              showingControls: shouldShowControls,
-              bookTitle: currentBook?.metadata.title,
-              onCenterTap: {
-                toggleControls()
-              },
-              onEndReached: {
-                if !showingEndPage {
-                  viewModel.syncEndProgression()
-                  showingEndPage = true
-                }
-              }
-            )
           case .cover:
             WebPubPagedCoverView(
               viewModel: viewModel,
               preferences: activePreferences,
               colorScheme: colorScheme,
+              animateTapTurns: animateEpubTapTurns,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
               onCenterTap: {
@@ -458,7 +441,7 @@
           case .scroll, .pageCurl:
             WebPubPagedScrollView(
               viewModel: viewModel,
-              animatePageTransitions: true,
+              animatePageTransitions: animateEpubTapTurns,
               preferences: activePreferences,
               colorScheme: colorScheme,
               showingControls: shouldShowControls,
@@ -479,7 +462,7 @@
             viewModel: viewModel,
             preferences: activePreferences,
             colorScheme: colorScheme,
-            tapPageTransitionDuration: tapPageTransitionDuration,
+            animateTapTurns: animateEpubTapTurns,
             showingControls: shouldShowControls,
             bookTitle: currentBook?.metadata.title,
             onCenterTap: {
@@ -497,28 +480,10 @@
         switch activePreferences.flowStyle {
         case .paged:
           switch epubPageTransitionStyle {
-          case .none:
-            WebPubPagedScrollView(
-              viewModel: viewModel,
-              animatePageTransitions: false,
-              preferences: activePreferences,
-              colorScheme: colorScheme,
-              showingControls: shouldShowControls,
-              bookTitle: currentBook?.metadata.title,
-              onCenterTap: {
-                toggleControls()
-              },
-              onEndReached: {
-                if !showingEndPage {
-                  viewModel.syncEndProgression()
-                  showingEndPage = true
-                }
-              }
-            ).readerIgnoresSafeArea()
           case .scroll:
             WebPubPagedScrollView(
               viewModel: viewModel,
-              animatePageTransitions: true,
+              animatePageTransitions: animateEpubTapTurns,
               preferences: activePreferences,
               colorScheme: colorScheme,
               showingControls: shouldShowControls,
@@ -538,6 +503,7 @@
               viewModel: viewModel,
               preferences: activePreferences,
               colorScheme: colorScheme,
+              animateTapTurns: animateEpubTapTurns,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
               onCenterTap: {
@@ -555,6 +521,7 @@
               viewModel: viewModel,
               preferences: activePreferences,
               colorScheme: colorScheme,
+              animateTapTurns: animateEpubTapTurns,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
               onCenterTap: {
@@ -573,7 +540,7 @@
             viewModel: viewModel,
             preferences: activePreferences,
             colorScheme: colorScheme,
-            tapPageTransitionDuration: tapPageTransitionDuration,
+            animateTapTurns: animateEpubTapTurns,
             showingControls: shouldShowControls,
             bookTitle: currentBook?.metadata.title,
             onCenterTap: {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
@@ -11,6 +11,7 @@
     @Bindable var viewModel: EpubReaderViewModel
     let preferences: EpubReaderPreferences
     let colorScheme: ColorScheme
+    let animateTapTurns: Bool
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -103,7 +104,7 @@
           || (targetChapterIndex == context.coordinator.currentChapterIndex
             && normalizedPageIndex > context.coordinator.currentPageIndex)
 
-        let shouldAnimate = context.coordinator.hasCompletedInitialUpdate
+        let shouldAnimate = context.coordinator.hasCompletedInitialUpdate && animateTapTurns
 
         if shouldAnimate {
           context.coordinator.animateTransition(

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView_macOS.swift
@@ -7,6 +7,7 @@
     @Bindable var viewModel: EpubReaderViewModel
     let preferences: EpubReaderPreferences
     let colorScheme: ColorScheme
+    let animateTapTurns: Bool
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -181,6 +182,7 @@
         parent.viewModel.targetChapterIndex != nil || parent.viewModel.targetPageIndex != nil
       let shouldAnimateNavigation =
         hasPendingNavigation
+        && parent.animateTapTurns
         && isContentLoaded
         && (requestedChapterIndex != chapterIndex || requestedPageIndex != currentSubPageIndex)
 

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
@@ -12,6 +12,7 @@
     @Bindable var viewModel: EpubReaderViewModel
     let preferences: EpubReaderPreferences
     let colorScheme: ColorScheme
+    let animateTapTurns: Bool
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -167,7 +168,7 @@
         let direction: UIPageViewController.NavigationDirection = isForward ? .forward : .reverse
 
         context.coordinator.isAnimating = true
-        let shouldAnimateTransition = context.coordinator.hasCompletedInitialUpdate
+        let shouldAnimateTransition = context.coordinator.hasCompletedInitialUpdate && animateTapTurns
         let transitionControllers = pageCurlControllers(
           primary: targetVC,
           targetChapterIndex: targetChapterIndex,

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
@@ -13,7 +13,7 @@
     @Bindable var viewModel: EpubReaderViewModel
     let preferences: EpubReaderPreferences
     let colorScheme: ColorScheme
-    let tapPageTransitionDuration: Double
+    let animateTapTurns: Bool
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -43,7 +43,7 @@
         rootURL: viewModel.resourceRootURL,
         containerInsets: viewModel.containerInsetsForLabels().uiEdgeInsets,
         tapScrollPercentage: preferences.tapScrollPercentage,
-        tapPageTransitionDuration: tapPageTransitionDuration,
+        animateTapTurns: animateTapTurns,
         theme: theme,
         contentCSS: readiumPayload.css,
         readiumProperties: readiumPayload.properties,
@@ -201,7 +201,7 @@
         rootURL: viewModel.resourceRootURL,
         containerInsets: containerInsets,
         tapScrollPercentage: preferences.tapScrollPercentage,
-        tapPageTransitionDuration: tapPageTransitionDuration,
+        animateTapTurns: animateTapTurns,
         theme: theme,
         contentCSS: readiumPayload.css,
         readiumProperties: readiumPayload.properties,
@@ -247,7 +247,7 @@
     private var totalPagesInChapter: Int = 1
     private var containerInsets: UIEdgeInsets
     private var tapScrollPercentage: Double
-    private var tapPageTransitionDuration: TimeInterval
+    private var animateTapTurns: Bool
     private var theme: ReaderTheme
     private var contentCSS: String
     private var readiumProperties: [String: String?]
@@ -319,7 +319,7 @@
       rootURL: URL?,
       containerInsets: UIEdgeInsets,
       tapScrollPercentage: Double,
-      tapPageTransitionDuration: Double,
+      animateTapTurns: Bool,
       theme: ReaderTheme,
       contentCSS: String,
       readiumProperties: [String: String?],
@@ -341,7 +341,7 @@
       self.rootURL = rootURL
       self.containerInsets = containerInsets
       self.tapScrollPercentage = Self.normalizedTapScrollPercentage(tapScrollPercentage)
-      self.tapPageTransitionDuration = Self.normalizedTapPageTransitionDuration(tapPageTransitionDuration)
+      self.animateTapTurns = animateTapTurns
       self.theme = theme
       self.contentCSS = contentCSS
       self.readiumProperties = readiumProperties
@@ -687,7 +687,7 @@
       rootURL: URL?,
       containerInsets: UIEdgeInsets,
       tapScrollPercentage: Double,
-      tapPageTransitionDuration: Double,
+      animateTapTurns: Bool,
       theme: ReaderTheme,
       contentCSS: String,
       readiumProperties: [String: String?],
@@ -705,14 +705,11 @@
     ) {
       let shouldReload = chapterURL != self.chapterURL || rootURL != self.rootURL
       let normalizedTapScrollPercentage = Self.normalizedTapScrollPercentage(tapScrollPercentage)
-      let normalizedTapPageTransitionDuration = Self.normalizedTapPageTransitionDuration(
-        tapPageTransitionDuration
-      )
       let appearanceChanged =
         theme != self.theme
         || containerInsets != self.containerInsets
         || normalizedTapScrollPercentage != self.tapScrollPercentage
-        || normalizedTapPageTransitionDuration != self.tapPageTransitionDuration
+        || animateTapTurns != self.animateTapTurns
         || contentCSS != self.contentCSS
         || readiumProperties != self.readiumProperties
         || publicationLanguage != self.publicationLanguage
@@ -725,7 +722,7 @@
       self.rootURL = rootURL
       self.containerInsets = containerInsets
       self.tapScrollPercentage = normalizedTapScrollPercentage
-      self.tapPageTransitionDuration = normalizedTapPageTransitionDuration
+      self.animateTapTurns = animateTapTurns
       self.theme = theme
       self.contentCSS = contentCSS
       self.readiumProperties = readiumProperties
@@ -759,10 +756,6 @@
 
     private static func normalizedTapScrollPercentage(_ value: Double) -> Double {
       min(100.0, max(25.0, value))
-    }
-
-    private static func normalizedTapPageTransitionDuration(_ value: Double) -> TimeInterval {
-      min(1.0, max(0.0, value))
     }
 
     private func loadContentIfNeeded(force: Bool) {
@@ -906,7 +899,7 @@
       let clampedOffset = max(0, targetOffset)
       lastKnownDocumentScrollTop = clampedOffset
       let offset = Double(clampedOffset)
-      let duration = animated ? tapPageTransitionDuration : 0
+      let duration = animated && animateTapTurns ? 0.3 : 0
       let js = """
           (function() {
             var top = \(offset);

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
@@ -7,7 +7,7 @@
     @Bindable var viewModel: EpubReaderViewModel
     let preferences: EpubReaderPreferences
     let colorScheme: ColorScheme
-    let tapPageTransitionDuration: Double
+    let animateTapTurns: Bool
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -76,7 +76,7 @@
     private var lastKnownDocumentViewportHeight: CGFloat = 0
     private var chapterTitle: String?
     private var totalProgression: Double?
-    private var tapPageTransitionDuration: TimeInterval = 0.3
+    private var animateTapTurns = true
 
     init(parent: WebPubScrolledView) {
       self.parent = parent
@@ -116,15 +116,12 @@
       let nextChapterURL = parent.viewModel.chapterURL(at: selectedChapterIndex)
       let nextRootURL = parent.viewModel.resourceRootURL
       let shouldReload = nextChapterURL != chapterURL || nextRootURL != rootURL
-      let normalizedTapPageTransitionDuration = Self.normalizedTapPageTransitionDuration(
-        parent.tapPageTransitionDuration
-      )
       let appearanceChanged =
         contentCSS != readiumPayload.css
         || readiumProperties != readiumPayload.properties
         || publicationLanguage != parent.viewModel.publicationLanguage
         || publicationReadingProgression != parent.viewModel.publicationReadingProgression
-        || tapPageTransitionDuration != normalizedTapPageTransitionDuration
+        || animateTapTurns != parent.animateTapTurns
 
       chapterIndex = selectedChapterIndex
       chapterURL = nextChapterURL
@@ -134,7 +131,7 @@
       publicationLanguage = parent.viewModel.publicationLanguage
       publicationReadingProgression = parent.viewModel.publicationReadingProgression
       chapterTitle = currentLocation?.title
-      tapPageTransitionDuration = normalizedTapPageTransitionDuration
+      animateTapTurns = parent.animateTapTurns
       totalProgression = currentLocation.flatMap { location in
         parent.viewModel.totalProgression(location: location, chapterProgress: nil)
       }
@@ -270,7 +267,7 @@
       let clampedOffset = max(0, targetOffset)
       lastKnownDocumentScrollTop = clampedOffset
       let offset = Double(clampedOffset)
-      let duration = tapPageTransitionDuration
+      let duration = animateTapTurns ? 0.3 : 0
       let js = """
           (function() {
             var top = \(offset);
@@ -340,10 +337,6 @@
           })();
         """
       webView.evaluateJavaScript(js, completionHandler: nil)
-    }
-
-    private static func normalizedTapPageTransitionDuration(_ value: Double) -> TimeInterval {
-      min(1.0, max(0.0, value))
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/KMReader/Features/Reader/Views/Sheets/EpubPreferencesView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubPreferencesView_macOS.swift
@@ -17,6 +17,7 @@
     @State private var newPresetName: String = ""
     @State private var showSystemFontPicker: Bool = false
     @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
+    @AppStorage("animateEpubTapTurns") private var animateEpubTapTurns: Bool = AppConfig.animateEpubTapTurns
     @AppStorage("epubShowsProgressFooter") private var epubShowsProgressFooter: Bool = false
     @AppStorage("epubShowKeyboardHelpOverlay")
     private var showKeyboardHelpOverlay: Bool = AppConfig.epubShowKeyboardHelpOverlay
@@ -175,6 +176,15 @@
                 }
               }
               .pickerStyle(.menu)
+
+              Toggle(isOn: $animateEpubTapTurns) {
+                VStack(alignment: .leading, spacing: 4) {
+                  Text("Animate Page Turns")
+                  Text("Use animation when tapping zones to turn pages")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+              }
 
               if draft.flowStyle.isPaged {
                 Picker(

--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -21,7 +21,7 @@ struct ReaderSettingsSheet: View {
   @AppStorage("tapZoneMode") private var tapZoneMode: TapZoneMode = .auto
   @AppStorage("showTapZoneHints") private var showTapZoneHints: Bool = true
   @AppStorage("tapZoneSize") private var tapZoneSize: TapZoneSize = .large
-  @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.3
+  @AppStorage("animateTapTurns") private var animateTapTurns: Bool = AppConfig.animateTapTurns
   @AppStorage("showKeyboardHelpOverlay") private var showKeyboardHelpOverlay: Bool = true
   @AppStorage("autoFullscreenOnOpen") private var autoFullscreenOnOpen: Bool = false
   @AppStorage("enableLiveText") private var enableLiveText: Bool = false
@@ -44,16 +44,8 @@ struct ReaderSettingsSheet: View {
     !isWebtoonDirection
   }
 
-  private var shouldShowTapTransitionDuration: Bool {
-    shouldShowPagedTurnSettings && pageTransitionStyle != .pageCurl
-  }
-
-  private var tapPageTransitionDurationText: String {
-    if tapPageTransitionDuration <= 0 {
-      return String(localized: "Page Turn Animation Off")
-    }
-
-    return String(format: "%.1fs", tapPageTransitionDuration)
+  private var shouldShowTapTurnAnimation: Bool {
+    isWebtoonDirection || shouldShowPagedTurnSettings
   }
 
   var body: some View {
@@ -241,27 +233,20 @@ struct ReaderSettingsSheet: View {
                 .foregroundColor(.secondary)
             }
 
-            #if os(iOS) || os(macOS)
-              if shouldShowTapTransitionDuration {
-                VStack(alignment: .leading, spacing: 8) {
-                  HStack {
-                    Text("Page Turn Animation Duration")
-                    Spacer()
-                    Text(tapPageTransitionDurationText)
-                      .foregroundColor(.secondary)
-                  }
-                  Slider(
-                    value: $tapPageTransitionDuration,
-                    in: 0...1,
-                    step: 0.1
-                  )
-                  Text("Animation duration for tap-based page turns. Set to 0 to turn off page turn animation.")
+          }
+
+          #if os(iOS) || os(macOS)
+            if shouldShowTapTurnAnimation {
+              Toggle(isOn: $animateTapTurns) {
+                VStack(alignment: .leading, spacing: 4) {
+                  Text("Animate Page Turns")
+                  Text("Use animation when tapping zones to turn pages")
                     .font(.caption)
                     .foregroundColor(.secondary)
                 }
               }
-            #endif
-          }
+            }
+          #endif
 
           Toggle(isOn: $showKeyboardHelpOverlay) {
             Text("Auto-Show Keyboard Help")

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -1084,8 +1084,15 @@
         }
         cancelDeferredMaintenance()
         preheatPages(at: targetOffset, in: collectionView)
-        isProgrammaticAnimatedScroll = true
-        collectionView.setContentOffset(CGPoint(x: 0, y: targetOffset), animated: true)
+        let shouldAnimate = AppConfig.animateTapTurns
+        isProgrammaticAnimatedScroll = shouldAnimate
+        collectionView.setContentOffset(
+          CGPoint(x: 0, y: targetOffset),
+          animated: shouldAnimate
+        )
+        if !shouldAnimate {
+          finalizeScrollInteraction()
+        }
       }
 
       private func preheatPages(at targetOffset: CGFloat, in collectionView: UICollectionView) {

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
@@ -967,17 +967,26 @@
         preheatPages(at: targetY)
 
         isProgrammaticScrolling = true
-        NSAnimationContext.runAnimationGroup { context in
-          context.duration = WebtoonConstants.scrollAnimationDuration
-          context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-          context.allowsImplicitAnimation = true
-          clipView.animator().scroll(to: NSPoint(x: 0, y: targetY))
-        } completionHandler: { [weak self, weak scrollView, weak clipView] in
-          Task { @MainActor [weak self, weak scrollView, weak clipView] in
-            self?.finalizeProgrammaticScroll()
-            guard let scrollView, let clipView else { return }
-            scrollView.reflectScrolledClipView(clipView)
-          }
+        if AppConfig.animateTapTurns {
+          NSAnimationContext.runAnimationGroup(
+            { context in
+              context.duration = WebtoonConstants.scrollAnimationDuration
+              context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+              context.allowsImplicitAnimation = true
+              clipView.animator().scroll(to: NSPoint(x: 0, y: targetY))
+            },
+            completionHandler: { [weak self, weak scrollView, weak clipView] in
+              Task { @MainActor [weak self, weak scrollView, weak clipView] in
+                self?.finalizeProgrammaticScroll()
+                guard let scrollView, let clipView else { return }
+                scrollView.reflectScrolledClipView(clipView)
+              }
+            }
+          )
+        } else {
+          clipView.scroll(to: NSPoint(x: 0, y: targetY))
+          finalizeProgrammaticScroll()
+          scrollView.reflectScrolledClipView(clipView)
         }
       }
 

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -21,7 +21,7 @@ struct DivinaPreferencesView: View {
   @AppStorage("forceDefaultReadingDirection") private var forceDefaultReadingDirection: Bool = false
   @AppStorage("showPageNumber") private var showPageNumber: Bool = true
   @AppStorage("showPageShadow") private var showPageShadow: Bool = AppConfig.showPageShadow
-  @AppStorage("tapPageTransitionDuration") private var tapPageTransitionDuration: Double = 0.3
+  @AppStorage("animateTapTurns") private var animateTapTurns: Bool = AppConfig.animateTapTurns
   @AppStorage("pageTransitionStyle") private var pageTransitionStyle: PageTransitionStyle = .cover
   @AppStorage("doubleTapZoomScale") private var doubleTapZoomScale: Double = 3.0
   @AppStorage("doubleTapZoomMode") private var doubleTapZoomMode: DoubleTapZoomMode = .fast
@@ -51,16 +51,8 @@ struct DivinaPreferencesView: View {
     return forcedReadingDirection != .webtoon
   }
 
-  private var shouldShowTapTransitionDuration: Bool {
-    shouldShowPagedSpecificSettings && pageTransitionStyle != .pageCurl
-  }
-
-  private var tapPageTransitionDurationText: String {
-    if tapPageTransitionDuration <= 0 {
-      return String(localized: "Page Turn Animation Off")
-    }
-
-    return String(format: "%.1fs", tapPageTransitionDuration)
+  private var shouldShowTapTurnAnimation: Bool {
+    shouldShowWebtoonSpecificSettings || shouldShowPagedSpecificSettings
   }
 
   private var shouldShowWebtoonTapNavigationSettings: Bool {
@@ -344,27 +336,20 @@ struct DivinaPreferencesView: View {
               .foregroundColor(.secondary)
           }
 
-          #if os(iOS) || os(macOS)
-            if shouldShowTapTransitionDuration {
-              VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                  Text("Page Turn Animation Duration")
-                  Spacer()
-                  Text(tapPageTransitionDurationText)
-                    .foregroundColor(.secondary)
-                }
-                Slider(
-                  value: $tapPageTransitionDuration,
-                  in: 0...1,
-                  step: 0.1
-                )
-                Text("Animation duration for tap-based page turns. Set to 0 to turn off page turn animation.")
+        }
+
+        #if os(iOS) || os(macOS)
+          if shouldShowTapTurnAnimation {
+            Toggle(isOn: $animateTapTurns) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Animate Page Turns")
+                Text("Use animation when tapping zones to turn pages")
                   .font(.caption)
                   .foregroundColor(.secondary)
               }
             }
-          #endif
-        }
+          }
+        #endif
 
         Toggle(isOn: $showKeyboardHelpOverlay) {
           VStack(alignment: .leading, spacing: 4) {

--- a/KMReader/Features/Settings/EpubPreferencesView.swift
+++ b/KMReader/Features/Settings/EpubPreferencesView.swift
@@ -23,6 +23,7 @@
     @State private var newPresetName: String = ""
     @State private var fontListRefreshId: UUID = UUID()
     @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
+    @AppStorage("animateEpubTapTurns") private var animateEpubTapTurns: Bool = AppConfig.animateEpubTapTurns
     @AppStorage("epubShowsStatusBarWhileReading") private var epubShowsStatusBarWhileReading: Bool = false
     @AppStorage("epubShowsProgressFooter") private var epubShowsProgressFooter: Bool = false
     @AppStorage("epubShowKeyboardHelpOverlay")
@@ -162,6 +163,15 @@
             }
           }
           .pickerStyle(.menu)
+
+          Toggle(isOn: $animateEpubTapTurns) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Animate Page Turns")
+              Text("Use animation when tapping zones to turn pages")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+          }
 
           if draft.flowStyle.isPaged {
             Picker(String(localized: "Page Transition Style"), selection: $epubPageTransitionStyle) {

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -4381,66 +4381,66 @@
         }
       }
     },
-    "Animation duration for tap-based page turns. Set to 0 to turn off page turn animation." : {
+    "Animate Page Turns" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Animationsdauer für tipbasierte Seitenwechsel. Auf 0 setzen, um die Blätteranimation auszuschalten."
+            "value" : "Seitenwechsel animieren"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Animation duration for tap-based page turns. Set to 0 to turn off page turn animation."
+            "value" : "Animate Page Turns"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Duración de la animación para el cambio de página al tocar. Establécela en 0 para desactivar la animación de cambio de página."
+            "value" : "Animar cambios de página"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Durée de l'animation pour le changement de page par appui. Réglez sur 0 pour désactiver l'animation de changement de page."
+            "value" : "Animer les changements de page"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Durata dell'animazione per il cambio pagina tramite tocco. Imposta 0 per disattivare l'animazione di cambio pagina."
+            "value" : "Anima i cambi di pagina"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "タップでページを切り替える際のアニメーション時間です。0 にするとページめくりアニメーションをオフにします。"
+            "value" : "ページめくりをアニメーション表示"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "탭으로 페이지를 넘길 때의 애니메이션 시간입니다. 0으로 설정하면 페이지 넘김 애니메이션이 꺼집니다."
+            "value" : "페이지 넘김 애니메이션"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Длительность анимации перелистывания при переходе по тапу. Установите 0, чтобы отключить анимацию перелистывания."
+            "value" : "Анимировать перелистывание страниц"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "设置点击翻页时的动画时长。设为 0 可关闭翻页动画。"
+            "value" : "翻页动画"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "設定點擊翻頁時的動畫時長。設為 0 可關閉翻頁動畫。"
+            "value" : "翻頁動畫"
           }
         }
       }
@@ -48287,134 +48287,6 @@
         }
       }
     },
-    "Page Turn Animation Duration" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dauer der Blätteranimation"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Turn Animation Duration"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Duración de la animación de cambio de página"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durée de l'animation de changement de page"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durata animazione cambio pagina"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ページめくりアニメーション時間"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "페이지 넘김 애니메이션 시간"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Длительность анимации перелистывания"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "翻页动画时长"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "翻頁動畫時長"
-          }
-        }
-      }
-    },
-    "Page Turn Animation Off" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blätteranimation aus"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Page Turn Animation Off"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Animación de cambio de página desactivada"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Animation de changement de page désactivée"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Animazione cambio pagina disattivata"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ページめくりアニメーションオフ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "페이지 넘김 애니메이션 끔"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Анимация перелистывания отключена"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭翻页动画"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "關閉翻頁動畫"
-          }
-        }
-      }
-    },
     "Pages Read" : {
       "localizations" : {
         "de" : {
@@ -52123,134 +51995,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "當前頁像蓋板一樣滑開，下一頁保持靜止"
-          }
-        }
-      }
-    },
-    "reader.page_transition.none" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "None"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ninguna"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nessuna"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "なし"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "없음"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無"
-          }
-        }
-      }
-    },
-    "reader.page_transition.none.description" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wechselt Seiten sofort ohne Animation."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Change pages instantly without animation."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia de página al instante, sin animación."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Change de page instantanément, sans animation."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia pagina istantaneamente, senza animazione."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アニメーションなしで即座にページを切り替えます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "애니메이션 없이 즉시 페이지를 전환합니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Мгновенно переключает страницы без анимации."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无动画，立即切换页面。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無動畫，立即切換頁面。"
           }
         }
       }
@@ -74971,6 +74715,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "URL 連結"
+          }
+        }
+      }
+    },
+    "Use animation when tapping zones to turn pages" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Animation beim Umblättern über Tippzonen verwenden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use animation when tapping zones to turn pages"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usar animación al tocar zonas para cambiar de página"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utiliser une animation lorsque les zones tactiles changent de page"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa animazioni quando tocchi le zone per cambiare pagina"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タップゾーンでページをめくるときにアニメーションを使用します"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탭 영역으로 페이지를 넘길 때 애니메이션 사용"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Использовать анимацию при перелистывании через зоны касания"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击区域翻页时使用动画"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點擊區域翻頁時使用動畫"
           }
         }
       }


### PR DESCRIPTION
## Problem
The tap page turn duration slider was more detailed than the reader behavior needed, and EPUB also had a separate `None` transition style that duplicated the new animation toggle concept.

## Approach
Replace the duration value with boolean animation preferences. DIVINA and Webtoon use `animateTapTurns`, while EPUB gets its own `animateEpubTapTurns` setting surfaced in the EPUB preferences UI. Reader transition paths now consume those booleans directly, including page curl, cover, scroll, and scrolled EPUB flows.

## Scope
- Replace tap turn duration storage with boolean animation toggles
- Add an EPUB-specific tap turn animation setting
- Remove the redundant EPUB `None` page transition style
- Update localized strings for the simplified settings
- Bump build version to 416

## Validation
- [x] `make format`
- [x] `make build`
- [x] `make localize`
- [x] `./misc/translate.py list`
