### PR TITLE
feat: add native pdf scroll mode setting

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 416;
+				CURRENT_PROJECT_VERSION = 417;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 416;
+				CURRENT_PROJECT_VERSION = 417;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 416;
+				CURRENT_PROJECT_VERSION = 417;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 416;
+				CURRENT_PROJECT_VERSION = 417;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -139,6 +139,16 @@ enum AppConfig {
     set { UserDefaults.standard.set(newValue.rawValue, forKey: "pdfOfflineRenderQuality") }
   }
 
+  static nonisolated var pdfContinuousScroll: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "pdfContinuousScroll") != nil {
+        return UserDefaults.standard.bool(forKey: "pdfContinuousScroll")
+      }
+      return false
+    }
+    set { UserDefaults.standard.set(newValue, forKey: "pdfContinuousScroll") }
+  }
+
   static nonisolated var isOffline: Bool {
     get { UserDefaults.standard.bool(forKey: "isOffline") }
     set { UserDefaults.standard.set(newValue, forKey: "isOffline") }

--- a/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_iOS.swift
@@ -6,6 +6,7 @@
     let documentURL: URL
     let pageLayout: PageLayout
     let isolateCoverPage: Bool
+    let continuousScroll: Bool
     let readingDirection: ReadingDirection
     let initialPageNumber: Int
     let targetPageNumber: Int?
@@ -75,40 +76,47 @@
 
       if coordinator.lastResolvedPageLayout == resolvedLayout,
         coordinator.lastResolvedReadingDirection == direction,
-        coordinator.lastResolvedIsolateCoverPage == isolateCoverPage
+        coordinator.lastResolvedIsolateCoverPage == isolateCoverPage,
+        coordinator.lastResolvedContinuousScroll == continuousScroll
       {
         return
       }
 
       let currentPage = pdfView.currentPage
-      let currentPageNumberBeforeConfiguration = currentPageNumber(in: pdfView)
+      let targetPageAfterConfiguration =
+        currentPageNumber(in: pdfView)
+        ?? (coordinator.lastKnownPageNumber > 0 ? coordinator.lastKnownPageNumber : initialPageNumber)
       let displayMode: PDFDisplayMode
 
       switch resolvedLayout {
       case .dual:
-        displayMode = .twoUpContinuous
+        displayMode = continuousScroll ? .twoUpContinuous : .twoUp
       case .single, .auto:
-        displayMode = .singlePageContinuous
+        displayMode = continuousScroll ? .singlePageContinuous : .singlePage
       }
 
       pdfView.displayMode = displayMode
       pdfView.displayDirection = direction == .vertical ? .vertical : .horizontal
       pdfView.displaysRTL = direction == .rtl
       pdfView.displaysAsBook = resolvedLayout == .dual && isolateCoverPage
-      pdfView.usePageViewController(false, withViewOptions: nil)
+      pdfView.usePageViewController(!continuousScroll, withViewOptions: nil)
 
       coordinator.lastResolvedPageLayout = resolvedLayout
       coordinator.lastResolvedReadingDirection = direction
       coordinator.lastResolvedIsolateCoverPage = isolateCoverPage
+      coordinator.lastResolvedContinuousScroll = continuousScroll
 
       if let currentPage {
-        if currentPageNumber(in: pdfView) != currentPageNumberBeforeConfiguration {
-          pdfView.go(to: currentPage)
-        }
+        pdfView.go(to: currentPage)
       } else if pdfView.document != nil {
-        let fallbackPage = coordinator.lastKnownPageNumber > 0 ? coordinator.lastKnownPageNumber : initialPageNumber
-        goToPage(fallbackPage, in: pdfView)
+        goToPage(targetPageAfterConfiguration, in: pdfView)
       }
+
+      scheduleInitialPageCorrection(
+        targetPage: targetPageAfterConfiguration,
+        in: pdfView,
+        coordinator: coordinator
+      )
     }
 
     private func resolvedPageLayout(for size: CGSize) -> PageLayout {
@@ -138,8 +146,8 @@
       in pdfView: PDFView,
       coordinator: Coordinator
     ) {
-      // In continuous mode, PDFKit may reset current page multiple times
-      // during initial layout; retry briefly until the target page sticks.
+      // PDFKit may reset current page multiple times during initial layout;
+      // retry briefly until the target page sticks.
       let retryDelays: [TimeInterval] = [0.0, 0.05, 0.2, 0.5]
       for delay in retryDelays {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak pdfView, weak coordinator] in
@@ -167,6 +175,7 @@
       var lastResolvedPageLayout: PageLayout?
       var lastResolvedReadingDirection: ReadingDirection?
       var lastResolvedIsolateCoverPage: Bool?
+      var lastResolvedContinuousScroll: Bool?
       var lastKnownPageNumber: Int = 1
       private weak var observedPDFView: PDFView?
       private weak var singleTapRecognizer: UITapGestureRecognizer?

--- a/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_macOS.swift
@@ -6,6 +6,7 @@
     let documentURL: URL
     let pageLayout: PageLayout
     let isolateCoverPage: Bool
+    let continuousScroll: Bool
     let readingDirection: ReadingDirection
     let initialPageNumber: Int
     let targetPageNumber: Int?
@@ -75,20 +76,23 @@
 
       if coordinator.lastResolvedPageLayout == resolvedLayout,
         coordinator.lastResolvedReadingDirection == direction,
-        coordinator.lastResolvedIsolateCoverPage == isolateCoverPage
+        coordinator.lastResolvedIsolateCoverPage == isolateCoverPage,
+        coordinator.lastResolvedContinuousScroll == continuousScroll
       {
         return
       }
 
       let currentPage = pdfView.currentPage
-      let currentPageNumberBeforeConfiguration = currentPageNumber(in: pdfView)
+      let targetPageAfterConfiguration =
+        currentPageNumber(in: pdfView)
+        ?? (coordinator.lastKnownPageNumber > 0 ? coordinator.lastKnownPageNumber : initialPageNumber)
       let displayMode: PDFDisplayMode
 
       switch resolvedLayout {
       case .dual:
-        displayMode = .twoUpContinuous
+        displayMode = continuousScroll ? .twoUpContinuous : .twoUp
       case .single, .auto:
-        displayMode = .singlePageContinuous
+        displayMode = continuousScroll ? .singlePageContinuous : .singlePage
       }
 
       pdfView.displayMode = displayMode
@@ -99,15 +103,19 @@
       coordinator.lastResolvedPageLayout = resolvedLayout
       coordinator.lastResolvedReadingDirection = direction
       coordinator.lastResolvedIsolateCoverPage = isolateCoverPage
+      coordinator.lastResolvedContinuousScroll = continuousScroll
 
       if let currentPage {
-        if currentPageNumber(in: pdfView) != currentPageNumberBeforeConfiguration {
-          pdfView.go(to: currentPage)
-        }
+        pdfView.go(to: currentPage)
       } else if pdfView.document != nil {
-        let fallbackPage = coordinator.lastKnownPageNumber > 0 ? coordinator.lastKnownPageNumber : initialPageNumber
-        goToPage(fallbackPage, in: pdfView)
+        goToPage(targetPageAfterConfiguration, in: pdfView)
       }
+
+      scheduleInitialPageCorrection(
+        targetPage: targetPageAfterConfiguration,
+        in: pdfView,
+        coordinator: coordinator
+      )
     }
 
     private func resolvedPageLayout(for size: CGSize) -> PageLayout {
@@ -134,8 +142,8 @@
       in pdfView: PDFView,
       coordinator: Coordinator
     ) {
-      // In continuous mode, PDFKit may reset current page multiple times
-      // during initial layout; retry briefly until the target page sticks.
+      // PDFKit may reset current page multiple times during initial layout;
+      // retry briefly until the target page sticks.
       let retryDelays: [TimeInterval] = [0.0, 0.05, 0.2, 0.5]
       for delay in retryDelays {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak pdfView, weak coordinator] in
@@ -163,6 +171,7 @@
       var lastResolvedPageLayout: PageLayout?
       var lastResolvedReadingDirection: ReadingDirection?
       var lastResolvedIsolateCoverPage: Bool?
+      var lastResolvedContinuousScroll: Bool?
       var lastKnownPageNumber: Int = 1
       private weak var observedPDFView: PDFView?
       private weak var singleClickRecognizer: NSClickGestureRecognizer?

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -20,6 +20,8 @@
     private var forceDefaultReadingDirection: Bool = false
     @AppStorage("pdfPageLayout") private var pageLayout: PageLayout = .auto
     @AppStorage("pdfIsolateCoverPage") private var isolateCoverPage: Bool = true
+    @AppStorage("pdfContinuousScroll")
+    private var continuousScroll: Bool = AppConfig.pdfContinuousScroll
     @AppStorage("pdfShowKeyboardHelpOverlay")
     private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
 
@@ -227,7 +229,7 @@
     }
 
     private var documentViewIdentity: String {
-      "continuous-\(book.id)"
+      "native-pdf-\(book.id)"
     }
 
     private var documentInitialPage: Int {
@@ -281,6 +283,7 @@
           documentURL: documentURL,
           pageLayout: pageLayout,
           isolateCoverPage: isolateCoverPage,
+          continuousScroll: continuousScroll,
           readingDirection: readingDirection,
           initialPageNumber: documentInitialPage,
           targetPageNumber: targetPageNumber,

--- a/KMReader/Features/Settings/PdfPreferencesView.swift
+++ b/KMReader/Features/Settings/PdfPreferencesView.swift
@@ -14,6 +14,8 @@
     private var pageLayout: PageLayout = .auto
     @AppStorage("pdfIsolateCoverPage")
     private var isolateCoverPage: Bool = true
+    @AppStorage("pdfContinuousScroll")
+    private var continuousScroll: Bool = AppConfig.pdfContinuousScroll
     @AppStorage("pdfShowKeyboardHelpOverlay")
     private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
     @AppStorage("pdfOfflineRenderQuality")
@@ -98,9 +100,18 @@
               }
               .pickerStyle(.menu)
 
-              Text("Used for single and dual-page presentation in continuous mode")
+              Text("Used for single and dual-page presentation")
                 .font(.caption)
                 .foregroundColor(.secondary)
+            }
+
+            Toggle(isOn: $continuousScroll) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Continuous Scroll")
+                Text("Scroll through pages continuously instead of paging one page or spread at a time.")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+              }
             }
 
             if pageLayout.supportsDualPageOptions {

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -13469,6 +13469,70 @@
         }
       }
     },
+    "Continuous Scroll" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontinuierlicher Bildlauf"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuous Scroll"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desplazamiento continuo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Défilement continu"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scorrimento continuo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連続スクロール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연속 스크롤"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Непрерывная прокрутка"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连续滚动"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連續捲動"
+          }
+        }
+      }
+    },
     "Copy" : {
       "localizations" : {
         "de" : {
@@ -57247,6 +57311,70 @@
         }
       }
     },
+    "Scroll through pages continuously instead of paging one page or spread at a time." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seiten fortlaufend durchblättern, statt jeweils eine Seite oder Doppelseite umzuschalten."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scroll through pages continuously instead of paging one page or spread at a time."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desplázate por las páginas de forma continua en lugar de avanzar una página o pliego cada vez."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faites défiler les pages en continu au lieu de passer une page ou une double page à la fois."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scorri le pagine in modo continuo invece di avanzare una pagina o una doppia pagina alla volta."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1ページまたは見開きごとにページ送りせず、ページを連続してスクロールします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "한 번에 한 페이지나 펼침면씩 넘기는 대신 페이지를 연속해서 스크롤합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прокручивать страницы непрерывно вместо постраничного перехода по одной странице или развороту."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连续滚动页面，而不是每次翻动一页或一组跨页。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連續捲動頁面，而不是每次翻動一頁或一組跨頁。"
+          }
+        }
+      }
+    },
     "Search" : {
       "localizations" : {
         "de" : {
@@ -74911,66 +75039,66 @@
         }
       }
     },
-    "Used for single and dual-page presentation in continuous mode" : {
+    "Used for single and dual-page presentation" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wird für die Einzel- und Doppelseitenanzeige im kontinuierlichen Modus verwendet"
+            "value" : "Wird für Einzel- und Doppelseitenanzeige verwendet"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Used for single and dual-page presentation in continuous mode"
+            "value" : "Used for single and dual-page presentation"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Se usa para presentacion de pagina unica y doble en modo continuo"
+            "value" : "Se usa para la presentación de página única y doble"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Utilisé pour l'affichage en page simple et en double page en mode défilement continu"
+            "value" : "Utilisé pour l'affichage en page simple et en double page"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Usato per la presentazione a pagina singola e doppia in modalita continua"
+            "value" : "Usato per la presentazione a pagina singola e doppia"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "連続スクロールモードでの単ページおよび見開き表示に使用されます"
+            "value" : "単ページおよび見開き表示に使用されます"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "연속 스크롤 모드에서 단일 및 양면 페이지 표시 방식에 사용됩니다"
+            "value" : "단일 및 양면 페이지 표시 방식에 사용됩니다"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Используется для одиночного и двойного отображения страниц в непрерывном режиме"
+            "value" : "Используется для одиночного и двойного отображения страниц"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "用于连续滚动模式下的单页和双页显示"
+            "value" : "用于单页和双页显示"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "用於連續捲動模式下的單頁與雙頁顯示"
+            "value" : "用於單頁與雙頁顯示"
           }
         }
       }


### PR DESCRIPTION
## Problem
The native PDF reader always used continuous PDFKit display modes, so swiping could move across page boundaries even when users expected page-by-page reading. Switching from paged mode back to continuous mode also needed to keep the visible document position aligned with the current page.

Refs #574

## Approach
Add a native PDF reader setting for continuous scrolling and default it off, mapping PDFKit display modes from the explicit single/dual page layout plus the continuous-scroll toggle. When PDFKit display configuration changes, re-anchor the view to the active page and retry briefly after layout resets so the visible page matches the reader progress state.

## Scope
- Add `pdfContinuousScroll` persisted configuration
- Add the PDF reader settings toggle and translations
- Switch iOS/macOS PDFKit display modes between paged and continuous variants
- Preserve current reading position while changing display modes
- Bump build version to 417

## Validation
- [x] `make format`
- [x] `make build`
- [x] `make localize`
- [x] `./misc/translate.py list`
- [x] `jq empty KMReader/Localizable.xcstrings`
