### PR TITLE
feat: add reader control gradient settings

### DIFF
--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -127,6 +127,16 @@ enum AppConfig {
     set { UserDefaults.standard.set(newValue, forKey: "enableDivinaImageContextMenu") }
   }
 
+  static nonisolated var showDivinaControlsGradientBackground: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "showDivinaControlsGradientBackground") != nil {
+        return UserDefaults.standard.bool(forKey: "showDivinaControlsGradientBackground")
+      }
+      return false
+    }
+    set { UserDefaults.standard.set(newValue, forKey: "showDivinaControlsGradientBackground") }
+  }
+
   static nonisolated var pdfOfflineRenderQuality: PdfOfflineRenderQuality {
     get {
       if let stored = UserDefaults.standard.string(forKey: "pdfOfflineRenderQuality"),
@@ -147,6 +157,16 @@ enum AppConfig {
       return false
     }
     set { UserDefaults.standard.set(newValue, forKey: "pdfContinuousScroll") }
+  }
+
+  static nonisolated var showPdfControlsGradientBackground: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "showPdfControlsGradientBackground") != nil {
+        return UserDefaults.standard.bool(forKey: "showPdfControlsGradientBackground")
+      }
+      return false
+    }
+    set { UserDefaults.standard.set(newValue, forKey: "showPdfControlsGradientBackground") }
   }
 
   static nonisolated var isOffline: Bool {

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -27,6 +27,7 @@ struct DivinaControlsOverlayView: View {
   let onNextBook: ((String) -> Void)?
   let controlsVisible: Bool
   let showingControls: Bool
+  let showGradientBackground: Bool
 
   #if os(tvOS)
     private enum ControlFocus: Hashable {
@@ -391,15 +392,17 @@ struct DivinaControlsOverlayView: View {
     startPoint: UnitPoint,
     endPoint: UnitPoint
   ) -> some View {
-    LinearGradient(
-      gradient: Gradient(colors: [
-        Color.black.opacity(0.72),
-        Color.black.opacity(0.44),
-        Color.clear,
-      ]),
-      startPoint: startPoint,
-      endPoint: endPoint
-    )
+    if showGradientBackground {
+      LinearGradient(
+        gradient: Gradient(colors: [
+          Color.black.opacity(0.72),
+          Color.black.opacity(0.44),
+          Color.clear,
+        ]),
+        startPoint: startPoint,
+        endPoint: endPoint
+      )
+    }
   }
 
   @ViewBuilder

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -30,6 +30,9 @@ struct DivinaReaderView: View {
   @AppStorage("enableLiveText") private var enableLiveText: Bool = false
   @AppStorage("enableDivinaImageContextMenu")
   private var enableDivinaImageContextMenu: Bool = AppConfig.enableDivinaImageContextMenu
+  @AppStorage("showDivinaControlsGradientBackground")
+  private var showControlsGradientBackground: Bool =
+    AppConfig.showDivinaControlsGradientBackground
   @AppStorage("doubleTapZoomScale") private var doubleTapZoomScale: Double = 3.0
   @AppStorage("doubleTapZoomMode") private var doubleTapZoomMode: DoubleTapZoomMode = .fast
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
@@ -821,7 +824,8 @@ struct DivinaReaderView: View {
       onPreviousBook: { openPreviousBook(previousBookId: $0) },
       onNextBook: { openNextBook(nextBookId: $0) },
       controlsVisible: shouldShowControls,
-      showingControls: showingControls
+      showingControls: showingControls,
+      showGradientBackground: showControlsGradientBackground
     )
   }
 

--- a/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
@@ -20,6 +20,7 @@
     let hasTOC: Bool
     let canSearch: Bool
     let controlsVisible: Bool
+    let showGradientBackground: Bool
     let onDismiss: () -> Void
 
     private var animation: Animation {
@@ -256,15 +257,17 @@
       startPoint: UnitPoint,
       endPoint: UnitPoint
     ) -> some View {
-      LinearGradient(
-        gradient: Gradient(colors: [
-          Color.black.opacity(0.72),
-          Color.black.opacity(0.44),
-          Color.clear,
-        ]),
-        startPoint: startPoint,
-        endPoint: endPoint
-      )
+      if showGradientBackground {
+        LinearGradient(
+          gradient: Gradient(colors: [
+            Color.black.opacity(0.72),
+            Color.black.opacity(0.44),
+            Color.clear,
+          ]),
+          startPoint: startPoint,
+          endPoint: endPoint
+        )
+      }
     }
 
     private var titleText: String {

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -24,6 +24,9 @@
     private var continuousScroll: Bool = AppConfig.pdfContinuousScroll
     @AppStorage("pdfShowKeyboardHelpOverlay")
     private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
+    @AppStorage("showPdfControlsGradientBackground")
+    private var showControlsGradientBackground: Bool =
+      AppConfig.showPdfControlsGradientBackground
 
     @State private var viewModel: PdfReaderViewModel
     @State private var readingDirection: ReadingDirection
@@ -326,6 +329,7 @@
         hasTOC: !viewModel.tableOfContents.isEmpty,
         canSearch: viewModel.documentURL != nil,
         controlsVisible: shouldShowControls,
+        showGradientBackground: showControlsGradientBackground,
         onDismiss: closeReader
       )
     }

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -35,6 +35,9 @@ struct DivinaPreferencesView: View {
   @AppStorage("enableLiveText") private var enableLiveText: Bool = false
   @AppStorage("enableDivinaImageContextMenu")
   private var enableDivinaImageContextMenu: Bool = AppConfig.enableDivinaImageContextMenu
+  @AppStorage("showDivinaControlsGradientBackground")
+  private var showControlsGradientBackground: Bool =
+    AppConfig.showDivinaControlsGradientBackground
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
 
   private var forcedReadingDirection: ReadingDirection? {
@@ -159,6 +162,15 @@ struct DivinaPreferencesView: View {
           VStack(alignment: .leading, spacing: 4) {
             Text("Show Page Shadow")
             Text("Render a subtle shadow around pages. Turn off for seamless dual-page spreads.")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+        }
+
+        Toggle(isOn: $showControlsGradientBackground) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Controls Gradient Background")
+            Text("Add a gradient behind reader controls for better contrast over pages.")
               .font(.caption)
               .foregroundColor(.secondary)
           }

--- a/KMReader/Features/Settings/PdfPreferencesView.swift
+++ b/KMReader/Features/Settings/PdfPreferencesView.swift
@@ -18,6 +18,9 @@
     private var continuousScroll: Bool = AppConfig.pdfContinuousScroll
     @AppStorage("pdfShowKeyboardHelpOverlay")
     private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
+    @AppStorage("showPdfControlsGradientBackground")
+    private var showControlsGradientBackground: Bool =
+      AppConfig.showPdfControlsGradientBackground
     @AppStorage("pdfOfflineRenderQuality")
     private var pdfOfflineRenderQuality: PdfOfflineRenderQuality = AppConfig.pdfOfflineRenderQuality
 
@@ -136,6 +139,15 @@
           }
 
           Section(header: Text("Reader Overlay")) {
+            Toggle(isOn: $showControlsGradientBackground) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Controls Gradient Background")
+                Text("Add a gradient behind reader controls for better contrast over pages.")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+              }
+            }
+
             Toggle(isOn: $showKeyboardHelpOverlay) {
               VStack(alignment: .leading, spacing: 4) {
                 Text("Auto-Show Keyboard Help")

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -2845,6 +2845,70 @@
         }
       }
     },
+    "Add a gradient behind reader controls for better contrast over pages." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fügt hinter den Reader-Steuerelementen einen Verlauf hinzu, damit sie auf Seiten besser lesbar sind."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add a gradient behind reader controls for better contrast over pages."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añade un degradado detrás de los controles del lector para mejorar el contraste sobre las páginas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajoute un dégradé derrière les commandes du lecteur pour améliorer le contraste sur les pages."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiunge una sfumatura dietro i controlli del lettore per migliorare il contrasto sulle pagine."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページ上で読みやすくするため、リーダーのコントロール背後にグラデーションを追加します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 위에서 더 잘 보이도록 리더 컨트롤 뒤에 그라데이션을 추가합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавляет градиент за элементами управления читалки, чтобы повысить контраст на страницах."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在阅读器控件后添加渐变，以提升其在页面上的对比度。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在閱讀器控制項後方加入漸層，以提升其在頁面上的對比度。"
+          }
+        }
+      }
+    },
     "Add a library from Komga's web interface to manage it here." : {
       "localizations" : {
         "de" : {
@@ -13529,6 +13593,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "連續捲動"
+          }
+        }
+      }
+    },
+    "Controls Gradient Background" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verlaufshintergrund für Steuerelemente"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controls Gradient Background"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fondo degradado para los controles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fond en dégradé des commandes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sfondo sfumato dei controlli"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コントロールのグラデーション背景"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "컨트롤 그라데이션 배경"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Градиентный фон элементов управления"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控件渐变背景"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控制項漸層背景"
           }
         }
       }


### PR DESCRIPTION
## Problem
Reader controls currently always render gradient backgrounds when shown. That makes the overlay more legible, but it also prevents users from choosing a cleaner controls presentation for PDF and DIVINA readers independently.

## Approach
Add separate AppStorage-backed settings for the PDF reader and DIVINA reader, both defaulting to disabled. The reader root views read those preferences and pass plain boolean values into their controls overlays, keeping the overlay dependency direction explicit.

## Scope
- Add PDF and DIVINA controls gradient background preferences
- Gate the existing top and bottom overlay gradients behind those preferences
- Add settings toggles and localized copy for all supported languages

## Validation
- [x] make format
- [x] make build
- [x] make localize
- [x] ./misc/translate.py list
- [x] python3 -m json.tool KMReader/Localizable.xcstrings >/dev/null
