### PR TITLE
fix: add reader progress shadow

### DIFF
--- a/KMReader/Features/Reader/Views/Epub/WebPubInfoOverlaySupport.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubInfoOverlaySupport.swift
@@ -206,7 +206,11 @@
           bottomProgressTrackView = UIView()
           bottomProgressTrackView.translatesAutoresizingMaskIntoConstraints = false
           bottomProgressTrackView.layer.cornerRadius = 1.5
-          bottomProgressTrackView.clipsToBounds = true
+          bottomProgressTrackView.layer.shadowColor = UIColor.black.cgColor
+          bottomProgressTrackView.layer.shadowOpacity = 0.45
+          bottomProgressTrackView.layer.shadowRadius = 3
+          bottomProgressTrackView.layer.shadowOffset = CGSize(width: 0, height: 1)
+          bottomProgressTrackView.clipsToBounds = false
           bottomProgressTrackView.isUserInteractionEnabled = false
           bottomProgressTrackView.alpha = 0
 
@@ -387,6 +391,10 @@
           bottomProgressTrackView.translatesAutoresizingMaskIntoConstraints = false
           bottomProgressTrackView.wantsLayer = true
           bottomProgressTrackView.layer?.cornerRadius = 1.5
+          bottomProgressTrackView.layer?.shadowColor = NSColor.black.cgColor
+          bottomProgressTrackView.layer?.shadowOpacity = 0.45
+          bottomProgressTrackView.layer?.shadowRadius = 3
+          bottomProgressTrackView.layer?.shadowOffset = CGSize(width: 0, height: -1)
           bottomProgressTrackView.alphaValue = 0
 
           bottomProgressFillView = NSView()

--- a/KMReader/Shared/UI/ReadingProgressBar.swift
+++ b/KMReader/Shared/UI/ReadingProgressBar.swift
@@ -15,21 +15,10 @@ struct ReadingProgressBar: View {
   let height: CGFloat
   let color: Color
   let background: Color
+  let showsShadow: Bool
 
-  init(progress: Double, type: ReadingProgressBarType) {
-    self.progress = progress
-    self.height = PlatformHelper.progressBarHeight
-    switch type {
-    case .reader:
-      self.color = .white
-      self.background = .secondary.opacity(0.4)
-    case .card:
-      self.color = .accentColor
-      self.background = .accentColor.opacity(0.4)
-    }
-  }
-
-  var body: some View {
+  @ViewBuilder
+  private var progressContent: some View {
     GeometryReader { geometry in
       ZStack(alignment: .leading) {
         Capsule()
@@ -43,6 +32,32 @@ struct ReadingProgressBar: View {
             height: height
           )
           .animation(.easeInOut(duration: 0.2), value: progress)
+      }
+    }
+  }
+
+  init(progress: Double, type: ReadingProgressBarType) {
+    self.progress = progress
+    self.height = PlatformHelper.progressBarHeight
+    switch type {
+    case .reader:
+      self.color = .white
+      self.background = .secondary.opacity(0.4)
+      self.showsShadow = true
+    case .card:
+      self.color = .accentColor
+      self.background = .accentColor.opacity(0.4)
+      self.showsShadow = false
+    }
+  }
+
+  var body: some View {
+    Group {
+      if showsShadow {
+        progressContent
+          .shadow(color: .black.opacity(0.35), radius: 3, x: 0, y: 1)
+      } else {
+        progressContent
       }
     }
     .frame(height: height)


### PR DESCRIPTION
## Problem
Reader progress bars can blend into comic pages or EPUB content because they sit directly over reader imagery and text surfaces without any depth treatment.

## Approach
Apply a small black drop shadow only to reader progress bars so the bar gains separation from the underlying content. Card progress bars keep the original flat rendering, and EPUB native overlays get matching layer shadows on both UIKit and AppKit implementations.

## Scope
- Add conditional reader-only shadow rendering to the shared SwiftUI progress bar
- Add matching black layer shadows to EPUB bottom progress tracks on iOS and macOS
- Leave browse/card progress indicators unchanged

## Validation
- [x] `make format`
- [x] `make build-macos`
