### PR TITLE
refactor: align reader settings surfaces

### DIFF
--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -159,6 +159,28 @@ enum AppConfig {
     set { UserDefaults.standard.set(newValue, forKey: "pdfContinuousScroll") }
   }
 
+  static nonisolated var pdfPageLayout: PageLayout {
+    get {
+      if let stored = UserDefaults.standard.string(forKey: "pdfPageLayout"),
+        let layout = PageLayout(rawValue: stored)
+      {
+        return layout
+      }
+      return .auto
+    }
+    set { UserDefaults.standard.set(newValue.rawValue, forKey: "pdfPageLayout") }
+  }
+
+  static nonisolated var pdfIsolateCoverPage: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "pdfIsolateCoverPage") != nil {
+        return UserDefaults.standard.bool(forKey: "pdfIsolateCoverPage")
+      }
+      return true
+    }
+    set { UserDefaults.standard.set(newValue, forKey: "pdfIsolateCoverPage") }
+  }
+
   static nonisolated var showPdfControlsGradientBackground: Bool {
     get {
       if UserDefaults.standard.object(forKey: "showPdfControlsGradientBackground") != nil {

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -1479,7 +1479,8 @@ struct DivinaReaderView: View {
           },
           setSplitWidePageMode: { mode in
             splitWidePageMode = mode
-          }
+          },
+          toggleContinuousScroll: {}
         )
       )
     }

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -904,7 +904,8 @@
             setPageLayout: { _ in },
             toggleIsolateCoverPage: {},
             toggleIsolatePage: { _ in },
-            setSplitWidePageMode: { _ in }
+            setSplitWidePageMode: { _ in },
+            toggleContinuousScroll: {}
           )
         )
       }

--- a/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
@@ -5,6 +5,7 @@
     @Binding var readingDirection: ReadingDirection
     @Binding var pageLayout: PageLayout
     @Binding var isolateCoverPage: Bool
+    @Binding var continuousScroll: Bool
 
     @Binding var showingPageJumpSheet: Bool
     @Binding var showingSearchSheet: Bool
@@ -201,6 +202,10 @@
 
         if pageLayout.supportsDualPageOptions {
           pageIsolation()
+        }
+
+        Toggle(isOn: $continuousScroll) {
+          Label(String(localized: "Continuous Scroll"), systemImage: "scroll")
         }
       } header: {
         Text(String(localized: "Current Reading Options"))

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderSettingsSheet.swift
@@ -2,8 +2,41 @@
   import SwiftUI
 
   struct PdfReaderSettingsSheet: View {
+    @AppStorage("pdfReaderBackground") private var readerBackground: ReaderBackground = .system
+    @AppStorage("pdfShowKeyboardHelpOverlay")
+    private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
+    @AppStorage("showPdfControlsGradientBackground")
+    private var showControlsGradientBackground: Bool =
+      AppConfig.showPdfControlsGradientBackground
+
     var body: some View {
-      PdfPreferencesView(inSheet: true)
+      SheetView(
+        title: String(localized: "Reader Settings"),
+        size: .medium,
+        applyFormStyle: true
+      ) {
+        Form {
+          Section(header: Text("Appearance")) {
+            Picker("Reader Background", selection: $readerBackground) {
+              ForEach(ReaderBackground.allCases, id: \.self) { background in
+                Text(background.displayName).tag(background)
+              }
+            }
+            .pickerStyle(.menu)
+          }
+
+          Section(header: Text("Reader Overlay")) {
+            Toggle(isOn: $showControlsGradientBackground) {
+              Text("Controls Gradient Background")
+            }
+
+            Toggle(isOn: $showKeyboardHelpOverlay) {
+              Text("Auto-Show Keyboard Help")
+            }
+          }
+        }
+      }
+      .presentationDragIndicator(.visible)
     }
   }
 #endif

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -18,10 +18,6 @@
     private var defaultReadingDirection: ReadingDirection = .ltr
     @AppStorage("pdfForceDefaultReadingDirection")
     private var forceDefaultReadingDirection: Bool = false
-    @AppStorage("pdfPageLayout") private var pageLayout: PageLayout = .auto
-    @AppStorage("pdfIsolateCoverPage") private var isolateCoverPage: Bool = true
-    @AppStorage("pdfContinuousScroll")
-    private var continuousScroll: Bool = AppConfig.pdfContinuousScroll
     @AppStorage("pdfShowKeyboardHelpOverlay")
     private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
     @AppStorage("showPdfControlsGradientBackground")
@@ -30,6 +26,9 @@
 
     @State private var viewModel: PdfReaderViewModel
     @State private var readingDirection: ReadingDirection
+    @State private var pageLayout: PageLayout
+    @State private var isolateCoverPage: Bool
+    @State private var continuousScroll: Bool
     @State private var currentBook: Book?
     @State private var currentSeries: Series?
     @State private var showingControls = false
@@ -60,6 +59,9 @@
       self.onClose = onClose
       _viewModel = State(initialValue: PdfReaderViewModel(incognito: incognito))
       _readingDirection = State(initialValue: .ltr)
+      _pageLayout = State(initialValue: AppConfig.pdfPageLayout)
+      _isolateCoverPage = State(initialValue: AppConfig.pdfIsolateCoverPage)
+      _continuousScroll = State(initialValue: AppConfig.pdfContinuousScroll)
       _currentBook = State(initialValue: book)
     }
 
@@ -149,14 +151,6 @@
       .onChange(of: defaultReadingDirection) { _, newDirection in
         if newDirection == .webtoon {
           defaultReadingDirection = .vertical
-        }
-        Task {
-          await refreshPreferredReadingDirection()
-        }
-      }
-      .onChange(of: forceDefaultReadingDirection) { _, _ in
-        Task {
-          await refreshPreferredReadingDirection()
         }
       }
       .onReceive(NotificationCenter.default.publisher(for: .fileDownloadProgress)) { notification in
@@ -316,6 +310,7 @@
         readingDirection: $readingDirection,
         pageLayout: $pageLayout,
         isolateCoverPage: $isolateCoverPage,
+        continuousScroll: $continuousScroll,
         showingPageJumpSheet: $showingPageJumpSheet,
         showingSearchSheet: $showingSearchSheet,
         showingTOCSheet: $showingTOCSheet,
@@ -390,13 +385,6 @@
       readingDirection = resolvePreferredReadingDirection(series: resolvedSeries)
       await viewModel.load(book: resolvedBook)
       updateHandoff()
-    }
-
-    private func refreshPreferredReadingDirection() async {
-      let activeBook = currentBook ?? book
-      let resolvedSeries = await fetchSeries(for: activeBook)
-      currentSeries = resolvedSeries
-      readingDirection = resolvePreferredReadingDirection(series: resolvedSeries)
     }
 
     private func runSearch(query: String) {
@@ -547,12 +535,14 @@
           isolateCoverPage: isolateCoverPage,
           pageIsolationActions: [],
           splitWidePageMode: .none,
+          continuousScroll: continuousScroll,
           supportsSearch: true,
           canSearch: viewModel.documentURL != nil,
           supportsReadingDirectionSelection: true,
           supportsPageLayoutSelection: true,
           supportsDualPageOptions: pageLayout.supportsDualPageOptions,
-          supportsSplitWidePageMode: false
+          supportsSplitWidePageMode: false,
+          supportsContinuousScrollToggle: true
         )
       }
     #endif
@@ -616,7 +606,10 @@
               isolateCoverPage.toggle()
             },
             toggleIsolatePage: { _ in },
-            setSplitWidePageMode: { _ in }
+            setSplitWidePageMode: { _ in },
+            toggleContinuousScroll: {
+              continuousScroll.toggle()
+            }
           )
         )
       }

--- a/KMReader/Features/Reader/Views/ReaderCommandHandlers.swift
+++ b/KMReader/Features/Reader/Views/ReaderCommandHandlers.swift
@@ -13,4 +13,5 @@ struct ReaderCommandHandlers {
   let toggleIsolateCoverPage: () -> Void
   let toggleIsolatePage: (ReaderPageID) -> Void
   let setSplitWidePageMode: (SplitWidePageMode) -> Void
+  let toggleContinuousScroll: () -> Void
 }

--- a/KMReader/Features/Reader/Views/ReaderCommandState.swift
+++ b/KMReader/Features/Reader/Views/ReaderCommandState.swift
@@ -16,10 +16,12 @@ struct ReaderCommandState: Equatable {
   var isolateCoverPage: Bool = true
   var pageIsolationActions: [ReaderPageIsolationActions.Action] = []
   var splitWidePageMode: SplitWidePageMode = .none
+  var continuousScroll: Bool = false
   var supportsSearch: Bool = false
   var canSearch: Bool = false
   var supportsReadingDirectionSelection: Bool = false
   var supportsPageLayoutSelection: Bool = false
   var supportsDualPageOptions: Bool = false
   var supportsSplitWidePageMode: Bool = false
+  var supportsContinuousScrollToggle: Bool = false
 }

--- a/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
+++ b/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
@@ -204,6 +204,10 @@ final class ReaderPresentationManager {
     func setSplitWidePageModeFromCommand(_ mode: SplitWidePageMode) {
       readerCommandHandlers?.setSplitWidePageMode(mode)
     }
+
+    func toggleContinuousScrollFromCommand() {
+      readerCommandHandlers?.toggleContinuousScroll()
+    }
   #endif
 
   private func finishSession(_ session: ReaderSession, syncVisited: Bool) {

--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -35,6 +35,9 @@ struct ReaderSettingsSheet: View {
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
   @AppStorage("enableDivinaImageContextMenu")
   private var enableDivinaImageContextMenu: Bool = AppConfig.enableDivinaImageContextMenu
+  @AppStorage("showDivinaControlsGradientBackground")
+  private var showControlsGradientBackground: Bool =
+    AppConfig.showDivinaControlsGradientBackground
 
   private var isWebtoonDirection: Bool {
     readingDirection == .webtoon
@@ -68,12 +71,11 @@ struct ReaderSettingsSheet: View {
           }
 
           Toggle(isOn: $showPageShadow) {
-            VStack(alignment: .leading, spacing: 4) {
-              Text("Show Page Shadow")
-              Text("Render a subtle shadow around pages. Turn off for seamless dual-page spreads.")
-                .font(.caption)
-                .foregroundColor(.secondary)
-            }
+            Text("Show Page Shadow")
+          }
+
+          Toggle(isOn: $showControlsGradientBackground) {
+            Text("Controls Gradient Background")
           }
 
           #if os(iOS) || os(macOS)
@@ -102,148 +104,22 @@ struct ReaderSettingsSheet: View {
 
         }
 
-        #if os(iOS)
-          Section(header: Text("Zooming")) {
-            Picker("Double Tap to Zoom", selection: $doubleTapZoomMode) {
-              ForEach(DoubleTapZoomMode.allCases, id: \.self) { mode in
-                Text(mode.displayName).tag(mode)
-              }
-            }
-            .pickerStyle(.menu)
-            if doubleTapZoomMode != .disabled {
-              VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                  Text("Double Tap Zoom Scale")
-                  Spacer()
-                  Text(String(format: "%.1fx", doubleTapZoomScale))
-                    .foregroundColor(.secondary)
-                }
-                Slider(
-                  value: $doubleTapZoomScale,
-                  in: 1.0...8.0,
-                  step: 0.5
-                )
-              }
-            }
-          }
-        #endif
-
-        #if os(iOS) || os(macOS)
-          Section(header: Text("Image Upscaling")) {
-            VStack(alignment: .leading, spacing: 8) {
-              Picker("Waifu2x Mode", selection: $imageUpscalingMode) {
-                ForEach(ReaderImageUpscalingMode.allCases, id: \.self) { mode in
-                  Text(mode.displayName).tag(mode)
-                }
-              }
-              .pickerStyle(.menu)
-
-              Text("Improve clarity for low-resolution pages using built-in waifu2x (2x).")
-                .font(.caption)
-                .foregroundColor(.secondary)
-            }
-
-            Group {
-              switch imageUpscalingMode {
-              case .auto:
-                VStack(alignment: .leading, spacing: 8) {
-                  HStack {
-                    Text("Auto Trigger Scale Threshold")
-                    Spacer()
-                    Text(String(format: "%.2fx", imageUpscaleAutoTriggerScale))
-                      .foregroundColor(.secondary)
-                  }
-                  Slider(
-                    value: $imageUpscaleAutoTriggerScale,
-                    in: 1.0...1.5,
-                    step: 0.01
-                  )
-                  Text("Auto scale only when required scale to fit the page on screen is greater than this value.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                }
-              case .always:
-                VStack(alignment: .leading, spacing: 8) {
-                  HStack {
-                    Text("Always Mode Source Size Threshold")
-                    Spacer()
-                    Text(String(format: "%.2fx", imageUpscaleAlwaysMaxScreenScale))
-                      .foregroundColor(.secondary)
-                  }
-                  Slider(
-                    value: $imageUpscaleAlwaysMaxScreenScale,
-                    in: 1.0...3.0,
-                    step: 0.05
-                  )
-                  Text("In Always mode, upscale unless source width or height exceeds this multiple of the screen.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                }
-              case .disabled:
-                EmptyView()
-              }
-            }
-          }
-        #endif
-
-        #if os(iOS) || os(macOS)
-          Section(header: Text("Live Text")) {
-            Toggle(isOn: $enableLiveText) {
-              VStack(alignment: .leading, spacing: 4) {
-                Text("Enable Live Text")
-                Text("Automatically enable Live Text for all images.")
-                  .font(.caption)
-                  .foregroundColor(.secondary)
-              }
-            }
-            #if os(iOS)
-              Toggle(isOn: $shakeToOpenLiveText) {
-                VStack(alignment: .leading, spacing: 4) {
-                  Text("Shake to Open Live Text")
-                  Text("Shake your device to toggle Live Text")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                }
-              }
-            #endif
-          }
-        #endif
-
-        #if os(iOS) || os(macOS)
-          Section(header: Text("Context Menu")) {
-            Toggle(isOn: $enableDivinaImageContextMenu) {
-              Text("Enable Image Context Menu")
-            }
-          }
-        #endif
-
         // MARK: - Page Turn Section
 
         Section(header: Text("Page Turn")) {
           if shouldShowPagedTurnSettings {
-            VStack(alignment: .leading, spacing: 8) {
-              Picker("Page Transition Style", selection: $pageTransitionStyle) {
-                ForEach(PageTransitionStyle.availableCases, id: \.self) { style in
-                  Text(style.displayName).tag(style)
-                }
+            Picker("Page Transition Style", selection: $pageTransitionStyle) {
+              ForEach(PageTransitionStyle.availableCases, id: \.self) { style in
+                Text(style.displayName).tag(style)
               }
-              .pickerStyle(.menu)
-              Text(pageTransitionStyle.description)
-                .font(.caption)
-                .foregroundColor(.secondary)
             }
-
+            .pickerStyle(.menu)
           }
 
           #if os(iOS) || os(macOS)
             if shouldShowTapTurnAnimation {
               Toggle(isOn: $animateTapTurns) {
-                VStack(alignment: .leading, spacing: 4) {
-                  Text("Animate Page Turns")
-                  Text("Use animation when tapping zones to turn pages")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                }
+                Text("Animate Page Turns")
               }
             }
           #endif
@@ -310,6 +186,101 @@ struct ReaderSettingsSheet: View {
             }
           #endif
         }
+
+        #if os(iOS)
+          Section(header: Text("Zooming")) {
+            Picker("Double Tap to Zoom", selection: $doubleTapZoomMode) {
+              ForEach(DoubleTapZoomMode.allCases, id: \.self) { mode in
+                Text(mode.displayName).tag(mode)
+              }
+            }
+            .pickerStyle(.menu)
+            if doubleTapZoomMode != .disabled {
+              VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                  Text("Double Tap Zoom Scale")
+                  Spacer()
+                  Text(String(format: "%.1fx", doubleTapZoomScale))
+                    .foregroundColor(.secondary)
+                }
+                Slider(
+                  value: $doubleTapZoomScale,
+                  in: 1.0...8.0,
+                  step: 0.5
+                )
+              }
+            }
+          }
+        #endif
+
+        #if os(iOS) || os(macOS)
+          Section(header: Text("Image Upscaling")) {
+            VStack(alignment: .leading, spacing: 8) {
+              Picker("Waifu2x Mode", selection: $imageUpscalingMode) {
+                ForEach(ReaderImageUpscalingMode.allCases, id: \.self) { mode in
+                  Text(mode.displayName).tag(mode)
+                }
+              }
+              .pickerStyle(.menu)
+            }
+
+            Group {
+              switch imageUpscalingMode {
+              case .auto:
+                VStack(alignment: .leading, spacing: 8) {
+                  HStack {
+                    Text("Auto Trigger Scale Threshold")
+                    Spacer()
+                    Text(String(format: "%.2fx", imageUpscaleAutoTriggerScale))
+                      .foregroundColor(.secondary)
+                  }
+                  Slider(
+                    value: $imageUpscaleAutoTriggerScale,
+                    in: 1.0...1.5,
+                    step: 0.01
+                  )
+                }
+              case .always:
+                VStack(alignment: .leading, spacing: 8) {
+                  HStack {
+                    Text("Always Mode Source Size Threshold")
+                    Spacer()
+                    Text(String(format: "%.2fx", imageUpscaleAlwaysMaxScreenScale))
+                      .foregroundColor(.secondary)
+                  }
+                  Slider(
+                    value: $imageUpscaleAlwaysMaxScreenScale,
+                    in: 1.0...3.0,
+                    step: 0.05
+                  )
+                }
+              case .disabled:
+                EmptyView()
+              }
+            }
+          }
+        #endif
+
+        #if os(iOS) || os(macOS)
+          Section(header: Text("Live Text")) {
+            Toggle(isOn: $enableLiveText) {
+              Text("Enable Live Text")
+            }
+            #if os(iOS)
+              Toggle(isOn: $shakeToOpenLiveText) {
+                Text("Shake to Open Live Text")
+              }
+            #endif
+          }
+        #endif
+
+        #if os(iOS) || os(macOS)
+          Section(header: Text("Context Menu")) {
+            Toggle(isOn: $enableDivinaImageContextMenu) {
+              Text("Enable Image Context Menu")
+            }
+          }
+        #endif
       }
     }
     .animation(.default, value: tapZoneMode)

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -209,6 +209,123 @@ struct DivinaPreferencesView: View {
         #endif
       }
 
+      Section(header: Text("Page Turn")) {
+        if shouldShowPagedSpecificSettings {
+          VStack(alignment: .leading, spacing: 8) {
+            Picker("Page Transition Style", selection: $pageTransitionStyle) {
+              ForEach(PageTransitionStyle.availableCases, id: \.self) { style in
+                Text(style.displayName).tag(style)
+              }
+            }
+            .pickerStyle(.menu)
+            Text(pageTransitionStyle.description)
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+
+        }
+
+        #if os(iOS) || os(macOS)
+          if shouldShowTapTurnAnimation {
+            Toggle(isOn: $animateTapTurns) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Animate Page Turns")
+                Text("Use animation when tapping zones to turn pages")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+              }
+            }
+          }
+        #endif
+
+        Toggle(isOn: $showKeyboardHelpOverlay) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Auto-Show Keyboard Help")
+            Text("Briefly show keyboard shortcuts when opening the reader")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+        }
+
+        #if os(iOS) || os(macOS)
+          VStack(alignment: .leading, spacing: 8) {
+            Picker("Tap Zone Mode", selection: $tapZoneMode) {
+              ForEach(TapZoneMode.allCases, id: \.self) { mode in
+                Text(mode.displayName).tag(mode)
+              }
+            }
+            .pickerStyle(.menu)
+            Text("Choose how tap zones work: auto matches reading direction, or select a fixed layout")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+
+          if !tapZoneMode.isDisabled {
+            Toggle(isOn: $showTapZoneHints) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Show Tap Zone Hints")
+                Text("Display tap zone hints when opening the reader")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+              }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+              Picker("Tap Zone Size", selection: $tapZoneSize) {
+                ForEach(TapZoneSize.allCases, id: \.self) { size in
+                  Text(size.displayName).tag(size)
+                }
+              }
+              .pickerStyle(.menu)
+
+              HStack(spacing: 12) {
+                switch tapZoneMode {
+                case .none:
+                  EmptyView()
+                case .auto:
+                  TapZonePreview(size: tapZoneSize, direction: .ltr)
+                  TapZonePreview(size: tapZoneSize, direction: .rtl)
+                  TapZonePreview(size: tapZoneSize, direction: .vertical)
+                  TapZonePreview(size: tapZoneSize, direction: .webtoon)
+                case .ltr:
+                  TapZonePreview(size: tapZoneSize, direction: .ltr)
+                case .rtl:
+                  TapZonePreview(size: tapZoneSize, direction: .rtl)
+                case .vertical:
+                  TapZonePreview(size: tapZoneSize, direction: .vertical)
+                case .webtoon:
+                  TapZonePreview(size: tapZoneSize, direction: .webtoon)
+                }
+              }
+              .frame(height: 80)
+
+              Text("Size of tap zones for page navigation")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+
+            if shouldShowWebtoonTapNavigationSettings {
+              VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                  Text("Webtoon Tap Scroll Height")
+                  Spacer()
+                  Text("\(Int(webtoonTapScrollPercentage))%")
+                    .foregroundColor(.secondary)
+                }
+                Slider(
+                  value: $webtoonTapScrollPercentage,
+                  in: 25...100,
+                  step: 5
+                )
+                Text("Scroll distance when tapping to navigate in webtoon mode")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+              }
+            }
+          }
+        #endif
+      }
+
       #if os(iOS)
         Section(header: Text("Zooming")) {
           Picker("Double Tap to Zoom", selection: $doubleTapZoomMode) {
@@ -333,123 +450,6 @@ struct DivinaPreferencesView: View {
           }
         }
       #endif
-
-      Section(header: Text("Page Turn")) {
-        if shouldShowPagedSpecificSettings {
-          VStack(alignment: .leading, spacing: 8) {
-            Picker("Page Transition Style", selection: $pageTransitionStyle) {
-              ForEach(PageTransitionStyle.availableCases, id: \.self) { style in
-                Text(style.displayName).tag(style)
-              }
-            }
-            .pickerStyle(.menu)
-            Text(pageTransitionStyle.description)
-              .font(.caption)
-              .foregroundColor(.secondary)
-          }
-
-        }
-
-        #if os(iOS) || os(macOS)
-          if shouldShowTapTurnAnimation {
-            Toggle(isOn: $animateTapTurns) {
-              VStack(alignment: .leading, spacing: 4) {
-                Text("Animate Page Turns")
-                Text("Use animation when tapping zones to turn pages")
-                  .font(.caption)
-                  .foregroundColor(.secondary)
-              }
-            }
-          }
-        #endif
-
-        Toggle(isOn: $showKeyboardHelpOverlay) {
-          VStack(alignment: .leading, spacing: 4) {
-            Text("Auto-Show Keyboard Help")
-            Text("Briefly show keyboard shortcuts when opening the reader")
-              .font(.caption)
-              .foregroundColor(.secondary)
-          }
-        }
-
-        #if os(iOS) || os(macOS)
-          VStack(alignment: .leading, spacing: 8) {
-            Picker("Tap Zone Mode", selection: $tapZoneMode) {
-              ForEach(TapZoneMode.allCases, id: \.self) { mode in
-                Text(mode.displayName).tag(mode)
-              }
-            }
-            .pickerStyle(.menu)
-            Text("Choose how tap zones work: auto matches reading direction, or select a fixed layout")
-              .font(.caption)
-              .foregroundColor(.secondary)
-          }
-
-          if !tapZoneMode.isDisabled {
-            Toggle(isOn: $showTapZoneHints) {
-              VStack(alignment: .leading, spacing: 4) {
-                Text("Show Tap Zone Hints")
-                Text("Display tap zone hints when opening the reader")
-                  .font(.caption)
-                  .foregroundColor(.secondary)
-              }
-            }
-
-            VStack(alignment: .leading, spacing: 8) {
-              Picker("Tap Zone Size", selection: $tapZoneSize) {
-                ForEach(TapZoneSize.allCases, id: \.self) { size in
-                  Text(size.displayName).tag(size)
-                }
-              }
-              .pickerStyle(.menu)
-
-              HStack(spacing: 12) {
-                switch tapZoneMode {
-                case .none:
-                  EmptyView()
-                case .auto:
-                  TapZonePreview(size: tapZoneSize, direction: .ltr)
-                  TapZonePreview(size: tapZoneSize, direction: .rtl)
-                  TapZonePreview(size: tapZoneSize, direction: .vertical)
-                  TapZonePreview(size: tapZoneSize, direction: .webtoon)
-                case .ltr:
-                  TapZonePreview(size: tapZoneSize, direction: .ltr)
-                case .rtl:
-                  TapZonePreview(size: tapZoneSize, direction: .rtl)
-                case .vertical:
-                  TapZonePreview(size: tapZoneSize, direction: .vertical)
-                case .webtoon:
-                  TapZonePreview(size: tapZoneSize, direction: .webtoon)
-                }
-              }
-              .frame(height: 80)
-
-              Text("Size of tap zones for page navigation")
-                .font(.caption)
-                .foregroundColor(.secondary)
-            }
-
-            if shouldShowWebtoonTapNavigationSettings {
-              VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                  Text("Webtoon Tap Scroll Height")
-                  Spacer()
-                  Text("\(Int(webtoonTapScrollPercentage))%")
-                    .foregroundColor(.secondary)
-                }
-                Slider(
-                  value: $webtoonTapScrollPercentage,
-                  in: 25...100,
-                  step: 5
-                )
-                Text("Scroll distance when tapping to navigate in webtoon mode")
-                  .font(.caption)
-                  .foregroundColor(.secondary)
-              }
-            }
-          }
-        #endif
-      }
 
     }
     .animation(.default, value: tapZoneMode)

--- a/KMReader/Features/Settings/PdfPreferencesView.swift
+++ b/KMReader/Features/Settings/PdfPreferencesView.swift
@@ -2,8 +2,6 @@
   import SwiftUI
 
   struct PdfPreferencesView: View {
-    let inSheet: Bool
-
     @AppStorage("useNativePdfReader") private var useNativePdfReader: Bool = true
     @AppStorage("pdfReaderBackground") private var readerBackground: ReaderBackground = .system
     @AppStorage("pdfDefaultReadingDirection")
@@ -24,36 +22,7 @@
     @AppStorage("pdfOfflineRenderQuality")
     private var pdfOfflineRenderQuality: PdfOfflineRenderQuality = AppConfig.pdfOfflineRenderQuality
 
-    init(inSheet: Bool = false) {
-      self.inSheet = inSheet
-    }
-
     var body: some View {
-      Group {
-        if inSheet {
-          SheetView(
-            title: String(localized: "Reader Settings"),
-            size: .medium,
-            applyFormStyle: true
-          ) {
-            preferencesForm
-          }
-          .presentationDragIndicator(.visible)
-        } else {
-          preferencesForm
-            .formStyle(.grouped)
-            .inlineNavigationBarTitle(SettingsSection.pdfReader.title)
-        }
-      }
-      .onAppear {
-        if defaultReadingDirection == .webtoon {
-          defaultReadingDirection = .vertical
-        }
-      }
-      .animation(.easeInOut(duration: 0.2), value: useNativePdfReader)
-    }
-
-    private var preferencesForm: some View {
       Form {
         Section {
           Toggle(isOn: $useNativePdfReader) {
@@ -178,9 +147,16 @@
                 .foregroundColor(.secondary)
             }
           }
-
         }
       }
+      .onAppear {
+        if defaultReadingDirection == .webtoon {
+          defaultReadingDirection = .vertical
+        }
+      }
+      .animation(.easeInOut(duration: 0.2), value: useNativePdfReader)
+      .formStyle(.grouped)
+      .inlineNavigationBarTitle(SettingsSection.pdfReader.title)
     }
   }
 #endif

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -225,6 +225,7 @@ struct MainApp: App {
           || state.supportsPageLayoutSelection
           || state.supportsDualPageOptions
           || state.supportsSplitWidePageMode
+          || state.supportsContinuousScrollToggle
         {
           Divider()
         }
@@ -295,6 +296,19 @@ struct MainApp: App {
                   Text(mode.displayName)
                 }
               }
+            }
+          }
+          .disabled(!state.isActive)
+        }
+
+        if state.supportsContinuousScrollToggle {
+          Button {
+            readerPresentation.toggleContinuousScrollFromCommand()
+          } label: {
+            if state.continuousScroll {
+              Label(String(localized: "Continuous Scroll"), systemImage: "checkmark")
+            } else {
+              Text(String(localized: "Continuous Scroll"))
             }
           }
           .disabled(!state.isActive)


### PR DESCRIPTION
## Problem
DIVINA and PDF reader settings had drifted between the global Settings screens and the in-reader sheets. Some sheet controls were missing, sheet-only surfaces still showed explanatory descriptions, and PDF session controls were mixed with persisted default reader preferences.

## Approach
Separate global defaults from in-reader session behavior. The global settings pages keep default reading options and descriptions, while reader sheets focus on settings that can apply cleanly inside the active reader. PDF session-only options now live in the reader menu state instead of writing through AppStorage defaults.

## Scope
- Align DIVINA settings sheet controls with the global Settings page and move Page Turn below Appearance
- Split PDF settings and PDF reader sheet into separate views
- Keep PDF reading direction, layout, cover isolation, and continuous scroll as current-session reader menu options
- Add macOS reader command support for PDF continuous scroll toggling

## Validation
- [x] make format
- [x] make build-macos
