### PR TITLE
docs: refresh product docs and changelog

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,20 +1,16 @@
-Reader Improvements
-- External keyboard shortcuts now work in the reader on iPhone, iPad, and Apple TV, with expanded keyboard help across DIVINA, EPUB, and PDF readers.
-- DIVINA cover and scroll reading are more reliable, especially around drag gestures, tap navigation, zoom dismissal, split wide pages, and Webtoon end pages.
-- Split wide pages in scroll mode now line up more cleanly while swiping, reducing the visible gap between page halves.
-- Reader overlays and controls are easier to interact with on older system versions.
+Reader Settings and Controls
+- DIVINA and PDF reader settings are now more consistent between global Settings and in-reader controls.
+- PDF reading now supports an optional continuous scrolling mode, while page-by-page reading remains the default.
+- Reader controls can show optional gradient backgrounds for better contrast over page artwork.
+- Tap page-turn animation settings are simpler, with separate controls for DIVINA/Webtoon and EPUB.
+- Reader progress bars are easier to see over comics, PDFs, and EPUB content.
+- Reader overlay buttons have better contrast on older system versions.
 
-Offline and Downloads
-- Large original book downloads now stream directly to disk, reducing memory pressure for large CBR, EPUB, and PDF files.
-- Offline downloads for CBZ, CBR, and supported EPUB books now use a faster single-file workflow with local extraction.
-- Download progress updates are smoother, and offline tasks now show a processing state while extraction or finalization continues.
-- Stale offline books removed from the server are cleaned up more reliably instead of retrying forever.
+Reader Reliability
+- Cover-mode table of contents and page jumps are more stable and should no longer snap back to the previous page.
+- Webtoon scrolling is smoother when moving between book segments.
+- PDF display mode changes preserve the current reading position more reliably.
 
-Browsing and Settings
-- Cover thumbnails can refresh automatically after a configurable expiration period, helping updated covers appear without manual refresh.
-- Sync and Handoff settings now have their own settings page, making network settings easier to scan.
-- Filter sheets are more stable on iOS 17.
-
-Reliability
-- Dashboard and reading-progress sync are more stable on iOS 17.
-- Thumbnail refreshes, cache fallbacks, and local offline state handling are more resilient during transient network failures.
+Offline and Recovery
+- Offline archive extraction is more consistent for EPUB, CBZ, and CBR downloads.
+- If local storage damage prevents KMReader from opening, the startup failure screen now offers a Reset Local Data recovery action.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -1,38 +1,25 @@
 KMReader - Native Komga Client for iPhone, iPad, Mac, and Apple TV
 
-KMReader helps you read, browse, download, and manage your Komga library with fast native readers and practical offline workflows across Apple platforms.
+KMReader helps you read, browse, download, and manage your Komga library with native Apple-platform readers and practical offline workflows.
 
 IMPORTANT FEATURES
 
-- Native readers for every format
-DIVINA on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl (iOS), cover-style transitions, optional page shadows, customizable tap zones, and optional page image actions on iOS/macOS for sharing or isolating a page.
-EPUB on iOS and macOS with paged, scrolled, or cover layouts, custom fonts, themes, text alignment and font-weight controls, configurable overlays, and nested table of contents.
-Animated GIF and WebP pages play inline and stay smooth while you zoom or scroll.
-PDF on iOS and macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality, and strong keyboard support on macOS.
-External keyboard shortcuts and keyboard help are available across supported readers on iPhone, iPad, Mac, and Apple TV.
-Incognito mode, optional reader Live Activities with progress or incognito status, and iOS Live Text support let you read your way.
+- Native readers
+Read comics and books with DIVINA on iOS, macOS, and tvOS, plus EPUB and PDF on iOS and macOS. Readers support LTR, RTL, vertical, Webtoon, spreads, zoom, page curl or cover transitions, custom EPUB fonts and typography, nested EPUB tables of contents, PDF search, keyboard shortcuts, per-book preferences, animated pages, and incognito reading.
 
-- Dashboard, discovery, and shortcuts
-Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/read lists, and saved filters keep the right parts of your library close.
-Browse Series, Books, Collections, and Read Lists with advanced metadata filters, optional unread-cover blur, synced reading history, configurable cover thumbnail freshness, and copy-friendly detail views for titles and metadata.
-Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions, help you jump back into reading faster.
-KMReader UI is localized in English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
+- Browse and discover
+Use Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/read lists, reading history, saved filters, advanced metadata filters with all/any matching, optional unread-cover blur, Spotlight indexing, widgets, and Home Screen quick actions.
 
-- Offline that actually works
-Download books for offline reading across DIVINA, EPUB, and PDF workflows.
-Large original book downloads stream directly to disk to reduce memory pressure, while CBZ, CBR, PDF, and supported EPUB offline flows use single-file downloads with local extraction or storage.
-Use manual offline mode controls and predictable iOS background downloads.
-Get Live Activities for both active reading sessions and downloads, including processing status while extraction or finalization continues.
-Set per-series policies: Manual, Unread only, Unread + cleanup, or All books.
-Sync progress and offline changes when you reconnect, with safer conflict handling and cleanup for stale offline books.
+- Offline and sync
+Download books for offline reading, set per-series download policies, browse downloaded items, keep reading with iOS background downloads and Live Activities, and sync progress when you reconnect.
 
 - Multi-server and admin tools
 Save multiple Komga servers and switch instantly.
 Sign in with password or API key, and manage API keys in the app.
-Edit metadata, manage libraries and media (analysis, missing posters, duplicate files, duplicate pages, and page-hash matches), monitor tasks, and view logs.
-On macOS, reader actions also live in the menu bar and Reader menu for faster keyboard-first control.
+Edit metadata, manage libraries and media, find missing posters or duplicates, monitor tasks, and view logs.
 
 KMReader targets Komga 1.19.0+ and supports API v1/v2.
+KMReader UI is localized in English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
 
 Privacy Policy: https://kmreader.everpcpc.com/privacy/
 Terms of Use: https://www.apple.com/legal/internet-services/itunes/dev/stdeula/

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 417;
+				CURRENT_PROJECT_VERSION = 418;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 417;
+				CURRENT_PROJECT_VERSION = 418;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 417;
+				CURRENT_PROJECT_VERSION = 418;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 417;
+				CURRENT_PROJECT_VERSION = 418;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/README.md
+++ b/README.md
@@ -20,51 +20,40 @@
 
 ## Important Features
 
-### Native Reading Experience
+### Readers
 
-- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, customizable tap zones, page curl (iOS), cover-style page transitions on all platforms, optional page shadows, optional page-image context menus on iOS/macOS for share and isolate actions, clearer page-turn animation controls, and steadier scroll, cover, split-wide-page, and Webtoon end-page navigation with better RTL, gesture, and interruption handling.
-- EPUB reader on iOS/macOS with paged, scrolled, and cover layouts, custom font importing (`.ttf`/`.otf`), theme presets, text alignment and font-weight controls, optional status/footer overlays, multi-column reading, and nested table of contents.
-- Animated GIF and WebP pages start immediately, stay smooth while you zoom or scroll, and remain reliable when reopening or revisiting pages.
-- PDF reading on iOS/macOS with a native PDF reader or DIVINA mode, plus search, table of contents, page jump, configurable render quality tiers for offline preparation, clearer progress feedback, and full keyboard help and command coverage on supported platforms.
-- Per-book preferences save reading direction, page layout, and theme settings.
-- Reader keyboard shortcuts and keyboard help are available across DIVINA, EPUB, and PDF workflows on supported iPhone, iPad, Mac, and Apple TV devices.
-- Incognito mode and iOS Live Text support, including optional shake-to-toggle.
+- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl on iOS, cover transitions, custom tap zones, keyboard support, and per-book preferences.
+- EPUB reader on iOS/macOS with paged, scrolled, or cover layouts, custom fonts, themes, typography controls, status/footer overlays, multi-column reading, and nested table of contents.
+- PDF reader on iOS/macOS with native PDF or DIVINA mode, search, table of contents, page jump, spread layouts, configurable render quality, and optional continuous scrolling.
+- Animated GIF and WebP pages play inline. Incognito mode, page image actions, reader progress overlays, and iOS Live Text are supported where available.
 
-### Dashboard and Discovery
+### Browse and Discovery
 
 - Dashboard sections for Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists.
-- Browse Series, Books, Collections, and Read Lists with metadata filters for publishers, authors, genres, tags, and languages using all/any logic.
-- Save and reuse filters across browse surfaces.
-- Optional unread-cover blur helps hide spoiler-heavy artwork until you start reading.
-- Reading history and stats stay fresh with automatic sync and help surface recent activity from synced local data.
-- Configurable cover thumbnail freshness helps updated covers appear automatically without forcing every cached thumbnail to refresh at once.
-- Detail views make titles and metadata easy to copy when you need to search, share, or organize library data.
-- Spotlight integration for downloaded content on iOS/macOS, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
-- UI localization includes English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
+- Browse Series, Books, Collections, and Read Lists with metadata filters, all/any matching, saved filters, reading history, and optional unread-cover blur.
+- Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
 
 ### Offline and Sync
 
-- Download books for full offline reading across DIVINA, EPUB, and PDF workflows.
-- Large original book downloads stream directly to disk to reduce memory pressure for CBR, EPUB, and PDF files.
-- CBZ, CBR, PDF, and supported EPUB offline flows use single-file downloads with local extraction or storage for faster, more reliable offline saves.
-- Manual offline mode controls and more predictable iOS background downloads for page files and extra resources.
-- Optional iOS Live Activities for both active reading sessions and downloads, including reader progress, incognito status, and processing feedback while extraction or finalization continues.
-- Per-series download policies: Manual, Unread only, Unread + cleanup, and All books.
-- Offline mode includes dedicated downloaded-library browsing and metadata filters.
-- Progress and offline data sync automatically when reconnecting, including safer conflict handling and cleanup for stale offline books that disappeared from the server.
-- Cache controls cover pages and thumbnails.
+- Download books for offline reading across DIVINA, EPUB, and PDF workflows.
+- Per-series policies support manual, unread-only, unread + cleanup, and all-books downloads.
+- Large downloads stream to disk, and CBZ, CBR, PDF, and supported EPUB offline flows use local extraction or storage.
+- Progress and offline changes sync when reconnecting. Cache controls cover pages and thumbnails.
+- iOS background downloads and Live Activities show reader progress, incognito status, download progress, and processing state.
 
 ### Multi-Server and Management
 
 - Save multiple Komga servers and switch instantly.
 - Sign in with username/password or API key, and manage Komga API keys inside the app.
-- Admin tools for metadata editing, library management, media management (media analysis, missing posters, duplicate files, duplicate pages, and page-hash matches), task monitoring, and log viewing/export.
+- Admin tools cover metadata editing, library management, media analysis, missing posters, duplicate files/pages, task monitoring, and log viewing/export.
 
 ### Platform Highlights
 
-- iOS/iPadOS: widgets, quick actions, Spotlight search, Dynamic Island Live Activities for reader/downloads, background downloads, Live Text, reader keyboard shortcuts, and page curl/cover transitions.
-- macOS: dedicated reader windows, reader actions in the system menu bar and Reader menu, Spotlight search for downloaded content, keyboard shortcuts, and keyboard help overlay.
-- tvOS: remote-first DIVINA reading with cover transitions, external keyboard support, and a TV-optimized browsing experience.
+- iOS/iPadOS: widgets, quick actions, Spotlight search, Dynamic Island Live Activities, background downloads, Live Text, and reader keyboard shortcuts.
+- macOS: dedicated reader windows, menu bar reader actions, Spotlight search, keyboard shortcuts, and keyboard help.
+- tvOS: remote-first DIVINA reading and TV-optimized browsing.
+
+KMReader UI is localized in English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.
 
 ## Getting Started
 

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
         <title>KMReader · Native Komga Client for iOS, macOS & tvOS</title>
         <meta
             name="description"
-            content="KMReader is a native SwiftUI Komga client with DIVINA, EPUB, and PDF readers, keyboard support, page-level reader actions, reliable offline downloads, advanced filtering, admin tools, and multi-server support."
+            content="KMReader is a native Komga client for iOS, macOS, and tvOS with DIVINA, EPUB, and PDF readers, Webtoon and spread layouts, offline downloads, filtering, multi-server support, and admin tools."
         />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -27,13 +27,10 @@
                 <h1>KMReader</h1>
                 <p class="tagline">
                     Read, download, browse, and manage your Komga library with
-                    native readers, keyboard shortcuts, page-level reader
-                    actions, richer EPUB typography controls, smooth animated
-                    page playback, reliable large-file offline downloads,
-                    advanced filtering, multi-server support, and practical
-                    Apple-platform extras like widgets, Spotlight, Dynamic
-                    Island updates, and keyboard-first controls on iPhone,
-                    iPad, Mac, and Apple TV.
+                    native DIVINA, EPUB, and PDF readers, Webtoon and spread
+                    layouts, offline sync, advanced filtering, multi-server
+                    support, and Apple-platform integrations on iPhone, iPad,
+                    Mac, and Apple TV.
                 </p>
                 <div class="cta">
                     <a
@@ -75,87 +72,58 @@
             <section id="features">
                 <h2 class="section-title">Important features</h2>
                 <p class="section-subtitle">
-                    Focused on reliable reading, practical offline workflows,
-                    and smooth day-to-day library management.
+                    The core tools for daily Komga reading and management.
                 </p>
                 <div class="feature-grid">
                     <article class="card">
                         <span class="pill">Readers</span>
                         <h3>DIVINA, EPUB, and PDF</h3>
                         <p>
-                            DIVINA on iOS/macOS/tvOS with LTR, RTL, vertical,
-                            Webtoon, spreads, zoom, tap zones, page curl
-                            (iOS), cover transitions on all platforms,
-                            optional page shadows, optional page image context
-                            menus on iOS/macOS for sharing or isolating a page,
-                            clearer page-turn animation controls, keyboard
-                            help, and steadier scroll, cover, split-wide-page,
-                            and Webtoon end-page navigation with better RTL,
-                            gesture, and interruption handling.
-                            EPUB on iOS/macOS adds custom fonts, paged,
-                            scrolled, or cover layouts, text alignment and
-                            font-weight controls, configurable status/footer
-                            overlays, and nested table of contents. Animated
-                            pages play immediately, stay smooth while you zoom
-                            or scroll, and remain reliable when you revisit
-                            pages, while PDF on iOS/macOS offers a native
-                            reader or DIVINA mode with search, TOC,
-                            configurable render quality, and strong keyboard
-                            support on supported platforms.
+                            Read comics with DIVINA on iOS, macOS, and tvOS,
+                            plus EPUB and PDF on iOS and macOS. Readers support
+                            LTR, RTL, vertical, Webtoon, spreads, zoom,
+                            page curl or cover transitions, keyboard shortcuts,
+                            per-book preferences, custom EPUB fonts and
+                            typography, nested EPUB table of contents, PDF
+                            search, animated pages, and incognito reading.
                         </p>
                     </article>
                     <article class="card">
-                        <span class="pill">Dashboard</span>
-                        <h3>Keep reading, recent updates, and favorites</h3>
+                        <span class="pill">Browse</span>
+                        <h3>Find the right book faster</h3>
                         <p>
                             Keep Reading, On Deck, Recently Added, Recently
-                            Updated, reading history and stats, pinned
-                            collections/read lists, saved filters, configurable
-                            cover thumbnail freshness, and optional
-                            unread-cover blur keep the most useful parts of
-                            your library close, while copy-friendly detail
-                            views make titles and metadata easier to reuse.
+                            Updated, pinned collections/read lists, reading
+                            history, metadata filters with all/any matching,
+                            saved filters, optional unread-cover blur, widgets,
+                            quick actions, and Spotlight indexing keep the
+                            useful parts of your library close.
                         </p>
                     </article>
                     <article class="card">
                         <span class="pill">Offline</span>
                         <h3>Download and keep reading anywhere</h3>
                         <p>
-                            Download books for offline reading, stream large
-                            original book files directly to disk, use
-                            single-file CBZ, CBR, PDF, and supported EPUB
-                            offline workflows with local extraction or storage,
-                            run more predictable background downloads on iOS,
-                            switch Offline mode manually, and apply per-series
-                            policies to automate what stays on device.
+                            Download books for offline reading, set per-series
+                            download policies, browse downloaded items, use iOS
+                            background downloads and Live Activities, and sync
+                            progress when you reconnect.
                         </p>
                     </article>
                     <article class="card">
-                        <span class="pill">Live Status</span>
-                        <h3>Reader and download progress at a glance</h3>
+                        <span class="pill">Apple Platforms</span>
+                        <h3>Useful system integrations</h3>
                         <p>
-                            Live Activities keep current reading sessions and
-                            download progress visible, can be turned off for
-                            the reader, show reading progress, incognito state,
-                            or offline processing after transfers complete with
-                            Dynamic Island support on iPhone, while EPUB
-                            overlay controls can stay minimal or more
-                            informative.
-                        </p>
-                    </article>
-                    <article class="card">
-                        <span class="pill">Browse</span>
-                        <h3>Advanced filtering and saved views</h3>
-                        <p>
-                            Browse series, books, collections, and read lists.
-                            Filter by publisher, author, genre, tag, and
-                            language, use all/any logic, and save filters for
-                            later, including in Offline mode.
+                            Use widgets, Home Screen quick actions, Spotlight
+                            indexing for downloaded content, iOS background
+                            downloads, Live Activities, Live Text, dedicated
+                            macOS reader windows, menu bar reader actions, and
+                            tvOS remote-first browsing.
                         </p>
                     </article>
                     <article class="card">
                         <span class="pill">Multi-Server</span>
-                        <h3>Switch servers and credentials quickly</h3>
+                        <h3>Switch Komga servers quickly</h3>
                         <p>
                             Save multiple Komga servers and switch quickly.
                             Sign in with username/password or API key, and
@@ -166,19 +134,9 @@
                         <span class="pill">Admin</span>
                         <h3>Manage your server in-app</h3>
                         <p>
-                            Edit metadata, manage libraries and media
-                            (analysis, missing posters, duplicate files and
-                            pages, and page-hash matches), monitor tasks, and
-                            view logs directly in KMReader.
-                        </p>
-                    </article>
-                    <article class="card">
-                        <span class="pill">Localization</span>
-                        <h3>Read and manage in your language</h3>
-                        <p>
-                            KMReader UI supports English, German, French,
-                            Japanese, Korean, Simplified Chinese, Traditional
-                            Chinese, Italian, Russian, and Spanish.
+                            Edit metadata, manage libraries and media, monitor
+                            tasks, view logs, and find missing posters or
+                            duplicate files/pages.
                         </p>
                     </article>
                 </div>
@@ -221,7 +179,7 @@
             </section>
 
             <section id="faq">
-                <h2 class="section-title">FAQ</h2>
+                <h2 class="section-title">Details</h2>
                 <div class="faq-grid">
                     <article class="faq-item">
                         <h4>Is KMReader an official Komga app?</h4>
@@ -234,15 +192,9 @@
                         <h4>Which readers are available?</h4>
                         <p>
                             DIVINA is available on iOS, macOS, and tvOS. EPUB
-                            and PDF are available on iOS and macOS, with EPUB
-                            supporting cover mode, richer typography and
-                            overlay controls, and PDF offering a native reader
-                            or DIVINA mode, while animated GIF and WebP pages
-                            play inline with the reader. Reader settings
-                            include page shadows, page-turn animation
-                            controls, optional page image actions on
-                            iOS/macOS, and strong keyboard support across
-                            supported reader platforms.
+                            and PDF are available on iOS and macOS. Animated
+                            GIF and WebP pages play inline in supported reader
+                            flows.
                         </p>
                     </article>
                     <article class="faq-item">
@@ -256,22 +208,9 @@
                     <article class="faq-item">
                         <h4>How does offline mode work?</h4>
                         <p>
-                            Downloaded books stay readable offline, large files
-                            stream to disk, CBZ, CBR, PDF, and supported EPUB
-                            saves use single-file workflows, filtering is
-                            available for offline items, and sync resumes when
-                            you reconnect.
-                        </p>
-                    </article>
-                    <article class="faq-item">
-                        <h4>Does KMReader support widgets and quick actions?</h4>
-                        <p>
-                            Yes. On iOS and iPadOS, KMReader includes widgets
-                            plus Home Screen quick actions for Keep Reading,
-                            Search, and Downloads, supports Spotlight search
-                            for downloaded content on iOS and macOS, and shows
-                            reader/download Live Activities on iPhone with
-                            progress or incognito status.
+                            Downloaded books stay readable offline, per-series
+                            policies help decide what stays on device, and
+                            reading progress syncs when you reconnect.
                         </p>
                     </article>
                     <article class="faq-item">


### PR DESCRIPTION
## Problem
The README, App Store description, landing page, and release notes had accumulated too many implementation-level details, making the product story harder to scan while still missing a few high-signal user-facing highlights.

## Approach
Refresh the docs around the core KMReader value areas: native readers, browse and discovery, offline sync, multi-server support, platform integrations, and admin tools. The copy stays concise while preserving distinctive features such as Webtoon and spread layouts, EPUB typography, PDF search, Live Activities, Spotlight, widgets, and media management.

## Scope
- Update README, App Store description, and landing page feature copy
- Refresh App Store changelog for the current release range
- Bump build version to 418

## Validation
- [x] Ran `make bump`
- [x] Ran `git diff --check`
