### PR TITLE
fix: bootstrap StoreKit entitlement checks

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 418;
+				CURRENT_PROJECT_VERSION = 419;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 418;
+				CURRENT_PROJECT_VERSION = 419;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 418;
+				CURRENT_PROJECT_VERSION = 419;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 418;
+				CURRENT_PROJECT_VERSION = 419;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Settings/SubscriptionView.swift
+++ b/KMReader/Features/Settings/SubscriptionView.swift
@@ -41,6 +41,10 @@ struct SubscriptionView: View {
         .padding()
       }
     }
+    .task {
+      await StoreManager.shared.start()
+      await StoreManager.shared.loadProductsIfNeeded()
+    }
   }
 
   private var headerSection: some View {

--- a/KMReader/Features/Store/StoreManager.swift
+++ b/KMReader/Features/Store/StoreManager.swift
@@ -32,15 +32,22 @@ final class StoreManager {
     products.first { $0.id == Self.yearlyProductID }
   }
 
-  private var updateListenerTask: Task<Void, Error>?
+  private var updateListenerTask: Task<Void, Never>?
+  private var hasStarted = false
   private static let restoreTimeoutSeconds: Double = 20
 
-  private init() {
+  private init() {}
+
+  func start() async {
+    guard !hasStarted else { return }
+    hasStarted = true
     updateListenerTask = listenForTransactions()
-    Task {
-      await loadProducts()
-      await updatePurchasedProducts()
-    }
+    await updatePurchasedProducts()
+  }
+
+  func loadProductsIfNeeded() async {
+    guard products.isEmpty, !isLoadingProducts else { return }
+    await loadProducts()
   }
 
   func loadProducts() async {
@@ -131,8 +138,8 @@ final class StoreManager {
     purchasedProductIDs = purchasedIDs
   }
 
-  private func listenForTransactions() -> Task<Void, Error> {
-    Task.detached {
+  private func listenForTransactions() -> Task<Void, Never> {
+    Task {
       for await result in Transaction.updates {
         if case .verified(let transaction) = result {
           await self.updatePurchasedProducts()

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -174,6 +174,9 @@ struct MainApp: App {
       }
     #endif
     .modelContainer(modelContainer)
+    .task {
+      await StoreManager.shared.start()
+    }
   }
 
   #if os(macOS)


### PR DESCRIPTION
## Problem
StoreKit entitlement refresh was only guaranteed after Settings-related views touched `StoreManager.shared`, so supporter state could remain stale when users launched the app without opening Settings.

## Approach
Move StoreKit startup to an explicit app-level bootstrap path. The manager now starts transaction listening and refreshes current entitlements through an idempotent `start()` method, while product fetching stays lazy for the subscription sheet where prices are actually displayed.

## Scope
- Start StoreKit entitlement checks from `MainApp`
- Keep subscription product loading scoped to `SubscriptionView`
- Bump build version to 419

## Validation
- [x] `make format`
- [x] `make build-macos`
