### PR TITLE
fix: unify webtoon scroll navigation

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 420;
+				CURRENT_PROJECT_VERSION = 421;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 420;
+				CURRENT_PROJECT_VERSION = 421;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 420;
+				CURRENT_PROJECT_VERSION = 421;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 420;
+				CURRENT_PROJECT_VERSION = 421;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -6,6 +6,11 @@
 import SwiftUI
 
 struct DivinaReaderView: View {
+  private enum ReaderNavigationStep {
+    case previous
+    case next
+  }
+
   let sessionID: UUID
   let book: Book
   let incognito: Bool
@@ -59,6 +64,7 @@ struct DivinaReaderView: View {
   @State private var keyboardHelpTimer: Timer?
   @State private var preserveReaderOptions = false
   @State private var usesDualPagePresentation = false
+  @State private var webtoonScrollController = WebtoonScrollController()
 
   // UI Panels states
   @State private var showingPageJumpSheet = false
@@ -360,7 +366,7 @@ struct DivinaReaderView: View {
       if isShowingEndPage {
         if isBackwardTVMove(direction) {
           logger.debug("📺 \(source) move on end page: go to previous page")
-          goToPreviousPage()
+          goToReaderPosition(.previous)
           return true
         }
 
@@ -373,16 +379,16 @@ struct DivinaReaderView: View {
         switch direction {
         case .left:
           if readingDirection == .rtl {
-            goToNextPage()
+            goToReaderPosition(.next)
           } else {
-            goToPreviousPage()
+            goToReaderPosition(.previous)
           }
           return true
         case .right:
           if readingDirection == .rtl {
-            goToPreviousPage()
+            goToReaderPosition(.previous)
           } else {
-            goToNextPage()
+            goToReaderPosition(.next)
           }
           return true
         default:
@@ -391,10 +397,10 @@ struct DivinaReaderView: View {
       case .vertical:
         switch direction {
         case .up:
-          goToPreviousPage()
+          goToReaderPosition(.previous)
           return true
         case .down:
-          goToNextPage()
+          goToReaderPosition(.next)
           return true
         default:
           return false
@@ -402,10 +408,10 @@ struct DivinaReaderView: View {
       case .webtoon:
         switch direction {
         case .up:
-          goToPreviousPage()
+          goToReaderPosition(.previous)
           return true
         case .down:
-          goToNextPage()
+          goToReaderPosition(.next)
           return true
         default:
           return false
@@ -646,6 +652,7 @@ struct DivinaReaderView: View {
                 readListContext: readListContext,
                 onDismiss: { closeReader() },
                 toggleControls: { toggleControls() },
+                scrollController: webtoonScrollController,
                 pageWidthPercentage: webtoonPageWidthPercentage,
                 renderConfig: renderConfig
               )
@@ -956,10 +963,10 @@ struct DivinaReaderView: View {
     case .ltr:
       switch event.key {
       case .rightArrow:
-        goToNextPage()
+        goToReaderPosition(.next)
         return true
       case .leftArrow:
-        goToPreviousPage()
+        goToReaderPosition(.previous)
         return true
       default:
         return false
@@ -967,10 +974,10 @@ struct DivinaReaderView: View {
     case .rtl:
       switch event.key {
       case .leftArrow:
-        goToNextPage()
+        goToReaderPosition(.next)
         return true
       case .rightArrow:
-        goToPreviousPage()
+        goToReaderPosition(.previous)
         return true
       default:
         return false
@@ -978,17 +985,37 @@ struct DivinaReaderView: View {
     case .vertical:
       switch event.key {
       case .downArrow:
-        goToNextPage()
+        goToReaderPosition(.next)
         return true
       case .upArrow:
-        goToPreviousPage()
+        goToReaderPosition(.previous)
         return true
       default:
         return false
       }
     case .webtoon:
-      return false
+      switch event.key {
+      case .downArrow:
+        goToReaderPosition(.next)
+        return true
+      case .upArrow:
+        goToReaderPosition(.previous)
+        return true
+      default:
+        return false
+      }
     }
+  }
+
+  private func sendWebtoonScrollCommand(for step: ReaderNavigationStep) {
+    let direction: WebtoonScrollDirection =
+      switch step {
+      case .previous:
+        .up
+      case .next:
+        .down
+      }
+    webtoonScrollController.scroll(direction)
   }
 
   private func loadBook(bookId: String, preserveReaderOptions: Bool) async {
@@ -1497,38 +1524,38 @@ struct DivinaReaderView: View {
   private func handleTapZoneAction(_ action: TapZoneAction) {
     switch action {
     case .previous:
-      goToPreviousPage()
+      goToReaderPosition(.previous)
     case .next:
-      goToNextPage()
+      goToReaderPosition(.next)
     case .toggleControls:
       toggleControls()
     }
   }
 
-  private func goToNextPage() {
+  private func goToReaderPosition(_ step: ReaderNavigationStep) {
     guard viewModel.hasPages else { return }
     switch readingDirection {
-    case .ltr, .rtl, .vertical, .webtoon:
-      if let nextItem = viewModel.adjacentViewItem(offset: 1) {
-        viewModel.requestNavigation(toViewItem: nextItem)
-      } else {
-        Task { @MainActor in
-          _ = await navigateAcrossBoundaryIfNeeded(offset: 1)
-        }
-      }
+    case .ltr, .rtl, .vertical:
+      goToPagedReaderPosition(step)
+    case .webtoon:
+      sendWebtoonScrollCommand(for: step)
     }
   }
 
-  private func goToPreviousPage() {
-    guard viewModel.hasPages else { return }
-    switch readingDirection {
-    case .ltr, .rtl, .vertical, .webtoon:
-      if let previousItem = viewModel.adjacentViewItem(offset: -1) {
-        viewModel.requestNavigation(toViewItem: previousItem)
-      } else {
-        Task { @MainActor in
-          _ = await navigateAcrossBoundaryIfNeeded(offset: -1)
-        }
+  private func goToPagedReaderPosition(_ step: ReaderNavigationStep) {
+    let offset: Int =
+      switch step {
+      case .previous:
+        -1
+      case .next:
+        1
+      }
+
+    if let item = viewModel.adjacentViewItem(offset: offset) {
+      viewModel.requestNavigation(toViewItem: item)
+    } else {
+      Task { @MainActor in
+        _ = await navigateAcrossBoundaryIfNeeded(offset: offset)
       }
     }
   }

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonPageView.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonPageView.swift
@@ -11,6 +11,7 @@
     let readListContext: ReaderReadListContext?
     let onDismiss: () -> Void
     let toggleControls: () -> Void
+    let scrollController: WebtoonScrollController
     let pageWidthPercentage: Double
     let renderConfig: ReaderRenderConfig
     @State private var zoomTargetPageID: ReaderPageID?
@@ -35,7 +36,8 @@
             },
             onZoomRequest: { pageID, anchor in
               openZoomOverlay(pageID: pageID, anchor: anchor)
-            }
+            },
+            scrollController: scrollController
           )
 
           if let zoomTargetPageID, let zoomRequestID {

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -15,6 +15,7 @@
     let onZoomRequest: ((ReaderPageID, CGPoint) -> Void)?
     let pageWidth: CGFloat
     let renderConfig: ReaderRenderConfig
+    let scrollController: WebtoonScrollController
 
     init(
       viewModel: ReaderViewModel,
@@ -23,7 +24,8 @@
       readListContext: ReaderReadListContext? = nil,
       onDismiss: @escaping () -> Void = {},
       onCenterTap: (() -> Void)? = nil,
-      onZoomRequest: ((ReaderPageID, CGPoint) -> Void)? = nil
+      onZoomRequest: ((ReaderPageID, CGPoint) -> Void)? = nil,
+      scrollController: WebtoonScrollController
     ) {
       self.viewModel = viewModel
       self.pageWidth = pageWidth
@@ -32,6 +34,7 @@
       self.onDismiss = onDismiss
       self.onCenterTap = onCenterTap
       self.onZoomRequest = onZoomRequest
+      self.scrollController = scrollController
     }
 
     func makeUIView(context: Context) -> UICollectionView {
@@ -86,6 +89,7 @@
       collectionView.addGestureRecognizer(pinchGesture)
 
       context.coordinator.collectionView = collectionView
+      scrollController.target = context.coordinator
       context.coordinator.scheduleInitialScroll()
 
       return collectionView
@@ -103,6 +107,8 @@
         collectionView: collectionView,
         renderConfig: renderConfig
       )
+      context.coordinator.scrollController = scrollController
+      scrollController.target = context.coordinator
     }
 
     @MainActor
@@ -116,7 +122,7 @@
 
     @MainActor
     class Coordinator: NSObject, UICollectionViewDelegate, UICollectionViewDataSource,
-      UICollectionViewDelegateFlowLayout, UIGestureRecognizerDelegate
+      UICollectionViewDelegateFlowLayout, UIGestureRecognizerDelegate, WebtoonScrollCommandHandling
     {
       var collectionView: UICollectionView?
       private var scrollEngine: WebtoonScrollEngine
@@ -125,6 +131,7 @@
       var onDismiss: (() -> Void)?
       var onCenterTap: (() -> Void)?
       var onZoomRequest: ((ReaderPageID, CGPoint) -> Void)?
+      weak var scrollController: WebtoonScrollController?
       var lastPagesCount: Int = 0
       var isUserScrolling: Bool = false
       var isProgrammaticAnimatedScroll: Bool = false
@@ -158,6 +165,7 @@
         self.onDismiss = parent.onDismiss
         self.onCenterTap = parent.onCenterTap
         self.onZoomRequest = parent.onZoomRequest
+        self.scrollController = parent.scrollController
         self.lastPagesCount = parent.viewModel.pageCount
         self.pageWidth = parent.pageWidth
         self.heightCache.lastPageWidth = parent.pageWidth
@@ -578,6 +586,7 @@
       }
 
       func teardown() {
+        scrollController?.clearTarget(self)
         singleTapWorkItem?.cancel()
         singleTapWorkItem = nil
         cancelDeferredMaintenance()
@@ -1074,6 +1083,20 @@
           maxOffset
         )
         scrollToOffsetIfNeeded(targetOffset, in: collectionView)
+      }
+
+      func scrollWebtoon(_ direction: WebtoonScrollDirection) {
+        guard let collectionView else { return }
+
+        let screenHeight = collectionView.bounds.height
+        guard screenHeight > 0 else { return }
+
+        switch direction {
+        case .up:
+          scrollUp(collectionView: collectionView, screenHeight: screenHeight)
+        case .down:
+          scrollDown(collectionView: collectionView, screenHeight: screenHeight)
+        }
       }
 
       private func scrollToOffsetIfNeeded(_ targetOffset: CGFloat, in collectionView: UICollectionView) {

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -1085,7 +1085,7 @@
         scrollToOffsetIfNeeded(targetOffset, in: collectionView)
       }
 
-      func scrollWebtoon(_ direction: WebtoonScrollDirection) {
+      func scroll(_ direction: WebtoonScrollDirection) {
         guard let collectionView else { return }
 
         let screenHeight = collectionView.bounds.height

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
@@ -15,6 +15,7 @@
     let onZoomRequest: ((ReaderPageID, CGPoint) -> Void)?
     let pageWidth: CGFloat
     let renderConfig: ReaderRenderConfig
+    let scrollController: WebtoonScrollController
 
     init(
       viewModel: ReaderViewModel,
@@ -23,7 +24,8 @@
       readListContext: ReaderReadListContext? = nil,
       onDismiss: @escaping () -> Void = {},
       onCenterTap: (() -> Void)? = nil,
-      onZoomRequest: ((ReaderPageID, CGPoint) -> Void)? = nil
+      onZoomRequest: ((ReaderPageID, CGPoint) -> Void)? = nil,
+      scrollController: WebtoonScrollController
     ) {
       self.viewModel = viewModel
       self.pageWidth = pageWidth
@@ -32,6 +34,7 @@
       self.onDismiss = onDismiss
       self.onCenterTap = onCenterTap
       self.onZoomRequest = onZoomRequest
+      self.scrollController = scrollController
     }
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -78,8 +81,8 @@
 
       context.coordinator.collectionView = collectionView
       context.coordinator.scrollView = scrollView
+      scrollController.target = context.coordinator
       context.coordinator.scheduleInitialScroll()
-      context.coordinator.setupKeyboardMonitor()
 
       NotificationCenter.default.addObserver(
         context.coordinator,
@@ -108,6 +111,8 @@
           pageWidth: pageWidth,
           collectionView: collectionView,
           renderConfig: renderConfig)
+        context.coordinator.scrollController = scrollController
+        scrollController.target = context.coordinator
       }
     }
 
@@ -122,7 +127,7 @@
 
     @MainActor
     class Coordinator: NSObject, NSCollectionViewDelegate, NSCollectionViewDataSource,
-      NSCollectionViewDelegateFlowLayout, NSGestureRecognizerDelegate
+      NSCollectionViewDelegateFlowLayout, NSGestureRecognizerDelegate, WebtoonScrollCommandHandling
     {
       var collectionView: NSCollectionView?
       var scrollView: NSScrollView?
@@ -132,6 +137,7 @@
       var onDismiss: (() -> Void)?
       var onCenterTap: (() -> Void)?
       var onZoomRequest: ((ReaderPageID, CGPoint) -> Void)?
+      weak var scrollController: WebtoonScrollController?
       var lastPagesCount: Int = 0
       var isUserScrolling: Bool = false
       var isProgrammaticScrolling: Bool = false
@@ -142,7 +148,6 @@
       var showPageNumber: Bool = true
       var isLongPress: Bool = false
       var heightCache = WebtoonPageHeightCache()
-      var keyMonitor: Any?
       var lastScrollTime: TimeInterval = 0
       var hasTriggeredZoomGesture: Bool = false
       private var deferredReloadWorkItem: DispatchWorkItem?
@@ -164,6 +169,7 @@
         self.onDismiss = parent.onDismiss
         self.onCenterTap = parent.onCenterTap
         self.onZoomRequest = parent.onZoomRequest
+        self.scrollController = parent.scrollController
         self.lastPagesCount = parent.viewModel.pageCount
         self.pageWidth = parent.pageWidth
         self.heightCache.lastPageWidth = parent.pageWidth
@@ -184,38 +190,12 @@
       }
 
       func teardown() {
+        scrollController?.clearTarget(self)
         cancelDeferredMaintenance()
         sizeProbeTasks.values.forEach { $0.cancel() }
         sizeProbeTasks.removeAll()
         pendingMeasuredPageIDs.removeAll()
         NotificationCenter.default.removeObserver(self)
-        if let monitor = keyMonitor {
-          NSEvent.removeMonitor(monitor)
-          keyMonitor = nil
-        }
-      }
-
-      func setupKeyboardMonitor() {
-        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-          guard let self = self else { return event }
-          return self.handleKeyDown(event) ? nil : event
-        }
-      }
-
-      func handleKeyDown(_ event: NSEvent) -> Bool {
-        guard let sv = scrollView, let window = sv.window, window.isKeyWindow else { return false }
-        let screenHeight = window.contentView?.bounds.height ?? window.frame.height
-
-        switch event.keyCode {
-        case 125:  // Down arrow
-          scrollDown(screenHeight)
-          return true
-        case 126:  // Up arrow
-          scrollUp(screenHeight)
-          return true
-        default:
-          return false
-        }
       }
 
       private func itemIndex(forPageID pageID: ReaderPageID?) -> Int? {
@@ -605,6 +585,7 @@
       private func finalizeProgrammaticScroll() {
         isProgrammaticScrolling = false
         applyPendingMeasuredLayoutUpdatesIfNeeded()
+        updateCurrentPage()
         scheduleDeferredPendingReloadIfNeeded()
         scheduleDeferredCleanupIfNeeded()
       }
@@ -955,11 +936,26 @@
         scrollToOffsetIfNeeded(targetY, in: sv)
       }
 
+      func scrollWebtoon(_ direction: WebtoonScrollDirection) {
+        guard let sv = scrollView else { return }
+
+        let screenHeight = sv.contentView.bounds.height
+        guard screenHeight > 0 else { return }
+
+        switch direction {
+        case .up:
+          scrollUp(screenHeight)
+        case .down:
+          scrollDown(screenHeight)
+        }
+      }
+
       private func scrollToOffsetIfNeeded(_ targetY: CGFloat, in scrollView: NSScrollView) {
         let clipView = scrollView.contentView
         let currentY = clipView.bounds.origin.y
         guard abs(targetY - currentY) > WebtoonConstants.offsetEpsilon else {
           isProgrammaticScrolling = false
+          updateCurrentPage()
           return
         }
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
@@ -936,7 +936,7 @@
         scrollToOffsetIfNeeded(targetY, in: sv)
       }
 
-      func scrollWebtoon(_ direction: WebtoonScrollDirection) {
+      func scroll(_ direction: WebtoonScrollDirection) {
         guard let sv = scrollView else { return }
 
         let screenHeight = sv.contentView.bounds.height

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonScrollCommandHandling.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonScrollCommandHandling.swift
@@ -1,0 +1,9 @@
+//
+// WebtoonScrollCommandHandling.swift
+//
+//
+
+@MainActor
+protocol WebtoonScrollCommandHandling: AnyObject {
+  func scrollWebtoon(_ direction: WebtoonScrollDirection)
+}

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonScrollCommandHandling.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonScrollCommandHandling.swift
@@ -5,5 +5,5 @@
 
 @MainActor
 protocol WebtoonScrollCommandHandling: AnyObject {
-  func scrollWebtoon(_ direction: WebtoonScrollDirection)
+  func scroll(_ direction: WebtoonScrollDirection)
 }

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonScrollController.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonScrollController.swift
@@ -1,0 +1,18 @@
+//
+// WebtoonScrollController.swift
+//
+//
+
+@MainActor
+final class WebtoonScrollController {
+  weak var target: WebtoonScrollCommandHandling?
+
+  func scroll(_ direction: WebtoonScrollDirection) {
+    target?.scrollWebtoon(direction)
+  }
+
+  func clearTarget(_ target: WebtoonScrollCommandHandling) {
+    guard self.target === target else { return }
+    self.target = nil
+  }
+}

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonScrollController.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonScrollController.swift
@@ -8,7 +8,7 @@ final class WebtoonScrollController {
   weak var target: WebtoonScrollCommandHandling?
 
   func scroll(_ direction: WebtoonScrollDirection) {
-    target?.scrollWebtoon(direction)
+    target?.scroll(direction)
   }
 
   func clearTarget(_ target: WebtoonScrollCommandHandling) {

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonScrollDirection.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonScrollDirection.swift
@@ -1,0 +1,9 @@
+//
+// WebtoonScrollDirection.swift
+//
+//
+
+enum WebtoonScrollDirection {
+  case up
+  case down
+}


### PR DESCRIPTION
## Problem
Webtoon navigation on macOS could move the visible scroll position without committing the resolved current page back to the reader state, leaving the page number, progress bar, and next-book behavior stale. Keyboard and remote navigation also mixed webtoon scrolling semantics with paged-reader item navigation.

## Approach
Route reader previous/next intents through a single Divina navigation path, then let webtoon translate that intent into viewport scrolling via an explicit scroll controller target. This keeps paged readers on item navigation while webtoon readers use their native scroll behavior on both iOS and macOS.

## Scope
- Add a webtoon scroll controller and command handling protocol
- Unify Divina keyboard, tap, and TV move navigation through reader previous/next intents
- Remove macOS webtoon's separate key monitor in favor of the shared reader keyboard path
- Commit macOS webtoon programmatic scroll completion back to current-page state
- Bump build number to 421

## Validation
- [x] make format
- [x] make build-ios
- [x] make build-macos
- [x] make build-tvos
