### PR TITLE
fix: collapse dashboard SSE header when disabled

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 422;
+				CURRENT_PROJECT_VERSION = 423;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 422;
+				CURRENT_PROJECT_VERSION = 423;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 422;
+				CURRENT_PROJECT_VERSION = 423;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 422;
+				CURRENT_PROJECT_VERSION = 423;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Dashboard/Views/DashboardView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardView.swift
@@ -40,6 +40,49 @@ struct DashboardView: View {
     )
   }
 
+  @ViewBuilder
+  private var dashboardHeader: some View {
+    HStack {
+      #if os(tvOS)
+        Button {
+          showLibraryPicker = true
+        } label: {
+          Label(String(localized: "Libraries"), systemImage: ContentIcon.library)
+        }
+      #endif
+
+      if enableSSE {
+        #if os(tvOS)
+          if isOffline {
+            Button {
+              Task {
+                await tryReconnect()
+              }
+            } label: {
+              if isCheckingConnection {
+                LoadingIcon()
+              } else {
+                Label(String(localized: "settings.offline"), systemImage: "wifi.slash")
+                  .foregroundStyle(.orange)
+              }
+            }
+            .disabled(isCheckingConnection)
+          } else {
+            Button {
+              refreshDashboard(reason: "Manual tvOS button")
+            } label: {
+              Label("Refresh", systemImage: "arrow.clockwise")
+            }
+            .disabled(isRefreshing)
+          }
+        #endif
+        ServerUpdateStatusView()
+      }
+      Spacer()
+    }
+    .padding()
+  }
+
   private func performRefresh(
     reason: String,
     source: DashboardRefreshSource,
@@ -180,44 +223,13 @@ struct DashboardView: View {
   var body: some View {
     ScrollView {
       VStack(alignment: .leading, spacing: 0) {
-        HStack {
-          #if os(tvOS)
-            Button {
-              showLibraryPicker = true
-            } label: {
-              Label(String(localized: "Libraries"), systemImage: ContentIcon.library)
-            }
-          #endif
-
+        #if os(tvOS)
+          dashboardHeader
+        #else
           if enableSSE {
-            #if os(tvOS)
-              if isOffline {
-                Button {
-                  Task {
-                    await tryReconnect()
-                  }
-                } label: {
-                  if isCheckingConnection {
-                    LoadingIcon()
-                  } else {
-                    Label(String(localized: "settings.offline"), systemImage: "wifi.slash")
-                      .foregroundStyle(.orange)
-                  }
-                }
-                .disabled(isCheckingConnection)
-              } else {
-                Button {
-                  refreshDashboard(reason: "Manual tvOS button")
-                } label: {
-                  Label("Refresh", systemImage: "arrow.clockwise")
-                }
-                .disabled(isRefreshing)
-              }
-            #endif
-            ServerUpdateStatusView()
+            dashboardHeader
           }
-          Spacer()
-        }.padding()
+        #endif
 
         ForEach(dashboard.sections, id: \.id) { section in
           if section.isLocalSection {


### PR DESCRIPTION
## Problem
Turning off SSE hides the dashboard server update status, but the padded header row still remains on iOS and macOS. That leaves a visible blank gap above the dashboard sections.

## Approach
Extract the dashboard header into a dedicated view builder and only insert it on iOS and macOS when SSE is enabled. The tvOS header remains visible because it also owns the library and refresh controls.

## Scope
- Collapse the dashboard SSE status header when SSE is disabled on iOS and macOS
- Preserve the existing tvOS dashboard header controls
- Bump the build number to 423

## Validation
- [x] make format
- [x] make build
