### PR TITLE
fix: store API snapshots as raw data

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 422;
+				CURRENT_PROJECT_VERSION = 423;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 422;
+				CURRENT_PROJECT_VERSION = 423;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 422;
+				CURRENT_PROJECT_VERSION = 423;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 422;
+				CURRENT_PROJECT_VERSION = 423;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -210,10 +210,11 @@ actor DatabaseOperator {
           progressCompleted: existing.progressCompleted,
           progressPage: existing.progressPage
         )
+        let readProgressRaw = RawCodableStore.encodeOptional(book.readProgress)
 
-        guard existing.hasDifferentReadProgressFields(book.readProgress) else { continue }
+        guard existing.readProgressRaw != readProgressRaw else { continue }
 
-        existing.updateReadProgress(book.readProgress)
+        existing.updateReadProgress(book.readProgress, raw: readProgressRaw)
 
         let newStatus = readingStatus(
           progressCompleted: existing.progressCompleted,
@@ -860,13 +861,9 @@ actor DatabaseOperator {
   }
 
   private func applyBook(dto: Book, to existing: KomgaBook) {
-    let shouldApplyContent =
-      existing.lastModified != dto.lastModified
-      || existing.hasDifferentContentFields(
-        media: dto.media,
-        metadata: dto.metadata,
-        readProgress: dto.readProgress
-      )
+    let mediaRaw = RawCodableStore.encode(dto.media)
+    let metadataRaw = RawCodableStore.encode(dto.metadata)
+    let readProgressRaw = RawCodableStore.encodeOptional(dto.readProgress)
 
     if existing.name != dto.name { existing.name = dto.name }
     if existing.url != dto.url { existing.url = dto.url }
@@ -874,8 +871,14 @@ actor DatabaseOperator {
     if existing.lastModified != dto.lastModified { existing.lastModified = dto.lastModified }
     if existing.sizeBytes != dto.sizeBytes { existing.sizeBytes = dto.sizeBytes }
     if existing.size != dto.size { existing.size = dto.size }
-    if shouldApplyContent {
-      existing.applyContent(media: dto.media, metadata: dto.metadata, readProgress: dto.readProgress)
+    if mediaRaw == nil || existing.mediaRaw != mediaRaw {
+      existing.updateMedia(dto.media, raw: mediaRaw)
+    }
+    if metadataRaw == nil || existing.metadataRaw != metadataRaw {
+      existing.updateMetadata(dto.metadata, raw: metadataRaw)
+    }
+    if existing.readProgressRaw != readProgressRaw {
+      existing.updateReadProgress(dto.readProgress, raw: readProgressRaw)
     }
     if existing.isUnavailable != dto.deleted { existing.isUnavailable = dto.deleted }
     if existing.oneshot != dto.oneshot { existing.oneshot = dto.oneshot }
@@ -883,12 +886,8 @@ actor DatabaseOperator {
   }
 
   private func applySeries(dto: Series, to existing: KomgaSeries) {
-    let shouldApplyContent =
-      existing.lastModified != dto.lastModified
-      || existing.hasDifferentContentFields(
-        metadata: dto.metadata,
-        booksMetadata: dto.booksMetadata
-      )
+    let metadataRaw = RawCodableStore.encode(dto.metadata)
+    let booksMetadataRaw = RawCodableStore.encode(dto.booksMetadata)
 
     if existing.name != dto.name { existing.name = dto.name }
     if existing.url != dto.url { existing.url = dto.url }
@@ -903,8 +902,11 @@ actor DatabaseOperator {
     if existing.booksInProgressCount != dto.booksInProgressCount {
       existing.booksInProgressCount = dto.booksInProgressCount
     }
-    if shouldApplyContent {
-      existing.applyContent(metadata: dto.metadata, booksMetadata: dto.booksMetadata)
+    if metadataRaw == nil || existing.metadataRaw != metadataRaw {
+      existing.updateMetadata(dto.metadata, raw: metadataRaw)
+    }
+    if booksMetadataRaw == nil || existing.booksMetadataRaw != booksMetadataRaw {
+      existing.updateBooksMetadata(dto.booksMetadata, raw: booksMetadataRaw)
     }
     if existing.isUnavailable != dto.deleted { existing.isUnavailable = dto.deleted }
     if existing.oneshot != dto.oneshot { existing.oneshot = dto.oneshot }

--- a/KMReader/Core/Storage/RawCodableStore.swift
+++ b/KMReader/Core/Storage/RawCodableStore.swift
@@ -1,0 +1,24 @@
+//
+// RawCodableStore.swift
+//
+//
+
+import Foundation
+
+nonisolated enum RawCodableStore {
+  static func encode<T: Encodable>(_ value: T) -> Data? {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    return try? encoder.encode(value)
+  }
+
+  static func encodeOptional<T: Encodable>(_ value: T?) -> Data? {
+    guard let value else { return nil }
+    return encode(value)
+  }
+
+  static func decode<T: Decodable>(_ type: T.Type, from data: Data?) -> T? {
+    guard let data else { return nil }
+    return try? JSONDecoder().decode(type, from: data)
+  }
+}

--- a/KMReader/Core/Storage/Schema/KMReaderMigrationPlan.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderMigrationPlan.swift
@@ -19,10 +19,25 @@ nonisolated private struct MigrationSeriesSnapshot: Codable {
   let booksMetadata: SeriesBooksMetadata
 }
 
+nonisolated private struct MigrationBookRawSnapshot: Codable {
+  let id: String
+  let mediaRaw: Data?
+  let metadataRaw: Data?
+  let readProgressRaw: Data?
+}
+
+nonisolated private struct MigrationSeriesRawSnapshot: Codable {
+  let id: String
+  let metadataRaw: Data?
+  let booksMetadataRaw: Data?
+}
+
 nonisolated private enum MigrationSnapshotStore {
   private static let directoryName = "kmreader_swiftdata_v1_v2_migration"
   private static let booksPrefix = "books"
   private static let seriesPrefix = "series"
+  private static let rawBooksPrefix = "raw-books"
+  private static let rawSeriesPrefix = "raw-series"
 
   private static var directoryURL: URL {
     let baseURL =
@@ -48,11 +63,27 @@ nonisolated private enum MigrationSnapshotStore {
     try writeChunk(chunk, prefix: seriesPrefix, index: index)
   }
 
+  static func writeRawBookChunk(_ chunk: [MigrationBookRawSnapshot], index: Int) throws {
+    try writeChunk(chunk, prefix: rawBooksPrefix, index: index)
+  }
+
+  static func writeRawSeriesChunk(_ chunk: [MigrationSeriesRawSnapshot], index: Int) throws {
+    try writeChunk(chunk, prefix: rawSeriesPrefix, index: index)
+  }
+
   static func readBookChunk(at url: URL) throws -> [MigrationBookSnapshot] {
     try readChunk(at: url)
   }
 
   static func readSeriesChunk(at url: URL) throws -> [MigrationSeriesSnapshot] {
+    try readChunk(at: url)
+  }
+
+  static func readRawBookChunk(at url: URL) throws -> [MigrationBookRawSnapshot] {
+    try readChunk(at: url)
+  }
+
+  static func readRawSeriesChunk(at url: URL) throws -> [MigrationSeriesRawSnapshot] {
     try readChunk(at: url)
   }
 
@@ -62,6 +93,14 @@ nonisolated private enum MigrationSnapshotStore {
 
   static func seriesChunkURLs() -> [URL] {
     chunkURLs(prefix: seriesPrefix)
+  }
+
+  static func rawBookChunkURLs() -> [URL] {
+    chunkURLs(prefix: rawBooksPrefix)
+  }
+
+  static func rawSeriesChunkURLs() -> [URL] {
+    chunkURLs(prefix: rawSeriesPrefix)
   }
 
   private static func writeChunk<T: Encodable>(
@@ -112,6 +151,7 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
       KMReaderSchemaV1.self,
       KMReaderSchemaV2.self,
       KMReaderSchemaV3.self,
+      KMReaderSchemaV4.self,
     ]
   }
 
@@ -119,6 +159,7 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
     [
       migrateV1toV2,
       migrateV2toV3,
+      migrateV3toV4,
     ]
   }
 
@@ -145,6 +186,26 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
   static let migrateV2toV3 = MigrationStage.lightweight(
     fromVersion: KMReaderSchemaV2.self,
     toVersion: KMReaderSchemaV3.self
+  )
+
+  static let migrateV3toV4 = MigrationStage.custom(
+    fromVersion: KMReaderSchemaV3.self,
+    toVersion: KMReaderSchemaV4.self,
+    willMigrate: { context in
+      try MigrationSnapshotStore.prepare()
+      try snapshotRawBooks(context: context)
+      try snapshotRawSeries(context: context)
+    },
+    didMigrate: { context in
+      defer { MigrationSnapshotStore.clear() }
+
+      try applyRawBookSnapshots(context: context)
+      try applyRawSeriesSnapshots(context: context)
+
+      if context.hasChanges {
+        try context.save()
+      }
+    }
   )
 
   private static func snapshotBooks(context: ModelContext) throws {
@@ -198,7 +259,7 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
 
       let byID = Dictionary(uniqueKeysWithValues: snapshots.map { ($0.id, $0) })
       let ids = Set(byID.keys)
-      let descriptor = FetchDescriptor<KomgaBook>(
+      let descriptor = FetchDescriptor<KMReaderSchemaV2.KomgaBook>(
         predicate: #Predicate { ids.contains($0.id) }
       )
       let books = try context.fetch(descriptor)
@@ -225,7 +286,7 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
 
       let byID = Dictionary(uniqueKeysWithValues: snapshots.map { ($0.id, $0) })
       let ids = Set(byID.keys)
-      let descriptor = FetchDescriptor<KomgaSeries>(
+      let descriptor = FetchDescriptor<KMReaderSchemaV2.KomgaSeries>(
         predicate: #Predicate { ids.contains($0.id) }
       )
       let seriesList = try context.fetch(descriptor)
@@ -236,6 +297,99 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
           metadata: snapshot.metadata,
           booksMetadata: snapshot.booksMetadata
         )
+      }
+
+      if context.hasChanges {
+        try context.save()
+      }
+    }
+  }
+
+  private static func snapshotRawBooks(context: ModelContext) throws {
+    var offset = 0
+    var chunkIndex = 0
+
+    while true {
+      var descriptor = FetchDescriptor<KMReaderSchemaV3.KomgaBook>(
+        sortBy: [SortDescriptor(\KMReaderSchemaV3.KomgaBook.id, order: .forward)]
+      )
+      descriptor.fetchOffset = offset
+      descriptor.fetchLimit = migrationBatchSize
+
+      let books = try context.fetch(descriptor)
+      guard !books.isEmpty else { break }
+
+      let chunk = books.map(makeRawBookSnapshot)
+      try MigrationSnapshotStore.writeRawBookChunk(chunk, index: chunkIndex)
+
+      offset += books.count
+      chunkIndex += 1
+    }
+  }
+
+  private static func snapshotRawSeries(context: ModelContext) throws {
+    var offset = 0
+    var chunkIndex = 0
+
+    while true {
+      var descriptor = FetchDescriptor<KMReaderSchemaV3.KomgaSeries>(
+        sortBy: [SortDescriptor(\KMReaderSchemaV3.KomgaSeries.id, order: .forward)]
+      )
+      descriptor.fetchOffset = offset
+      descriptor.fetchLimit = migrationBatchSize
+
+      let series = try context.fetch(descriptor)
+      guard !series.isEmpty else { break }
+
+      let chunk = series.map(makeRawSeriesSnapshot)
+      try MigrationSnapshotStore.writeRawSeriesChunk(chunk, index: chunkIndex)
+
+      offset += series.count
+      chunkIndex += 1
+    }
+  }
+
+  private static func applyRawBookSnapshots(context: ModelContext) throws {
+    for chunkURL in MigrationSnapshotStore.rawBookChunkURLs() {
+      let snapshots = try MigrationSnapshotStore.readRawBookChunk(at: chunkURL)
+      guard !snapshots.isEmpty else { continue }
+
+      let byID = Dictionary(uniqueKeysWithValues: snapshots.map { ($0.id, $0) })
+      let ids = Set(byID.keys)
+      let descriptor = FetchDescriptor<KomgaBook>(
+        predicate: #Predicate { ids.contains($0.id) }
+      )
+      let books = try context.fetch(descriptor)
+
+      for book in books {
+        guard let snapshot = byID[book.id] else { continue }
+        book.mediaRaw = snapshot.mediaRaw
+        book.metadataRaw = snapshot.metadataRaw
+        book.readProgressRaw = snapshot.readProgressRaw
+      }
+
+      if context.hasChanges {
+        try context.save()
+      }
+    }
+  }
+
+  private static func applyRawSeriesSnapshots(context: ModelContext) throws {
+    for chunkURL in MigrationSnapshotStore.rawSeriesChunkURLs() {
+      let snapshots = try MigrationSnapshotStore.readRawSeriesChunk(at: chunkURL)
+      guard !snapshots.isEmpty else { continue }
+
+      let byID = Dictionary(uniqueKeysWithValues: snapshots.map { ($0.id, $0) })
+      let ids = Set(byID.keys)
+      let descriptor = FetchDescriptor<KomgaSeries>(
+        predicate: #Predicate { ids.contains($0.id) }
+      )
+      let seriesList = try context.fetch(descriptor)
+
+      for series in seriesList {
+        guard let snapshot = byID[series.id] else { continue }
+        series.metadataRaw = snapshot.metadataRaw
+        series.booksMetadataRaw = snapshot.booksMetadataRaw
       }
 
       if context.hasChanges {
@@ -304,6 +458,17 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
     )
   }
 
+  private static func makeRawBookSnapshot(
+    _ book: KMReaderSchemaV3.KomgaBook
+  ) -> MigrationBookRawSnapshot {
+    MigrationBookRawSnapshot(
+      id: book.id,
+      mediaRaw: RawCodableStore.encode(book.media ?? Media.empty),
+      metadataRaw: RawCodableStore.encode(book.metadata ?? BookMetadata.empty),
+      readProgressRaw: RawCodableStore.encodeOptional(book.readProgress)
+    )
+  }
+
   private static func makeSeriesSnapshot(_ series: KMReaderSchemaV1.KomgaSeries) -> MigrationSeriesSnapshot {
     let metadata = SeriesMetadata(
       status: series.metaStatus,
@@ -352,6 +517,16 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
       id: series.id,
       metadata: metadata,
       booksMetadata: booksMetadata
+    )
+  }
+
+  private static func makeRawSeriesSnapshot(
+    _ series: KMReaderSchemaV3.KomgaSeries
+  ) -> MigrationSeriesRawSnapshot {
+    MigrationSeriesRawSnapshot(
+      id: series.id,
+      metadataRaw: RawCodableStore.encode(series.metadata ?? SeriesMetadata.empty),
+      booksMetadataRaw: RawCodableStore.encode(series.booksMetadata ?? SeriesBooksMetadata.empty)
     )
   }
 

--- a/KMReader/Core/Storage/Schema/KMReaderSchemaV2.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderSchemaV2.swift
@@ -15,8 +15,8 @@ enum KMReaderSchemaV2: VersionedSchema {
     [
       KomgaInstance.self,
       KomgaLibrary.self,
-      KomgaSeries.self,
-      KomgaBook.self,
+      KMReaderSchemaV2.KomgaSeries.self,
+      KMReaderSchemaV2.KomgaBook.self,
       KMReaderSchemaV2.KomgaCollection.self,
       KMReaderSchemaV2.KomgaReadList.self,
       CustomFont.self,
@@ -24,6 +24,136 @@ enum KMReaderSchemaV2: VersionedSchema {
       SavedFilter.self,
       EpubThemePreset.self,
     ]
+  }
+
+  @Model
+  final class KomgaBook {
+    @Attribute(.unique) var id: String = ""
+
+    var bookId: String = ""
+    var seriesId: String = ""
+    var libraryId: String = ""
+    var instanceId: String = ""
+
+    var name: String = ""
+    var url: String = ""
+    var number: Double = 0
+    var created: Date = Date(timeIntervalSince1970: 0)
+    var lastModified: Date = Date(timeIntervalSince1970: 0)
+    var sizeBytes: Int64 = 0
+    var size: String = ""
+
+    var media: Media?
+    var metadata: BookMetadata?
+    var readProgress: ReadProgress?
+
+    var mediaPagesCount: Int = 0
+    var mediaProfile: String?
+    var metaTitle: String = ""
+    var metaNumber: String = ""
+    var metaNumberSort: Double = 0
+    var metaReleaseDate: String?
+    var progressPage: Int?
+    var progressCompleted: Bool?
+    var progressReadDate: Date?
+    var metaAuthorsIndex: String = "|"
+    var metaTagsIndex: String = "|"
+
+    var isUnavailable: Bool = false
+    var oneshot: Bool = false
+    var seriesTitle: String = ""
+
+    var pagesRaw: Data?
+    var tocRaw: Data?
+    var webPubManifestRaw: Data?
+    var epubProgressionRaw: Data?
+
+    var downloadStatusRaw: String = "notDownloaded"
+    var downloadError: String?
+    var downloadAt: Date?
+    var downloadedSize: Int64 = 0
+
+    var readListIdsRaw: Data?
+
+    var isolatePagesRaw: Data?
+    var epubPreferencesRaw: String?
+
+    init() {}
+
+    func applyContent(media: Media, metadata: BookMetadata, readProgress: ReadProgress?) {
+      self.media = media
+      self.metadata = metadata
+      self.readProgress = readProgress
+      mediaPagesCount = media.pagesCount
+      mediaProfile = media.mediaProfile
+      metaTitle = metadata.title
+      metaNumber = metadata.number
+      metaNumberSort = metadata.numberSort
+      metaReleaseDate = metadata.releaseDate
+      progressPage = readProgress?.page
+      progressCompleted = readProgress?.completed
+      progressReadDate = readProgress?.readDate
+      metaAuthorsIndex = MetadataIndex.encode(values: metadata.authors?.map(\.name) ?? [])
+      metaTagsIndex = MetadataIndex.encode(values: metadata.tags ?? [])
+    }
+  }
+
+  @Model
+  final class KomgaSeries {
+    @Attribute(.unique) var id: String = ""
+
+    var seriesId: String = ""
+    var libraryId: String = ""
+    var instanceId: String = ""
+
+    var name: String = ""
+    var url: String = ""
+    var created: Date = Date(timeIntervalSince1970: 0)
+    var lastModified: Date = Date(timeIntervalSince1970: 0)
+
+    var booksCount: Int = 0
+    var booksReadCount: Int = 0
+    var booksUnreadCount: Int = 0
+    var booksInProgressCount: Int = 0
+
+    var metadata: SeriesMetadata?
+    var booksMetadata: SeriesBooksMetadata?
+
+    var metaTitle: String = ""
+    var metaTitleSort: String = ""
+    var metaPublisherIndex: String = "|"
+    var metaAuthorsIndex: String = "|"
+    var metaGenresIndex: String = "|"
+    var metaTagsIndex: String = "|"
+    var metaLanguageIndex: String = "|"
+
+    var isUnavailable: Bool = false
+    var oneshot: Bool = false
+
+    var downloadStatusRaw: String = "notDownloaded"
+    var downloadError: String?
+    var downloadAt: Date?
+    var downloadedSize: Int64 = 0
+    var downloadedBooks: Int = 0
+    var pendingBooks: Int = 0
+    var offlinePolicyRaw: String = "manual"
+    var offlinePolicyLimit: Int = 0
+
+    var collectionIdsRaw: Data?
+
+    init() {}
+
+    func applyContent(metadata: SeriesMetadata, booksMetadata: SeriesBooksMetadata) {
+      self.metadata = metadata
+      self.booksMetadata = booksMetadata
+      metaTitle = metadata.title
+      metaTitleSort = metadata.titleSort
+      metaPublisherIndex = MetadataIndex.encode(value: metadata.publisher)
+      metaAuthorsIndex = MetadataIndex.encode(values: booksMetadata.authors?.map(\.name) ?? [])
+      metaGenresIndex = MetadataIndex.encode(values: metadata.genres ?? [])
+      metaTagsIndex = MetadataIndex.encode(values: metadata.tags ?? [])
+      metaLanguageIndex = MetadataIndex.encode(value: metadata.language)
+    }
   }
 
   @Model

--- a/KMReader/Core/Storage/Schema/KMReaderSchemaV3.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderSchemaV3.swift
@@ -3,6 +3,7 @@
 //
 //
 
+import Foundation
 import SwiftData
 
 enum KMReaderSchemaV3: VersionedSchema {
@@ -14,8 +15,8 @@ enum KMReaderSchemaV3: VersionedSchema {
     [
       KomgaInstance.self,
       KomgaLibrary.self,
-      KomgaSeries.self,
-      KomgaBook.self,
+      KMReaderSchemaV3.KomgaSeries.self,
+      KMReaderSchemaV3.KomgaBook.self,
       KomgaCollection.self,
       KomgaReadList.self,
       CustomFont.self,
@@ -23,5 +24,106 @@ enum KMReaderSchemaV3: VersionedSchema {
       SavedFilter.self,
       EpubThemePreset.self,
     ]
+  }
+
+  @Model
+  final class KomgaBook {
+    @Attribute(.unique) var id: String = ""
+
+    var bookId: String = ""
+    var seriesId: String = ""
+    var libraryId: String = ""
+    var instanceId: String = ""
+
+    var name: String = ""
+    var url: String = ""
+    var number: Double = 0
+    var created: Date = Date(timeIntervalSince1970: 0)
+    var lastModified: Date = Date(timeIntervalSince1970: 0)
+    var sizeBytes: Int64 = 0
+    var size: String = ""
+
+    var media: Media?
+    var metadata: BookMetadata?
+    var readProgress: ReadProgress?
+
+    var mediaPagesCount: Int = 0
+    var mediaProfile: String?
+    var metaTitle: String = ""
+    var metaNumber: String = ""
+    var metaNumberSort: Double = 0
+    var metaReleaseDate: String?
+    var progressPage: Int?
+    var progressCompleted: Bool?
+    var progressReadDate: Date?
+    var metaAuthorsIndex: String = "|"
+    var metaTagsIndex: String = "|"
+
+    var isUnavailable: Bool = false
+    var oneshot: Bool = false
+    var seriesTitle: String = ""
+
+    var pagesRaw: Data?
+    var tocRaw: Data?
+    var webPubManifestRaw: Data?
+    var epubProgressionRaw: Data?
+
+    var downloadStatusRaw: String = "notDownloaded"
+    var downloadError: String?
+    var downloadAt: Date?
+    var downloadedSize: Int64 = 0
+
+    var readListIdsRaw: Data?
+
+    var isolatePagesRaw: Data?
+    var epubPreferencesRaw: String?
+
+    init() {}
+  }
+
+  @Model
+  final class KomgaSeries {
+    @Attribute(.unique) var id: String = ""
+
+    var seriesId: String = ""
+    var libraryId: String = ""
+    var instanceId: String = ""
+
+    var name: String = ""
+    var url: String = ""
+    var created: Date = Date(timeIntervalSince1970: 0)
+    var lastModified: Date = Date(timeIntervalSince1970: 0)
+
+    var booksCount: Int = 0
+    var booksReadCount: Int = 0
+    var booksUnreadCount: Int = 0
+    var booksInProgressCount: Int = 0
+
+    var metadata: SeriesMetadata?
+    var booksMetadata: SeriesBooksMetadata?
+
+    var metaTitle: String = ""
+    var metaTitleSort: String = ""
+    var metaPublisherIndex: String = "|"
+    var metaAuthorsIndex: String = "|"
+    var metaGenresIndex: String = "|"
+    var metaTagsIndex: String = "|"
+    var metaLanguageIndex: String = "|"
+
+    var isUnavailable: Bool = false
+    var oneshot: Bool = false
+
+    var downloadStatusRaw: String = "notDownloaded"
+    var downloadError: String?
+    var downloadAt: Date?
+    var downloadedSize: Int64 = 0
+    var downloadedBooks: Int = 0
+    var pendingBooks: Int = 0
+    var offlinePolicyRaw: String = "manual"
+    var offlinePolicyLimit: Int = 0
+
+    var collectionIdsRaw: Data?
+
+    init() {}
   }
 }

--- a/KMReader/Core/Storage/Schema/KMReaderSchemaV4.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderSchemaV4.swift
@@ -1,0 +1,27 @@
+//
+// KMReaderSchemaV4.swift
+//
+//
+
+import SwiftData
+
+enum KMReaderSchemaV4: VersionedSchema {
+  static var versionIdentifier: Schema.Version {
+    Schema.Version(4, 0, 0)
+  }
+
+  static var models: [any PersistentModel.Type] {
+    [
+      KomgaInstance.self,
+      KomgaLibrary.self,
+      KomgaSeries.self,
+      KomgaBook.self,
+      KomgaCollection.self,
+      KomgaReadList.self,
+      CustomFont.self,
+      PendingProgress.self,
+      SavedFilter.self,
+      EpubThemePreset.self,
+    ]
+  }
+}

--- a/KMReader/Features/Book/Models/KomgaBook.swift
+++ b/KMReader/Features/Book/Models/KomgaBook.swift
@@ -23,10 +23,10 @@ final class KomgaBook {
   var sizeBytes: Int64
   var size: String
 
-  // API-aligned fields
-  var media: Media?
-  var metadata: BookMetadata?
-  var readProgress: ReadProgress?
+  // API-aligned raw storage
+  var mediaRaw: Data?
+  var metadataRaw: Data?
+  var readProgressRaw: Data?
 
   // Query fields
   var mediaPagesCount: Int
@@ -76,6 +76,21 @@ final class KomgaBook {
   var epubPreferences: EpubReaderPreferences? {
     get { epubPreferencesRaw.flatMap { EpubReaderPreferences(rawValue: $0) } }
     set { epubPreferencesRaw = newValue?.rawValue }
+  }
+
+  var media: Media? {
+    get { RawCodableStore.decode(Media.self, from: mediaRaw) }
+    set { mediaRaw = RawCodableStore.encodeOptional(newValue) }
+  }
+
+  var metadata: BookMetadata? {
+    get { RawCodableStore.decode(BookMetadata.self, from: metadataRaw) }
+    set { metadataRaw = RawCodableStore.encodeOptional(newValue) }
+  }
+
+  var readProgress: ReadProgress? {
+    get { RawCodableStore.decode(ReadProgress.self, from: readProgressRaw) }
+    set { readProgressRaw = RawCodableStore.encodeOptional(newValue) }
   }
 
   /// Computed property for download status.
@@ -161,9 +176,9 @@ final class KomgaBook {
     self.sizeBytes = sizeBytes
     self.size = size
 
-    self.media = media
-    self.metadata = metadata
-    self.readProgress = readProgress
+    self.mediaRaw = RawCodableStore.encode(media)
+    self.metadataRaw = RawCodableStore.encode(metadata)
+    self.readProgressRaw = RawCodableStore.encodeOptional(readProgress)
 
     self.mediaPagesCount = media.pagesCount
     self.mediaProfile = media.mediaProfile
@@ -187,44 +202,37 @@ final class KomgaBook {
     self.epubProgressionRaw = nil
   }
 
+  func updateMedia(_ media: Media, raw: Data?) {
+    mediaRaw = raw ?? RawCodableStore.encode(media)
+    syncMediaFields(media)
+  }
+
+  func updateMetadata(_ metadata: BookMetadata, raw: Data?) {
+    metadataRaw = raw ?? RawCodableStore.encode(metadata)
+    syncMetadataFields(metadata)
+  }
+
   func applyContent(media: Media, metadata: BookMetadata, readProgress: ReadProgress?) {
-    self.media = media
-    self.metadata = metadata
-    self.readProgress = readProgress
-    syncQueryFields(media: media, metadata: metadata, readProgress: readProgress)
+    updateMedia(media, raw: RawCodableStore.encode(media))
+    updateMetadata(metadata, raw: RawCodableStore.encode(metadata))
+    updateReadProgress(readProgress, raw: RawCodableStore.encodeOptional(readProgress))
   }
 
   func updateReadProgress(_ readProgress: ReadProgress?) {
-    self.readProgress = readProgress
+    updateReadProgress(readProgress, raw: RawCodableStore.encodeOptional(readProgress))
+  }
+
+  func updateReadProgress(_ readProgress: ReadProgress?, raw: Data?) {
+    readProgressRaw = raw
     syncReadProgressFields(readProgress)
   }
 
-  func hasDifferentContentFields(
-    media: Media,
-    metadata: BookMetadata,
-    readProgress: ReadProgress?
-  ) -> Bool {
-    return mediaPagesCount != media.pagesCount
-      || mediaProfile != media.mediaProfile
-      || metaTitle != metadata.title
-      || metaNumber != metadata.number
-      || metaNumberSort != metadata.numberSort
-      || metaReleaseDate != metadata.releaseDate
-      || metaAuthorsIndex != MetadataIndex.encode(values: metadata.authors?.map(\.name) ?? [])
-      || metaTagsIndex != MetadataIndex.encode(values: metadata.tags ?? [])
-      || hasDifferentReadProgressFields(readProgress)
-  }
-
-  func hasDifferentReadProgressFields(_ readProgress: ReadProgress?) -> Bool {
-    return progressPage != readProgress?.page
-      || progressCompleted != readProgress?.completed
-      || progressReadDate != readProgress?.readDate
-  }
-
-  private func syncQueryFields(media: Media, metadata: BookMetadata, readProgress: ReadProgress?) {
+  private func syncMediaFields(_ media: Media) {
     mediaPagesCount = media.pagesCount
     mediaProfile = media.mediaProfile
+  }
 
+  private func syncMetadataFields(_ metadata: BookMetadata) {
     metaTitle = metadata.title
     metaNumber = metadata.number
     metaNumberSort = metadata.numberSort
@@ -232,7 +240,6 @@ final class KomgaBook {
     metaAuthorsIndex = MetadataIndex.encode(values: metadata.authors?.map(\.name) ?? [])
     metaTagsIndex = MetadataIndex.encode(values: metadata.tags ?? [])
 
-    syncReadProgressFields(readProgress)
   }
 
   private func syncReadProgressFields(_ readProgress: ReadProgress?) {

--- a/KMReader/Features/Series/Models/KomgaSeries.swift
+++ b/KMReader/Features/Series/Models/KomgaSeries.swift
@@ -24,9 +24,9 @@ final class KomgaSeries {
   var booksUnreadCount: Int
   var booksInProgressCount: Int
 
-  // API-aligned fields
-  var metadata: SeriesMetadata?
-  var booksMetadata: SeriesBooksMetadata?
+  // API-aligned raw storage
+  var metadataRaw: Data?
+  var booksMetadataRaw: Data?
 
   // Query fields
   var metaTitle: String
@@ -58,6 +58,16 @@ final class KomgaSeries {
       collectionIdsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? []
     }
     set { collectionIdsRaw = try? JSONEncoder().encode(newValue) }
+  }
+
+  var metadata: SeriesMetadata? {
+    get { RawCodableStore.decode(SeriesMetadata.self, from: metadataRaw) }
+    set { metadataRaw = RawCodableStore.encodeOptional(newValue) }
+  }
+
+  var booksMetadata: SeriesBooksMetadata? {
+    get { RawCodableStore.decode(SeriesBooksMetadata.self, from: booksMetadataRaw) }
+    set { booksMetadataRaw = RawCodableStore.encodeOptional(newValue) }
   }
 
   /// Computed property for download status.
@@ -136,8 +146,8 @@ final class KomgaSeries {
     self.booksUnreadCount = booksUnreadCount
     self.booksInProgressCount = booksInProgressCount
 
-    self.metadata = metadata
-    self.booksMetadata = booksMetadata
+    self.metadataRaw = RawCodableStore.encode(metadata)
+    self.booksMetadataRaw = RawCodableStore.encode(booksMetadata)
     self.metaTitle = metadata.title
     self.metaTitleSort = metadata.titleSort
     self.metaPublisherIndex = MetadataIndex.encode(value: metadata.publisher)
@@ -156,34 +166,33 @@ final class KomgaSeries {
     self.collectionIdsRaw = try? JSONEncoder().encode([] as [String])
   }
 
+  func updateMetadata(_ metadata: SeriesMetadata, raw: Data?) {
+    metadataRaw = raw ?? RawCodableStore.encode(metadata)
+    syncMetadataFields(metadata)
+  }
+
+  func updateBooksMetadata(_ booksMetadata: SeriesBooksMetadata, raw: Data?) {
+    booksMetadataRaw = raw ?? RawCodableStore.encode(booksMetadata)
+    syncBooksMetadataFields(booksMetadata)
+  }
+
   func applyContent(metadata: SeriesMetadata, booksMetadata: SeriesBooksMetadata) {
-    self.metadata = metadata
-    self.booksMetadata = booksMetadata
-    syncQueryFields(metadata: metadata, booksMetadata: booksMetadata)
+    updateMetadata(metadata, raw: RawCodableStore.encode(metadata))
+    updateBooksMetadata(booksMetadata, raw: RawCodableStore.encode(booksMetadata))
   }
 
-  func hasDifferentContentFields(
-    metadata: SeriesMetadata,
-    booksMetadata: SeriesBooksMetadata
-  ) -> Bool {
-    return metaTitle != metadata.title
-      || metaTitleSort != metadata.titleSort
-      || metaPublisherIndex != MetadataIndex.encode(value: metadata.publisher)
-      || metaAuthorsIndex != MetadataIndex.encode(values: booksMetadata.authors?.map(\.name) ?? [])
-      || metaGenresIndex != MetadataIndex.encode(values: metadata.genres ?? [])
-      || metaTagsIndex != MetadataIndex.encode(values: metadata.tags ?? [])
-      || metaLanguageIndex != MetadataIndex.encode(value: metadata.language)
-  }
-
-  private func syncQueryFields(metadata: SeriesMetadata, booksMetadata: SeriesBooksMetadata) {
+  private func syncMetadataFields(_ metadata: SeriesMetadata) {
     metaTitle = metadata.title
     metaTitleSort = metadata.titleSort
 
     metaPublisherIndex = MetadataIndex.encode(value: metadata.publisher)
-    metaAuthorsIndex = MetadataIndex.encode(values: booksMetadata.authors?.map(\.name) ?? [])
     metaGenresIndex = MetadataIndex.encode(values: metadata.genres ?? [])
     metaTagsIndex = MetadataIndex.encode(values: metadata.tags ?? [])
     metaLanguageIndex = MetadataIndex.encode(value: metadata.language)
+  }
+
+  private func syncBooksMetadataFields(_ booksMetadata: SeriesBooksMetadata) {
+    metaAuthorsIndex = MetadataIndex.encode(values: booksMetadata.authors?.map(\.name) ?? [])
   }
 
   func toSeries() -> Series {

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -75,7 +75,7 @@ struct MainApp: App {
   }
 
   private func makeModelContainer() throws -> ModelContainer {
-    let schema = Schema(versionedSchema: KMReaderSchemaV3.self)
+    let schema = Schema(versionedSchema: KMReaderSchemaV4.self)
     let configuration = ModelConfiguration(schema: schema)
     return try ModelContainer(
       for: schema,


### PR DESCRIPTION
## Problem
Book and series detail refreshes could miss server-side changes after the first fetch because the upsert path only compared selected shadow fields and used `lastModified` as part of the content update decision. Komga metadata timestamps are not reliable enough for that role, and reading SwiftData transformables directly during upsert was already known to be crash-prone.

## Approach
Store API detail payload groups as sorted raw JSON `Data` in SwiftData and compare those raw snapshots during upsert. The raw fields are split by ownership boundary, so `media`, `metadata`, `readProgress`, and series book metadata can update independently while their query shadow fields stay derived from the decoded payloads.

A new V4 schema migrates existing V3 transformable values into raw snapshots. Historical V2 and V3 book/series models are frozen inside their schema definitions so future runtime model changes do not mutate shipped schema shapes.

## Scope
- Replace book and series transformable detail storage with raw data fields.
- Compare raw API payload snapshots during book, series, and reading-progress upserts.
- Add `KMReaderSchemaV4` and a V3-to-V4 custom migration.
- Bump build version to 423.

## Validation
- [x] `make format`
- [x] `make build`
