### PR TITLE
fix(reader): isolate tap zones from controls

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 424;
+				CURRENT_PROJECT_VERSION = 425;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 424;
+				CURRENT_PROJECT_VERSION = 425;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 424;
+				CURRENT_PROJECT_VERSION = 425;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 424;
+				CURRENT_PROJECT_VERSION = 425;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -146,6 +146,7 @@ struct DivinaControlsOverlayView: View {
     VStack(spacing: 0) {
       if controlsVisible {
         topBar
+          .readerControlHitTestRegion()
           .transition(
             .move(edge: .top)
               .combined(with: .opacity)
@@ -156,6 +157,7 @@ struct DivinaControlsOverlayView: View {
 
       if controlsVisible {
         bottomBar
+          .readerControlHitTestRegion()
           .transition(
             .move(edge: .bottom)
               .combined(with: .opacity)

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -58,6 +58,7 @@ struct DivinaReaderView: View {
   @State private var nextBook: Book?
   @State private var previousBook: Book?
   @State private var showTapZoneOverlay = false
+  @State private var controlHitTestRegions: [CGRect] = []
   @State private var tapZoneOverlayTimer: Timer?
 
   @State private var showKeyboardHelp = false
@@ -651,7 +652,6 @@ struct DivinaReaderView: View {
                 viewModel: viewModel,
                 readListContext: readListContext,
                 onDismiss: { closeReader() },
-                toggleControls: { toggleControls() },
                 scrollController: webtoonScrollController,
                 pageWidthPercentage: webtoonPageWidthPercentage,
                 renderConfig: renderConfig
@@ -726,6 +726,7 @@ struct DivinaReaderView: View {
               tapZoneInversionMode: tapZoneInversionMode,
               doubleTapZoomMode: doubleTapZoomMode,
               enableLiveText: enableLiveText,
+              excludedHitTestRegions: controlHitTestRegions,
               onAction: handleTapZoneAction
             )
           )
@@ -838,6 +839,9 @@ struct DivinaReaderView: View {
       showingControls: showingControls,
       showGradientBackground: showControlsGradientBackground
     )
+    .onPreferenceChange(ReaderControlHitTestRegionPreferenceKey.self) { regions in
+      controlHitTestRegions = shouldShowControls ? regions : []
+    }
   }
 
   private var keyboardCommands: [ReaderKeyboardCommand] {
@@ -1520,7 +1524,7 @@ struct DivinaReaderView: View {
   #if os(iOS) || os(macOS)
     private var isTapZoneGestureEnabled: Bool {
       viewModel.hasPages
-        && readingDirection != .webtoon
+        && !isPresentingModalSheet
         && !viewModel.isZoomed
     }
   #endif

--- a/KMReader/Features/Reader/Views/DivinaTapZoneGestureBridge.swift
+++ b/KMReader/Features/Reader/Views/DivinaTapZoneGestureBridge.swift
@@ -19,6 +19,7 @@
     let tapZoneInversionMode: TapZoneInversionMode
     let doubleTapZoomMode: DoubleTapZoomMode
     let enableLiveText: Bool
+    let excludedHitTestRegions: [CGRect]
     let onAction: (TapZoneAction) -> Void
 
     var body: some View {
@@ -38,7 +39,8 @@
         tapZoneMode: tapZoneMode,
         tapZoneInversionMode: tapZoneInversionMode,
         tapDebounceDelay: doubleTapZoomMode.tapDebounceDelay,
-        enableLiveText: enableLiveText
+        enableLiveText: enableLiveText,
+        excludedHitTestRegions: excludedHitTestRegions
       )
     }
 
@@ -49,6 +51,7 @@
       let tapZoneInversionMode: TapZoneInversionMode
       let tapDebounceDelay: TimeInterval
       let enableLiveText: Bool
+      let excludedHitTestRegions: [CGRect]
     }
 
     #if os(iOS)
@@ -266,6 +269,9 @@
 
           func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
             guard configuration.isEnabled else { return false }
+            if isExcludedHitTestRegion(touch: touch) {
+              return false
+            }
             if isInteractiveElement(touch.view) {
               return false
             }
@@ -284,6 +290,13 @@
             }
 
             return true
+          }
+
+          private func isExcludedHitTestRegion(touch: UITouch) -> Bool {
+            guard !configuration.excludedHitTestRegions.isEmpty else { return false }
+            guard let window = touch.window ?? touch.view?.window else { return false }
+            let location = touch.location(in: window)
+            return configuration.excludedHitTestRegions.contains { $0.contains(location) }
           }
 
           func gestureRecognizer(
@@ -562,6 +575,9 @@
             guard let attachedView else { return false }
 
             let windowLocation = event.locationInWindow
+            if isExcludedHitTestRegion(windowLocation: windowLocation, attachedView: attachedView) {
+              return false
+            }
             let location = attachedView.convert(windowLocation, from: nil)
             guard
               let hitView = resolvedHitView(
@@ -584,6 +600,16 @@
             }
 
             return true
+          }
+
+          private func isExcludedHitTestRegion(
+            windowLocation: NSPoint,
+            attachedView: NSView
+          ) -> Bool {
+            guard !configuration.excludedHitTestRegions.isEmpty else { return false }
+            let contentHeight = attachedView.window?.contentView?.bounds.height ?? attachedView.bounds.height
+            let location = CGPoint(x: windowLocation.x, y: contentHeight - windowLocation.y)
+            return configuration.excludedHitTestRegions.contains { $0.contains(location) }
           }
 
           private func resolvedHitView(for windowLocation: NSPoint, attachedView: NSView) -> NSView? {

--- a/KMReader/Features/Reader/Views/ReaderControlHitTestRegionPreferenceKey.swift
+++ b/KMReader/Features/Reader/Views/ReaderControlHitTestRegionPreferenceKey.swift
@@ -1,0 +1,27 @@
+//
+// ReaderControlHitTestRegionPreferenceKey.swift
+//
+//
+
+import SwiftUI
+
+struct ReaderControlHitTestRegionPreferenceKey: PreferenceKey {
+  static var defaultValue: [CGRect] = []
+
+  static func reduce(value: inout [CGRect], nextValue: () -> [CGRect]) {
+    value.append(contentsOf: nextValue())
+  }
+}
+
+extension View {
+  func readerControlHitTestRegion() -> some View {
+    background(
+      GeometryReader { geometry in
+        Color.clear.preference(
+          key: ReaderControlHitTestRegionPreferenceKey.self,
+          value: [geometry.frame(in: .global)]
+        )
+      }
+    )
+  }
+}

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonPageView.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonPageView.swift
@@ -10,7 +10,6 @@
     let viewModel: ReaderViewModel
     let readListContext: ReaderReadListContext?
     let onDismiss: () -> Void
-    let toggleControls: () -> Void
     let scrollController: WebtoonScrollController
     let pageWidthPercentage: Double
     let renderConfig: ReaderRenderConfig
@@ -31,9 +30,6 @@
             renderConfig: renderConfig,
             readListContext: readListContext,
             onDismiss: onDismiss,
-            onCenterTap: {
-              toggleControls()
-            },
             onZoomRequest: { pageID, anchor in
               openZoomOverlay(pageID: pageID, anchor: anchor)
             },

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -11,7 +11,6 @@
     let viewModel: ReaderViewModel
     let readListContext: ReaderReadListContext?
     let onDismiss: () -> Void
-    let onCenterTap: (() -> Void)?
     let onZoomRequest: ((ReaderPageID, CGPoint) -> Void)?
     let pageWidth: CGFloat
     let renderConfig: ReaderRenderConfig
@@ -23,7 +22,6 @@
       renderConfig: ReaderRenderConfig,
       readListContext: ReaderReadListContext? = nil,
       onDismiss: @escaping () -> Void = {},
-      onCenterTap: (() -> Void)? = nil,
       onZoomRequest: ((ReaderPageID, CGPoint) -> Void)? = nil,
       scrollController: WebtoonScrollController
     ) {
@@ -32,7 +30,6 @@
       self.renderConfig = renderConfig
       self.readListContext = readListContext
       self.onDismiss = onDismiss
-      self.onCenterTap = onCenterTap
       self.onZoomRequest = onZoomRequest
       self.scrollController = scrollController
     }
@@ -53,15 +50,6 @@
       collectionView.register(WebtoonPageCell.self, forCellWithReuseIdentifier: "WebtoonPageCell")
       collectionView.register(
         WebtoonFooterCell.self, forCellWithReuseIdentifier: "WebtoonFooterCell")
-
-      let tapGesture = UITapGestureRecognizer(
-        target: context.coordinator,
-        action: #selector(Coordinator.handleTap(_:))
-      )
-      tapGesture.numberOfTapsRequired = 1
-      tapGesture.cancelsTouchesInView = false
-      tapGesture.delegate = context.coordinator
-      collectionView.addGestureRecognizer(tapGesture)
 
       let doubleTapGesture = UITapGestureRecognizer(
         target: context.coordinator,
@@ -101,7 +89,6 @@
         viewModel: viewModel,
         readListContext: readListContext,
         onDismiss: onDismiss,
-        onCenterTap: onCenterTap,
         onZoomRequest: onZoomRequest,
         pageWidth: pageWidth,
         collectionView: collectionView,
@@ -129,7 +116,6 @@
       weak var viewModel: ReaderViewModel?
       var readListContext: ReaderReadListContext?
       var onDismiss: (() -> Void)?
-      var onCenterTap: (() -> Void)?
       var onZoomRequest: ((ReaderPageID, CGPoint) -> Void)?
       weak var scrollController: WebtoonScrollController?
       var lastPagesCount: Int = 0
@@ -143,7 +129,6 @@
       var showPageNumber: Bool = true
       var isLongPress: Bool = false
       var hasTriggeredZoomGesture: Bool = false
-      private var singleTapWorkItem: DispatchWorkItem?
       private var deferredReloadWorkItem: DispatchWorkItem?
       private var deferredCleanupWorkItem: DispatchWorkItem?
       private var sizeProbeTasks: [ReaderPageID: Task<Void, Never>] = [:]
@@ -163,7 +148,6 @@
         self.viewModel = parent.viewModel
         self.readListContext = parent.readListContext
         self.onDismiss = parent.onDismiss
-        self.onCenterTap = parent.onCenterTap
         self.onZoomRequest = parent.onZoomRequest
         self.scrollController = parent.scrollController
         self.lastPagesCount = parent.viewModel.pageCount
@@ -371,7 +355,6 @@
         viewModel: ReaderViewModel,
         readListContext: ReaderReadListContext?,
         onDismiss: @escaping () -> Void,
-        onCenterTap: (() -> Void)?,
         onZoomRequest: ((ReaderPageID, CGPoint) -> Void)?,
         pageWidth: CGFloat,
         collectionView: UICollectionView,
@@ -381,7 +364,6 @@
         self.viewModel = viewModel
         self.readListContext = readListContext
         self.onDismiss = onDismiss
-        self.onCenterTap = onCenterTap
         self.onZoomRequest = onZoomRequest
         self.pageWidth = pageWidth
         self.readerBackground = renderConfig.readerBackground
@@ -587,8 +569,6 @@
 
       func teardown() {
         scrollController?.clearTarget(self)
-        singleTapWorkItem?.cancel()
-        singleTapWorkItem = nil
         cancelDeferredMaintenance()
         sizeProbeTasks.values.forEach { $0.cancel() }
         sizeProbeTasks.removeAll()
@@ -918,63 +898,11 @@
         }
       }
 
-      @objc func handleTap(_ gesture: UITapGestureRecognizer) {
-        singleTapWorkItem?.cancel()
-
-        guard !isLongPress else { return }
-
-        guard let collectionView = collectionView,
-          let view = collectionView.superview
-        else { return }
-
-        if collectionView.isDragging || collectionView.isDecelerating {
-          return
-        }
-
-        let location = gesture.location(in: view)
-        let screenHeight = view.bounds.height
-        let screenWidth = view.bounds.width
-
-        let normalizedX = location.x / screenWidth
-        let normalizedY = location.y / screenHeight
-
-        let action = TapZoneHelper.action(
-          normalizedX: normalizedX,
-          normalizedY: normalizedY,
-          tapZoneMode: tapZoneMode,
-          tapZoneInversionMode: tapZoneInversionMode,
-          readingDirection: .webtoon
-        )
-
-        let workItem = DispatchWorkItem { [weak self] in
-          guard let self = self else { return }
-          switch action {
-          case .previous:
-            self.scrollUp(collectionView: collectionView, screenHeight: screenHeight)
-          case .next:
-            self.scrollDown(collectionView: collectionView, screenHeight: screenHeight)
-          case .toggleControls:
-            self.onCenterTap?()
-          }
-        }
-        singleTapWorkItem = workItem
-
-        let delay = doubleTapZoomMode.tapDebounceDelay
-        if delay <= 0 {
-          workItem.perform()
-        } else {
-          DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
-        }
-      }
-
       @objc func handleDoubleTap(_ gesture: UITapGestureRecognizer) {
         guard !isLongPress else { return }
         guard let collectionView = collectionView else { return }
         if collectionView.isDragging || collectionView.isDecelerating { return }
         if doubleTapZoomMode == .disabled { return }
-
-        singleTapWorkItem?.cancel()
-        singleTapWorkItem = nil
 
         let location = gesture.location(in: collectionView)
         requestZoom(at: location)

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
@@ -11,7 +11,6 @@
     let viewModel: ReaderViewModel
     let readListContext: ReaderReadListContext?
     let onDismiss: () -> Void
-    let onCenterTap: (() -> Void)?
     let onZoomRequest: ((ReaderPageID, CGPoint) -> Void)?
     let pageWidth: CGFloat
     let renderConfig: ReaderRenderConfig
@@ -23,7 +22,6 @@
       renderConfig: ReaderRenderConfig,
       readListContext: ReaderReadListContext? = nil,
       onDismiss: @escaping () -> Void = {},
-      onCenterTap: (() -> Void)? = nil,
       onZoomRequest: ((ReaderPageID, CGPoint) -> Void)? = nil,
       scrollController: WebtoonScrollController
     ) {
@@ -32,7 +30,6 @@
       self.renderConfig = renderConfig
       self.readListContext = readListContext
       self.onDismiss = onDismiss
-      self.onCenterTap = onCenterTap
       self.onZoomRequest = onZoomRequest
       self.scrollController = scrollController
     }
@@ -60,11 +57,6 @@
       // scrollView.autohidesScrollers = true
       scrollView.backgroundColor = NSColor(renderConfig.readerBackground.color)
       scrollView.contentView.postsBoundsChangedNotifications = true
-
-      let clickGesture = NSClickGestureRecognizer(
-        target: context.coordinator, action: #selector(Coordinator.handleClick(_:)))
-      clickGesture.delegate = context.coordinator
-      collectionView.addGestureRecognizer(clickGesture)
 
       let pressGesture = NSPressGestureRecognizer(
         target: context.coordinator, action: #selector(Coordinator.handlePress(_:)))
@@ -106,7 +98,6 @@
           viewModel: viewModel,
           readListContext: readListContext,
           onDismiss: onDismiss,
-          onCenterTap: onCenterTap,
           onZoomRequest: onZoomRequest,
           pageWidth: pageWidth,
           collectionView: collectionView,
@@ -135,7 +126,6 @@
       weak var viewModel: ReaderViewModel?
       var readListContext: ReaderReadListContext?
       var onDismiss: (() -> Void)?
-      var onCenterTap: (() -> Void)?
       var onZoomRequest: ((ReaderPageID, CGPoint) -> Void)?
       weak var scrollController: WebtoonScrollController?
       var lastPagesCount: Int = 0
@@ -167,7 +157,6 @@
         self.viewModel = parent.viewModel
         self.readListContext = parent.readListContext
         self.onDismiss = parent.onDismiss
-        self.onCenterTap = parent.onCenterTap
         self.onZoomRequest = parent.onZoomRequest
         self.scrollController = parent.scrollController
         self.lastPagesCount = parent.viewModel.pageCount
@@ -365,7 +354,6 @@
         viewModel: ReaderViewModel,
         readListContext: ReaderReadListContext?,
         onDismiss: @escaping () -> Void,
-        onCenterTap: (() -> Void)?,
         onZoomRequest: ((ReaderPageID, CGPoint) -> Void)?,
         pageWidth: CGFloat,
         collectionView: NSCollectionView,
@@ -374,7 +362,6 @@
         self.viewModel = viewModel
         self.readListContext = readListContext
         self.onDismiss = onDismiss
-        self.onCenterTap = onCenterTap
         self.onZoomRequest = onZoomRequest
         self.pageWidth = pageWidth
         self.readerBackground = renderConfig.readerBackground
@@ -846,55 +833,6 @@
             [weak self] in
             self?.isLongPress = false
           }
-        }
-      }
-
-      @objc func handleClick(_ gesture: NSClickGestureRecognizer) {
-        guard !isLongPress else { return }
-
-        if isUserScrolling { return }
-
-        if Date().timeIntervalSinceReferenceDate - lastScrollTime < WebtoonConstants.clickDebounceAfterScroll {
-          return
-        }
-
-        guard let sv = scrollView, let window = sv.window, let cv = collectionView else { return }
-
-        let locationInCollection = gesture.location(in: cv)
-        if let indexPath = cv.indexPathForItem(at: locationInCollection),
-          indexPath.item < scrollEngine.contentItems.count,
-          case .end = scrollEngine.contentItems[indexPath.item],
-          let footerCell = cv.item(at: indexPath) as? WebtoonFooterCell,
-          footerCell.isInteractingWithCloseButton(at: locationInCollection, in: cv)
-        {
-          return
-        }
-
-        let locInWindow = gesture.location(in: nil)
-        let windowHeight = window.contentView?.bounds.height ?? window.frame.height
-        let loc = NSPoint(x: locInWindow.x, y: windowHeight - locInWindow.y)
-
-        let h = windowHeight
-        let w = window.contentView?.bounds.width ?? window.frame.width
-
-        let normalizedX = loc.x / w
-        let normalizedY = loc.y / h
-
-        let action = TapZoneHelper.action(
-          normalizedX: normalizedX,
-          normalizedY: normalizedY,
-          tapZoneMode: tapZoneMode,
-          tapZoneInversionMode: tapZoneInversionMode,
-          readingDirection: .webtoon
-        )
-
-        switch action {
-        case .previous:
-          scrollUp(h)
-        case .next:
-          scrollDown(h)
-        case .toggleControls:
-          onCenterTap?()
         }
       }
 


### PR DESCRIPTION
## Problem
DIVINA controls overlay buttons could still be seen by the reader tap-zone recognizer because the shared platform gesture bridge attaches above the SwiftUI controls layer. A button click could therefore both press the control and dispatch a tap-zone action, while webtoon avoided the issue only because it kept a separate tap recognizer inside its collection view.

## Approach
Keep the controls overlay in SwiftUI, but make the interactive top and bottom bars report explicit hit-test regions. The platform tap-zone bridge now rejects taps inside those regions before resolving tap-zone actions. Webtoon single-tap routing now uses the same DIVINA tap-zone bridge and parent-level reader intent path, so webtoon scrolling still goes through `WebtoonScrollController` without maintaining a second tap-zone implementation.

## Scope
- Add a reader control hit-test region preference helper
- Exclude controls overlay regions in UIKit and AppKit tap-zone gesture delegates
- Enable the shared tap-zone bridge for webtoon mode
- Remove webtoon iOS/macOS internal single-click tap-zone routing
- Bump build version to 425

## Validation
- [x] `make format`
- [x] `make build-macos`
- [x] `make build-ios`
- [x] `make build-tvos`
