### PR TITLE
feat(settings): add toggle for dashboard section gradient background

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 425;
+				CURRENT_PROJECT_VERSION = 426;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 425;
+				CURRENT_PROJECT_VERSION = 426;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 425;
+				CURRENT_PROJECT_VERSION = 426;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 425;
+				CURRENT_PROJECT_VERSION = 426;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -354,6 +354,18 @@ enum AppConfig {
     }
   }
 
+  static nonisolated var showDashboardSectionGradientBackground: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "showDashboardSectionGradientBackground") != nil {
+        return UserDefaults.standard.bool(forKey: "showDashboardSectionGradientBackground")
+      }
+      return true
+    }
+    set {
+      UserDefaults.standard.set(newValue, forKey: "showDashboardSectionGradientBackground")
+    }
+  }
+
   // MARK: - Browse Layouts
   static nonisolated var seriesBrowseLayout: BrowseLayoutMode {
     get {

--- a/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
@@ -13,6 +13,9 @@ struct DashboardPinnedSectionView: View {
 
   @AppStorage("currentInstanceId") private var currentInstanceId: String = ""
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
+  @AppStorage("showDashboardSectionGradientBackground")
+  private var showDashboardSectionGradientBackground: Bool =
+    AppConfig.showDashboardSectionGradientBackground
 
   @Query private var pinnedCollections: [KomgaCollection]
   @Query private var pinnedReadLists: [KomgaReadList]
@@ -121,11 +124,13 @@ struct DashboardPinnedSectionView: View {
     if isSupportedSection {
       ZStack {
         #if os(iOS) || os(macOS)
-          LinearGradient(
-            colors: backgroundColors,
-            startPoint: .top,
-            endPoint: .bottom
-          ).ignoresSafeArea()
+          if showDashboardSectionGradientBackground {
+            LinearGradient(
+              colors: backgroundColors,
+              startPoint: .top,
+              endPoint: .bottom
+            ).ignoresSafeArea()
+          }
         #endif
 
         VStack(alignment: .leading, spacing: 0) {

--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -24,6 +24,9 @@ struct DashboardSectionView: View {
 
   @AppStorage("dashboard") private var dashboard: DashboardConfiguration = DashboardConfiguration()
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
+  @AppStorage("showDashboardSectionGradientBackground")
+  private var showDashboardSectionGradientBackground: Bool =
+    AppConfig.showDashboardSectionGradientBackground
   @Environment(\.modelContext) private var modelContext
   @Environment(\.colorScheme) private var colorScheme
 
@@ -63,11 +66,13 @@ struct DashboardSectionView: View {
   var body: some View {
     ZStack {
       #if os(iOS) || os(macOS)
-        LinearGradient(
-          colors: backgroundColors,
-          startPoint: .top,
-          endPoint: .bottom
-        ).ignoresSafeArea()
+        if showDashboardSectionGradientBackground {
+          LinearGradient(
+            colors: backgroundColors,
+            startPoint: .top,
+            endPoint: .bottom
+          ).ignoresSafeArea()
+        }
       #endif
 
       VStack(alignment: .leading, spacing: 0) {

--- a/KMReader/Features/Settings/SettingsAppearanceView.swift
+++ b/KMReader/Features/Settings/SettingsAppearanceView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 struct SettingsAppearanceView: View {
   @AppStorage("themeColorHex") private var themeColor: ThemeColor = .orange
   @AppStorage("appColorScheme") private var appColorScheme: AppColorScheme = .system
+  @AppStorage("showDashboardSectionGradientBackground") private var showDashboardSectionGradientBackground: Bool =
+    AppConfig.showDashboardSectionGradientBackground
   @AppStorage("privacyProtection") private var privacyProtection: Bool = false
   #if os(iOS)
     @AppStorage("enableReaderLiveActivity") private var enableReaderLiveActivity: Bool = true
@@ -100,6 +102,14 @@ struct SettingsAppearanceView: View {
             supportsOpacity: false)
         #endif
 
+        Toggle(isOn: $showDashboardSectionGradientBackground) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text(String(localized: "settings.appearance.dashboardSectionGradientBackground.title"))
+            Text(String(localized: "settings.appearance.dashboardSectionGradientBackground.caption"))
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+        }
       }
 
       Section(header: Text(String(localized: "settings.appearance.privacy"))) {

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -63455,6 +63455,134 @@
         }
       }
     },
+    "settings.appearance.dashboardSectionGradientBackground.caption" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Farbverlauf hinter Dashboard-Abschnitten anzeigen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show a gradient behind each dashboard section."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar un degradado detras de cada seccion del panel."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher un dégradé derrière chaque section du tableau de bord."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra un gradiente dietro ogni sezione della dashboard."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダッシュボードの各セクションの背後にグラデーションを表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대시보드의 각 섹션 뒤에 그라데이션을 표시합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать градиент за каждым разделом панели."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在每个主页分区后显示渐变背景。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在每個主頁分區後顯示漸變背景。"
+          }
+        }
+      }
+    },
+    "settings.appearance.dashboardSectionGradientBackground.title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dashboard-Abschnittshintergrund"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dashboard Section Background"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fondo de secciones del panel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrière-plan des sections du tableau de bord"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sfondo sezioni dashboard"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダッシュボードセクションの背景"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대시보드 섹션 배경"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фон разделов панели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主页分区背景"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主頁分區背景"
+          }
+        }
+      }
+    },
     "settings.appearance.privacy" : {
       "localizations" : {
         "de" : {


### PR DESCRIPTION
## Problem

Each dashboard section has a gradient background, but users had no way to disable it. Some find it visually noisy when content is dense, so a toggle is needed.

## Approach

Added a `showDashboardSectionGradientBackground` config option (default `true`) to `AppConfig`, backed by `UserDefaults`. Exposed as a Toggle in Settings → Appearance. Both `LinearGradient` render points in `DashboardSectionView` and `DashboardPinnedSectionView` are gated by this flag.

## Scope
- `AppConfig`: new `showDashboardSectionGradientBackground` property, defaults to `true`
- `SettingsAppearanceView`: new Toggle with title and caption
- `DashboardSectionView` / `DashboardPinnedSectionView`: wrapped gradient in `if showDashboardSectionGradientBackground`
- Localization strings updated in `Localizable.xcstrings`

## Testing
- [x] Toggle on by default, gradient renders as before
- [x] Toggle off → gradient disappears, section content unaffected
- [x] Setting persists across app restarts
