### PR TITLE
fix(reader): preserve webtoon final-page progress

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 426;
+				CURRENT_PROJECT_VERSION = 427;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 426;
+				CURRENT_PROJECT_VERSION = 427;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 426;
+				CURRENT_PROJECT_VERSION = 427;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 426;
+				CURRENT_PROJECT_VERSION = 427;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -854,11 +854,23 @@
         }
 
         if scrollEngine.currentPageID != resolvedPageID {
+          commitLastPageBeforeBookBoundaryIfNeeded(nextPageID: resolvedPageID)
           scrollEngine.currentPageID = resolvedPageID
         }
         if commitToViewModel, viewModel?.currentReaderPage?.id != resolvedPageID {
           viewModel?.updateCurrentPosition(pageID: resolvedPageID)
         }
+      }
+
+      private func commitLastPageBeforeBookBoundaryIfNeeded(nextPageID: ReaderPageID) {
+        let currentBookId = scrollEngine.currentPageID?.bookId ?? viewModel?.currentReaderPage?.bookId
+        guard let currentBookId,
+          currentBookId != nextPageID.bookId,
+          let lastPageID = viewModel?.lastPageID(forSegmentBookId: currentBookId),
+          viewModel?.currentReaderPage?.id != lastPageID
+        else { return }
+
+        viewModel?.updateCurrentPosition(pageID: lastPageID)
       }
 
       // MARK: - Image Loading

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
@@ -807,11 +807,23 @@
         }
 
         if scrollEngine.currentPageID != resolvedPageID {
+          commitLastPageBeforeBookBoundaryIfNeeded(nextPageID: resolvedPageID)
           scrollEngine.currentPageID = resolvedPageID
         }
         if commitToViewModel, viewModel?.currentReaderPage?.id != resolvedPageID {
           viewModel?.updateCurrentPosition(pageID: resolvedPageID)
         }
+      }
+
+      private func commitLastPageBeforeBookBoundaryIfNeeded(nextPageID: ReaderPageID) {
+        let currentBookId = scrollEngine.currentPageID?.bookId ?? viewModel?.currentReaderPage?.bookId
+        guard let currentBookId,
+          currentBookId != nextPageID.bookId,
+          let lastPageID = viewModel?.lastPageID(forSegmentBookId: currentBookId),
+          viewModel?.currentReaderPage?.id != lastPageID
+        else { return }
+
+        viewModel?.updateCurrentPosition(pageID: lastPageID)
       }
 
       // MARK: - Image Loading


### PR DESCRIPTION
## Problem
Webtoon progress updates are debounced while scrolling, so a very short final page can be skipped when the reader scrolls directly through the end footer into the next book. In that case the previous book can keep stale progress on the penultimate page and never be marked completed.

## Approach
Preserve the lightweight debounced scrolling behavior, but detect the precise book-boundary transition. When the resolved page changes to a different book, commit the previous segment's last page before updating the scroll engine to the next book.

## Scope
- Add boundary-only final-page commit handling for iOS webtoon scrolling
- Apply the same handling to macOS webtoon scrolling
- Bump build version to 427

## Testing
- [x] make format
- [x] make build-macos
- [x] make build-ios
