### PR TITLE
fix: handle backslash separators in archive entry paths

### DIFF
--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -2424,7 +2424,14 @@ actor OfflineManager {
   }
 
   private static func normalizeArchivePath(_ path: String) -> String? {
-    let components = path.split(separator: "/").map(String.init)
+    // Treat both `/` and `\` as separators. CBR archives created on Windows tooling
+    // use backslashes inside entry paths, and Komga returns those verbatim in
+    // `BookPage.fileName`. libarchive normalizes RAR `\` to `/` when extracting, so
+    // matching the dictionary key and the staged relative path requires both sides
+    // to canonicalize to the same form.
+    let components = path
+      .split(whereSeparator: { $0 == "/" || $0 == "\\" })
+      .map(String.init)
     guard !components.isEmpty else { return nil }
 
     var normalized: [String] = []


### PR DESCRIPTION
Closes #779

## Summary

Offline download of CBR archives fails at the extraction step when the archive was created on Windows tooling and its entries use `\` as the path separator. `normalizeArchivePath` in `OfflineManager.swift` split only on `/`, so the page-side dictionary key (built from `page.fileName`) and the extraction-side staged relative path normalized to different forms. The lookup missed, `extracted.count < pages.count`, and finalization threw `Missing required data: Archive is missing page resource: …`.

Reproduced from a user-supplied log (book \"The Iron Wagon\" #3, source CBR named with `(HP)-(gesserit)` — a common Windows scene tagger):

```
[ERROR] [Offline] ❌ Background archive extraction failed for book 0Q5V20RCAJ50G,
file=book.cbr, ...,
error=Missing required data: Archive is missing page resource:
The Iron Wagon (2003) (Digital-1500) (HP)-(gesserit)\1002951733-I00001.jpg.
```

## Fix

Treat both `/` and `\` as separators in `normalizeArchivePath`:

```swift
let components = path
  .split(whereSeparator: { $0 == \"/\" || $0 == \"\\\\\" })
  .map(String.init)
```

Both the page-side key (from Komga's `BookPage.fileName`) and the extraction-side relative path (from `regularFiles` walking the staging directory) now canonicalize to the same `/`-joined form, regardless of which separator the original archive used.

## Why this is robust

`normalizeArchivePath` is symmetric — both sides of the lookup are normalized through the same function, so the fix is correct under either possible libarchive behavior:

| libarchive RAR behavior | Without fix | With fix |
|---|---|---|
| Translates `\` → `/` while reading entry path (RAR convention) | Page key = `\"Dir\\file.jpg\"`; staged key = `\"Dir/file.jpg\"` → **mismatch** | Both → `\"Dir/file.jpg\"` → **match** |
| Preserves `\` literally; staged file has `\\` in its filename | Both → `\"Dir\\file.jpg\"` → match (no bug) | Both → `\"Dir/file.jpg\"` → still match |

The bug being reproducible from the log proves we're in the first row — but the fix works in either case. There's also no regression for paths that contain neither `\\` nor `/` (single-component filenames extract identically) or that use only `/` (every EPUB, WebPub HREF, well-formed CBZ — output is byte-identical to current behavior).

## Affected callers

`normalizeArchivePath` is called from:

| Caller | Input | Effect of fix |
|---|---|---|
| `extractCompressedImageArchive` (CBR + CBZ) | `BookPage.fileName` | **Fixes the bug** for Windows-created CBRs; no change for `/`-only CBZs. |
| `extractEpubToWebPub`, `extractEpubDivinaImages`, `divinaImageTargets` | EPUB resource paths | EPUB is ZIP with `/` separator; no behavioral change. |
| `manifestResourcePath`, `webPubRelativePath` | WebPub HREFs | URL paths use `/`; no behavioral change. |

`imageArchivePageDestination` produces `page-N.ext` flat names in `bookDir` and doesn't carry the archive path forward, so it's unaffected.

## Testing

**Not tested.** I do not have an Xcode build environment for this project, so the change has not been built or run.

The diagnosis is grounded in the user-supplied log (which proves `BookPage.fileName` contains a literal `\\`), the static call graph for `normalizeArchivePath`, and reading the upstream `libarchive-swift` extraction code (which itself splits entry paths only on `/`, so any backslash in the entry pathname coming back from the C library would not produce a subdirectory tree on disk via the Swift wrapper either way). The fix is symmetric across both sides of the lookup, so its correctness does not depend on any specific libarchive behavior.

A maintainer with the build environment should verify:
1. The reported book downloads cleanly (the `(HP)-(gesserit)` group's CBRs are a good corpus — most contain `\\` in entry paths).
2. CBZ downloads continue to work (sanity check that `/`-only archives are unaffected).
3. EPUB downloads continue to work (resource path normalization is unaffected for `/`-only paths).
4. A pathological archive whose filenames *legitimately* contain `\\` as a literal character (Linux/macOS-created, not as a separator) — the new logic splits these into multiple components but does so on both sides of the lookup, so they still match. No on-disk behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)