### PR TITLE
fix(settings): move live activity settings

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 427;
+				CURRENT_PROJECT_VERSION = 428;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 427;
+				CURRENT_PROJECT_VERSION = 428;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 427;
+				CURRENT_PROJECT_VERSION = 428;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 427;
+				CURRENT_PROJECT_VERSION = 428;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Settings/SettingsAppearanceView.swift
+++ b/KMReader/Features/Settings/SettingsAppearanceView.swift
@@ -13,9 +13,6 @@ struct SettingsAppearanceView: View {
     AppConfig.showDashboardSectionGradientBackground
   @AppStorage("privacyProtection") private var privacyProtection: Bool = false
   #if os(iOS)
-    @AppStorage("enableReaderLiveActivity") private var enableReaderLiveActivity: Bool = true
-  #endif
-  #if os(iOS)
     @State private var selectedAppIcon: AppIconOption = .primary
     @State private var isUpdatingAppIcon: Bool = false
   #endif
@@ -123,18 +120,6 @@ struct SettingsAppearanceView: View {
         }
       }
 
-      #if os(iOS)
-        Section(header: Text("Live Activities")) {
-          Toggle(isOn: $enableReaderLiveActivity) {
-            VStack(alignment: .leading, spacing: 4) {
-              Text("Reader Live Activity")
-              Text("Show reader progress on the Lock Screen and in Dynamic Island.")
-                .font(.caption)
-                .foregroundColor(.secondary)
-            }
-          }
-        }
-      #endif
     }
     .formStyle(.grouped)
     .inlineNavigationBarTitle(SettingsSection.appearance.title)

--- a/KMReader/Features/Settings/SettingsSyncView.swift
+++ b/KMReader/Features/Settings/SettingsSyncView.swift
@@ -7,8 +7,13 @@ import SwiftUI
 
 struct SettingsSyncView: View {
   @AppStorage("readingHistoryAutoSyncIntervalHours") private var readingHistoryAutoSyncIntervalHours: Int = 24
-  @AppStorage("enableBrowseHandoff") private var enableBrowseHandoff: Bool = true
-  @AppStorage("enableReaderHandoff") private var enableReaderHandoff: Bool = false
+  #if os(iOS) || os(macOS)
+    @AppStorage("enableBrowseHandoff") private var enableBrowseHandoff: Bool = true
+    @AppStorage("enableReaderHandoff") private var enableReaderHandoff: Bool = false
+  #endif
+  #if os(iOS)
+    @AppStorage("enableReaderLiveActivity") private var enableReaderLiveActivity: Bool = true
+  #endif
 
   var body: some View {
     Form {
@@ -43,25 +48,40 @@ struct SettingsSyncView: View {
         }
       }
 
-      Section(header: Text(String(localized: "settings.network.handoff"))) {
-        Toggle(isOn: $enableBrowseHandoff) {
-          VStack(alignment: .leading, spacing: 4) {
-            Text(String(localized: "settings.network.handoff.browse.title"))
-            Text(String(localized: "settings.network.handoff.browse.caption"))
-              .font(.caption)
-              .foregroundStyle(.secondary)
+      #if os(iOS) || os(macOS)
+        Section(header: Text(String(localized: "settings.network.handoff"))) {
+          Toggle(isOn: $enableBrowseHandoff) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text(String(localized: "settings.network.handoff.browse.title"))
+              Text(String(localized: "settings.network.handoff.browse.caption"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
           }
-        }
 
-        Toggle(isOn: $enableReaderHandoff) {
-          VStack(alignment: .leading, spacing: 4) {
-            Text(String(localized: "settings.network.handoff.reader.title"))
-            Text(String(localized: "settings.network.handoff.reader.caption"))
-              .font(.caption)
-              .foregroundStyle(.secondary)
+          Toggle(isOn: $enableReaderHandoff) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text(String(localized: "settings.network.handoff.reader.title"))
+              Text(String(localized: "settings.network.handoff.reader.caption"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
           }
         }
-      }
+      #endif
+
+      #if os(iOS)
+        Section(header: Text("Live Activities")) {
+          Toggle(isOn: $enableReaderLiveActivity) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Reader Live Activity")
+              Text("Show reader progress on the Lock Screen and in Dynamic Island.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+          }
+        }
+      #endif
     }
     .formStyle(.grouped)
     .inlineNavigationBarTitle(SettingsSection.sync.title)


### PR DESCRIPTION
## Problem
The Reader Live Activity setting lived under Appearance, even though it controls reader continuity behavior and belongs with other Sync & Handoff options.

## Approach
Move the Live Activities section into Sync & Handoff while keeping the same storage key, labels, and iOS-only availability. While touching the destination page, gate Handoff settings to iOS and macOS so tvOS no longer shows unsupported continuity controls.

## Scope
- Move Reader Live Activity from Appearance to Sync & Handoff
- Keep Live Activities iOS-only
- Show Handoff controls only on iOS and macOS
- Increment build version to 428

## Validation
- [x] make format
- [ ] make build-ios unavailable locally: no iOS simulator or device selected
- [ ] make build-tvos unavailable locally: no tvOS simulator or device selected
