### PR TITLE
docs: refresh release copy

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,16 +1,12 @@
-Reader Settings and Controls
-- DIVINA and PDF reader settings are now more consistent between global Settings and in-reader controls.
-- PDF reading now supports an optional continuous scrolling mode, while page-by-page reading remains the default.
-- Reader controls can show optional gradient backgrounds for better contrast over page artwork.
-- Tap page-turn animation settings are simpler, with separate controls for DIVINA/Webtoon and EPUB.
-- Reader progress bars are easier to see over comics, PDFs, and EPUB content.
-- Reader overlay buttons have better contrast on older system versions.
+Reader Controls
+- Tap zone layout presets make it easier to choose how page turns and controls respond while reading.
+- Reader tap zones now stay separate from buttons and controls, reducing accidental actions.
+- Live Activity options have been moved to a more appropriate Settings location.
 
 Reader Reliability
-- Cover-mode table of contents and page jumps are more stable and should no longer snap back to the previous page.
-- Webtoon scrolling is smoother when moving between book segments.
-- PDF display mode changes preserve the current reading position more reliably.
+- Webtoon navigation is more consistent across scrolling and page-turn actions.
+- Webtoon books now preserve progress more reliably when reaching the final page.
 
-Offline and Recovery
-- Offline archive extraction is more consistent for EPUB, CBZ, and CBR downloads.
-- If local storage damage prevents KMReader from opening, the startup failure screen now offers a Reset Local Data recovery action.
+Offline and Library Reliability
+- Downloaded archives with mixed path styles open more reliably.
+- Library details refresh more consistently after changes made on the server.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ### Readers
 
-- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl on iOS, cover transitions, custom tap zones, keyboard support, and per-book preferences.
+- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl on iOS, cover transitions, tap zone layout presets, keyboard support, and per-book preferences.
 - EPUB reader on iOS/macOS with paged, scrolled, or cover layouts, custom fonts, themes, typography controls, status/footer overlays, multi-column reading, and nested table of contents.
 - PDF reader on iOS/macOS with native PDF or DIVINA mode, search, table of contents, page jump, spread layouts, configurable render quality, and optional continuous scrolling.
 - Animated GIF and WebP pages play inline. Incognito mode, page image actions, reader progress overlays, and iOS Live Text are supported where available.

--- a/static/index.html
+++ b/static/index.html
@@ -82,8 +82,8 @@
                             Read comics with DIVINA on iOS, macOS, and tvOS,
                             plus EPUB and PDF on iOS and macOS. Readers support
                             LTR, RTL, vertical, Webtoon, spreads, zoom,
-                            page curl or cover transitions, keyboard shortcuts,
-                            per-book preferences, custom EPUB fonts and
+                            page curl or cover transitions, tap zone presets,
+                            keyboard shortcuts, per-book preferences, custom EPUB fonts and
                             typography, nested EPUB table of contents, PDF
                             search, animated pages, and incognito reading.
                         </p>


### PR DESCRIPTION
## Problem
The release copy needed to be refreshed for the changes since v4.8, while evergreen docs should stay focused on durable product capabilities instead of short-lived settings polish.

## Approach
Generate the App Store changelog from the latest tag to HEAD, keep it user-facing, and align README plus landing page wording around the reader-facing tap zone preset capability.

## Scope
- Refresh App Store changelog for v4.8-to-HEAD changes
- Mention tap zone layout presets in README reader features
- Align landing page reader copy with the same durable feature language

## Validation
- [x] Ran `git diff --check`
- [x] Checked changelog for stale pre-v4.8 entries
- [x] Checked docs for dashboard appearance wording
