### PR TITLE
fix: skip stale pending progress replays to prevent regressions

### DIFF
--- a/KMReader/Features/Sync/Services/ProgressSyncService.swift
+++ b/KMReader/Features/Sync/Services/ProgressSyncService.swift
@@ -52,21 +52,30 @@ actor ProgressSyncService {
     var failureCount = 0
     var ignoredConflictCount = 0
     var ignoredNonRetryableCount = 0
+    var skippedStaleCount = 0
     var completedBookIds = Set<String>()
+    var staleSkippedBookIds = Set<String>()
 
     for item in pending {
       logger.debug(
         "🧾 Sync pending item id=\(item.id), book=\(item.bookId), page=\(item.page), completed=\(item.completed), hasProgressionData=\(item.progressionData != nil), createdAt=\(item.createdAt.ISO8601Format())"
       )
       do {
-        try await syncProgressItem(item)
+        let outcome = try await syncProgressItem(item)
         await database.deletePendingProgress(id: item.id)
         await database.commit()
-        successCount += 1
-        logger.debug("🧹 Removed synced pending item id=\(item.id)")
 
-        if item.completed {
-          completedBookIds.insert(item.bookId)
+        switch outcome {
+        case .replayed:
+          successCount += 1
+          logger.debug("🧹 Removed synced pending item id=\(item.id)")
+          if item.completed {
+            completedBookIds.insert(item.bookId)
+          }
+        case .skippedStale:
+          skippedStaleCount += 1
+          logger.debug("🧹 Removed stale pending item id=\(item.id) without replaying to server")
+          staleSkippedBookIds.insert(item.bookId)
         }
       } catch {
         if let apiError = error as? APIError {
@@ -102,17 +111,24 @@ actor ProgressSyncService {
       }
     }
 
-    // Batch sync books and series after individual progress items are processed
-    var completedSeriesIds = Set<String>()
-    for bookId in completedBookIds {
-      logger.debug("🔄 Refreshing completed book after progress sync: book=\(bookId)")
+    // Batch sync books and series after individual progress items are processed.
+    // Stale-skipped books are also refreshed so the local cache catches up to the
+    // server's authoritative state (the local cache holds the offline-written value
+    // from before the pending was discarded).
+    var seriesIdsToRefresh = Set<String>()
+    let booksToRefresh = completedBookIds.union(staleSkippedBookIds)
+    for bookId in booksToRefresh {
+      let isStaleSkip = staleSkippedBookIds.contains(bookId)
+      logger.debug(
+        "🔄 Refreshing book after progress sync: book=\(bookId), reason=\(isStaleSkip ? "stale-skip" : "completed")"
+      )
       if let book = try? await SyncService.shared.syncBook(bookId: bookId) {
-        completedSeriesIds.insert(book.seriesId)
+        seriesIdsToRefresh.insert(book.seriesId)
       }
     }
 
-    for seriesId in completedSeriesIds {
-      logger.debug("🔄 Refreshing series after completed book sync: series=\(seriesId)")
+    for seriesId in seriesIdsToRefresh {
+      logger.debug("🔄 Refreshing series after progress sync: series=\(seriesId)")
       _ = try? await SyncService.shared.syncSeriesDetail(seriesId: seriesId)
     }
 
@@ -135,6 +151,12 @@ actor ProgressSyncService {
       logger.info("⏭️ Ignored \(ignoredNonRetryableCount) non-retryable progress errors (4xx)")
     }
 
+    if skippedStaleCount > 0 {
+      logger.info(
+        "⏭️ Skipped \(skippedStaleCount) stale pending items (server had a newer write than the queued pending)"
+      )
+    }
+
     if failureCount > 0 {
       logger.warning("⚠️ Failed to sync \(failureCount) progress items, will retry later")
       await MainActor.run {
@@ -145,7 +167,38 @@ actor ProgressSyncService {
     }
   }
 
-  private func syncProgressItem(_ item: PendingProgressSummary) async throws {
+  private enum ProgressItemSyncOutcome {
+    case replayed
+    case skippedStale
+  }
+
+  /// Tolerance for client/server clock skew when comparing pending `createdAt` against
+  /// server-side `readProgress.lastModified`. NTP-synced devices typically agree within
+  /// a second; 60s is generous and avoids false positives without weakening the guard.
+  private static let staleDetectionClockSkewTolerance: TimeInterval = 60
+
+  private func syncProgressItem(_ item: PendingProgressSummary) async throws -> ProgressItemSyncOutcome {
+    // Defensive guard against replaying a pending entry that the server has already
+    // moved past via some other path (markAsRead from this device, completion via the
+    // Komga web UI, completion on another client, etc.). If the server's read-progress
+    // was last modified after this pending was queued, the pending is by definition
+    // stale — replaying it would silently regress the server's state.
+    //
+    // This is the first conflict-resolution use of `lastModified` in the codebase. It
+    // does not cover every regression path (notably: pending queued *after* a server
+    // completion, where the lastModified is older than the pending's createdAt — that
+    // case would need intent tracking that we don't have today).
+    if let serverBook = try? await BookService.shared.getBook(id: item.bookId),
+      let serverProgress = serverBook.readProgress,
+      serverProgress.lastModified
+        > item.createdAt.addingTimeInterval(Self.staleDetectionClockSkewTolerance)
+    {
+      logger.info(
+        "⏭️ Skipping stale pending for book \(item.bookId): server.lastModified=\(serverProgress.lastModified.ISO8601Format()) is newer than pending.createdAt=\(item.createdAt.ISO8601Format()) (+ \(Int(Self.staleDetectionClockSkewTolerance))s tolerance)"
+      )
+      return .skippedStale
+    }
+
     // Check if this is EPUB progression or page-based progress
     if let progressionData = item.progressionData {
       logger.debug(
@@ -180,5 +233,7 @@ actor ProgressSyncService {
       )
       logger.debug("✅ Synced page progress for book \(item.bookId) - page \(item.page)")
     }
+
+    return .replayed
   }
 }

--- a/KMReader/Features/Sync/Services/ProgressSyncService.swift
+++ b/KMReader/Features/Sync/Services/ProgressSyncService.swift
@@ -196,6 +196,35 @@ actor ProgressSyncService {
       logger.info(
         "⏭️ Skipping stale pending for book \(item.bookId): server.lastModified=\(serverProgress.lastModified.ISO8601Format()) is newer than pending.createdAt=\(item.createdAt.ISO8601Format()) (+ \(Int(Self.staleDetectionClockSkewTolerance))s tolerance)"
       )
+
+      // For EPUB pendings, also refresh the local `epubProgressionRaw` locator from
+      // the server. The caller's post-loop `SyncService.syncBook` only refreshes the
+      // Book DTO via `applyBook`, which does not touch `epubProgressionRaw` — that
+      // field is written only by `updateBookEpubProgression`. Without this extra
+      // fetch, the stale local locator would persist after a stale-skip and the
+      // next EPUB resume would use it (especially when the user reopens the book
+      // offline). Best-effort: failures here are logged but do not fail the skip.
+      if item.progressionData != nil {
+        do {
+          let serverProgression = try await BookService.shared.getWebPubProgression(
+            bookId: item.bookId
+          )
+          if let database = try? await DatabaseOperator.database() {
+            await database.updateBookEpubProgression(
+              bookId: item.bookId,
+              progression: serverProgression
+            )
+            logger.debug(
+              "💾 Refreshed local EPUB progression from server after stale-skip: book=\(item.bookId)"
+            )
+          }
+        } catch {
+          logger.warning(
+            "⚠️ Failed to refresh EPUB progression from server after stale-skip for book \(item.bookId): \(error.localizedDescription)"
+          )
+        }
+      }
+
       return .skippedStale
     }
 


### PR DESCRIPTION
Closes #784

## Summary

`ProgressSyncService.syncPendingProgress` blindly replayed every queued `PendingProgress` entry against the server when the device transitioned from offline → online, with no awareness of whether the server's state had advanced in the meantime. If a competing write had happened (mark-as-read from this device, completion via the Komga web UI, completion on another client, etc.), the stale pending would silently regress the server's read progress to an earlier in-progress state. The affected book would resurface in dashboard sections at whatever page the pending recorded — typically a noticeable percentage like ~80%.

This PR adds a single conflict-resolution check at the pending replay path and ensures local cache catches up after a skip.

## Root cause

`ProgressSyncService.syncProgressItem` (around line 148 before this change):

```swift
try await BookService.shared.updatePageReadProgress(
  bookId: item.bookId,
  page: item.page,
  completed: item.completed
)
```

No comparison against current server state. The Komga API returns `readProgress.lastModified` on every read-progress response, and the local `ReadProgress` model parses it, but **no path in the codebase currently uses these timestamps for conflict resolution.** Every write path — `applyBook`, `updateReadingProgress`, `syncProgressItem`, `markAsRead`, etc. — is last-write-wins by source-code order. The architectural gap is what makes this class of regression possible.

## Fix

```swift
if let serverBook = try? await BookService.shared.getBook(id: item.bookId),
  let serverProgress = serverBook.readProgress,
  serverProgress.lastModified
    > item.createdAt.addingTimeInterval(Self.staleDetectionClockSkewTolerance)
{
  logger.info(\"⏭️ Skipping stale pending for book \\(item.bookId): …\")
  return .skippedStale
}
```

Plus:
- `syncProgressItem` now returns a `ProgressItemSyncOutcome` (`.replayed` or `.skippedStale`).
- The caller tracks stale-skipped books separately and adds them to the post-loop refetch set, so the local KomgaBook cache (which still holds the offline-written value) is updated to the server's authoritative state via `SyncService.syncBook`. Same series-refresh treatment as completed books.
- New telemetry log line on skip count.
- 60-second clock-skew tolerance on the comparison to avoid false positives from minor NTP drift between client and server.

## Scenarios fixed

| Scenario | Today's behavior | After this PR |
|---|---|---|
| Multi-device clash: another client wrote to server after this device queued offline | iPad replays stale pending → server regresses | Skip, refresh from server, no regression |
| Same-device markAsRead UI tap while offline pending exists | markAsRead PATCHes server → server.lastModified updates → later replay regresses | Skip on next replay; local catches up |
| Same-device online completion races with stale offline pending | online PATCH wins, then offline replay arrives and regresses | Skip the stale offline replay |
| Normal offline read → online catchup | Replay applies, server caught up | Same. `pending.createdAt` is newer than `server.lastModified`, check is silent. ✓ |
| Legitimate offline re-read of a previously-completed book | Replay applies, server transitions completed → in-progress | Same. The original `lastModified` is days old; the re-read pending is fresh; check is silent. ✓ |
| Network failure when fetching server state for the comparison | (didn't exist before) | Falls through to existing replay logic (try? = nil → no skip) — no behavior change ✓ |
| Server has no readProgress (book never read) | (didn't exist before) | Falls through to existing replay logic — pending becomes the first server-side progress ✓ |

## Scenarios this PR explicitly does NOT fix

- **Pending queued *after* a stale server-side completion.** If the server's `readProgress.lastModified` is older than the pending's `createdAt` (e.g., the user briefly opens a completed book while offline today, queueing a pending whose `createdAt = now`, while the server was last modified days ago when the book was first completed), the comparison says \"server is older, replay normally\" and the regression still happens. This case can't be distinguished from a legitimate offline re-read using only timestamps and progress values; it would need explicit intent tracking, which is out of scope for this PR.
- **Direct online PATCHes from other client paths** (e.g., the multi-segment reader navigating into an adjacent previously-completed book) regress the server without ever going through `PendingProgress`. Those would need a reader-layer guard, also out of scope.

## Architectural note

This is the first conflict-resolution use of `lastModified` in the codebase. The pattern could reasonably be extended to `applyBook` (so that an API-returned older readProgress doesn't overwrite a newer local one) in a follow-up. Not done in this PR to keep the change minimal.

## Trade-off note

This fix prevents *future* regressions only. Books that have already been regressed by this bug will not auto-heal — affected users may need to manually \"Mark as Read\" them once.

## Testing

**Not tested.** I do not have an Xcode build environment for this project, so the change has not been built or run. The reasoning is purely static:

- The new pattern (`try?`, optional unwrap, inequality with tolerance) is straightforward Swift; no novel control flow.
- Failure modes (network error fetching server state, nil readProgress, clock skew) all degrade to the existing replay behavior — no regression risk for the happy path.
- The new `ProgressItemSyncOutcome` enum has only two cases and is exhaustively switched at the single call site.
- The cache-refresh post-loop is the same `SyncService.syncBook` / `syncSeriesDetail` already used for completed books — just extended to include stale-skipped books.

A maintainer with the build environment should verify:
1. Normal offline → online sync still works for fresh pending entries (the most common case).
2. After deliberately staging the bug (e.g., queue a pending offline, mark the book as read via a separate device or the web UI, bring this device online), the regression no longer happens; the book stays completed; the local cache reflects the server's completed state after sync.
3. The affected book is fully refreshed locally (cache update via the post-loop `syncBook`).
4. EPUB pending entries are also covered by the new guard (they go through the same `syncProgressItem` path before hitting the EPUB-specific branch).
5. Logs reflect the new \"⏭️ Skipping stale pending\" line when the guard fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)