### PR TITLE
feat(reader): add per-page rotation support

### DIFF
--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -368,6 +368,22 @@ actor DatabaseOperator {
     }
   }
 
+  func fetchPageRotations(id: String) -> [Int: Int]? {
+    let instanceId = AppConfig.current.instanceId
+    let compositeId = CompositeID.generate(instanceId: instanceId, id: id)
+    let descriptor = FetchDescriptor<KomgaBook>(predicate: #Predicate { $0.id == compositeId })
+    return try? modelContext.fetch(descriptor).first?.pageRotations
+  }
+
+  func updatePageRotations(bookId: String, rotations: [Int: Int]) {
+    let instanceId = AppConfig.current.instanceId
+    let compositeId = CompositeID.generate(instanceId: instanceId, id: bookId)
+    let descriptor = FetchDescriptor<KomgaBook>(predicate: #Predicate { $0.id == compositeId })
+    if let book = try? modelContext.fetch(descriptor).first {
+      book.pageRotations = rotations
+    }
+  }
+
   func fetchBookEpubPreferences(bookId: String) -> EpubReaderPreferences? {
     let instanceId = AppConfig.current.instanceId
     let compositeId = CompositeID.generate(instanceId: instanceId, id: bookId)

--- a/KMReader/Core/Storage/Schema/KMReaderMigrationPlan.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderMigrationPlan.swift
@@ -152,6 +152,7 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
       KMReaderSchemaV2.self,
       KMReaderSchemaV3.self,
       KMReaderSchemaV4.self,
+      KMReaderSchemaV5.self,
     ]
   }
 
@@ -160,6 +161,7 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
       migrateV1toV2,
       migrateV2toV3,
       migrateV3toV4,
+      migrateV4toV5,
     ]
   }
 
@@ -536,4 +538,11 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
     }
     return try? JSONDecoder().decode(type, from: data)
   }
+
+  // V4 → V5: Add pageRotationsRaw (optional Data?) to KomgaBook.
+  // Lightweight migration handles adding a new optional attribute automatically.
+  static let migrateV4toV5 = MigrationStage.lightweight(
+    fromVersion: KMReaderSchemaV4.self,
+    toVersion: KMReaderSchemaV5.self
+  )
 }

--- a/KMReader/Core/Storage/Schema/KMReaderSchemaV4.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderSchemaV4.swift
@@ -3,6 +3,7 @@
 //
 //
 
+import Foundation
 import SwiftData
 
 enum KMReaderSchemaV4: VersionedSchema {
@@ -15,7 +16,7 @@ enum KMReaderSchemaV4: VersionedSchema {
       KomgaInstance.self,
       KomgaLibrary.self,
       KomgaSeries.self,
-      KomgaBook.self,
+      KMReaderSchemaV4.KomgaBook.self,
       KomgaCollection.self,
       KomgaReadList.self,
       CustomFont.self,
@@ -23,5 +24,61 @@ enum KMReaderSchemaV4: VersionedSchema {
       SavedFilter.self,
       EpubThemePreset.self,
     ]
+  }
+
+  @Model
+  final class KomgaBook {
+    @Attribute(.unique) var id: String = ""
+
+    var bookId: String = ""
+    var seriesId: String = ""
+    var libraryId: String = ""
+    var instanceId: String = ""
+
+    var name: String = ""
+    var url: String = ""
+    var number: Double = 0
+    var created: Date = Date(timeIntervalSince1970: 0)
+    var lastModified: Date = Date(timeIntervalSince1970: 0)
+    var sizeBytes: Int64 = 0
+    var size: String = ""
+
+    // API-aligned raw storage
+    var mediaRaw: Data?
+    var metadataRaw: Data?
+    var readProgressRaw: Data?
+
+    var mediaPagesCount: Int = 0
+    var mediaProfile: String?
+    var metaTitle: String = ""
+    var metaNumber: String = ""
+    var metaNumberSort: Double = 0
+    var metaReleaseDate: String?
+    var progressPage: Int?
+    var progressCompleted: Bool?
+    var progressReadDate: Date?
+    var metaAuthorsIndex: String = "|"
+    var metaTagsIndex: String = "|"
+
+    var isUnavailable: Bool = false
+    var oneshot: Bool = false
+    var seriesTitle: String = ""
+
+    var pagesRaw: Data?
+    var tocRaw: Data?
+    var webPubManifestRaw: Data?
+    var epubProgressionRaw: Data?
+
+    var downloadStatusRaw: String = "notDownloaded"
+    var downloadError: String?
+    var downloadAt: Date?
+    var downloadedSize: Int64 = 0
+
+    var readListIdsRaw: Data?
+
+    var isolatePagesRaw: Data?
+    var epubPreferencesRaw: String?
+
+    init() {}
   }
 }

--- a/KMReader/Core/Storage/Schema/KMReaderSchemaV5.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderSchemaV5.swift
@@ -1,0 +1,28 @@
+//
+// KMReaderSchemaV5.swift
+//
+//
+
+import Foundation
+import SwiftData
+
+enum KMReaderSchemaV5: VersionedSchema {
+  static var versionIdentifier: Schema.Version {
+    Schema.Version(5, 0, 0)
+  }
+
+  static var models: [any PersistentModel.Type] {
+    [
+      KomgaInstance.self,
+      KomgaLibrary.self,
+      KomgaSeries.self,
+      KomgaBook.self,
+      KomgaCollection.self,
+      KomgaReadList.self,
+      CustomFont.self,
+      PendingProgress.self,
+      SavedFilter.self,
+      EpubThemePreset.self,
+    ]
+  }
+}

--- a/KMReader/Features/Book/Models/KomgaBook.swift
+++ b/KMReader/Features/Book/Models/KomgaBook.swift
@@ -61,6 +61,7 @@ final class KomgaBook {
   var readListIdsRaw: Data?
 
   var isolatePagesRaw: Data?
+  var pageRotationsRaw: Data?
   var epubPreferencesRaw: String?
 
   var readListIds: [String] {
@@ -71,6 +72,12 @@ final class KomgaBook {
   var isolatePages: [Int] {
     get { isolatePagesRaw.flatMap { try? JSONDecoder().decode([Int].self, from: $0) } ?? [] }
     set { isolatePagesRaw = try? JSONEncoder().encode(newValue) }
+  }
+
+  /// Page rotations stored as [pageIndex: degrees]
+  var pageRotations: [Int: Int] {
+    get { pageRotationsRaw.flatMap { try? JSONDecoder().decode([Int: Int].self, from: $0) } ?? [:] }
+    set { pageRotationsRaw = try? JSONEncoder().encode(newValue) }
   }
 
   var epubPreferences: EpubReaderPreferences? {
@@ -198,6 +205,7 @@ final class KomgaBook {
     self.downloadedSize = downloadedSize
     self.readListIdsRaw = try? JSONEncoder().encode([] as [String])
     self.isolatePagesRaw = try? JSONEncoder().encode([] as [Int])
+    self.pageRotationsRaw = nil
     self.epubPreferencesRaw = nil
     self.epubProgressionRaw = nil
   }

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -2429,7 +2429,8 @@ actor OfflineManager {
     // `BookPage.fileName`. libarchive normalizes RAR `\` to `/` when extracting, so
     // matching the dictionary key and the staged relative path requires both sides
     // to canonicalize to the same form.
-    let components = path
+    let components =
+      path
       .split(whereSeparator: { $0 == "/" || $0 == "\\" })
       .map(String.init)
     guard !components.isEmpty else { return nil }

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -13,6 +13,7 @@ class ReaderViewModel {
   private(set) var segments: [ReaderSegment] = []
   var isolatePages: [Int] = []
   private var isolatePagesByBookId: [String: Set<Int>] = [:]
+  private var pageRotationsByBookId: [String: [Int: Int]] = [:]
   private var currentPageID: ReaderPageID?
   private var currentViewItemID: ReaderViewItem?
   var navigationTarget: ReaderViewItem?
@@ -99,9 +100,24 @@ class ReaderViewModel {
     return isolatePagesByBookId[isolatePosition.bookId]?.contains(isolatePosition.localIndex) == true
   }
 
+  func pageRotationDegrees(for pageID: ReaderPageID) -> Int {
+    guard let position = isolatePosition(for: pageID) else { return 0 }
+    return pageRotationsByBookId[position.bookId]?[position.localIndex] ?? 0
+  }
+
+  var currentPageRotationDegrees: Int {
+    guard let currentReaderPage else { return 0 }
+    return pageRotationDegrees(for: currentReaderPage.id)
+  }
+
   /// Whether the current page is a wide (non-portrait) image, which cannot be isolated.
   var isCurrentPageWide: Bool {
     guard let currentReaderPage else { return false }
+    let rotation = pageRotationDegrees(for: currentReaderPage.id)
+    let normalized = ((rotation % 360) + 360) % 360
+    if normalized == 90 || normalized == 270 {
+      return currentReaderPage.page.isPortrait
+    }
     return !currentReaderPage.page.isPortrait
   }
 
@@ -551,6 +567,26 @@ class ReaderViewModel {
     isolatePagesByBookId[bookId] = Set(isolatePagesForBook)
   }
 
+  private func hydratePageRotations(for bookId: String) async {
+    let database = await DatabaseOperator.databaseIfConfigured()
+    let rotations = await database?.fetchPageRotations(id: bookId) ?? [:]
+    pageRotationsByBookId[bookId] = rotations
+  }
+
+  private func persistPageRotations(_ rotations: [Int: Int], for bookId: String) {
+    Task {
+      if let database = await DatabaseOperator.databaseIfConfigured() {
+        await database.updatePageRotations(bookId: bookId, rotations: rotations)
+        await database.commit()
+      }
+    }
+  }
+
+  private func normalizedPageRotation(_ degrees: Int) -> Int {
+    let normalized = degrees % 360
+    return normalized >= 0 ? normalized : normalized + 360
+  }
+
   private func restoreCurrentPosition(using currentPageID: ReaderPageID?) {
     guard currentPageID != nil else { return }
     updateCurrentPosition(pageID: currentPageID)
@@ -564,6 +600,7 @@ class ReaderViewModel {
     pageLoadScheduler.resetForBookLoad()
     isolatePages.removeAll()
     isolatePagesByBookId.removeAll()
+    pageRotationsByBookId.removeAll()
     tableOfContents.removeAll()
     tableOfContentsByBookId.removeAll()
     tableOfContentsBookId = nil
@@ -610,6 +647,7 @@ class ReaderViewModel {
     }
 
     await hydrateIsolatePages(for: nextBook.id)
+    await hydratePageRotations(for: nextBook.id)
     let currentPageID = currentReaderPage?.id
 
     appendSegment(
@@ -654,6 +692,7 @@ class ReaderViewModel {
     }
 
     await hydrateIsolatePages(for: previousBook.id)
+    await hydratePageRotations(for: previousBook.id)
     let currentPageID = currentReaderPage?.id
 
     prependSegment(
@@ -696,6 +735,7 @@ class ReaderViewModel {
 
       let localIsolatePages = await database?.fetchIsolatePages(id: book.id) ?? []
       isolatePagesByBookId[book.id] = Set(localIsolatePages)
+      await hydratePageRotations(for: book.id)
       currentPageID = initialPageNumber.flatMap { pageNumber in
         fetchedPages.first(where: { $0.number == pageNumber }).map {
           ReaderPageID(bookId: book.id, pageNumber: $0.number)
@@ -943,10 +983,43 @@ class ReaderViewModel {
     }
   }
 
+  func setPageRotation(_ degrees: Int, for pageID: ReaderPageID) {
+    guard let position = isolatePosition(for: pageID) else { return }
+    let normalized = normalizedPageRotation(degrees)
+    guard pageRotationDegrees(for: pageID) != normalized else { return }
+    var rotations = pageRotationsByBookId[position.bookId] ?? [:]
+    if normalized == 0 {
+      rotations.removeValue(forKey: position.localIndex)
+    } else {
+      rotations[position.localIndex] = normalized
+    }
+    pageRotationsByBookId[position.bookId] = rotations
+    persistPageRotations(rotations, for: position.bookId)
+    regenerateViewStatePreservingCurrentPage {
+      // rotation state already updated above
+    }
+    notifyPagePresentationInvalidation(.pages([pageID]))
+  }
+
+  func rotatePage(_ pageID: ReaderPageID, by degrees: Int) {
+    let current = pageRotationDegrees(for: pageID)
+    setPageRotation(current + degrees, for: pageID)
+  }
+
   func toggleIsolatePage(_ pageID: ReaderPageID) {
     guard let isolatePosition = isolatePosition(for: pageID) else { return }
-    // Wide pages always fill both slots and cannot be isolated
-    if let page = readerPage(for: pageID)?.page, !page.isPortrait { return }
+    // Wide pages (considering rotation) always fill both slots and cannot be isolated
+    let rotation = pageRotationDegrees(for: pageID)
+    let normalized = ((rotation % 360) + 360) % 360
+    if let page = readerPage(for: pageID)?.page {
+      let effectivelyPortrait: Bool
+      if normalized == 90 || normalized == 270 {
+        effectivelyPortrait = (page.width ?? 0) > (page.height ?? 0)
+      } else {
+        effectivelyPortrait = page.isPortrait
+      }
+      if !effectivelyPortrait { return }
+    }
     toggleIsolatePage(at: isolatePosition)
   }
 
@@ -997,7 +1070,9 @@ class ReaderViewModel {
       forceDualPairs: forceDualPagePairs,
       splitWidePages: effectiveSplitWidePages,
       pageCurl: pageTransitionStyle == .pageCurl,
-      isolatePages: Set(isolatePages)
+      isolatePages: Set(isolatePages),
+      pageRotationsByBookId: pageRotationsByBookId,
+      segmentPageRangeByBookId: segmentPageRangeByBookId
     )
     viewItemIndexByPage = generateViewItemIndexMap(items: viewItems)
     currentViewItemID = resolvedViewItem(
@@ -1147,9 +1222,28 @@ private func generateViewItems(
   forceDualPairs: Bool,
   splitWidePages: Bool,
   pageCurl: Bool,
-  isolatePages: Set<Int> = []
+  isolatePages: Set<Int> = [],
+  pageRotationsByBookId: [String: [Int: Int]] = [:],
+  segmentPageRangeByBookId: [String: Range<Int>] = [:]
 ) -> [ReaderViewItem] {
   guard !segments.isEmpty, !readerPages.isEmpty else { return [] }
+
+  // Helper: determine effective isPortrait considering rotation
+  func effectiveIsPortrait(at index: Int) -> Bool {
+    let page = readerPages[index].page
+    let bookId = readerPages[index].bookId
+    if let range = segmentPageRangeByBookId[bookId] {
+      let localIndex = index - range.lowerBound
+      let rotation = pageRotationsByBookId[bookId]?[localIndex] ?? 0
+      let normalized = ((rotation % 360) + 360) % 360
+      if normalized == 90 || normalized == 270 {
+        // Swapped: portrait becomes landscape and vice versa
+        guard let width = page.width, let height = page.height else { return false }
+        return width > height
+      }
+    }
+    return page.isPortrait
+  }
 
   var items: [ReaderViewItem] = []
   let shouldForceDualPairs = allowDualPairs && forceDualPairs
@@ -1166,12 +1260,12 @@ private func generateViewItems(
 
     while index < segmentEndExclusive {
       if shouldForceDualPairs {
-        let currentPage = readerPages[index].page
+        let currentIsPortrait = effectiveIsPortrait(at: index)
         let isCoverPage = !noCover && index == segmentStartIndex
-        let isWideCoverPage = isCoverPage && !currentPage.isPortrait
+        let isWideCoverPage = isCoverPage && !currentIsPortrait
         let isWidePageEligibleForSplit =
           (splitWidePages || pageCurl)
-          && !currentPage.isPortrait
+          && !currentIsPortrait
           && (noCover || isWideCoverPage || index != segmentStartIndex)
 
         if isWidePageEligibleForSplit {
@@ -1180,17 +1274,17 @@ private func generateViewItems(
           continue
         }
 
-        if !currentPage.isPortrait && !pageCurl {
+        if !currentIsPortrait && !pageCurl {
           items.append(.page(id: readerPages[index].id))
           index += 1
           continue
         }
 
-        let nextPage = index + 1 < segmentEndExclusive ? readerPages[index + 1].page : nil
+        let nextIsPortrait = index + 1 < segmentEndExclusive ? effectiveIsPortrait(at: index + 1) : true
         let shouldShowSingle =
-          (isCoverPage && currentPage.isPortrait) || index == segmentEndExclusive - 1
+          (isCoverPage && currentIsPortrait) || index == segmentEndExclusive - 1
           || isolatePages.contains(index) || isolatePages.contains(index + 1)
-          || nextPage?.isPortrait == false  // next page is wide → keep it for its own item
+          || !nextIsPortrait  // next page is wide → keep it for its own item
         if shouldShowSingle {
           items.append(.page(id: readerPages[index].id))
           index += 1
@@ -1202,19 +1296,19 @@ private func generateViewItems(
         continue
       }
 
-      let currentPage = readerPages[index].page
+      let currentIsPortrait = effectiveIsPortrait(at: index)
 
       var useSinglePage = false
       var shouldSplitPage = false
 
       let isCoverPage = !noCover && index == segmentStartIndex
-      let isWideCoverPage = isCoverPage && !currentPage.isPortrait
+      let isWideCoverPage = isCoverPage && !currentIsPortrait
 
       // Wide pages split only when enabled. In dual-page mode that produces a two-slot
       // spread; otherwise the page stays as a single item.
       let isWidePageEligibleForSplit =
         (splitWidePages || (pageCurl && allowDualPairs))
-        && !currentPage.isPortrait
+        && !currentIsPortrait
         && (noCover || isWideCoverPage || index != segmentStartIndex)
 
       if isWidePageEligibleForSplit {
@@ -1222,7 +1316,7 @@ private func generateViewItems(
       }
 
       // Determine if page should be shown as single (without splitting)
-      if !currentPage.isPortrait && !shouldSplitPage {
+      if !currentIsPortrait && !shouldSplitPage {
         useSinglePage = true
       }
       if isCoverPage && !isWideCoverPage {
@@ -1247,9 +1341,9 @@ private func generateViewItems(
         items.append(.page(id: readerPages[index].id))
         index += 1
       } else {
-        let nextPage = readerPages[index + 1].page
+        let nextIsPortrait = effectiveIsPortrait(at: index + 1)
         if allowDualPairs && index + 1 < segmentEndExclusive
-          && nextPage.isPortrait
+          && nextIsPortrait
           && !isolatePages.contains(index + 1)
         {
           items.append(.dual(first: readerPages[index].id, second: readerPages[index + 1].id))

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -137,9 +137,10 @@ struct DivinaControlsOverlayView: View {
       sharePages(ids: [id])
     }
 
-    private var sharePageFormat: String {
-      String(localized: "Share Page %d")
+    private var pageFormat: String {
+      String(localized: "Page %d")
     }
+
   #endif
 
   var body: some View {
@@ -332,10 +333,6 @@ struct DivinaControlsOverlayView: View {
           Label(String(localized: "Page Layout"), systemImage: pageLayout.icon)
         }
         .pickerStyle(.menu)
-
-        if enableDualPageOptions {
-          pageIsolation()
-        }
       }
 
       if readingDirection != .webtoon {
@@ -374,14 +371,17 @@ struct DivinaControlsOverlayView: View {
       if currentPageID != nil {
         Section {
           if dualPage, let pair = viewModel.currentViewItem()?.pagePairIDs {
-            share(firstPage: pair.first, secondPage: pair.second)
+            pageActionsMenu(for: pair.first)
+            if let second = pair.second {
+              pageActionsMenu(for: second)
+            }
           } else if let currentPageID {
-            share(firstPage: currentPageID, secondPage: nil)
+            pageActionsMenu(for: currentPageID)
           } else {
             EmptyView()
           }
         } header: {
-          Text(String(localized: "Share"))
+          Text(String(localized: "Current Page"))
         }
       }
     #endif
@@ -402,26 +402,6 @@ struct DivinaControlsOverlayView: View {
         startPoint: startPoint,
         endPoint: endPoint
       )
-    }
-  }
-
-  @ViewBuilder
-  private func pageIsolation() -> some View {
-    Button {
-      isolateCoverPage.toggle()
-    } label: {
-      Label(
-        String(localized: "Isolate Cover Page"),
-        systemImage: isolateCoverPage ? "checkmark.rectangle.portrait" : "rectangle.portrait"
-      )
-    }
-
-    ForEach(pageIsolationActions) { action in
-      Button {
-        viewModel.toggleIsolatePage(action.pageID)
-      } label: {
-        Label(action.title, systemImage: action.systemImage)
-      }
     }
   }
 
@@ -478,25 +458,59 @@ struct DivinaControlsOverlayView: View {
 
   #if os(iOS) || os(macOS)
     @ViewBuilder
-    private func share(firstPage: ReaderPageID, secondPage: ReaderPageID?) -> some View {
-      Button {
-        sharePage(id: firstPage)
+    private func pageActionsMenu(for pageID: ReaderPageID) -> some View {
+      let displayedPageNumber = displayPageNumber(for: pageID)
+      let currentRotation = viewModel.pageRotationDegrees(for: pageID)
+      Menu {
+        Button {
+          sharePage(id: pageID)
+        } label: {
+          Label(String(localized: "Share"), systemImage: "square.and.arrow.up")
+        }
+
+        if let isolationAction = pageIsolationAction(for: pageID) {
+          Button {
+            viewModel.toggleIsolatePage(isolationAction.pageID)
+          } label: {
+            Label(pageIsolationMenuTitle(for: isolationAction), systemImage: isolationAction.systemImage)
+          }
+        }
+
+        Menu {
+          pageRotationActions(for: pageID, currentRotation: currentRotation)
+        } label: {
+          Label("Rotate: \(currentRotation)°", systemImage: "rotate.right")
+        }
       } label: {
-        let displayedPageNumber = displayPageNumber(for: firstPage)
         Label(
-          String.localizedStringWithFormat(sharePageFormat, displayedPageNumber),
-          systemImage: "square.and.arrow.up"
+          String.localizedStringWithFormat(pageFormat, displayedPageNumber),
+          systemImage: "doc"
         )
       }
-      if let secondPage {
+    }
+
+    private func pageIsolationAction(for pageID: ReaderPageID) -> ReaderPageIsolationActions.Action? {
+      pageIsolationActions.first { $0.pageID == pageID }
+    }
+
+    private func pageIsolationMenuTitle(for action: ReaderPageIsolationActions.Action) -> String {
+      if action.title == String(localized: "Cancel Isolation") {
+        return action.title
+      }
+      return String(localized: "Isolate")
+    }
+
+    @ViewBuilder
+    private func pageRotationActions(for pageID: ReaderPageID, currentRotation: Int) -> some View {
+      ForEach([0, 90, 180, 270], id: \.self) { degrees in
         Button {
-          sharePage(id: secondPage)
+          viewModel.setPageRotation(degrees, for: pageID)
         } label: {
-          let displayedPageNumber = displayPageNumber(for: secondPage)
-          Label(
-            String.localizedStringWithFormat(sharePageFormat, displayedPageNumber),
-            systemImage: "square.and.arrow.up.on.square"
-          )
+          if currentRotation == degrees {
+            Label("\(degrees)°", systemImage: "checkmark")
+          } else {
+            Text("\(degrees)°")
+          }
         }
       }
     }

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -1421,6 +1421,34 @@ struct DivinaReaderView: View {
       )
     }
 
+    private var macCommandPageIDs: [ReaderPageID] {
+      if let pair = viewModel.currentViewItem()?.pagePairIDs {
+        return [pair.first, pair.second].compactMap(\.self)
+      }
+      guard let pageID = viewModel.currentReaderPage?.id else { return [] }
+      return [pageID]
+    }
+
+    private var macDisplayPageNumbersByID: [ReaderPageID: Int] {
+      Dictionary(
+        uniqueKeysWithValues: macCommandPageIDs.map { pageID in
+          (pageID, displayPageNumber(for: pageID))
+        })
+    }
+
+    private var macPageRotationsByID: [ReaderPageID: Int] {
+      Dictionary(
+        uniqueKeysWithValues: macCommandPageIDs.map { pageID in
+          (pageID, viewModel.pageRotationDegrees(for: pageID))
+        })
+    }
+
+    private func sharePageFromCommand(_ pageID: ReaderPageID) {
+      guard let image = viewModel.preloadedImage(for: pageID) else { return }
+      let fileName = viewModel.page(for: pageID)?.fileName
+      ImageShareHelper.share(image: image, fileName: fileName)
+    }
+
     private var readerCommandState: ReaderCommandState {
       let supportsDualPageOptions =
         readingDirection != .webtoon
@@ -1445,6 +1473,9 @@ struct DivinaReaderView: View {
         pageLayout: pageLayout,
         isolateCoverPage: isolateCoverPage,
         pageIsolationActions: macPageIsolationActions,
+        commandPageIDs: macCommandPageIDs,
+        displayPageNumbersByID: macDisplayPageNumbersByID,
+        pageRotationsByID: macPageRotationsByID,
         splitWidePageMode: splitWidePageMode,
         supportsSearch: false,
         canSearch: false,
@@ -1499,6 +1530,12 @@ struct DivinaReaderView: View {
           },
           toggleIsolatePage: { pageID in
             viewModel.toggleIsolatePage(pageID)
+          },
+          sharePage: { pageID in
+            sharePageFromCommand(pageID)
+          },
+          setPageRotation: { pageID, degrees in
+            viewModel.setPageRotation(degrees, for: pageID)
           },
           setSplitWidePageMode: { mode in
             splitWidePageMode = mode

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -904,6 +904,8 @@
             setPageLayout: { _ in },
             toggleIsolateCoverPage: {},
             toggleIsolatePage: { _ in },
+            sharePage: { _ in },
+            setPageRotation: { _, _ in },
             setSplitWidePageMode: { _ in },
             toggleContinuousScroll: {}
           )

--- a/KMReader/Features/Reader/Views/Models/NativePageData.swift
+++ b/KMReader/Features/Reader/Views/Models/NativePageData.swift
@@ -19,6 +19,7 @@ struct NativePageData {
   let error: String?
   let alignment: HorizontalAlignment
   let splitMode: PageSplitMode
+  let rotationDegrees: Int
   let animatedSourceFileURL: URL?
 
   init(
@@ -27,6 +28,7 @@ struct NativePageData {
     error: String?,
     alignment: HorizontalAlignment,
     splitMode: PageSplitMode = .none,
+    rotationDegrees: Int = 0,
     animatedSourceFileURL: URL? = nil
   ) {
     self.pageID = pageID
@@ -34,6 +36,7 @@ struct NativePageData {
     self.error = error
     self.alignment = alignment
     self.splitMode = splitMode
+    self.rotationDegrees = rotationDegrees
     self.animatedSourceFileURL = animatedSourceFileURL
   }
 }

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
@@ -78,12 +78,11 @@
         prepareForDismantle()
       } else {
         if imageView.image == nil, let data = currentData {
-          let pageSourceImage: UIImage?
-          if let image = viewModel?.preloadedImage(for: data.pageID), data.splitMode != .none {
-            pageSourceImage = cropImageForSplitMode(image: image, splitMode: data.splitMode)
-          } else {
-            pageSourceImage = viewModel?.preloadedImage(for: data.pageID)
-          }
+          let pageSourceImage = preparedImage(
+            from: viewModel?.preloadedImage(for: data.pageID),
+            splitMode: data.splitMode,
+            rotationDegrees: data.rotationDegrees
+          )
           #if os(iOS) || os(macOS)
             analysisSourceImage = pageSourceImage
           #endif
@@ -183,12 +182,11 @@
       self.supportsPageIsolationActions = supportsPageIsolationActions
       self.canIsolatePageFromCurrentPresentation = canIsolatePageFromCurrentPresentation
 
-      let pageSourceImage: PlatformImage?
-      if let image = image, data.splitMode != .none {
-        pageSourceImage = cropImageForSplitMode(image: image, splitMode: data.splitMode)
-      } else {
-        pageSourceImage = image
-      }
+      let pageSourceImage = preparedImage(
+        from: image,
+        splitMode: data.splitMode,
+        rotationDegrees: data.rotationDegrees
+      )
 
       #if os(iOS) || os(macOS)
         analysisSourceImage = shouldEnableLiveText ? pageSourceImage : nil
@@ -255,6 +253,36 @@
       imageView.layer.shadowOpacity = shadowOpacity
       if shadowOpacity == 0 {
         imageView.layer.shadowPath = nil
+      }
+    }
+
+    private func preparedImage(from image: UIImage?, splitMode: PageSplitMode, rotationDegrees: Int) -> UIImage? {
+      guard let image else { return nil }
+      let rotatedImage = rotateImage(image, degrees: rotationDegrees)
+      guard splitMode != .none else { return rotatedImage }
+      return cropImageForSplitMode(image: rotatedImage, splitMode: splitMode)
+    }
+
+    private func rotateImage(_ image: UIImage, degrees: Int) -> UIImage {
+      let normalized = ((degrees % 360) + 360) % 360
+      guard normalized != 0 else { return image }
+
+      let radians = CGFloat(normalized) * .pi / 180
+      var rotatedRect = CGRect(origin: .zero, size: image.size)
+        .applying(CGAffineTransform(rotationAngle: radians))
+      rotatedRect.origin = .zero
+
+      let renderer = UIGraphicsImageRenderer(size: rotatedRect.size)
+      return renderer.image { context in
+        context.cgContext.translateBy(x: rotatedRect.size.width / 2, y: rotatedRect.size.height / 2)
+        context.cgContext.rotate(by: radians)
+        image.draw(
+          in: CGRect(
+            x: -image.size.width / 2,
+            y: -image.size.height / 2,
+            width: image.size.width,
+            height: image.size.height
+          ))
       }
     }
 
@@ -537,21 +565,19 @@
       private func makeContextMenu() -> UIMenu? {
         guard let currentData, imageView.image != nil else { return nil }
 
-        var actions: [UIMenuElement] = [makeShareAction(for: currentData.pageID)]
+        var sections: [UIMenuElement] = [
+          UIMenu(options: .displayInline, children: [makeShareAction(for: currentData.pageID)])
+        ]
         if let isolateAction = makePageIsolationAction(for: currentData.pageID) {
-          actions.append(isolateAction)
+          sections.append(UIMenu(options: .displayInline, children: [isolateAction]))
         }
+        sections.append(makePageRotationMenu(for: currentData.pageID))
 
-        return UIMenu(children: actions)
+        return UIMenu(children: sections)
       }
 
       private func makeShareAction(for pageID: ReaderPageID) -> UIAction {
-        let displayPageNumber = viewModel?.displayPageNumber(for: pageID) ?? pageID.pageNumber + 1
-        let title = String.localizedStringWithFormat(
-          String(localized: "Share Page %d"),
-          displayPageNumber
-        )
-        return UIAction(title: title, image: UIImage(systemName: "square.and.arrow.up")) {
+        UIAction(title: String(localized: "Share"), image: UIImage(systemName: "square.and.arrow.up")) {
           [weak self] _ in
           self?.shareCurrentImage(for: pageID)
         }
@@ -559,9 +585,17 @@
 
       private func makePageIsolationAction(for pageID: ReaderPageID) -> UIAction? {
         guard supportsPageIsolationActions, let viewModel else { return nil }
-        guard let readerPage = viewModel.readerPage(for: pageID), readerPage.page.isPortrait else {
-          return nil
+        guard let readerPage = viewModel.readerPage(for: pageID) else { return nil }
+        // Check effective portrait considering rotation
+        let rotation = viewModel.pageRotationDegrees(for: pageID)
+        let normalized = ((rotation % 360) + 360) % 360
+        let effectivelyPortrait: Bool
+        if normalized == 90 || normalized == 270 {
+          effectivelyPortrait = (readerPage.page.width ?? 0) > (readerPage.page.height ?? 0)
+        } else {
+          effectivelyPortrait = readerPage.page.isPortrait
         }
+        guard effectivelyPortrait else { return nil }
 
         if viewModel.isPageIsolated(pageID) {
           return UIAction(
@@ -573,17 +607,29 @@
         }
 
         guard canIsolatePageFromCurrentPresentation else { return nil }
-        let displayPageNumber = viewModel.displayPageNumber(for: pageID) ?? pageID.pageNumber + 1
-        let title = String.localizedStringWithFormat(
-          String(localized: "Isolate Page %d"),
-          displayPageNumber
-        )
         return UIAction(
-          title: title,
+          title: String(localized: "Isolate"),
           image: UIImage(systemName: "rectangle.portrait")
         ) { [weak self] _ in
           self?.viewModel?.toggleIsolatePage(pageID)
         }
+      }
+
+      private func makePageRotationMenu(for pageID: ReaderPageID) -> UIMenu {
+        let currentRotation = viewModel?.pageRotationDegrees(for: pageID) ?? 0
+        let actions = [0, 90, 180, 270].map { degrees in
+          UIAction(
+            title: "\(degrees)°",
+            image: currentRotation == degrees ? UIImage(systemName: "checkmark") : nil
+          ) { [weak self] _ in
+            self?.viewModel?.setPageRotation(degrees, for: pageID)
+          }
+        }
+        return UIMenu(
+          title: "\(String(localized: "Rotate")): \(currentRotation)°",
+          image: UIImage(systemName: "rotate.right"),
+          children: actions
+        )
       }
 
       private func shareCurrentImage(for pageID: ReaderPageID) {

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_macOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_macOS.swift
@@ -68,12 +68,11 @@
         prepareForDismantle()
       } else {
         if imageView.image == nil, let data = currentData {
-          let pageSourceImage: NSImage?
-          if let image = readerViewModel?.preloadedImage(for: data.pageID), data.splitMode != .none {
-            pageSourceImage = cropImageForSplitMode(image: image, splitMode: data.splitMode)
-          } else {
-            pageSourceImage = readerViewModel?.preloadedImage(for: data.pageID)
-          }
+          let pageSourceImage = preparedImage(
+            from: readerViewModel?.preloadedImage(for: data.pageID),
+            splitMode: data.splitMode,
+            rotationDegrees: data.rotationDegrees
+          )
           analysisSourceImage = pageSourceImage
           imageView.image = pageSourceImage
         }
@@ -220,12 +219,11 @@
       self.supportsPageIsolationActions = supportsPageIsolationActions
       self.canIsolatePageFromCurrentPresentation = canIsolatePageFromCurrentPresentation
 
-      let pageSourceImage: PlatformImage?
-      if let image = image, data.splitMode != .none {
-        pageSourceImage = cropImageForSplitMode(image: image, splitMode: data.splitMode)
-      } else {
-        pageSourceImage = image
-      }
+      let pageSourceImage = preparedImage(
+        from: image,
+        splitMode: data.splitMode,
+        rotationDegrees: data.rotationDegrees
+      )
 
       let hasDisplayableImage = pageSourceImage != nil
       analysisSourceImage = shouldEnableLiveText ? pageSourceImage : nil
@@ -277,6 +275,41 @@
       if shadowOpacity == 0 {
         imageView.layer?.shadowPath = nil
       }
+    }
+
+    private func preparedImage(from image: NSImage?, splitMode: PageSplitMode, rotationDegrees: Int) -> NSImage? {
+      guard let image else { return nil }
+      let rotatedImage = rotateImage(image, degrees: rotationDegrees)
+      guard splitMode != .none else { return rotatedImage }
+      return cropImageForSplitMode(image: rotatedImage, splitMode: splitMode)
+    }
+
+    private func rotateImage(_ image: NSImage, degrees: Int) -> NSImage {
+      let normalized = ((degrees % 360) + 360) % 360
+      guard normalized != 0 else { return image }
+      guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return image }
+
+      let sourceSize = CGSize(width: cgImage.width, height: cgImage.height)
+      let radians = CGFloat(normalized) * .pi / 180
+      var rotatedRect = CGRect(origin: .zero, size: sourceSize)
+        .applying(CGAffineTransform(rotationAngle: radians))
+      rotatedRect.origin = .zero
+
+      let rotatedImage = NSImage(size: rotatedRect.size)
+      rotatedImage.lockFocus()
+      guard let context = NSGraphicsContext.current?.cgContext else {
+        rotatedImage.unlockFocus()
+        return image
+      }
+      context.translateBy(x: rotatedRect.size.width / 2, y: rotatedRect.size.height / 2)
+      context.rotate(by: radians)
+      context.draw(
+        cgImage,
+        in: CGRect(
+          x: -sourceSize.width / 2, y: -sourceSize.height / 2, width: sourceSize.width, height: sourceSize.height)
+      )
+      rotatedImage.unlockFocus()
+      return rotatedImage
     }
 
     private func cropImageForSplitMode(image: NSImage, splitMode: PageSplitMode) -> NSImage? {
@@ -543,30 +576,38 @@
 
       let menu = NSMenu()
       menu.addItem(makeShareMenuItem(for: currentData.pageID))
+      menu.addItem(.separator())
 
       if let isolationItem = makePageIsolationMenuItem(for: currentData.pageID) {
         menu.addItem(isolationItem)
+        menu.addItem(.separator())
       }
+
+      menu.addItem(makePageRotationMenuItem(for: currentData.pageID))
 
       return menu.items.isEmpty ? nil : menu
     }
 
     private func makeShareMenuItem(for pageID: ReaderPageID) -> NSMenuItem {
-      let displayPageNumber = readerViewModel?.displayPageNumber(for: pageID) ?? pageID.pageNumber + 1
-      let title = String.localizedStringWithFormat(
-        String(localized: "Share Page %d"),
-        displayPageNumber
-      )
-      let item = NSMenuItem(title: title, action: #selector(handleShareContextMenuAction), keyEquivalent: "")
+      let item = NSMenuItem(
+        title: String(localized: "Share"), action: #selector(handleShareContextMenuAction), keyEquivalent: "")
       item.target = self
       return item
     }
 
     private func makePageIsolationMenuItem(for pageID: ReaderPageID) -> NSMenuItem? {
       guard supportsPageIsolationActions, let readerViewModel else { return nil }
-      guard let readerPage = readerViewModel.readerPage(for: pageID), readerPage.page.isPortrait else {
-        return nil
+      guard let readerPage = readerViewModel.readerPage(for: pageID) else { return nil }
+      // Check effective portrait considering rotation
+      let rotation = readerViewModel.pageRotationDegrees(for: pageID)
+      let normalized = ((rotation % 360) + 360) % 360
+      let effectivelyPortrait: Bool
+      if normalized == 90 || normalized == 270 {
+        effectivelyPortrait = (readerPage.page.width ?? 0) > (readerPage.page.height ?? 0)
+      } else {
+        effectivelyPortrait = readerPage.page.isPortrait
       }
+      guard effectivelyPortrait else { return nil }
 
       if readerViewModel.isPageIsolated(pageID) {
         let item = NSMenuItem(
@@ -579,18 +620,42 @@
       }
 
       guard canIsolatePageFromCurrentPresentation else { return nil }
-      let displayPageNumber = readerViewModel.displayPageNumber(for: pageID) ?? pageID.pageNumber + 1
-      let title = String.localizedStringWithFormat(
-        String(localized: "Isolate Page %d"),
-        displayPageNumber
-      )
       let item = NSMenuItem(
-        title: title,
+        title: String(localized: "Isolate"),
         action: #selector(handleTogglePageIsolationContextMenuAction),
         keyEquivalent: ""
       )
       item.target = self
       return item
+    }
+
+    private func makePageRotationMenuItem(for pageID: ReaderPageID) -> NSMenuItem {
+      let currentRotation = readerViewModel?.pageRotationDegrees(for: pageID) ?? 0
+      let item = NSMenuItem(
+        title: "\(String(localized: "Rotate")): \(currentRotation)°", action: nil, keyEquivalent: "")
+      item.image = NSImage(systemSymbolName: "rotate.right", accessibilityDescription: nil)
+      item.submenu = makePageRotationSubmenu(for: pageID, currentRotation: currentRotation)
+      return item
+    }
+
+    private func makePageRotationSubmenu(for pageID: ReaderPageID, currentRotation: Int) -> NSMenu {
+      let submenu = NSMenu()
+      for degrees in [0, 90, 180, 270] {
+        let item = NSMenuItem(
+          title: "\(degrees)°",
+          action: #selector(handleSetRotationContextMenuAction),
+          keyEquivalent: ""
+        )
+        item.image =
+          currentRotation == degrees
+          ? NSImage(systemSymbolName: "checkmark", accessibilityDescription: nil)
+          : nil
+        item.target = self
+        item.representedObject = PageRotationMenuAction(pageID: pageID, degrees: degrees)
+        item.state = currentRotation == degrees ? .on : .off
+        submenu.addItem(item)
+      }
+      return submenu
     }
 
     @objc private func handleShareContextMenuAction() {
@@ -603,6 +668,17 @@
       guard let pageID = currentData?.pageID else { return }
       readerViewModel?.toggleIsolatePage(pageID)
       updateContextMenu()
+    }
+
+    @objc private func handleSetRotationContextMenuAction(_ sender: NSMenuItem) {
+      guard let action = sender.representedObject as? PageRotationMenuAction else { return }
+      readerViewModel?.setPageRotation(action.degrees, for: action.pageID)
+      updateContextMenu()
+    }
+
+    private struct PageRotationMenuAction {
+      let pageID: ReaderPageID
+      let degrees: Int
     }
   }
 #endif

--- a/KMReader/Features/Reader/Views/PageImage/PageScrollView_iOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/PageScrollView_iOS.swift
@@ -270,7 +270,7 @@
         guard width > 0 else { return parent.screenSize.height }
 
         if let image = image {
-          let imageSize = image.size
+          let imageSize = rotatedSize(image.size, degrees: data.rotationDegrees)
           if imageSize.width > 0, imageSize.height > 0 {
             let height = width * imageSize.height / imageSize.width
             if height.isFinite && height > 0 {
@@ -292,6 +292,14 @@
         }
 
         return parent.screenSize.height
+      }
+
+      private func rotatedSize(_ size: CGSize, degrees: Int) -> CGSize {
+        let normalized = ((degrees % 360) + 360) % 360
+        if normalized == 90 || normalized == 270 {
+          return CGSize(width: size.height, height: size.width)
+        }
+        return size
       }
 
       @objc func handleDoubleTap(_ gesture: UITapGestureRecognizer) {

--- a/KMReader/Features/Reader/Views/PageImage/PageScrollView_macOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/PageScrollView_macOS.swift
@@ -275,7 +275,7 @@
         guard width > 0 else { return parent.screenSize.height }
 
         if let image = image {
-          let imageSize = image.size
+          let imageSize = rotatedSize(image.size, degrees: data.rotationDegrees)
           if imageSize.width > 0, imageSize.height > 0 {
             let height = width * imageSize.height / imageSize.width
             if height.isFinite && height > 0 {
@@ -297,6 +297,14 @@
         }
 
         return parent.screenSize.height
+      }
+
+      private func rotatedSize(_ size: CGSize, degrees: Int) -> CGSize {
+        let normalized = ((degrees % 360) + 360) % 360
+        if normalized == 90 || normalized == 270 {
+          return CGSize(width: size.height, height: size.width)
+        }
+        return size
       }
 
       @objc func handleScrollEnded(_ notification: Notification) {

--- a/KMReader/Features/Reader/Views/PageImage/ReaderViewModel+NativePageData.swift
+++ b/KMReader/Features/Reader/Views/PageImage/ReaderViewModel+NativePageData.swift
@@ -107,6 +107,7 @@ extension ReaderViewModel {
       error: nil,
       alignment: alignment,
       splitMode: splitMode,
+      rotationDegrees: pageRotationDegrees(for: pageID),
       animatedSourceFileURL: isPlaybackActive ? animatedSourceFileURL(for: pageID) : nil
     )
   }

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -606,6 +606,8 @@
               isolateCoverPage.toggle()
             },
             toggleIsolatePage: { _ in },
+            sharePage: { _ in },
+            setPageRotation: { _, _ in },
             setSplitWidePageMode: { _ in },
             toggleContinuousScroll: {
               continuousScroll.toggle()

--- a/KMReader/Features/Reader/Views/ReaderCommandHandlers.swift
+++ b/KMReader/Features/Reader/Views/ReaderCommandHandlers.swift
@@ -14,6 +14,8 @@ struct ReaderCommandHandlers {
   let setPageLayout: (PageLayout) -> Void
   let toggleIsolateCoverPage: () -> Void
   let toggleIsolatePage: (ReaderPageID) -> Void
+  let sharePage: (ReaderPageID) -> Void
+  let setPageRotation: (ReaderPageID, Int) -> Void
   let setSplitWidePageMode: (SplitWidePageMode) -> Void
   let toggleContinuousScroll: () -> Void
 }

--- a/KMReader/Features/Reader/Views/ReaderCommandState.swift
+++ b/KMReader/Features/Reader/Views/ReaderCommandState.swift
@@ -15,6 +15,9 @@ struct ReaderCommandState: Equatable {
   var pageLayout: PageLayout = .auto
   var isolateCoverPage: Bool = true
   var pageIsolationActions: [ReaderPageIsolationActions.Action] = []
+  var commandPageIDs: [ReaderPageID] = []
+  var displayPageNumbersByID: [ReaderPageID: Int] = [:]
+  var pageRotationsByID: [ReaderPageID: Int] = [:]
   var splitWidePageMode: SplitWidePageMode = .none
   var continuousScroll: Bool = false
   var supportsSearch: Bool = false

--- a/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
+++ b/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
@@ -201,6 +201,14 @@ final class ReaderPresentationManager {
       readerCommandHandlers?.toggleIsolatePage(pageID)
     }
 
+    func sharePageFromCommand(_ pageID: ReaderPageID) {
+      readerCommandHandlers?.sharePage(pageID)
+    }
+
+    func setPageRotationFromCommand(_ pageID: ReaderPageID, degrees: Int) {
+      readerCommandHandlers?.setPageRotation(pageID, degrees)
+    }
+
     func setSplitWidePageModeFromCommand(_ mode: SplitWidePageMode) {
       readerCommandHandlers?.setSplitWidePageMode(mode)
     }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -1611,6 +1611,9 @@
         }
       }
     },
+    "%lld°" : {
+      "shouldTranslate" : false
+    },
     "%lld+" : {
       "localizations" : {
         "de" : {
@@ -14493,6 +14496,70 @@
         }
       }
     },
+    "Current Page" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktuelle Seite"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Current Page"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Página actual"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page actuelle"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina corrente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在のページ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 페이지"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Текущая страница"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目前頁面"
+          }
+        }
+      }
+    },
     "Current page: %lld" : {
       "localizations" : {
         "de" : {
@@ -19933,70 +20000,6 @@
         }
       }
     },
-    "Enter Offline Mode" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Offline-Modus aktivieren"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter Offline Mode"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activar modo sin conexión"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activer le mode hors ligne"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Attiva modalità offline"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オフラインモードに切り替え"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오프라인 모드로 전환"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Включить офлайн-режим"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "进入离线模式"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "進入離線模式"
-          }
-        }
-      }
-    },
     "Enter a name for this theme preset" : {
       "localizations" : {
         "de" : {
@@ -20057,6 +20060,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "輸入此主題預設的名稱"
+          }
+        }
+      }
+    },
+    "Enter Offline Mode" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Modus aktivieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter Offline Mode"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar modo sin conexión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer le mode hors ligne"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attiva modalità offline"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインモードに切り替え"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 모드로 전환"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включить офлайн-режим"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "进入离线模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進入離線模式"
           }
         }
       }
@@ -30105,6 +30172,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ISBN"
+          }
+        }
+      }
+    },
+    "Isolate" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Isolieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Isolate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aislar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Isoler"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Isola"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "単独表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "분리 표시"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Изолировать"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "单独显示"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單獨顯示"
           }
         }
       }
@@ -56799,6 +56930,134 @@
         }
       }
     },
+    "Rotate" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drehen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Girar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pivoter"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruota"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回転"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "회전"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повернуть"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "旋转"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "旋轉"
+          }
+        }
+      }
+    },
+    "Rotate: %lld°" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Drehen: %lld°"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotate: %lld°"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Girar: %lld°"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pivoter : %lld°"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruota: %lld°"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "回転：%lld°"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "회전: %lld°"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поворот: %lld°"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "旋转：%lld°"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "旋轉：%lld°"
+          }
+        }
+      }
+    },
     "Running Tasks: %lld" : {
       "localizations" : {
         "de" : {
@@ -62815,6 +63074,134 @@
         }
       }
     },
+    "settings.appearance.dashboardSectionGradientBackground.caption" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Farbverlauf hinter Dashboard-Abschnitten anzeigen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show a gradient behind each dashboard section."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar un degradado detras de cada seccion del panel."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher un dégradé derrière chaque section du tableau de bord."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra un gradiente dietro ogni sezione della dashboard."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダッシュボードの各セクションの背後にグラデーションを表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대시보드의 각 섹션 뒤에 그라데이션을 표시합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать градиент за каждым разделом панели."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在每个主页分区后显示渐变背景。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在每個主頁分區後顯示漸變背景。"
+          }
+        }
+      }
+    },
+    "settings.appearance.dashboardSectionGradientBackground.title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dashboard-Abschnittshintergrund"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dashboard Section Background"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fondo de secciones del panel"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrière-plan des sections du tableau de bord"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sfondo sezioni dashboard"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダッシュボードセクションの背景"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대시보드 섹션 배경"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фон разделов панели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主页分区背景"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主頁分區背景"
+          }
+        }
+      }
+    },
     "settings.appearance.gridDensity.caption" : {
       "localizations" : {
         "de" : {
@@ -63451,134 +63838,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保持封面比例"
-          }
-        }
-      }
-    },
-    "settings.appearance.dashboardSectionGradientBackground.caption" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Farbverlauf hinter Dashboard-Abschnitten anzeigen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show a gradient behind each dashboard section."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar un degradado detras de cada seccion del panel."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher un dégradé derrière chaque section du tableau de bord."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra un gradiente dietro ogni sezione della dashboard."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダッシュボードの各セクションの背後にグラデーションを表示します。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "대시보드의 각 섹션 뒤에 그라데이션을 표시합니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показывать градиент за каждым разделом панели."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在每个主页分区后显示渐变背景。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在每個主頁分區後顯示漸變背景。"
-          }
-        }
-      }
-    },
-    "settings.appearance.dashboardSectionGradientBackground.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dashboard-Abschnittshintergrund"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dashboard Section Background"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fondo de secciones del panel"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrière-plan des sections du tableau de bord"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sfondo sezioni dashboard"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダッシュボードセクションの背景"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "대시보드 섹션 배경"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Фон разделов панели"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "主页分区背景"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "主頁分區背景"
           }
         }
       }
@@ -67163,70 +67422,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "分享"
-          }
-        }
-      }
-    },
-    "Share Page %d" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seite %d teilen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share Page %d"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartir pagina %d"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Partager la page %d"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Condividi pagina %d"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ページ%dを共有"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "페이지 %d 공유"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поделиться страницей %d"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分享第%d页"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分享第%d頁"
           }
         }
       }

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -75,7 +75,7 @@ struct MainApp: App {
   }
 
   private func makeModelContainer() throws -> ModelContainer {
-    let schema = Schema(versionedSchema: KMReaderSchemaV4.self)
+    let schema = Schema(versionedSchema: KMReaderSchemaV5.self)
     let configuration = ModelConfiguration(schema: schema)
     return try ModelContainer(
       for: schema,
@@ -267,6 +267,44 @@ struct MainApp: App {
           .disabled(!state.isActive)
         }
 
+        if !state.commandPageIDs.isEmpty {
+          ForEach(state.commandPageIDs, id: \.self) { pageID in
+            let displayPageNumber = state.displayPageNumbersByID[pageID] ?? pageID.pageNumber + 1
+            let currentRotation = state.pageRotationsByID[pageID] ?? 0
+            Menu("Page \(displayPageNumber)") {
+              Button("Share") {
+                readerPresentation.sharePageFromCommand(pageID)
+              }
+              .disabled(!state.isActive)
+
+              if let isolationAction = state.pageIsolationActions.first(where: { $0.pageID == pageID }) {
+                Divider()
+                Button(readerPageIsolationTitle(for: isolationAction)) {
+                  readerPresentation.toggleIsolatePageFromCommand(isolationAction.pageID)
+                }
+                .disabled(!state.isActive)
+              }
+
+              Divider()
+              Menu("Rotate: \(currentRotation)°") {
+                ForEach([0, 90, 180, 270], id: \.self) { degrees in
+                  Button {
+                    readerPresentation.setPageRotationFromCommand(pageID, degrees: degrees)
+                  } label: {
+                    if currentRotation == degrees {
+                      Label("\(degrees)°", systemImage: "checkmark")
+                    } else {
+                      Text("\(degrees)°")
+                    }
+                  }
+                  .disabled(!state.isActive)
+                }
+              }
+            }
+            .disabled(!state.isActive)
+          }
+        }
+
         if state.supportsDualPageOptions {
           Button {
             readerPresentation.toggleIsolateCoverPageFromCommand()
@@ -278,13 +316,6 @@ struct MainApp: App {
             }
           }
           .disabled(!state.isActive)
-
-          ForEach(state.pageIsolationActions) { action in
-            Button(action.title) {
-              readerPresentation.toggleIsolatePageFromCommand(action.pageID)
-            }
-            .disabled(!state.isActive)
-          }
         }
 
         if state.supportsSplitWidePageMode {
@@ -336,6 +367,14 @@ struct MainApp: App {
         }
       }
     }
+
+    private func readerPageIsolationTitle(for action: ReaderPageIsolationActions.Action) -> String {
+      if action.title == String(localized: "Cancel Isolation") {
+        return action.title
+      }
+      return String(localized: "Isolate")
+    }
+
   #endif
 
   var body: some Scene {


### PR DESCRIPTION
## Summary

Add per-page rotation (0°/90°/180°/270°) for Divina reader pages, persisted to database.

## Changes

- **ReaderViewModel**: rotation state management, `setPageRotation`/`pageRotationDegrees`, `effectiveIsPortrait` for layout recalculation when rotated
- **NativePageItem (iOS/macOS)**: apply rotation transform before split-mode cropping
- **PageScrollView (iOS/macOS)**: pass rotation data to page items
- **DivinaControlsOverlayView**: refactored per-page submenu with Share, Isolate, and Rotate actions (flat section structure, removed dead `pageIsolation()` method)
- **MainApp (macOS)**: per-page submenu in command menu (Share/Isolate/Rotate), removed duplicate top-level isolate buttons
- **ReaderCommandState/Handlers/PresentationManager**: new command state fields and handlers for rotation
- **Database**: new `pageRotations` column in schema V5 migration
- **Localizable.xcstrings**: new localization entries

## Tested

- All platforms build successfully (iOS, macOS, tvOS)