### PR TITLE
feat: add offline mode startup button

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 429;
+				CURRENT_PROJECT_VERSION = 430;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 429;
+				CURRENT_PROJECT_VERSION = 430;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 429;
+				CURRENT_PROJECT_VERSION = 430;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 429;
+				CURRENT_PROJECT_VERSION = 430;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/ContentView.swift
+++ b/KMReader/ContentView.swift
@@ -71,7 +71,9 @@ struct ContentView: View {
               }
             #endif
           } else {
-            SplashView(initializer: instanceInitializer)
+            SplashView(initializer: instanceInitializer) {
+              isOffline = true
+            }
           }
         }
         .task(id: isLoggedIn) {

--- a/KMReader/Shared/UI/SplashView.swift
+++ b/KMReader/Shared/UI/SplashView.swift
@@ -13,10 +13,16 @@ struct SplashView: View {
 
   let initializer: InstanceInitializer?
   let isMigration: Bool
+  let enterOfflineMode: (() -> Void)?
 
-  init(initializer: InstanceInitializer? = nil, isMigration: Bool = false) {
+  init(
+    initializer: InstanceInitializer? = nil,
+    isMigration: Bool = false,
+    enterOfflineMode: (() -> Void)? = nil
+  ) {
     self.initializer = initializer
     self.isMigration = isMigration
+    self.enterOfflineMode = enterOfflineMode
     _isVisible = State(initialValue: isMigration)
   }
 
@@ -153,6 +159,20 @@ struct SplashView: View {
             .foregroundStyle(.tertiary)
             .multilineTextAlignment(.center)
             .frame(maxWidth: 320)
+          } else if let enterOfflineMode {
+            Button {
+              enterOfflineMode()
+            } label: {
+              Label(
+                String(
+                  localized: "splash.offline.enter",
+                  defaultValue: "Enter Offline Mode"
+                ),
+                systemImage: "wifi.slash"
+              )
+              .fontWeight(.semibold)
+            }
+            .adaptiveButtonStyle(.bordered)
           }
         }
       }


### PR DESCRIPTION
## Problem
When KMReader starts with a saved account but the server is still being validated, users are stuck on the connecting splash screen even if they only want to open already downloaded content.

## Approach
Add an optional offline action to the splash screen and wire it from `ContentView` through the existing `isOffline` app storage flow. The button is only available on the regular connecting state and remains hidden during migration or initializer sync progress so startup-critical work cannot be bypassed.

## Scope
- Add an `Enter Offline Mode` button to the normal startup splash state
- Enter offline mode by setting the existing `isOffline` flag
- Keep migration and initializer syncing screens unchanged
- Bump build version to 430

## Validation
- [x] `make format`
- [x] `xcodebuild -scheme KMReader -configuration Debug -destination 'generic/platform=iOS Simulator' build`
