### PR TITLE
fix: remove reading stats cached badge

### DIFF
--- a/KMReader/Features/History/ViewModels/ReadingStatsViewModel.swift
+++ b/KMReader/Features/History/ViewModels/ReadingStatsViewModel.swift
@@ -13,7 +13,6 @@ final class ReadingStatsViewModel {
   var selectedTimeRange: ReadingStatsTimeRange = .last30Days
   var isLoading = false
   var isRefreshing = false
-  var isUsingCachedData = false
   var errorMessage: String?
 
   // Cached stats are immediately displayed; if last refresh is older than this interval, refresh in background.
@@ -26,14 +25,13 @@ final class ReadingStatsViewModel {
       payload = nil
       lastUpdatedAt = nil
       errorMessage = nil
-      isUsingCachedData = false
       return
     }
 
     let cachedSnapshot = cacheStore.snapshot(instanceId: instanceId, libraryId: libraryId)
 
     if let cachedSnapshot {
-      apply(snapshot: cachedSnapshot, usingCache: true)
+      apply(snapshot: cachedSnapshot)
 
       let cacheAge = Date().timeIntervalSince(cachedSnapshot.cachedAt)
       if forceRefresh == false && cacheAge <= autoRefreshInterval {
@@ -52,10 +50,10 @@ final class ReadingStatsViewModel {
       let fetched = try await service.fetchReadingStats(libraryId: normalizedLibraryId(libraryId))
       let snapshot = ReadingStatsSnapshot(libraryId: normalizedLibraryId(libraryId), cachedAt: Date(), payload: fetched)
       cacheStore.upsert(snapshot: snapshot, instanceId: instanceId, libraryId: libraryId)
-      apply(snapshot: snapshot, usingCache: false)
+      apply(snapshot: snapshot)
     } catch {
       if let cachedSnapshot {
-        apply(snapshot: cachedSnapshot, usingCache: true)
+        apply(snapshot: cachedSnapshot)
         errorMessage = String(localized: "Failed to refresh reading stats. Showing cached data.")
       } else {
         payload = nil
@@ -262,10 +260,9 @@ final class ReadingStatsViewModel {
     return nil
   }
 
-  private func apply(snapshot: ReadingStatsSnapshot, usingCache: Bool) {
+  private func apply(snapshot: ReadingStatsSnapshot) {
     payload = snapshot.payload
     lastUpdatedAt = snapshot.cachedAt
-    isUsingCachedData = usingCache
   }
 
   private func normalizedLibraryId(_ libraryId: String) -> String {

--- a/KMReader/Features/History/Views/ServerReadingStatsView.swift
+++ b/KMReader/Features/History/Views/ServerReadingStatsView.swift
@@ -39,13 +39,6 @@ struct ServerReadingStatsView: View {
     return hasNeverSynced && !hasAnyLocalBook
   }
 
-  private var selectedLibraryName: String {
-    guard !selectedLibraryId.isEmpty else {
-      return String(localized: "All Libraries")
-    }
-    return libraries.first { $0.libraryId == selectedLibraryId }?.name ?? String(localized: "All Libraries")
-  }
-
   var body: some View {
     ScrollView {
       VStack(alignment: .leading, spacing: 16) {
@@ -128,18 +121,13 @@ struct ServerReadingStatsView: View {
 
   private var controlsSection: some View {
     HStack(spacing: 8) {
-      Picker(selection: $selectedLibraryId) {
+      Picker(String(localized: "Library"), selection: $selectedLibraryId) {
         Text(String(localized: "All Libraries"))
           .tag("")
         ForEach(libraries) { library in
           Text(library.name)
             .tag(library.libraryId)
         }
-      } label: {
-        Text(selectedLibraryName)
-          .lineLimit(1)
-          .truncationMode(.tail)
-          .frame(maxWidth: .infinity, alignment: .leading)
       }
       .pickerStyle(.menu)
       .frame(maxWidth: .infinity, alignment: .leading)

--- a/KMReader/Features/History/Views/ServerReadingStatsView.swift
+++ b/KMReader/Features/History/Views/ServerReadingStatsView.swift
@@ -39,6 +39,13 @@ struct ServerReadingStatsView: View {
     return hasNeverSynced && !hasAnyLocalBook
   }
 
+  private var selectedLibraryName: String {
+    guard !selectedLibraryId.isEmpty else {
+      return String(localized: "All Libraries")
+    }
+    return libraries.first { $0.libraryId == selectedLibraryId }?.name ?? String(localized: "All Libraries")
+  }
+
   var body: some View {
     ScrollView {
       VStack(alignment: .leading, spacing: 16) {
@@ -121,22 +128,24 @@ struct ServerReadingStatsView: View {
 
   private var controlsSection: some View {
     HStack(spacing: 8) {
-      Picker(String(localized: "Library"), selection: $selectedLibraryId) {
+      Picker(selection: $selectedLibraryId) {
         Text(String(localized: "All Libraries"))
-          .lineLimit(1)
-          .truncationMode(.tail)
           .tag("")
         ForEach(libraries) { library in
           Text(library.name)
-            .lineLimit(1)
-            .truncationMode(.tail)
             .tag(library.libraryId)
         }
+      } label: {
+        Text(selectedLibraryName)
+          .lineLimit(1)
+          .truncationMode(.tail)
+          .frame(maxWidth: 220, alignment: .leading)
       }
       .pickerStyle(.menu)
       .frame(maxWidth: 220, alignment: .leading)
       .lineLimit(1)
       .truncationMode(.tail)
+      .accessibilityLabel(String(localized: "Library"))
 
       Spacer()
 

--- a/KMReader/Features/History/Views/ServerReadingStatsView.swift
+++ b/KMReader/Features/History/Views/ServerReadingStatsView.swift
@@ -148,15 +148,6 @@ struct ServerReadingStatsView: View {
           .truncationMode(.tail)
       }
 
-      if viewModel.isUsingCachedData {
-        Text(String(localized: "Cached"))
-          .font(.caption)
-          .fontWeight(.semibold)
-          .padding(.horizontal, 8)
-          .padding(.vertical, 4)
-          .background(Color.orange.opacity(0.2), in: Capsule())
-          .foregroundStyle(.orange)
-      }
     }
     .padding(12)
     .background(.thinMaterial)

--- a/KMReader/Features/History/Views/ServerReadingStatsView.swift
+++ b/KMReader/Features/History/Views/ServerReadingStatsView.swift
@@ -139,12 +139,13 @@ struct ServerReadingStatsView: View {
         Text(selectedLibraryName)
           .lineLimit(1)
           .truncationMode(.tail)
-          .frame(maxWidth: 220, alignment: .leading)
+          .frame(maxWidth: .infinity, alignment: .leading)
       }
       .pickerStyle(.menu)
-      .frame(maxWidth: 220, alignment: .leading)
+      .frame(maxWidth: .infinity, alignment: .leading)
       .lineLimit(1)
       .truncationMode(.tail)
+      .layoutPriority(1)
       .accessibilityLabel(String(localized: "Library"))
 
       Spacer()
@@ -155,6 +156,7 @@ struct ServerReadingStatsView: View {
           .foregroundStyle(.secondary)
           .lineLimit(1)
           .truncationMode(.tail)
+          .fixedSize(horizontal: true, vertical: false)
       }
 
     }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -10080,70 +10080,6 @@
         }
       }
     },
-    "Cached" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zwischengespeichert"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cached"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En cache"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En cache"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In cache"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャッシュ済み"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "캐시됨"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "В кэше"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已缓存"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已快取"
-          }
-        }
-      }
-    },
     "Cached Covers" : {
       "localizations" : {
         "de" : {
@@ -69795,18 +69731,17 @@
       }
     },
     "splash.offline.enter" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enter Offline Mode"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Offline-Modus starten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter Offline Mode"
           }
         },
         "es" : {

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -69794,6 +69794,71 @@
         }
       }
     },
+    "splash.offline.enter" : {
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter Offline Mode"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Modus starten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrar en modo sin conexión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passer en mode hors ligne"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entra in modalità offline"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインモードに切り替える"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 모드로 전환"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перейти в автономный режим"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "进入离线模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進入離線模式"
+          }
+        }
+      }
+    },
     "Split Wide Pages" : {
       "localizations" : {
         "de" : {


### PR DESCRIPTION
## Problem
The reading stats controls showed a `Cached` badge whenever the page rendered cached stats. That label did not provide actionable information and took up space in an already compact header. Long library names could also wrap to two lines in the same control row.

## Approach
Remove the cached badge from the controls while keeping the existing cached snapshot loading and refresh fallback behavior intact. Since the badge was the only consumer of `isUsingCachedData`, remove that unused view-model state and simplify snapshot application.

Keep the library selector as the standard menu `Picker`, remove the fixed width cap so it can use available row space, and keep the timestamp single-line. Also complete the newly extracted splash offline-mode localization key across supported languages.

## Scope
- Remove the reading stats `Cached` UI badge
- Drop the unused `isUsingCachedData` state and `usingCache` apply parameter
- Keep the reading stats library selector as a standard `Picker`
- Let the picker use available row width and keep the timestamp single-line
- Add translations for `splash.offline.enter`
- Preserve cached stats display, refresh, and fallback error behavior

## Validation
- [x] Ran `make format`
- [x] Ran `make build`
- [x] Ran `make localize`
- [x] Ran `./misc/translate.py list`
- [x] Confirmed no `isUsingCachedData` or `usingCache` references remain
