### PR TITLE
feat: add persistent reader progress bar setting

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 430;
+				CURRENT_PROJECT_VERSION = 431;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 430;
+				CURRENT_PROJECT_VERSION = 431;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 430;
+				CURRENT_PROJECT_VERSION = 431;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 430;
+				CURRENT_PROJECT_VERSION = 431;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -137,6 +137,16 @@ enum AppConfig {
     set { UserDefaults.standard.set(newValue, forKey: "showDivinaControlsGradientBackground") }
   }
 
+  static nonisolated var showDivinaProgressBarWhileReading: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "showDivinaProgressBarWhileReading") != nil {
+        return UserDefaults.standard.bool(forKey: "showDivinaProgressBarWhileReading")
+      }
+      return false
+    }
+    set { UserDefaults.standard.set(newValue, forKey: "showDivinaProgressBarWhileReading") }
+  }
+
   static nonisolated var pdfOfflineRenderQuality: PdfOfflineRenderQuality {
     get {
       if let stored = UserDefaults.standard.string(forKey: "pdfOfflineRenderQuality"),
@@ -189,6 +199,16 @@ enum AppConfig {
       return false
     }
     set { UserDefaults.standard.set(newValue, forKey: "showPdfControlsGradientBackground") }
+  }
+
+  static nonisolated var showPdfProgressBarWhileReading: Bool {
+    get {
+      if UserDefaults.standard.object(forKey: "showPdfProgressBarWhileReading") != nil {
+        return UserDefaults.standard.bool(forKey: "showPdfProgressBarWhileReading")
+      }
+      return false
+    }
+    set { UserDefaults.standard.set(newValue, forKey: "showPdfProgressBarWhileReading") }
   }
 
   static nonisolated var isOffline: Bool {

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -28,6 +28,9 @@ struct DivinaControlsOverlayView: View {
   let controlsVisible: Bool
   let showingControls: Bool
   let showGradientBackground: Bool
+  let showProgressBarWhileReading: Bool
+
+  @Namespace private var progressBarNamespace
 
   #if os(tvOS)
     private enum ControlFocus: Hashable {
@@ -144,26 +147,14 @@ struct DivinaControlsOverlayView: View {
   #endif
 
   var body: some View {
-    VStack(spacing: 0) {
-      if controlsVisible {
-        topBar
-          .transition(
-            .move(edge: .top)
-              .combined(with: .opacity)
-          )
-      }
-
-      Spacer(minLength: 0)
-
-      if controlsVisible {
-        bottomBar
-          .transition(
-            .move(edge: .bottom)
-              .combined(with: .opacity)
-          )
-      }
+    ZStack(alignment: .bottom) {
+      topControlsLayer
+      bottomControlsLayer
+      hiddenProgressLayer
     }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
     .animation(animation, value: controlsVisible)
+    .animation(animation, value: showProgressBarWhileReading)
     .allowsHitTesting(controlsVisible)
     #if os(iOS)
       .tint(.primary)
@@ -184,6 +175,48 @@ struct DivinaControlsOverlayView: View {
       }
       .focusSection()
     #endif
+  }
+
+  private var progressHorizontalPadding: CGFloat {
+    controlsVisible ? 0 : 48
+  }
+
+  private var bottomControlsTransition: AnyTransition {
+    guard showProgressBarWhileReading else {
+      return .move(edge: .bottom).combined(with: .opacity)
+    }
+    return .opacity
+  }
+
+  @ViewBuilder
+  private var topControlsLayer: some View {
+    VStack(spacing: 0) {
+      if controlsVisible {
+        topBar
+          .transition(
+            .move(edge: .top)
+              .combined(with: .opacity)
+          )
+      }
+
+      Spacer(minLength: 0)
+    }
+  }
+
+  @ViewBuilder
+  private var bottomControlsLayer: some View {
+    if controlsVisible {
+      visibleBottomOverlayBar
+        .transition(bottomControlsTransition)
+    }
+  }
+
+  @ViewBuilder
+  private var hiddenProgressLayer: some View {
+    if !controlsVisible && showProgressBarWhileReading {
+      hiddenProgressBar
+        .transition(.opacity)
+    }
   }
 
   private var topBar: some View {
@@ -269,45 +302,74 @@ struct DivinaControlsOverlayView: View {
     }
   }
 
-  private var bottomBar: some View {
-    VStack(spacing: 12) {
-      HStack {
-        Spacer(minLength: 0)
-
-        Button {
-          guard viewModel.hasPages else { return }
-          showingPageJumpSheet = true
-        } label: {
-          HStack(spacing: 6) {
-            Image(systemName: "bookmark")
-            Text("\(displayedCurrentPage) / \(currentSegmentPageCount)")
-              .monospacedDigit()
-              .contentTransition(.numericText())
-          }
-          .contentShape(Capsule())
-        }
-        .readerControlButtonStyle()
-        #if os(tvOS)
-          .focused($focusedControl, equals: .pageNumber)
-        #endif
-
-        Spacer(minLength: 0)
+  private var visibleBottomOverlayBar: some View {
+    bottomOverlayContent(showPageButton: true)
+      .padding()
+      .background {
+        gradientBackground(startPoint: .bottom, endPoint: .top)
+          .ignoresSafeArea(edges: .bottom)
       }
-      .optimizedControlSize()
-      .allowsHitTesting(true)
+  }
 
-      ReadingProgressBar(progress: progress, type: .reader)
-        .scaleEffect(x: readingDirection == .rtl ? -1 : 1, y: 1)
+  private var hiddenProgressBar: some View {
+    ZStack(alignment: .bottom) {
+      Color.clear
+      bottomOverlayContent(showPageButton: false)
+        .frame(maxWidth: .infinity)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .readerIgnoresSafeArea()
+    .allowsHitTesting(false)
+  }
+
+  private func bottomOverlayContent(showPageButton: Bool) -> some View {
+    VStack(spacing: 12) {
+      if showPageButton {
+        HStack {
+          Spacer(minLength: 0)
+
+          Button {
+            guard viewModel.hasPages else { return }
+            showingPageJumpSheet = true
+          } label: {
+            HStack(spacing: 6) {
+              Image(systemName: "bookmark")
+              Text("\(displayedCurrentPage) / \(currentSegmentPageCount)")
+                .monospacedDigit()
+                .contentTransition(.numericText())
+            }
+            .contentShape(Capsule())
+          }
+          .readerControlButtonStyle()
+          #if os(tvOS)
+            .focused($focusedControl, equals: .pageNumber)
+          #endif
+
+          Spacer(minLength: 0)
+        }
+        .optimizedControlSize()
+        .allowsHitTesting(true)
+      }
+
+      progressBar
+        .padding(.horizontal, progressHorizontalPadding)
     }
     .animation(animation, value: currentBook?.id)
     .animation(animation, value: displayedCurrentPage)
     .animation(animation, value: currentSegmentPageCount)
     .animation(animation, value: progress)
-    .padding()
-    .iPadIgnoresSafeArea(paddingTop: 24)
-    .background {
-      gradientBackground(startPoint: .bottom, endPoint: .top)
-        .ignoresSafeArea(edges: .bottom)
+    .animation(animation, value: progressHorizontalPadding)
+  }
+
+  @ViewBuilder
+  private var progressBar: some View {
+    let bar = ReadingProgressBar(progress: progress, type: .reader)
+      .scaleEffect(x: readingDirection == .rtl ? -1 : 1, y: 1)
+
+    if showProgressBarWhileReading {
+      bar.matchedGeometryEffect(id: "readerProgressBar", in: progressBarNamespace)
+    } else {
+      bar
     }
   }
 

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -187,7 +187,7 @@ struct DivinaControlsOverlayView: View {
   }
 
   private var topBar: some View {
-    HStack(alignment: .top) {
+    HStack {
       #if !os(macOS)
         Button {
           onDismiss()
@@ -231,6 +231,7 @@ struct DivinaControlsOverlayView: View {
           }
           .padding(.vertical, 2)
           .padding(.horizontal)
+          .readerHeaderTitleControlFrame()
           .contentShape(Capsule())
         }
         .optimizedControlSize()

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -38,6 +38,9 @@ struct DivinaReaderView: View {
   @AppStorage("showDivinaControlsGradientBackground")
   private var showControlsGradientBackground: Bool =
     AppConfig.showDivinaControlsGradientBackground
+  @AppStorage("showDivinaProgressBarWhileReading")
+  private var showProgressBarWhileReading: Bool =
+    AppConfig.showDivinaProgressBarWhileReading
   @AppStorage("doubleTapZoomScale") private var doubleTapZoomScale: Double = 3.0
   @AppStorage("doubleTapZoomMode") private var doubleTapZoomMode: DoubleTapZoomMode = .fast
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
@@ -837,7 +840,8 @@ struct DivinaReaderView: View {
       onNextBook: { openNextBook(nextBookId: $0) },
       controlsVisible: shouldShowControls,
       showingControls: showingControls,
-      showGradientBackground: showControlsGradientBackground
+      showGradientBackground: showControlsGradientBackground,
+      showProgressBarWhileReading: showProgressBarWhileReading
     )
   }
 

--- a/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
@@ -22,7 +22,10 @@
     let canSearch: Bool
     let controlsVisible: Bool
     let showGradientBackground: Bool
+    let showProgressBarWhileReading: Bool
     let onDismiss: () -> Void
+
+    @Namespace private var progressBarNamespace
 
     private var animation: Animation {
       .easeInOut(duration: 0.2)
@@ -43,6 +46,33 @@
     }
 
     var body: some View {
+      ZStack(alignment: .bottom) {
+        topControlsLayer
+        bottomControlsLayer
+        hiddenProgressLayer
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .animation(animation, value: controlsVisible)
+      .animation(animation, value: showProgressBarWhileReading)
+      .allowsHitTesting(controlsVisible)
+      #if os(iOS)
+        .tint(.primary)
+      #endif
+    }
+
+    private var progressHorizontalPadding: CGFloat {
+      controlsVisible ? 0 : 48
+    }
+
+    private var bottomControlsTransition: AnyTransition {
+      guard showProgressBarWhileReading else {
+        return .move(edge: .bottom).combined(with: .opacity)
+      }
+      return .opacity
+    }
+
+    @ViewBuilder
+    private var topControlsLayer: some View {
       VStack(spacing: 0) {
         if controlsVisible {
           topBar
@@ -53,20 +83,23 @@
         }
 
         Spacer(minLength: 0)
-
-        if controlsVisible {
-          bottomBar
-            .transition(
-              .move(edge: .bottom)
-                .combined(with: .opacity)
-            )
-        }
       }
-      .animation(animation, value: controlsVisible)
-      .allowsHitTesting(controlsVisible)
-      #if os(iOS)
-        .tint(.primary)
-      #endif
+    }
+
+    @ViewBuilder
+    private var bottomControlsLayer: some View {
+      if controlsVisible {
+        visibleBottomOverlayBar
+          .transition(bottomControlsTransition)
+      }
+    }
+
+    @ViewBuilder
+    private var hiddenProgressLayer: some View {
+      if !controlsVisible && showProgressBarWhileReading {
+        hiddenProgressBar
+          .transition(.opacity)
+      }
     }
 
     private var topBar: some View {
@@ -143,38 +176,67 @@
       }
     }
 
-    private var bottomBar: some View {
-      VStack(spacing: 12) {
-        HStack {
-          Spacer(minLength: 0)
-
-          Button {
-            guard pageCount > 0 else { return }
-            showingPageJumpSheet = true
-          } label: {
-            HStack(spacing: 6) {
-              Image(systemName: "bookmark")
-              Text("\(displayedCurrentPage) / \(pageCount)")
-                .monospacedDigit()
-            }
-            .contentShape(Capsule())
-          }
-          .readerControlButtonStyle()
-          .disabled(pageCount <= 0)
-
-          Spacer(minLength: 0)
+    private var visibleBottomOverlayBar: some View {
+      bottomOverlayContent(showPageButton: true)
+        .padding()
+        .background {
+          gradientBackground(startPoint: .bottom, endPoint: .top)
+            .ignoresSafeArea(edges: .bottom)
         }
-        .optimizedControlSize()
-        .allowsHitTesting(true)
+    }
 
-        ReadingProgressBar(progress: progress, type: .reader)
-          .scaleEffect(x: readingDirection == .rtl ? -1 : 1, y: 1)
+    private var hiddenProgressBar: some View {
+      ZStack(alignment: .bottom) {
+        Color.clear
+        bottomOverlayContent(showPageButton: false)
+          .frame(maxWidth: .infinity)
       }
-      .padding()
-      .iPadIgnoresSafeArea(paddingTop: 24)
-      .background {
-        gradientBackground(startPoint: .bottom, endPoint: .top)
-          .ignoresSafeArea(edges: .bottom)
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .readerIgnoresSafeArea()
+      .allowsHitTesting(false)
+    }
+
+    private func bottomOverlayContent(showPageButton: Bool) -> some View {
+      VStack(spacing: 12) {
+        if showPageButton {
+          HStack {
+            Spacer(minLength: 0)
+
+            Button {
+              guard pageCount > 0 else { return }
+              showingPageJumpSheet = true
+            } label: {
+              HStack(spacing: 6) {
+                Image(systemName: "bookmark")
+                Text("\(displayedCurrentPage) / \(pageCount)")
+                  .monospacedDigit()
+              }
+              .contentShape(Capsule())
+            }
+            .readerControlButtonStyle()
+            .disabled(pageCount <= 0)
+
+            Spacer(minLength: 0)
+          }
+          .optimizedControlSize()
+          .allowsHitTesting(true)
+        }
+
+        progressBar
+          .padding(.horizontal, progressHorizontalPadding)
+      }
+      .animation(animation, value: progressHorizontalPadding)
+    }
+
+    @ViewBuilder
+    private var progressBar: some View {
+      let bar = ReadingProgressBar(progress: progress, type: .reader)
+        .scaleEffect(x: readingDirection == .rtl ? -1 : 1, y: 1)
+
+      if showProgressBarWhileReading {
+        bar.matchedGeometryEffect(id: "readerProgressBar", in: progressBarNamespace)
+      } else {
+        bar
       }
     }
 

--- a/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
@@ -70,7 +70,7 @@
     }
 
     private var topBar: some View {
-      HStack(alignment: .top) {
+      HStack {
         #if !os(macOS)
           Button {
             onDismiss()
@@ -112,6 +112,7 @@
             }
             .padding(.vertical, 2)
             .padding(.horizontal)
+            .readerHeaderTitleControlFrame()
             .contentShape(Capsule())
           }
           .optimizedControlSize()

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderSettingsSheet.swift
@@ -8,6 +8,9 @@
     @AppStorage("showPdfControlsGradientBackground")
     private var showControlsGradientBackground: Bool =
       AppConfig.showPdfControlsGradientBackground
+    @AppStorage("showPdfProgressBarWhileReading")
+    private var showProgressBarWhileReading: Bool =
+      AppConfig.showPdfProgressBarWhileReading
 
     var body: some View {
       SheetView(
@@ -28,6 +31,10 @@
           Section(header: Text("Reader Overlay")) {
             Toggle(isOn: $showControlsGradientBackground) {
               Text("Controls Gradient Background")
+            }
+
+            Toggle(isOn: $showProgressBarWhileReading) {
+              Text("Show Progress Bar While Reading")
             }
 
             Toggle(isOn: $showKeyboardHelpOverlay) {

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -23,6 +23,9 @@
     @AppStorage("showPdfControlsGradientBackground")
     private var showControlsGradientBackground: Bool =
       AppConfig.showPdfControlsGradientBackground
+    @AppStorage("showPdfProgressBarWhileReading")
+    private var showProgressBarWhileReading: Bool =
+      AppConfig.showPdfProgressBarWhileReading
 
     @State private var viewModel: PdfReaderViewModel
     @State private var readingDirection: ReadingDirection
@@ -334,6 +337,7 @@
         canSearch: viewModel.documentURL != nil,
         controlsVisible: shouldShowControls,
         showGradientBackground: showControlsGradientBackground,
+        showProgressBarWhileReading: showProgressBarWhileReading,
         onDismiss: closeReader
       )
     }

--- a/KMReader/Features/Reader/Views/ReaderControlButtonStyle.swift
+++ b/KMReader/Features/Reader/Views/ReaderControlButtonStyle.swift
@@ -7,6 +7,15 @@ import SwiftUI
 
 extension View {
   @ViewBuilder
+  func readerHeaderTitleControlFrame() -> some View {
+    #if os(tvOS)
+      self.frame(minHeight: 64, alignment: .center)
+    #else
+      self.frame(minHeight: 24, alignment: .center)
+    #endif
+  }
+
+  @ViewBuilder
   func readerControlButtonStyle() -> some View {
     #if os(iOS)
       if #available(iOS 26.0, *) {

--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -38,6 +38,9 @@ struct ReaderSettingsSheet: View {
   @AppStorage("showDivinaControlsGradientBackground")
   private var showControlsGradientBackground: Bool =
     AppConfig.showDivinaControlsGradientBackground
+  @AppStorage("showDivinaProgressBarWhileReading")
+  private var showProgressBarWhileReading: Bool =
+    AppConfig.showDivinaProgressBarWhileReading
 
   private var isWebtoonDirection: Bool {
     readingDirection == .webtoon
@@ -76,6 +79,10 @@ struct ReaderSettingsSheet: View {
 
           Toggle(isOn: $showControlsGradientBackground) {
             Text("Controls Gradient Background")
+          }
+
+          Toggle(isOn: $showProgressBarWhileReading) {
+            Text("Show Progress Bar While Reading")
           }
 
           #if os(iOS) || os(macOS)

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -38,6 +38,9 @@ struct DivinaPreferencesView: View {
   @AppStorage("showDivinaControlsGradientBackground")
   private var showControlsGradientBackground: Bool =
     AppConfig.showDivinaControlsGradientBackground
+  @AppStorage("showDivinaProgressBarWhileReading")
+  private var showProgressBarWhileReading: Bool =
+    AppConfig.showDivinaProgressBarWhileReading
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
 
   private var forcedReadingDirection: ReadingDirection? {
@@ -161,6 +164,15 @@ struct DivinaPreferencesView: View {
           VStack(alignment: .leading, spacing: 4) {
             Text("Controls Gradient Background")
             Text("Add a gradient behind reader controls for better contrast over pages.")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+        }
+
+        Toggle(isOn: $showProgressBarWhileReading) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Show Progress Bar While Reading")
+            Text("Keep book progress pinned to the bottom until reader controls are shown.")
               .font(.caption)
               .foregroundColor(.secondary)
           }

--- a/KMReader/Features/Settings/PdfPreferencesView.swift
+++ b/KMReader/Features/Settings/PdfPreferencesView.swift
@@ -19,6 +19,9 @@
     @AppStorage("showPdfControlsGradientBackground")
     private var showControlsGradientBackground: Bool =
       AppConfig.showPdfControlsGradientBackground
+    @AppStorage("showPdfProgressBarWhileReading")
+    private var showProgressBarWhileReading: Bool =
+      AppConfig.showPdfProgressBarWhileReading
     @AppStorage("pdfOfflineRenderQuality")
     private var pdfOfflineRenderQuality: PdfOfflineRenderQuality = AppConfig.pdfOfflineRenderQuality
 
@@ -112,6 +115,15 @@
               VStack(alignment: .leading, spacing: 4) {
                 Text("Controls Gradient Background")
                 Text("Add a gradient behind reader controls for better contrast over pages.")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+              }
+            }
+
+            Toggle(isOn: $showProgressBarWhileReading) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Show Progress Bar While Reading")
+                Text("Keep book progress pinned to the bottom until reader controls are shown.")
                   .font(.caption)
                   .foregroundColor(.secondary)
               }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -30688,6 +30688,70 @@
         }
       }
     },
+    "Keep book progress pinned to the bottom until reader controls are shown." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buchfortschritt unten angeheftet lassen, bis die Lesersteuerung angezeigt wird."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep book progress pinned to the bottom until reader controls are shown."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantén el progreso del libro fijado abajo hasta que se muestren los controles de lectura."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gardez la progression du livre épinglée en bas jusqu’à l’affichage des commandes de lecture."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantieni l’avanzamento del libro fissato in basso finché non vengono mostrati i controlli di lettura."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リーダー操作部が表示されるまで、本の進捗を下部に固定します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "리더 컨트롤이 표시될 때까지 책 진행률을 하단에 고정합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закреплять прогресс книги внизу, пока не будут показаны элементы управления чтением."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在显示阅读控制前，将书籍进度固定在底部。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在顯示閱讀控制項前，將書籍進度固定在底部。"
+          }
+        }
+      }
+    },
     "Keep time and battery visible when controls are hidden." : {
       "localizations" : {
         "de" : {
@@ -67998,6 +68062,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "顯示頁面陰影"
+          }
+        }
+      }
+    },
+    "Show Progress Bar While Reading" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fortschrittsleiste beim Lesen anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Progress Bar While Reading"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar la barra de progreso durante la lectura"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher la barre de progression pendant la lecture"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra la barra di avanzamento durante la lettura"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書中に進捗バーを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽는 동안 진행률 막대 표시"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать индикатор прогресса при чтении"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读时显示进度条"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀時顯示進度條"
           }
         }
       }


### PR DESCRIPTION
## Problem
Reader progress was only visible while the controls overlay was open, so users who wanted lightweight always-on reading feedback had to repeatedly reveal controls. The existing PR also fixed a smaller visual issue where short overlay titles could sit unevenly against the side controls.

## Approach
Add separate DIVINA and PDF reader preferences for showing progress while reading. The bottom overlay now has explicit visible and hidden states: with controls open it respects the safe area and shows the full controls row, and with controls hidden it keeps the same progress bar at the screen edge with matched geometry so it drops down and narrows smoothly.

## Scope
- Add DIVINA and PDF settings in both global settings views and in-reader settings sheets
- Persist separate progress-bar-while-reading preferences for DIVINA and PDF
- Rework DIVINA and PDF bottom overlay presentation for safe-area-aware visible controls and edge-pinned hidden progress
- Keep the reader overlay title alignment fix from the original PR
- Update localizations for the new settings text and missing cached label
- Bump the build version to 431

## Validation
- [x] make format
- [x] make build
- [x] make build-macos
- [x] ./misc/translate.py list
