### PR TITLE
fix: tune reader bottom progress padding

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 431;
+				CURRENT_PROJECT_VERSION = 432;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 431;
+				CURRENT_PROJECT_VERSION = 432;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 431;
+				CURRENT_PROJECT_VERSION = 432;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 431;
+				CURRENT_PROJECT_VERSION = 432;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -177,10 +177,6 @@ struct DivinaControlsOverlayView: View {
     #endif
   }
 
-  private var progressHorizontalPadding: CGFloat {
-    controlsVisible ? 0 : 48
-  }
-
   private var bottomControlsTransition: AnyTransition {
     guard showProgressBarWhileReading else {
       return .move(edge: .bottom).combined(with: .opacity)
@@ -314,15 +310,21 @@ struct DivinaControlsOverlayView: View {
   private var hiddenProgressBar: some View {
     ZStack(alignment: .bottom) {
       Color.clear
-      bottomOverlayContent(showPageButton: false)
-        .frame(maxWidth: .infinity)
+      bottomOverlayContent(
+        showPageButton: false,
+        progressHorizontalPadding: PlatformHelper.bottomEdgeHorizontalPadding
+      )
+      .frame(maxWidth: .infinity)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .readerIgnoresSafeArea()
     .allowsHitTesting(false)
   }
 
-  private func bottomOverlayContent(showPageButton: Bool) -> some View {
+  private func bottomOverlayContent(
+    showPageButton: Bool,
+    progressHorizontalPadding: CGFloat = 0
+  ) -> some View {
     VStack(spacing: 12) {
       if showPageButton {
         HStack {

--- a/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
@@ -60,10 +60,6 @@
       #endif
     }
 
-    private var progressHorizontalPadding: CGFloat {
-      controlsVisible ? 0 : 48
-    }
-
     private var bottomControlsTransition: AnyTransition {
       guard showProgressBarWhileReading else {
         return .move(edge: .bottom).combined(with: .opacity)
@@ -188,15 +184,21 @@
     private var hiddenProgressBar: some View {
       ZStack(alignment: .bottom) {
         Color.clear
-        bottomOverlayContent(showPageButton: false)
-          .frame(maxWidth: .infinity)
+        bottomOverlayContent(
+          showPageButton: false,
+          progressHorizontalPadding: PlatformHelper.bottomEdgeHorizontalPadding
+        )
+        .frame(maxWidth: .infinity)
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .readerIgnoresSafeArea()
       .allowsHitTesting(false)
     }
 
-    private func bottomOverlayContent(showPageButton: Bool) -> some View {
+    private func bottomOverlayContent(
+      showPageButton: Bool,
+      progressHorizontalPadding: CGFloat = 0
+    ) -> some View {
       VStack(spacing: 12) {
         if showPageButton {
           HStack {

--- a/KMReader/Shared/Helpers/PlatformHelpers.swift
+++ b/KMReader/Shared/Helpers/PlatformHelpers.swift
@@ -160,6 +160,31 @@ enum PlatformHelper {
   }
 
   @MainActor
+  static var bottomEdgeHorizontalPadding: CGFloat {
+    #if os(iOS)
+      if isPad {
+        return 24
+      }
+
+      let width = min(UIScreen.main.bounds.width, UIScreen.main.bounds.height)
+
+      if width >= 420 {
+        return 64
+      }
+
+      if width <= 375 {
+        return 36
+      }
+
+      return 48
+    #elseif os(macOS)
+      return 24
+    #else
+      return 24
+    #endif
+  }
+
+  @MainActor
   static var pageNumberFontSize: CGFloat {
     #if os(tvOS)
       return 24


### PR DESCRIPTION
## Problem
The hidden reader progress bar sits flush with the bottom edge, where the visible bottom width is shortened by rounded display corners. A fixed 48 pt horizontal padding was too large on smaller devices and too small on iPhone Air, while `safeAreaInsets.bottom` was not a reliable proxy because devices can share the same bottom inset with different display corner radii.

Reference data from community measurements of iOS `_displayCornerRadius` shows the shape we need to approximate: iPhone 12/13 mini are around 44 pt, common modern iPhones are around 47-55 pt, and iPhone 16 Pro / 17 / Air class devices are around 62 pt. iPad display corner radii are much smaller, around 18 pt, so they should not follow large iPhone screen-width buckets.

## Approach
Move the bottom-edge padding decision into `PlatformHelper.bottomEdgeHorizontalPadding` so DIVINA and PDF readers share one policy. iPhone uses width buckets calibrated to the corner-radius data: 36 pt for mini-width devices, 48 pt for the middle group, and 64 pt for iPhone Air / large rounded-corner devices. iPad, macOS, and tvOS keep a lighter 24 pt padding.

This also removes the temporary `GeometryReader` from the hidden progress bar overlays; the padding is platform-derived instead of layout-derived.

## Scope
- Add `PlatformHelper.bottomEdgeHorizontalPadding`
- Update DIVINA hidden reader progress padding to use the helper
- Update PDF hidden reader progress padding to use the helper
- Bump build version to 432

## Validation
- [x] `make format`
- [x] `make bump`
- [ ] Full platform build not run
