### PR TITLE
fix: smooth webtoon top padding

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 432;
+				CURRENT_PROJECT_VERSION = 433;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 432;
+				CURRENT_PROJECT_VERSION = 433;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 432;
+				CURRENT_PROJECT_VERSION = 433;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 432;
+				CURRENT_PROJECT_VERSION = 433;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/Helpers/WebtoonConstants.swift
+++ b/KMReader/Features/Reader/Views/Helpers/WebtoonConstants.swift
@@ -11,6 +11,7 @@ enum WebtoonConstants {
   static let initialScrollMaxRetries: Int = 8
   static let layoutReadyDelay: TimeInterval = 0.2
   static let bottomThreshold: CGFloat = 60
+  static let topContentPadding: CGFloat = 120
   static let footerHeight: CGFloat = 480
   static let measuringPlaceholderHeight: CGFloat = 120
   static let scrollAnimationDuration: TimeInterval = 0.3

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonLayout_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonLayout_iOS.swift
@@ -12,7 +12,10 @@
       scrollDirection = .vertical
       minimumLineSpacing = 0
       minimumInteritemSpacing = 0
-      sectionInset = .zero
+      let topInset =
+        collectionView?.traitCollection.userInterfaceIdiom == .phone
+        ? WebtoonConstants.topContentPadding : 0
+      sectionInset = UIEdgeInsets(top: topInset, left: 0, bottom: 0, right: 0)
     }
 
     override func shouldInvalidateLayout(forBoundsChange newBounds: CGRect) -> Bool {

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -377,7 +377,7 @@
         collectionView: UICollectionView,
         renderConfig: ReaderRenderConfig
       ) {
-        applySafeAreaInsetsIfNeeded(for: collectionView)
+        resetContentInsetsIfNeeded(for: collectionView)
         self.viewModel = viewModel
         self.readListContext = readListContext
         self.onDismiss = onDismiss
@@ -449,23 +449,17 @@
         }
       }
 
-      private func applySafeAreaInsetsIfNeeded(for collectionView: UICollectionView) {
-        guard collectionView.traitCollection.userInterfaceIdiom == .phone else {
-          if collectionView.contentInset != .zero {
-            collectionView.contentInset = .zero
-            collectionView.scrollIndicatorInsets = .zero
-          }
+      private func resetContentInsetsIfNeeded(for collectionView: UICollectionView) {
+        guard
+          collectionView.contentInset != .zero
+            || collectionView.verticalScrollIndicatorInsets != .zero
+            || collectionView.horizontalScrollIndicatorInsets != .zero
+        else {
           return
         }
-
-        let safeInsets = collectionView.safeAreaInsets
-        let newInsets = UIEdgeInsets(
-          top: safeInsets.top, left: 0, bottom: safeInsets.bottom, right: 0)
-
-        if collectionView.contentInset != newInsets {
-          collectionView.contentInset = newInsets
-          collectionView.scrollIndicatorInsets = newInsets
-        }
+        collectionView.contentInset = .zero
+        collectionView.verticalScrollIndicatorInsets = .zero
+        collectionView.horizontalScrollIndicatorInsets = .zero
       }
 
       private func handleDataReload(
@@ -630,11 +624,13 @@
         guard let collectionView = collectionView else { return }
         guard let itemIndex = itemIndex(forPageID: pageID) else { return }
 
-        let indexPath = IndexPath(item: itemIndex, section: 0)
-
         if collectionView.contentSize.height > 0 {
           isProgrammaticAnimatedScroll = animated
-          collectionView.scrollToItem(at: indexPath, at: .top, animated: animated)
+          collectionView.scrollToItem(
+            at: IndexPath(item: itemIndex, section: 0),
+            at: .top,
+            animated: animated
+          )
         } else {
           requestScrollToPage(
             pageID, animated: animated, delay: WebtoonConstants.layoutReadyDelay)


### PR DESCRIPTION
## Problem
Webtoon mode used iPhone safe-area values as collection view content insets. That made safe-area spacing participate in the scroll view's offset bounds and adjusted inset math, which could make continuous vertical scrolling and tap-scroll positioning feel less smooth.

## Approach
Keep the Webtoon collection view content and indicator insets at zero, and move the notch/Dynamic Island breathing room into the collection layout as a fixed 120-point top section inset on iPhone. Programmatic page positioning continues to use the collection view's native item scrolling, so the top padding remains a scrollable buffer before the first page instead of a permanent viewport inset.

## Scope
- Add a shared Webtoon top content padding constant
- Apply the padding through the iOS Webtoon collection layout on iPhone
- Remove safe-area-derived Webtoon content inset updates
- Bump build number to 433

## Validation
- [x] make format
- [x] make build-ios
