### PR TITLE
perf: defer adjacent-book fetch off the reader open path

### DIFF
--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -507,6 +507,26 @@ class ReaderViewModel {
     )
   }
 
+  /// Update the adjacent-book metadata for an existing segment. Called when the
+  /// reader's deferred adjacent-book fetch resolves so the segment's
+  /// `previousBook`/`nextBook` reflect the freshly-fetched values, preventing
+  /// redundant re-fetches from later code paths such as `resolveSegmentPreloadContext`
+  /// that read these from the segment.
+  ///
+  /// No-op when no segment matches `bookId` — e.g., the user has navigated away
+  /// before the deferred fetch resolved.
+  func updateAdjacentBooksForSegment(
+    bookId: String,
+    previousBook: Book?,
+    nextBook: Book?
+  ) {
+    updateSegmentContext(
+      forCurrentBookId: bookId,
+      previousBook: previousBook,
+      nextBook: nextBook
+    )
+  }
+
   private func appendSegment(
     currentBook: Book,
     previousBook: Book?,

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -79,6 +79,7 @@ struct DivinaReaderView: View {
   @State private var inFlightNextSegmentPreloads: [String: Task<Void, Never>] = [:]
   @State private var inFlightPreviousSegmentPreloads: [String: Task<Void, Never>] = [:]
   @State private var deferredPageMaintenanceTask: Task<Void, Never>?
+  @State private var deferredAdjacentBookTask: Task<Void, Never>?
 
   #if os(tvOS)
     @State private var lastTVRemoteMoveSignature: String = ""
@@ -573,6 +574,8 @@ struct DivinaReaderView: View {
       }
       deferredPageMaintenanceTask?.cancel()
       deferredPageMaintenanceTask = nil
+      deferredAdjacentBookTask?.cancel()
+      deferredAdjacentBookTask = nil
       requestedNextSegmentPreloads.removeAll()
       requestedPreviousSegmentPreloads.removeAll()
       inFlightNextSegmentPreloads.values.forEach { $0.cancel() }
@@ -606,6 +609,8 @@ struct DivinaReaderView: View {
       keyboardHelpTimer?.invalidate()
       deferredPageMaintenanceTask?.cancel()
       deferredPageMaintenanceTask = nil
+      deferredAdjacentBookTask?.cancel()
+      deferredAdjacentBookTask = nil
       inFlightNextSegmentPreloads.values.forEach { $0.cancel() }
       inFlightPreviousSegmentPreloads.values.forEach { $0.cancel() }
       inFlightNextSegmentPreloads.removeAll()
@@ -1113,10 +1118,30 @@ struct DivinaReaderView: View {
         }
       }
 
-      // 4. Resolve adjacent books for current segment context
-      let adjacentBooks = await resolveAdjacentBooks(for: bookId)
-      self.previousBook = adjacentBooks.previous
-      self.nextBook = adjacentBooks.next
+      // 4. Defer adjacent-book resolution to a background task. The two server
+      // round trips (`/books/{id}/previous` + `/.../next`) account for ~2/3 of the
+      // open-time network latency on a typical setup, but neither result affects
+      // the initial render — `previousBook`/`nextBook` are consumed only by
+      // post-open features (next/prev navigation buttons, end-page hints,
+      // adjacent-segment preloading). The active segment's `activeSegmentContext`
+      // already falls back to the view's @State when the segment metadata is nil,
+      // so the open path doesn't need to wait on these.
+      self.previousBook = nil
+      self.nextBook = nil
+      deferredAdjacentBookTask?.cancel()
+      deferredAdjacentBookTask = Task { [bookId] in
+        let adjacentBooks = await resolveAdjacentBooks(for: bookId)
+        guard !Task.isCancelled, currentBookId == bookId else { return }
+        previousBook = adjacentBooks.previous
+        nextBook = adjacentBooks.next
+        // Also write the resolved values back into the segment so `resolveSegmentPreloadContext`
+        // does not redundantly re-fetch when the user navigates near the start/end.
+        viewModel.updateAdjacentBooksForSegment(
+          bookId: bookId,
+          previousBook: adjacentBooks.previous,
+          nextBook: adjacentBooks.next
+        )
+      }
     }
 
     let resumePageNumber = viewModel.currentPage?.number ?? initialPageNumber
@@ -1129,8 +1154,8 @@ struct DivinaReaderView: View {
     await viewModel.loadPages(
       book: activeBook,
       initialPageNumber: resumePageNumber,
-      previousBook: previousBook,
-      nextBook: nextBook
+      previousBook: nil,
+      nextBook: nil
     )
 
     // Only preload pages if pages are available


### PR DESCRIPTION
Closes #795

## Summary

`DivinaReaderView.loadBook` blocks on three sequential server round trips before the reader UI appears:

1. `GET /books/{id}` (via `SyncService.syncBook`)
2. `GET /books/{id}/next` (via `BookService.getNextBook`)
3. `GET /books/{id}/previous` (via `BookService.getPreviousBook`)

On a typical NAS-hosted Komga, that's ~700ms–1.5s of latency on every book open, even when the book is fully downloaded for offline reading and the local DB has all the metadata.

This PR moves calls **#2 and #3** off the open path. They run as a fire-and-forget background `Task` and update the view state when they resolve. Call **#1 stays on the open path** because its result feeds `initialPageNumber` and has real multi-device-correctness implications (a separate, more careful change if anyone wants to tackle it).

Net result: typical open-time network calls drop from 3 sequential to 1.

## Why this is safe

`previousBook`/`nextBook` are consumed only by **post-open** features:

| Consumer | Code path |
|---|---|
| Next/Prev navigation buttons | `currentSegmentContext` → controls overlay (only visible when `showingControls = true`, which defaults to false) |
| End-of-book screen | only rendered when the user reaches the last page |
| Adjacent-segment preload | only triggered when within `segmentPreloadTriggerDistance = 2` of segment start/end |
| Handoff metadata | not user-visible at open time |

The flat `readerPages` array used for rendering is built from `segment.pages` only (`rebuildReaderPages` lines 137–162). It never reads `previousBook` or `nextBook`. So the initial render is independent of them.

The view's `activeSegmentContext` (lines 363–377 of `ReaderViewModel.swift`) already falls back to the view's @State `fallbackPreviousBook`/`fallbackNextBook` when the segment's stored metadata is nil — meaning we can safely create the segment with nil adjacent books and populate the @State once the deferred Task resolves. SwiftUI re-renders, and consumers that read through `currentSegmentPreviousBook` / `currentSegmentNextBook` automatically pick up the new values.

## Implementation

**`ReaderViewModel.swift`** — new public method exposing the existing private `updateSegmentContext`:

```swift
func updateAdjacentBooksForSegment(
  bookId: String,
  previousBook: Book?,
  nextBook: Book?
) { … }
```

This lets the deferred Task write the resolved values back into the segment so later adjacent-segment preload does not redundantly re-fetch. No-op when no segment matches `bookId`.

**`DivinaReaderView.swift`**:

- New `@State private var deferredAdjacentBookTask: Task<Void, Never>?`, cancelled in `.task(id: currentBookId)` and `.onDisappear` matching the existing `deferredPageMaintenanceTask` pattern.
- In `loadBook`, replace the awaited `resolveAdjacentBooks` + assignment with a fire-and-forget Task. Pass `previousBook: nil, nextBook: nil` to `viewModel.loadPages` so the segment is created with nil adjacent metadata.
- Inside the Task: `resolveAdjacentBooks(for: bookId)` → guard `!Task.isCancelled && currentBookId == bookId` → write @State + `viewModel.updateAdjacentBooksForSegment(...)`.

Diff: +51 / −6 across two files.

## Edge cases I considered

| Case | Behavior |
|---|---|
| User navigates A → B before the Task resolves | The Task is cancelled in `.task(id:)` (cancellation propagates to in-flight URLSession). Even if a write slipped through, the `currentBookId == bookId` guard rejects it. |
| User closes the reader before the Task resolves | Cancelled in `.onDisappear`. Same guard protects against late writes. |
| `resolveAdjacentBooks` fails (network error, cancelled) | Existing fallback to `cachedAdjacentBook` returns whatever's in local DB — same behavior as before. |
| User opens at page 1 → preload triggers immediately for previous segment | If the deferred Task has already resolved and written back to the segment, `resolveSegmentPreloadContext` reads non-nil values and skips its own fetch. If it hasn't resolved, both fetches race, but both are background and idempotent — no UX impact, slight server overhead in this narrow window only. |
| Server has stale cache for previous/next | Same as today — the existing fallback handles it. |
| User taps the previous/next book button before the Task resolves | The button is gated on `currentSegmentPreviousBook != nil` / `currentSegmentNextBook != nil`. While the Task is in flight, the buttons are simply hidden/disabled. They appear once @State updates. (`showingControls` defaults to `false`, so the controls overlay isn't visible at open time anyway — by the time the user taps to show controls, the Task has almost certainly resolved.) |

## What this PR does NOT change

- `syncBook` still runs synchronously on the open path. Its result affects `initialPageNumber`, which is the page the user lands on. Deferring or skipping it has multi-device-correctness implications and is out of scope here.
- The manifest fetch is already gated on `!isBookDownloaded` (line 1071), unchanged.
- EpubReaderView and PdfReaderView don't call `resolveAdjacentBooks` on the open path — verified via grep. No changes needed for those readers.

## Testing

**Not tested.** I do not have an Xcode build environment for this project, so the change has not been built or run. The reasoning is purely static.

What I verified by reading the code:

- All consumers of `self.previousBook` / `self.nextBook` go through `currentSegmentContext` → `viewModel.activeSegmentContext(... fallbackPreviousBook: previousBook, fallbackNextBook: nextBook)`, which correctly falls back to the @State when the segment's metadata is nil. Verified by grepping every read site (lines 145–148, 168–172, 836, 845, 962, 1531–1533, 1551–1557).
- `resolveSegmentPreloadContext` (lines 1276–1298) already calls `resolveAdjacentBooks` lazily when the segment metadata is nil — so the existing preload path continues to work even if the deferred Task hasn't resolved. With the deferred Task's writeback, it skips the fetch when already resolved.
- Cancellation lifecycle exactly mirrors `deferredPageMaintenanceTask` (declaration site, `.task` cancellation, `.onDisappear` cancellation) — same correctness guarantees.
- `Task { [bookId] in … }` capture: `bookId` is a String (value type), captured by value at Task creation; `currentBookId` accessed inside the closure reads the live @State.

A maintainer with the build environment should verify:

1. **Open a downloaded CBR/CBZ** — should appear noticeably faster than before.
2. **Open a non-downloaded book** — same improvement; pages load on demand as today.
3. **Open at page 1, immediately swipe backward** — previous-book preload either uses the deferred Task's already-resolved values (fast) or kicks its own fetch (same as today). Either way, no regression.
4. **Open a book and immediately swipe to the next book in series** — once the controls overlay is shown (`showingControls = true`), the next/previous buttons appear when the deferred Task resolves. Brief delay possible before they appear, but typically under the user's tap reaction time on a healthy network.
5. **Open a book in airplane mode (offline)** — `resolveAdjacentBooks` falls back to `cachedAdjacentBook`, same as today; no regression.
6. **Open book A, then immediately switch to book B before the deferred Task resolves** — Task A is cancelled by `.task(id:)`; Task B starts cleanly with B's bookId.
7. **Open a book and close it quickly** — Task is cancelled in `.onDisappear`; no leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)