### PR TITLE
fix: keep history timestamps on one line

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 433;
+				CURRENT_PROJECT_VERSION = 434;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 433;
+				CURRENT_PROJECT_VERSION = 434;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 433;
+				CURRENT_PROJECT_VERSION = 434;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 433;
+				CURRENT_PROJECT_VERSION = 434;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Server/ServerHistoryView.swift
+++ b/KMReader/Features/Server/ServerHistoryView.swift
@@ -135,12 +135,16 @@ struct ServerHistoryView: View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
           Text(event.type)
             .lineLimit(1)
+            .truncationMode(.tail)
+            .layoutPriority(1)
 
           Spacer()
 
           Text(event.timestamp.formattedMediumDateTime)
             .font(.caption)
             .foregroundColor(.secondary)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
 
           Button {
             selectedEvent = event
@@ -149,6 +153,7 @@ struct ServerHistoryView: View {
           }
           .buttonStyle(.borderless)
           .disabled(event.properties.isEmpty)
+          .frame(width: 24)
         }
 
         if let seriesId = event.seriesId, !seriesId.isEmpty {


### PR DESCRIPTION
## Problem
History rows could occasionally wrap the timestamp onto two lines when the event type, timestamp, and detail button competed for horizontal space. That made the row height unstable and harder to scan.

## Approach
Constrain the timestamp to a single horizontal line and give the detail button a stable width, so the event type truncates first instead of forcing metadata to wrap.

## Scope
- Keep history timestamps on one line
- Stabilize the detail button width in history rows
- Bump the build version to 434

## Validation
- [x] make format
- [x] make build-macos
