### PR TITLE
fix: align PDF page presentation modes

### DIFF
--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -159,26 +159,16 @@ enum AppConfig {
     set { UserDefaults.standard.set(newValue.rawValue, forKey: "pdfOfflineRenderQuality") }
   }
 
-  static nonisolated var pdfContinuousScroll: Bool {
+  static nonisolated var pdfPagePresentation: PdfPagePresentation {
     get {
-      if UserDefaults.standard.object(forKey: "pdfContinuousScroll") != nil {
-        return UserDefaults.standard.bool(forKey: "pdfContinuousScroll")
-      }
-      return false
-    }
-    set { UserDefaults.standard.set(newValue, forKey: "pdfContinuousScroll") }
-  }
-
-  static nonisolated var pdfPageLayout: PageLayout {
-    get {
-      if let stored = UserDefaults.standard.string(forKey: "pdfPageLayout"),
-        let layout = PageLayout(rawValue: stored)
+      if let stored = UserDefaults.standard.string(forKey: "pdfPagePresentation"),
+        let presentation = PdfPagePresentation(rawValue: stored)
       {
-        return layout
+        return presentation
       }
       return .auto
     }
-    set { UserDefaults.standard.set(newValue.rawValue, forKey: "pdfPageLayout") }
+    set { UserDefaults.standard.set(newValue.rawValue, forKey: "pdfPagePresentation") }
   }
 
   static nonisolated var pdfIsolateCoverPage: Bool {

--- a/KMReader/Features/Reader/Models/PdfPagePresentation.swift
+++ b/KMReader/Features/Reader/Models/PdfPagePresentation.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+enum PdfPagePresentation: String, CaseIterable, Hashable, Sendable {
+  case auto = "auto"
+  case singlePaged = "single-paged"
+  case singleContinuous = "single-continuous"
+  case dualContinuous = "dual-continuous"
+
+  func resolved(for size: CGSize) -> PdfPagePresentation {
+    guard self == .auto else { return self }
+    guard size.width > 0, size.height > 0 else { return .singlePaged }
+    return size.width > size.height ? .dualContinuous : .singlePaged
+  }
+
+  var resolvedPageLayout: PageLayout {
+    switch self {
+    case .auto:
+      return .auto
+    case .singlePaged, .singleContinuous:
+      return .single
+    case .dualContinuous:
+      return .dual
+    }
+  }
+
+  var resolvedContinuousScroll: Bool {
+    switch self {
+    case .auto, .singlePaged:
+      return false
+    case .singleContinuous, .dualContinuous:
+      return true
+    }
+  }
+
+  var displayName: String {
+    switch self {
+    case .auto:
+      return String(localized: "Auto")
+    case .singlePaged:
+      return String(localized: "Single Page")
+    case .singleContinuous:
+      return String(localized: "Single Page Continuous")
+    case .dualContinuous:
+      return String(localized: "Dual Page Continuous")
+    }
+  }
+
+  var detailText: String {
+    switch self {
+    case .auto:
+      return String(localized: "Uses dual-page continuous mode in landscape and single-page paged mode in portrait.")
+    case .singlePaged:
+      return String(localized: "Uses the native page controller for discrete page turns.")
+    case .singleContinuous:
+      return String(localized: "Scrolls through one page at a time continuously.")
+    case .dualContinuous:
+      return String(localized: "Scrolls through two-page spreads continuously.")
+    }
+  }
+
+  var icon: String {
+    switch self {
+    case .auto:
+      return "sparkles"
+    case .singlePaged:
+      return "rectangle.portrait"
+    case .singleContinuous:
+      return "scroll"
+    case .dualContinuous:
+      return "rectangle.split.2x1"
+    }
+  }
+
+  var supportsCoverIsolation: Bool {
+    self == .auto || self == .dualContinuous
+  }
+}

--- a/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfControlsOverlayView.swift
@@ -3,9 +3,8 @@
 
   struct PdfControlsOverlayView: View {
     @Binding var readingDirection: ReadingDirection
-    @Binding var pageLayout: PageLayout
+    @Binding var pagePresentation: PdfPagePresentation
     @Binding var isolateCoverPage: Bool
-    @Binding var continuousScroll: Bool
 
     @Binding var showingPageJumpSheet: Bool
     @Binding var showingSearchSheet: Bool
@@ -255,22 +254,18 @@
         }
         .pickerStyle(.menu)
 
-        Picker(selection: $pageLayout) {
-          ForEach(PageLayout.allCases, id: \.self) { layout in
-            Label(layout.displayName, systemImage: layout.icon)
-              .tag(layout)
+        Picker(selection: $pagePresentation) {
+          ForEach(PdfPagePresentation.allCases, id: \.self) { presentation in
+            Label(presentation.displayName, systemImage: presentation.icon)
+              .tag(presentation)
           }
         } label: {
-          Label(String(localized: "Page Layout"), systemImage: pageLayout.icon)
+          Label(String(localized: "Page Presentation"), systemImage: pagePresentation.icon)
         }
         .pickerStyle(.menu)
 
-        if pageLayout.supportsDualPageOptions {
+        if pagePresentation.supportsCoverIsolation {
           pageIsolation()
-        }
-
-        Toggle(isOn: $continuousScroll) {
-          Label(String(localized: "Continuous Scroll"), systemImage: "scroll")
         }
       } header: {
         Text(String(localized: "Current Reading Options"))

--- a/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_iOS.swift
@@ -4,9 +4,8 @@
 
   struct PdfDocumentView: UIViewRepresentable {
     let documentURL: URL
-    let pageLayout: PageLayout
+    let pagePresentation: PdfPagePresentation
     let isolateCoverPage: Bool
-    let continuousScroll: Bool
     let readingDirection: ReadingDirection
     let initialPageNumber: Int
     let targetPageNumber: Int?
@@ -46,6 +45,11 @@
         context.coordinator.lastNavigationToken = navigationToken
         if let targetPageNumber {
           goToPage(targetPageNumber, in: pdfView)
+          scheduleInitialPageCorrection(
+            targetPage: targetPageNumber,
+            in: pdfView,
+            coordinator: context.coordinator
+          )
         }
       }
     }
@@ -58,7 +62,6 @@
 
       let clampedInitialPage = max(1, min(initialPageNumber, max(1, document.pageCount)))
       goToPage(clampedInitialPage, in: pdfView)
-      coordinator.lastKnownPageNumber = clampedInitialPage
 
       coordinator.lastNavigationToken = navigationToken
       coordinator.notifyCurrentPage(from: pdfView)
@@ -71,44 +74,40 @@
     }
 
     private func applyPresentationConfiguration(to pdfView: PDFView, coordinator: Coordinator) {
-      let resolvedLayout = resolvedPageLayout(for: pdfView.bounds.size)
       let direction: ReadingDirection = readingDirection == .webtoon ? .vertical : readingDirection
 
-      if coordinator.lastResolvedPageLayout == resolvedLayout,
+      if coordinator.lastResolvedPagePresentation == pagePresentation,
         coordinator.lastResolvedReadingDirection == direction,
-        coordinator.lastResolvedIsolateCoverPage == isolateCoverPage,
-        coordinator.lastResolvedContinuousScroll == continuousScroll
+        coordinator.lastResolvedIsolateCoverPage == isolateCoverPage
       {
         return
       }
 
-      let currentPage = pdfView.currentPage
-      let targetPageAfterConfiguration =
-        currentPageNumber(in: pdfView)
-        ?? (coordinator.lastKnownPageNumber > 0 ? coordinator.lastKnownPageNumber : initialPageNumber)
+      let targetPageAfterConfiguration = currentPageNumber(in: pdfView) ?? initialPageNumber
       let displayMode: PDFDisplayMode
 
-      switch resolvedLayout {
-      case .dual:
-        displayMode = continuousScroll ? .twoUpContinuous : .twoUp
-      case .single, .auto:
-        displayMode = continuousScroll ? .singlePageContinuous : .singlePage
+      switch pagePresentation {
+      case .auto:
+        displayMode = .singlePage
+      case .singlePaged:
+        displayMode = .singlePage
+      case .singleContinuous:
+        displayMode = .singlePageContinuous
+      case .dualContinuous:
+        displayMode = .twoUpContinuous
       }
 
       pdfView.displayMode = displayMode
       pdfView.displayDirection = direction == .vertical ? .vertical : .horizontal
       pdfView.displaysRTL = direction == .rtl
-      pdfView.displaysAsBook = resolvedLayout == .dual && isolateCoverPage
-      pdfView.usePageViewController(!continuousScroll, withViewOptions: nil)
+      pdfView.displaysAsBook = pagePresentation == .dualContinuous && isolateCoverPage
+      pdfView.usePageViewController(pagePresentation == .singlePaged, withViewOptions: nil)
 
-      coordinator.lastResolvedPageLayout = resolvedLayout
+      coordinator.lastResolvedPagePresentation = pagePresentation
       coordinator.lastResolvedReadingDirection = direction
       coordinator.lastResolvedIsolateCoverPage = isolateCoverPage
-      coordinator.lastResolvedContinuousScroll = continuousScroll
 
-      if let currentPage {
-        pdfView.go(to: currentPage)
-      } else if pdfView.document != nil {
+      if pdfView.document != nil {
         goToPage(targetPageAfterConfiguration, in: pdfView)
       }
 
@@ -119,26 +118,17 @@
       )
     }
 
-    private func resolvedPageLayout(for size: CGSize) -> PageLayout {
-      guard pageLayout == .auto else {
-        return pageLayout
-      }
-
-      let effectiveSize: CGSize = {
-        guard size.width > 0, size.height > 0 else {
-          return UIScreen.main.bounds.size
-        }
-        return size
-      }()
-
-      return effectiveSize.width > effectiveSize.height ? .dual : .single
-    }
-
     private func goToPage(_ pageNumber: Int, in pdfView: PDFView) {
       guard let document = pdfView.document else { return }
       let index = max(0, min(pageNumber - 1, document.pageCount - 1))
       guard let page = document.page(at: index) else { return }
-      pdfView.go(to: page)
+      let bounds = page.bounds(for: pdfView.displayBox)
+      let destination = PDFDestination(
+        page: page,
+        at: CGPoint(x: bounds.minX, y: bounds.maxY)
+      )
+      destination.zoom = kPDFDestinationUnspecifiedValue
+      pdfView.go(to: destination)
     }
 
     private func scheduleInitialPageCorrection(
@@ -148,15 +138,17 @@
     ) {
       // PDFKit may reset current page multiple times during initial layout;
       // retry briefly until the target page sticks.
-      let retryDelays: [TimeInterval] = [0.0, 0.05, 0.2, 0.5]
-      for delay in retryDelays {
+      let retryDelays: [TimeInterval] = [0.0, 0.05, 0.2, 0.5, 1.0]
+      for (index, delay) in retryDelays.enumerated() {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak pdfView, weak coordinator] in
           guard let pdfView, let coordinator else { return }
           guard coordinator.loadedDocumentURL == documentURL else { return }
           if currentPageNumber(in: pdfView) != targetPage {
             goToPage(targetPage, in: pdfView)
           }
-          coordinator.notifyCurrentPage(from: pdfView)
+          if index == retryDelays.indices.last {
+            coordinator.notifyCurrentPage(from: pdfView)
+          }
         }
       }
     }
@@ -172,11 +164,9 @@
       var onSingleTap: (CGPoint) -> Void
       var loadedDocumentURL: URL?
       var lastNavigationToken: UUID?
-      var lastResolvedPageLayout: PageLayout?
+      var lastResolvedPagePresentation: PdfPagePresentation?
       var lastResolvedReadingDirection: ReadingDirection?
       var lastResolvedIsolateCoverPage: Bool?
-      var lastResolvedContinuousScroll: Bool?
-      var lastKnownPageNumber: Int = 1
       private weak var observedPDFView: PDFView?
       private weak var singleTapRecognizer: UITapGestureRecognizer?
       private weak var doubleTapRecognizer: UITapGestureRecognizer?
@@ -342,7 +332,6 @@
         }
 
         let pageNumber = document.index(for: currentPage) + 1
-        lastKnownPageNumber = max(1, pageNumber)
         onPageChange(max(1, pageNumber), totalPages)
       }
 

--- a/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_macOS.swift
@@ -4,9 +4,8 @@
 
   struct PdfDocumentView: NSViewRepresentable {
     let documentURL: URL
-    let pageLayout: PageLayout
+    let pagePresentation: PdfPagePresentation
     let isolateCoverPage: Bool
-    let continuousScroll: Bool
     let readingDirection: ReadingDirection
     let initialPageNumber: Int
     let targetPageNumber: Int?
@@ -46,6 +45,11 @@
         context.coordinator.lastNavigationToken = navigationToken
         if let targetPageNumber {
           goToPage(targetPageNumber, in: pdfView)
+          scheduleInitialPageCorrection(
+            targetPage: targetPageNumber,
+            in: pdfView,
+            coordinator: context.coordinator
+          )
         }
       }
     }
@@ -58,7 +62,6 @@
 
       let clampedInitialPage = max(1, min(initialPageNumber, max(1, document.pageCount)))
       goToPage(clampedInitialPage, in: pdfView)
-      coordinator.lastKnownPageNumber = clampedInitialPage
 
       coordinator.lastNavigationToken = navigationToken
       coordinator.notifyCurrentPage(from: pdfView)
@@ -71,43 +74,39 @@
     }
 
     private func applyPresentationConfiguration(to pdfView: PDFView, coordinator: Coordinator) {
-      let resolvedLayout = resolvedPageLayout(for: pdfView.bounds.size)
       let direction: ReadingDirection = readingDirection == .webtoon ? .vertical : readingDirection
 
-      if coordinator.lastResolvedPageLayout == resolvedLayout,
+      if coordinator.lastResolvedPagePresentation == pagePresentation,
         coordinator.lastResolvedReadingDirection == direction,
-        coordinator.lastResolvedIsolateCoverPage == isolateCoverPage,
-        coordinator.lastResolvedContinuousScroll == continuousScroll
+        coordinator.lastResolvedIsolateCoverPage == isolateCoverPage
       {
         return
       }
 
-      let currentPage = pdfView.currentPage
-      let targetPageAfterConfiguration =
-        currentPageNumber(in: pdfView)
-        ?? (coordinator.lastKnownPageNumber > 0 ? coordinator.lastKnownPageNumber : initialPageNumber)
+      let targetPageAfterConfiguration = currentPageNumber(in: pdfView) ?? initialPageNumber
       let displayMode: PDFDisplayMode
 
-      switch resolvedLayout {
-      case .dual:
-        displayMode = continuousScroll ? .twoUpContinuous : .twoUp
-      case .single, .auto:
-        displayMode = continuousScroll ? .singlePageContinuous : .singlePage
+      switch pagePresentation {
+      case .auto:
+        displayMode = .singlePage
+      case .singlePaged:
+        displayMode = .singlePage
+      case .singleContinuous:
+        displayMode = .singlePageContinuous
+      case .dualContinuous:
+        displayMode = .twoUpContinuous
       }
 
       pdfView.displayMode = displayMode
       pdfView.displayDirection = direction == .vertical ? .vertical : .horizontal
       pdfView.displaysRTL = direction == .rtl
-      pdfView.displaysAsBook = resolvedLayout == .dual && isolateCoverPage
+      pdfView.displaysAsBook = pagePresentation == .dualContinuous && isolateCoverPage
 
-      coordinator.lastResolvedPageLayout = resolvedLayout
+      coordinator.lastResolvedPagePresentation = pagePresentation
       coordinator.lastResolvedReadingDirection = direction
       coordinator.lastResolvedIsolateCoverPage = isolateCoverPage
-      coordinator.lastResolvedContinuousScroll = continuousScroll
 
-      if let currentPage {
-        pdfView.go(to: currentPage)
-      } else if pdfView.document != nil {
+      if pdfView.document != nil {
         goToPage(targetPageAfterConfiguration, in: pdfView)
       }
 
@@ -118,23 +117,17 @@
       )
     }
 
-    private func resolvedPageLayout(for size: CGSize) -> PageLayout {
-      guard pageLayout == .auto else {
-        return pageLayout
-      }
-
-      guard size.width > 0, size.height > 0 else {
-        return .single
-      }
-
-      return size.width > size.height ? .dual : .single
-    }
-
     private func goToPage(_ pageNumber: Int, in pdfView: PDFView) {
       guard let document = pdfView.document else { return }
       let index = max(0, min(pageNumber - 1, document.pageCount - 1))
       guard let page = document.page(at: index) else { return }
-      pdfView.go(to: page)
+      let bounds = page.bounds(for: pdfView.displayBox)
+      let destination = PDFDestination(
+        page: page,
+        at: CGPoint(x: bounds.minX, y: bounds.maxY)
+      )
+      destination.zoom = kPDFDestinationUnspecifiedValue
+      pdfView.go(to: destination)
     }
 
     private func scheduleInitialPageCorrection(
@@ -144,15 +137,17 @@
     ) {
       // PDFKit may reset current page multiple times during initial layout;
       // retry briefly until the target page sticks.
-      let retryDelays: [TimeInterval] = [0.0, 0.05, 0.2, 0.5]
-      for delay in retryDelays {
+      let retryDelays: [TimeInterval] = [0.0, 0.05, 0.2, 0.5, 1.0]
+      for (index, delay) in retryDelays.enumerated() {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak pdfView, weak coordinator] in
           guard let pdfView, let coordinator else { return }
           guard coordinator.loadedDocumentURL == documentURL else { return }
           if currentPageNumber(in: pdfView) != targetPage {
             goToPage(targetPage, in: pdfView)
           }
-          coordinator.notifyCurrentPage(from: pdfView)
+          if index == retryDelays.indices.last {
+            coordinator.notifyCurrentPage(from: pdfView)
+          }
         }
       }
     }
@@ -168,11 +163,9 @@
       var onSingleTap: (CGPoint) -> Void
       var loadedDocumentURL: URL?
       var lastNavigationToken: UUID?
-      var lastResolvedPageLayout: PageLayout?
+      var lastResolvedPagePresentation: PdfPagePresentation?
       var lastResolvedReadingDirection: ReadingDirection?
       var lastResolvedIsolateCoverPage: Bool?
-      var lastResolvedContinuousScroll: Bool?
-      var lastKnownPageNumber: Int = 1
       private weak var observedPDFView: PDFView?
       private weak var singleClickRecognizer: NSClickGestureRecognizer?
       private weak var doubleClickRecognizer: NSClickGestureRecognizer?
@@ -333,7 +326,6 @@
         }
 
         let pageNumber = document.index(for: currentPage) + 1
-        lastKnownPageNumber = max(1, pageNumber)
         onPageChange(max(1, pageNumber), totalPages)
       }
 

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -29,9 +29,8 @@
 
     @State private var viewModel: PdfReaderViewModel
     @State private var readingDirection: ReadingDirection
-    @State private var pageLayout: PageLayout
+    @State private var pagePresentation: PdfPagePresentation
     @State private var isolateCoverPage: Bool
-    @State private var continuousScroll: Bool
     @State private var currentBook: Book?
     @State private var currentSeries: Series?
     @State private var showingControls = false
@@ -62,9 +61,8 @@
       self.onClose = onClose
       _viewModel = State(initialValue: PdfReaderViewModel(incognito: incognito))
       _readingDirection = State(initialValue: .ltr)
-      _pageLayout = State(initialValue: AppConfig.pdfPageLayout)
+      _pagePresentation = State(initialValue: AppConfig.pdfPagePresentation)
       _isolateCoverPage = State(initialValue: AppConfig.pdfIsolateCoverPage)
-      _continuousScroll = State(initialValue: AppConfig.pdfContinuousScroll)
       _currentBook = State(initialValue: book)
     }
 
@@ -237,8 +235,15 @@
       .default
     }
 
-    private var documentViewIdentity: String {
+    private var documentSourceIdentity: String {
       "native-pdf-\(book.id)"
+    }
+
+    private func documentViewIdentity(
+      documentURL: URL,
+      resolvedPresentation: PdfPagePresentation
+    ) -> String {
+      "\(documentURL.path)-\(documentSourceIdentity)-\(resolvedPresentation.rawValue)"
     }
 
     private var documentInitialPage: Int {
@@ -288,24 +293,27 @@
         }
         .padding()
       } else if let documentURL = viewModel.documentURL {
-        PdfDocumentView(
-          documentURL: documentURL,
-          pageLayout: pageLayout,
-          isolateCoverPage: isolateCoverPage,
-          continuousScroll: continuousScroll,
-          readingDirection: readingDirection,
-          initialPageNumber: documentInitialPage,
-          targetPageNumber: targetPageNumber,
-          navigationToken: navigationToken,
-          onPageChange: { pageNumber, totalPages in
-            viewModel.updateCurrentPage(pageNumber: pageNumber, totalPages: totalPages)
-          },
-          onSingleTap: { normalizedPoint in
-            handleSingleTap(normalizedPoint: normalizedPoint)
-          }
-        )
-        // Rebuild PDFView when the source file changes.
-        .id("\(documentURL.path)-\(documentViewIdentity)")
+        GeometryReader { proxy in
+          let resolvedPresentation = pagePresentation.resolved(for: proxy.size)
+          PdfDocumentView(
+            documentURL: documentURL,
+            pagePresentation: resolvedPresentation,
+            isolateCoverPage: isolateCoverPage,
+            readingDirection: readingDirection,
+            initialPageNumber: documentInitialPage,
+            targetPageNumber: targetPageNumber,
+            navigationToken: navigationToken,
+            onPageChange: { pageNumber, totalPages in
+              viewModel.updateCurrentPage(pageNumber: pageNumber, totalPages: totalPages)
+            },
+            onSingleTap: { normalizedPoint in
+              handleSingleTap(normalizedPoint: normalizedPoint)
+            }
+          )
+          // Rebuild PDFView when the source document or resolved presentation changes.
+          .id(documentViewIdentity(documentURL: documentURL, resolvedPresentation: resolvedPresentation))
+          .readerIgnoresSafeArea()
+        }
         .readerIgnoresSafeArea()
       } else {
         ReaderUnavailableView(
@@ -320,9 +328,8 @@
     private var controlsOverlay: some View {
       PdfControlsOverlayView(
         readingDirection: $readingDirection,
-        pageLayout: $pageLayout,
+        pagePresentation: $pagePresentation,
         isolateCoverPage: $isolateCoverPage,
-        continuousScroll: $continuousScroll,
         showingPageJumpSheet: $showingPageJumpSheet,
         showingSearchSheet: $showingSearchSheet,
         showingTOCSheet: $showingTOCSheet,
@@ -544,18 +551,18 @@
           canOpenNextBook: false,
           readingDirection: readingDirection,
           availableReadingDirections: ReadingDirection.pdfAvailableCases,
-          pageLayout: pageLayout,
+          pageLayout: pagePresentation.resolvedPageLayout,
           isolateCoverPage: isolateCoverPage,
           pageIsolationActions: [],
           splitWidePageMode: .none,
-          continuousScroll: continuousScroll,
+          continuousScroll: pagePresentation.resolvedContinuousScroll,
           supportsSearch: true,
           canSearch: viewModel.documentURL != nil,
           supportsReadingDirectionSelection: true,
-          supportsPageLayoutSelection: true,
-          supportsDualPageOptions: pageLayout.supportsDualPageOptions,
+          supportsPageLayoutSelection: false,
+          supportsDualPageOptions: pagePresentation.supportsCoverIsolation,
           supportsSplitWidePageMode: false,
-          supportsContinuousScrollToggle: true
+          supportsContinuousScrollToggle: false
         )
       }
     #endif
@@ -612,9 +619,7 @@
             setReadingDirection: { direction in
               readingDirection = pdfReadingDirection(from: direction)
             },
-            setPageLayout: { layout in
-              pageLayout = layout
-            },
+            setPageLayout: { _ in },
             toggleIsolateCoverPage: {
               isolateCoverPage.toggle()
             },
@@ -622,9 +627,7 @@
             sharePage: { _ in },
             setPageRotation: { _, _ in },
             setSplitWidePageMode: { _ in },
-            toggleContinuousScroll: {
-              continuousScroll.toggle()
-            }
+            toggleContinuousScroll: {}
           )
         )
       }

--- a/KMReader/Features/Settings/PdfPreferencesView.swift
+++ b/KMReader/Features/Settings/PdfPreferencesView.swift
@@ -8,12 +8,10 @@
     private var defaultReadingDirection: ReadingDirection = .ltr
     @AppStorage("pdfForceDefaultReadingDirection")
     private var forceDefaultReadingDirection: Bool = false
-    @AppStorage("pdfPageLayout")
-    private var pageLayout: PageLayout = .auto
+    @AppStorage("pdfPagePresentation")
+    private var pagePresentation: PdfPagePresentation = AppConfig.pdfPagePresentation
     @AppStorage("pdfIsolateCoverPage")
     private var isolateCoverPage: Bool = true
-    @AppStorage("pdfContinuousScroll")
-    private var continuousScroll: Bool = AppConfig.pdfContinuousScroll
     @AppStorage("pdfShowKeyboardHelpOverlay")
     private var showKeyboardHelpOverlay: Bool = AppConfig.pdfShowKeyboardHelpOverlay
     @AppStorage("showPdfControlsGradientBackground")
@@ -67,29 +65,20 @@
             }
 
             VStack(alignment: .leading, spacing: 8) {
-              Picker("Page Layout", selection: $pageLayout) {
-                ForEach(PageLayout.allCases, id: \.self) { layout in
-                  Label(layout.displayName, systemImage: layout.icon)
-                    .tag(layout)
+              Picker("Page Presentation", selection: $pagePresentation) {
+                ForEach(PdfPagePresentation.allCases, id: \.self) { presentation in
+                  Label(presentation.displayName, systemImage: presentation.icon)
+                    .tag(presentation)
                 }
               }
               .pickerStyle(.menu)
 
-              Text("Used for single and dual-page presentation")
+              Text(pagePresentation.detailText)
                 .font(.caption)
                 .foregroundColor(.secondary)
             }
 
-            Toggle(isOn: $continuousScroll) {
-              VStack(alignment: .leading, spacing: 4) {
-                Text("Continuous Scroll")
-                Text("Scroll through pages continuously instead of paging one page or spread at a time.")
-                  .font(.caption)
-                  .foregroundColor(.secondary)
-              }
-            }
-
-            if pageLayout.supportsDualPageOptions {
+            if pagePresentation.supportsCoverIsolation {
               Toggle(isOn: $isolateCoverPage) {
                 VStack(alignment: .leading, spacing: 4) {
                   Text("Isolate Cover Page")

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -18720,6 +18720,70 @@
         }
       }
     },
+    "Dual Page Continuous" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doppelseite fortlaufend"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dual Page Continuous"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Página doble continua"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Double page en continu"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doppia pagina continua"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見開き連続"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "두 페이지 연속"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Две страницы непрерывно"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "双页连续"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "雙頁連續"
+          }
+        }
+      }
+    },
     "Duplicate Files" : {
       "localizations" : {
         "de" : {
@@ -48674,6 +48738,70 @@
         }
       }
     },
+    "Page Presentation" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seitendarstellung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Presentation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Presentación de página"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Présentation des pages"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Presentazione pagina"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページ表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 표시 방식"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Представление страниц"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "页面呈现"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁面呈現"
+          }
+        }
+      }
+    },
     "Page Transition Style" : {
       "localizations" : {
         "de" : {
@@ -58146,66 +58274,130 @@
         }
       }
     },
-    "Scroll through pages continuously instead of paging one page or spread at a time." : {
+    "Scrolls through one page at a time continuously." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Seiten fortlaufend durchblättern, statt jeweils eine Seite oder Doppelseite umzuschalten."
+            "value" : "Scrollt fortlaufend Seite für Seite."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Scroll through pages continuously instead of paging one page or spread at a time."
+            "value" : "Scrolls through one page at a time continuously."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Desplázate por las páginas de forma continua en lugar de avanzar una página o pliego cada vez."
+            "value" : "Desplaza una página a la vez de forma continua."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Faites défiler les pages en continu au lieu de passer une page ou une double page à la fois."
+            "value" : "Fait défiler une page à la fois en continu."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Scorri le pagine in modo continuo invece di avanzare una pagina o una doppia pagina alla volta."
+            "value" : "Scorre continuamente una pagina alla volta."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1ページまたは見開きごとにページ送りせず、ページを連続してスクロールします。"
+            "value" : "1ページずつ連続してスクロールします。"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "한 번에 한 페이지나 펼침면씩 넘기는 대신 페이지를 연속해서 스크롤합니다."
+            "value" : "한 페이지씩 연속으로 스크롤합니다."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Прокручивать страницы непрерывно вместо постраничного перехода по одной странице или развороту."
+            "value" : "Непрерывная прокрутка по одной странице."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "连续滚动页面，而不是每次翻动一页或一组跨页。"
+            "value" : "一次一页连续滚动。"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "連續捲動頁面，而不是每次翻動一頁或一組跨頁。"
+            "value" : "一次一頁連續捲動。"
+          }
+        }
+      }
+    },
+    "Scrolls through two-page spreads continuously." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrollt fortlaufend durch Doppelseiten."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrolls through two-page spreads continuously."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desplaza pliegos de dos páginas de forma continua."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fait défiler les doubles pages en continu."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scorre continuamente le doppie pagine."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "見開きを連続してスクロールします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "두 페이지 펼침을 연속으로 스크롤합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Непрерывная прокрутка разворотов из двух страниц."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连续滚动双页跨页。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連續捲動雙頁跨頁。"
           }
         }
       }
@@ -68706,6 +68898,134 @@
         }
       }
     },
+    "Single Page" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einzelseite"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Single Page"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Página única"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page simple"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina singola"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "単一ページ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단일 페이지"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Одна страница"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "单页"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單頁"
+          }
+        }
+      }
+    },
+    "Single Page Continuous" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einzelseite fortlaufend"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Single Page Continuous"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Página única continua"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page simple en continu"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina singola continua"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "単一ページ連続"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단일 페이지 연속"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Одна страница непрерывно"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "单页连续"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單頁連續"
+          }
+        }
+      }
+    },
     "Size" : {
       "localizations" : {
         "de" : {
@@ -75938,70 +76258,6 @@
         }
       }
     },
-    "Used for single and dual-page presentation" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird für Einzel- und Doppelseitenanzeige verwendet"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Used for single and dual-page presentation"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se usa para la presentación de página única y doble"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilisé pour l'affichage en page simple et en double page"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usato per la presentazione a pagina singola e doppia"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "単ページおよび見開き表示に使用されます"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "단일 및 양면 페이지 표시 방식에 사용됩니다"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Используется для одиночного и двойного отображения страниц"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "用于单页和双页显示"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "用於單頁與雙頁顯示"
-          }
-        }
-      }
-    },
     "Used when a book or series doesn't specify a reading direction" : {
       "localizations" : {
         "de" : {
@@ -76766,6 +77022,134 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "使用者名稱和密碼"
+          }
+        }
+      }
+    },
+    "Uses dual-page continuous mode in landscape and single-page paged mode in portrait." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwendet im Querformat den fortlaufenden Doppelseitenmodus und im Hochformat den paginierten Einzelseitenmodus."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uses dual-page continuous mode in landscape and single-page paged mode in portrait."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa el modo continuo de doble página en horizontal y el modo paginado de página única en vertical."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilise le mode double page en continu en paysage et le mode page simple paginé en portrait."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa la modalità doppia pagina continua in orizzontale e la modalità pagina singola paginata in verticale."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "横向きでは見開き連続モード、縦向きでは単一ページのページ送りモードを使用します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가로에서는 두 페이지 연속 모드를, 세로에서는 단일 페이지 넘김 모드를 사용합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В альбомной ориентации используется непрерывный режим двух страниц, а в портретной — постраничный режим одной страницы."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "横屏使用双页连续模式，竖屏使用单页分页模式。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "橫向使用雙頁連續模式，直向使用單頁分頁模式。"
+          }
+        }
+      }
+    },
+    "Uses the native page controller for discrete page turns." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwendet den nativen Seitencontroller für einzelne Seitenwechsel."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uses the native page controller for discrete page turns."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa el controlador de páginas nativo para pasar páginas de forma discreta."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilise le contrôleur de pages natif pour des changements de page distincts."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usa il controller pagine nativo per voltare pagina in modo discreto."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ネイティブのページコントローラで1ページずつめくります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본 페이지 컨트롤러로 페이지를 한 장씩 넘깁니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Использует системный контроллер страниц для отдельных перелистываний."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用原生页面控制器进行离散翻页。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用原生頁面控制器進行離散翻頁。"
           }
         }
       }


### PR DESCRIPTION
## Problem
The native PDF reader exposed page layout and continuous scrolling as independent settings, which allowed an unsupported state: dual-page presentation with non-continuous page-controller navigation. On iOS, PDFKit's page-controller path does not reliably support two-up page turns, so disabling continuous scroll made dual-page mode effectively fall back to single-page behavior.

## Approach
Replace the two independent PDF settings with a single page presentation mode that only exposes native-supported combinations. Auto now resolves to single-page paged mode in portrait and dual-page continuous mode in landscape. The PDFKit wrappers resolve presentation from the current view size and re-anchor to the last stable page when Auto changes during rotation.

## Scope
- Add `PdfPagePresentation` with Auto, single paged, single continuous, and dual continuous modes
- Store native PDF presentation as one AppConfig value instead of separate layout/continuous-scroll values
- Update reader controls, settings, and PDFKit wrappers to use the unified presentation
- Fill translations for the new PDF presentation labels and help text

## Validation
- [x] `make build`
- [x] `make build-ios`
- [x] `make build-macos`
- [x] `./misc/translate.py list`
- [x] `git diff --check`
