### PR TITLE
fix: tune reader progress and long press handling

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 434;
+				CURRENT_PROJECT_VERSION = 435;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 434;
+				CURRENT_PROJECT_VERSION = 435;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 434;
+				CURRENT_PROJECT_VERSION = 435;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 434;
+				CURRENT_PROJECT_VERSION = 435;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -142,7 +142,7 @@ enum AppConfig {
       if UserDefaults.standard.object(forKey: "showDivinaProgressBarWhileReading") != nil {
         return UserDefaults.standard.bool(forKey: "showDivinaProgressBarWhileReading")
       }
-      return false
+      return true
     }
     set { UserDefaults.standard.set(newValue, forKey: "showDivinaProgressBarWhileReading") }
   }
@@ -196,7 +196,7 @@ enum AppConfig {
       if UserDefaults.standard.object(forKey: "showPdfProgressBarWhileReading") != nil {
         return UserDefaults.standard.bool(forKey: "showPdfProgressBarWhileReading")
       }
-      return false
+      return true
     }
     set { UserDefaults.standard.set(newValue, forKey: "showPdfProgressBarWhileReading") }
   }

--- a/KMReader/Features/Reader/Views/CurlDualPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlDualPageView.swift
@@ -196,6 +196,8 @@
       private var lastViewItemsCount: Int = 0
       private var lastFirstViewItem: ReaderViewItem?
       private var lastLastViewItem: ReaderViewItem?
+      private var lastLongPressEndTime: Date = .distantPast
+      private var isLongPressing = false
 
       init(_ parent: CurlDualPageView) {
         self.parent = parent
@@ -214,6 +216,12 @@
         doubleTap.cancelsTouchesInView = false
         doubleTap.delegate = self
         view.addGestureRecognizer(doubleTap)
+
+        let longPress = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
+        longPress.minimumPressDuration = ReaderGestureConstants.longPressMinimumDuration
+        longPress.cancelsTouchesInView = false
+        longPress.delegate = self
+        view.addGestureRecognizer(longPress)
       }
 
       private var totalSpreads: Int {
@@ -663,8 +671,29 @@
         singleTapWorkItem = nil
       }
 
+      @objc private func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+          isLongPressing = true
+          singleTapWorkItem?.cancel()
+          singleTapWorkItem = nil
+        case .ended, .cancelled, .failed:
+          lastLongPressEndTime = Date()
+          DispatchQueue.main.asyncAfter(deadline: .now() + ReaderGestureConstants.longPressReleaseDelay) {
+            [weak self] in
+            self?.isLongPressing = false
+          }
+        default:
+          break
+        }
+      }
+
       private var isTapZoneSuppressed: Bool {
-        isTransitioning || parent.viewModel.isZoomed
+        isTransitioning
+          || parent.viewModel.isZoomed
+          || isLongPressing
+          || Date().timeIntervalSince(lastLongPressEndTime)
+            < ReaderGestureConstants.longPressTapSuppressionInterval
       }
 
       private func dispatchTapZoneTap(at location: CGPoint, in view: UIView) {

--- a/KMReader/Features/Reader/Views/CurlPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlPageView.swift
@@ -219,6 +219,8 @@
       private var lastViewItemsCount: Int = 0
       private var lastFirstViewItem: ReaderViewItem?
       private var lastLastViewItem: ReaderViewItem?
+      private var lastLongPressEndTime: Date = .distantPast
+      private var isLongPressing = false
 
       init(_ parent: CurlPageView) {
         self.parent = parent
@@ -237,6 +239,12 @@
         doubleTap.cancelsTouchesInView = false
         doubleTap.delegate = self
         view.addGestureRecognizer(doubleTap)
+
+        let longPress = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
+        longPress.minimumPressDuration = ReaderGestureConstants.longPressMinimumDuration
+        longPress.cancelsTouchesInView = false
+        longPress.delegate = self
+        view.addGestureRecognizer(longPress)
       }
 
       var totalPages: Int {
@@ -592,8 +600,29 @@
         singleTapWorkItem = nil
       }
 
+      @objc private func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+          isLongPressing = true
+          singleTapWorkItem?.cancel()
+          singleTapWorkItem = nil
+        case .ended, .cancelled, .failed:
+          lastLongPressEndTime = Date()
+          DispatchQueue.main.asyncAfter(deadline: .now() + ReaderGestureConstants.longPressReleaseDelay) {
+            [weak self] in
+            self?.isLongPressing = false
+          }
+        default:
+          break
+        }
+      }
+
       private var isTapZoneSuppressed: Bool {
-        isTransitioning || parent.viewModel.isZoomed
+        isTransitioning
+          || parent.viewModel.isZoomed
+          || isLongPressing
+          || Date().timeIntervalSince(lastLongPressEndTime)
+            < ReaderGestureConstants.longPressTapSuppressionInterval
       }
 
       private func dispatchTapZoneTap(at location: CGPoint, in view: UIView) {

--- a/KMReader/Features/Reader/Views/Helpers/ReaderGestureConstants.swift
+++ b/KMReader/Features/Reader/Views/Helpers/ReaderGestureConstants.swift
@@ -1,0 +1,12 @@
+//
+// ReaderGestureConstants.swift
+//
+//
+
+import Foundation
+
+enum ReaderGestureConstants {
+  static let longPressMinimumDuration: TimeInterval = 0.5
+  static let longPressReleaseDelay: TimeInterval = 0.1
+  static let longPressTapSuppressionInterval: TimeInterval = 0.5
+}

--- a/KMReader/Features/Reader/Views/Helpers/WebtoonConstants.swift
+++ b/KMReader/Features/Reader/Views/Helpers/WebtoonConstants.swift
@@ -18,8 +18,8 @@ enum WebtoonConstants {
   static let clickDebounceAfterScroll: TimeInterval = 0.25
   static let preheatRadius: Int = 2
   static let offsetEpsilon: CGFloat = 0.5
-  static let longPressMinimumDuration: TimeInterval = 0.5
-  static let longPressReleaseDelay: TimeInterval = 0.1
+  static let longPressMinimumDuration = ReaderGestureConstants.longPressMinimumDuration
+  static let longPressReleaseDelay = ReaderGestureConstants.longPressReleaseDelay
   static let postScrollReloadDelay: TimeInterval = 0.12
   static let postScrollCleanupDelay: TimeInterval = 0.2
 }

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
@@ -90,7 +90,10 @@
       private var panRecognizer: UIPanGestureRecognizer?
       private var singleTapRecognizer: UITapGestureRecognizer?
       private var doubleTapRecognizer: UITapGestureRecognizer?
+      private var longPressRecognizer: UILongPressGestureRecognizer?
       private var singleTapWorkItem: DispatchWorkItem?
+      private var lastLongPressEndTime: Date = .distantPast
+      private var isLongPressing = false
 
       init(_ parent: NativeCoverPageView) {
         self.parent = parent
@@ -146,11 +149,16 @@
         if let doubleTapRecognizer {
           doubleTapRecognizer.view?.removeGestureRecognizer(doubleTapRecognizer)
         }
+        if let longPressRecognizer {
+          longPressRecognizer.view?.removeGestureRecognizer(longPressRecognizer)
+        }
         singleTapWorkItem?.cancel()
         singleTapWorkItem = nil
+        isLongPressing = false
         panRecognizer = nil
         singleTapRecognizer = nil
         doubleTapRecognizer = nil
+        longPressRecognizer = nil
         pagePresentationCoordinator.teardown()
         containerView = nil
       }
@@ -229,7 +237,10 @@
       }
 
       private func attachTapRecognizersIfNeeded(to containerView: NativeCoverContainerView) {
-        if singleTapRecognizer?.view === containerView, doubleTapRecognizer?.view === containerView {
+        if singleTapRecognizer?.view === containerView,
+          doubleTapRecognizer?.view === containerView,
+          longPressRecognizer?.view === containerView
+        {
           return
         }
 
@@ -238,6 +249,9 @@
         }
         if let doubleTapRecognizer {
           doubleTapRecognizer.view?.removeGestureRecognizer(doubleTapRecognizer)
+        }
+        if let longPressRecognizer {
+          longPressRecognizer.view?.removeGestureRecognizer(longPressRecognizer)
         }
 
         let singleTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleSingleTap(_:)))
@@ -252,8 +266,15 @@
         doubleTapRecognizer.delegate = self
         containerView.addGestureRecognizer(doubleTapRecognizer)
 
+        let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
+        longPressRecognizer.minimumPressDuration = ReaderGestureConstants.longPressMinimumDuration
+        longPressRecognizer.cancelsTouchesInView = false
+        longPressRecognizer.delegate = self
+        containerView.addGestureRecognizer(longPressRecognizer)
+
         self.singleTapRecognizer = singleTapRecognizer
         self.doubleTapRecognizer = doubleTapRecognizer
+        self.longPressRecognizer = longPressRecognizer
       }
 
       private func applyPanRecognizerState() {
@@ -843,8 +864,30 @@
         singleTapWorkItem = nil
       }
 
+      @objc private func handleLongPress(_ recognizer: UILongPressGestureRecognizer) {
+        switch recognizer.state {
+        case .began:
+          isLongPressing = true
+          singleTapWorkItem?.cancel()
+          singleTapWorkItem = nil
+        case .ended, .cancelled, .failed:
+          lastLongPressEndTime = Date()
+          DispatchQueue.main.asyncAfter(deadline: .now() + ReaderGestureConstants.longPressReleaseDelay) {
+            [weak self] in
+            self?.isLongPressing = false
+          }
+        default:
+          break
+        }
+      }
+
       private var isTapZoneSuppressed: Bool {
-        parent.viewModel.isZoomed || isUserPanning || isAnimatingTransition
+        parent.viewModel.isZoomed
+          || isUserPanning
+          || isAnimatingTransition
+          || isLongPressing
+          || Date().timeIntervalSince(lastLongPressEndTime)
+            < ReaderGestureConstants.longPressTapSuppressionInterval
       }
 
       private func dispatchTapZoneTap(at location: CGPoint, in containerView: NativeCoverContainerView) {

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
@@ -925,7 +925,7 @@
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
       ) -> Bool {
-        false
+        gestureRecognizer === longPressRecognizer || otherGestureRecognizer === longPressRecognizer
       }
 
       func gestureRecognizer(

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_macOS.swift
@@ -920,6 +920,12 @@
         if gestureRecognizer === panRecognizer {
           return !parent.viewModel.isZoomed && !isAnimatingTransition
         }
+        if gestureRecognizer === longPressRecognizer,
+          let containerView,
+          isInteractiveElement(at: gestureRecognizer.location(in: containerView), in: containerView)
+        {
+          return false
+        }
         return !isTapZoneSuppressed
       }
 

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_macOS.swift
@@ -90,7 +90,10 @@
       private var panRecognizer: NSPanGestureRecognizer?
       private var clickRecognizer: NSClickGestureRecognizer?
       private var doubleClickRecognizer: NSClickGestureRecognizer?
+      private var longPressRecognizer: NSPressGestureRecognizer?
       private var singleClickWorkItem: DispatchWorkItem?
+      private var lastLongPressEndTime: Date = .distantPast
+      private var isLongPressing = false
 
       init(_ parent: NativeCoverPageView) {
         self.parent = parent
@@ -147,11 +150,16 @@
         if let doubleClickRecognizer {
           doubleClickRecognizer.view?.removeGestureRecognizer(doubleClickRecognizer)
         }
+        if let longPressRecognizer {
+          longPressRecognizer.view?.removeGestureRecognizer(longPressRecognizer)
+        }
         singleClickWorkItem?.cancel()
         singleClickWorkItem = nil
+        isLongPressing = false
         panRecognizer = nil
         clickRecognizer = nil
         doubleClickRecognizer = nil
+        longPressRecognizer = nil
         pagePresentationCoordinator.teardown()
         containerView = nil
       }
@@ -224,7 +232,10 @@
       }
 
       private func attachClickRecognizersIfNeeded(to containerView: NativeCoverContainerView) {
-        if clickRecognizer?.view === containerView, doubleClickRecognizer?.view === containerView {
+        if clickRecognizer?.view === containerView,
+          doubleClickRecognizer?.view === containerView,
+          longPressRecognizer?.view === containerView
+        {
           return
         }
 
@@ -233,6 +244,9 @@
         }
         if let doubleClickRecognizer {
           doubleClickRecognizer.view?.removeGestureRecognizer(doubleClickRecognizer)
+        }
+        if let longPressRecognizer {
+          longPressRecognizer.view?.removeGestureRecognizer(longPressRecognizer)
         }
 
         let clickRecognizer = NSClickGestureRecognizer(target: self, action: #selector(handleClick(_:)))
@@ -245,8 +259,14 @@
         doubleClickRecognizer.delegate = self
         containerView.addGestureRecognizer(doubleClickRecognizer)
 
+        let longPressRecognizer = NSPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
+        longPressRecognizer.minimumPressDuration = ReaderGestureConstants.longPressMinimumDuration
+        longPressRecognizer.delegate = self
+        containerView.addGestureRecognizer(longPressRecognizer)
+
         self.clickRecognizer = clickRecognizer
         self.doubleClickRecognizer = doubleClickRecognizer
+        self.longPressRecognizer = longPressRecognizer
       }
 
       private func applyPanRecognizerState() {
@@ -859,8 +879,30 @@
         singleClickWorkItem = nil
       }
 
+      @objc private func handleLongPress(_ recognizer: NSPressGestureRecognizer) {
+        switch recognizer.state {
+        case .began:
+          isLongPressing = true
+          singleClickWorkItem?.cancel()
+          singleClickWorkItem = nil
+        case .ended, .cancelled, .failed:
+          lastLongPressEndTime = Date()
+          DispatchQueue.main.asyncAfter(deadline: .now() + ReaderGestureConstants.longPressReleaseDelay) {
+            [weak self] in
+            self?.isLongPressing = false
+          }
+        default:
+          break
+        }
+      }
+
       private var isTapZoneSuppressed: Bool {
-        parent.viewModel.isZoomed || isUserPanning || isAnimatingTransition
+        parent.viewModel.isZoomed
+          || isUserPanning
+          || isAnimatingTransition
+          || isLongPressing
+          || Date().timeIntervalSince(lastLongPressEndTime)
+            < ReaderGestureConstants.longPressTapSuppressionInterval
       }
 
       private func dispatchTapZoneTap(at location: CGPoint, in containerView: NativeCoverContainerView) {

--- a/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
@@ -102,6 +102,15 @@
       doubleTapGesture.delegate = context.coordinator
       collectionView.addGestureRecognizer(doubleTapGesture)
 
+      let longPressGesture = UILongPressGestureRecognizer(
+        target: context.coordinator,
+        action: #selector(Coordinator.handleLongPress(_:))
+      )
+      longPressGesture.minimumPressDuration = ReaderGestureConstants.longPressMinimumDuration
+      longPressGesture.cancelsTouchesInView = false
+      longPressGesture.delegate = context.coordinator
+      collectionView.addGestureRecognizer(longPressGesture)
+
       context.coordinator.collectionView = collectionView
       collectionView.onDidLayout = { [weak coordinator = context.coordinator] in
         coordinator?.handleCollectionViewLayout()
@@ -157,6 +166,8 @@
       private var visiblePreloadItem: ReaderViewItem?
       private var applicationWillResignActiveObserver: NSObjectProtocol?
       private var singleTapWorkItem: DispatchWorkItem?
+      private var lastLongPressEndTime: Date = .distantPast
+      private var isLongPressing = false
 
       init(_ parent: ScrollPageView) {
         self.parent = parent
@@ -167,6 +178,7 @@
       func teardown() {
         singleTapWorkItem?.cancel()
         singleTapWorkItem = nil
+        isLongPressing = false
         deferredViewModelCommitTask?.cancel()
         deferredViewModelCommitTask = nil
         visiblePreloadTask?.cancel()
@@ -980,8 +992,28 @@
         singleTapWorkItem = nil
       }
 
+      @objc func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+          isLongPressing = true
+          singleTapWorkItem?.cancel()
+          singleTapWorkItem = nil
+        case .ended, .cancelled, .failed:
+          lastLongPressEndTime = Date()
+          DispatchQueue.main.asyncAfter(deadline: .now() + ReaderGestureConstants.longPressReleaseDelay) {
+            [weak self] in
+            self?.isLongPressing = false
+          }
+        default:
+          break
+        }
+      }
+
       private func isTapZoneSuppressed(in collectionView: UICollectionView) -> Bool {
         parent.viewModel.isZoomed
+          || isLongPressing
+          || Date().timeIntervalSince(lastLongPressEndTime)
+            < ReaderGestureConstants.longPressTapSuppressionInterval
           || engine.isInteractionActive
           || collectionView.isDragging
           || collectionView.isDecelerating

--- a/KMReader/Features/Reader/Views/ScrollPageView_macOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_macOS.swift
@@ -88,6 +88,14 @@
       doubleClickGesture.delegate = context.coordinator
       scrollView.addGestureRecognizer(doubleClickGesture)
 
+      let longPressGesture = NSPressGestureRecognizer(
+        target: context.coordinator,
+        action: #selector(Coordinator.handleLongPress(_:))
+      )
+      longPressGesture.minimumPressDuration = ReaderGestureConstants.longPressMinimumDuration
+      longPressGesture.delegate = context.coordinator
+      scrollView.addGestureRecognizer(longPressGesture)
+
       collectionView.frame = CGRect(origin: .zero, size: scrollView.contentView.bounds.size)
       collectionView.autoresizingMask = [.width, .height]
 
@@ -153,6 +161,8 @@
       private var programmaticScrollToken: Int = 0
       private var lastObservedClipBounds: CGRect = .zero
       private var singleClickWorkItem: DispatchWorkItem?
+      private var lastLongPressEndTime: Date = .distantPast
+      private var isLongPressing = false
 
       init(_ parent: ScrollPageView) {
         self.parent = parent
@@ -182,6 +192,7 @@
         NotificationCenter.default.removeObserver(self)
         singleClickWorkItem?.cancel()
         singleClickWorkItem = nil
+        isLongPressing = false
         deferredViewModelCommitTask?.cancel()
         deferredViewModelCommitTask = nil
         visiblePreloadTask?.cancel()
@@ -934,8 +945,28 @@
         singleClickWorkItem = nil
       }
 
+      @objc func handleLongPress(_ gesture: NSPressGestureRecognizer) {
+        switch gesture.state {
+        case .began:
+          isLongPressing = true
+          singleClickWorkItem?.cancel()
+          singleClickWorkItem = nil
+        case .ended, .cancelled, .failed:
+          lastLongPressEndTime = Date()
+          DispatchQueue.main.asyncAfter(deadline: .now() + ReaderGestureConstants.longPressReleaseDelay) {
+            [weak self] in
+            self?.isLongPressing = false
+          }
+        default:
+          break
+        }
+      }
+
       private func isTapZoneSuppressed(in scrollView: NSScrollView) -> Bool {
         parent.viewModel.isZoomed
+          || isLongPressing
+          || Date().timeIntervalSince(lastLongPressEndTime)
+            < ReaderGestureConstants.longPressTapSuppressionInterval
           || isAdjustingBounds
           || engine.isInteractionActive
       }

--- a/KMReader/Shared/UI/SplashView.swift
+++ b/KMReader/Shared/UI/SplashView.swift
@@ -170,8 +170,9 @@ struct SplashView: View {
                 ),
                 systemImage: "wifi.slash"
               )
-              .fontWeight(.semibold)
+              .font(.caption)
             }
+            .controlSize(.small)
             .adaptiveButtonStyle(.bordered)
           }
         }


### PR DESCRIPTION
## Problem
The splash offline entry felt visually heavier than its role, and new reader installs hid DIVINA/PDF reading progress bars by default. DIVINA tap zones also treated a completed long press like a normal tap in several non-webtoon reader modes, which could trigger page navigation or controls after context-menu-style interactions.

## Approach
Tune the splash offline button locally while preserving its bordered style, switch DIVINA and PDF progress bar defaults only for users without an existing preference, and add long-press suppression at the DIVINA gesture coordinator layer before tap-zone actions are dispatched.

The long-press handling covers scroll, page curl, dual page curl, and cover readers on the relevant platforms. Context menu compatibility is preserved by allowing the cover long-press suppressor to coexist with iOS menu recognition and by avoiding the suppressor on macOS interactive menu targets.

## Scope
- Default DIVINA and PDF reading progress bars to visible for unset preferences
- Reduce splash offline button size and remove the explicit semibold label weight
- Suppress DIVINA tap-zone actions after recognized long presses
- Share reader long-press timing constants with existing Webtoon handling
- Increment build version to 435

## Validation
- [x] make build-ios
- [x] make build-macos
