### PR TITLE
fix: freeze historical SwiftData schemas

### DIFF
--- a/KMReader/Core/Storage/Schema/KMReaderMigrationPlan.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderMigrationPlan.swift
@@ -358,7 +358,7 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
 
       let byID = Dictionary(uniqueKeysWithValues: snapshots.map { ($0.id, $0) })
       let ids = Set(byID.keys)
-      let descriptor = FetchDescriptor<KomgaBook>(
+      let descriptor = FetchDescriptor<KMReaderSchemaV4.KomgaBook>(
         predicate: #Predicate { ids.contains($0.id) }
       )
       let books = try context.fetch(descriptor)
@@ -383,7 +383,7 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
 
       let byID = Dictionary(uniqueKeysWithValues: snapshots.map { ($0.id, $0) })
       let ids = Set(byID.keys)
-      let descriptor = FetchDescriptor<KomgaSeries>(
+      let descriptor = FetchDescriptor<KMReaderSchemaV4.KomgaSeries>(
         predicate: #Predicate { ids.contains($0.id) }
       )
       let seriesList = try context.fetch(descriptor)

--- a/KMReader/Core/Storage/Schema/KMReaderSchemaV1.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderSchemaV1.swift
@@ -13,17 +13,52 @@ enum KMReaderSchemaV1: VersionedSchema {
 
   static var models: [any PersistentModel.Type] {
     [
-      KomgaInstance.self,
-      KomgaLibrary.self,
+      KMReaderSchemaV1.KomgaInstance.self,
+      KMReaderSchemaV1.KomgaLibrary.self,
       KMReaderSchemaV1.KomgaSeries.self,
       KMReaderSchemaV1.KomgaBook.self,
       KMReaderSchemaV1.KomgaCollection.self,
       KMReaderSchemaV1.KomgaReadList.self,
-      CustomFont.self,
-      PendingProgress.self,
-      SavedFilter.self,
-      EpubThemePreset.self,
+      KMReaderSchemaV1.CustomFont.self,
+      KMReaderSchemaV1.PendingProgress.self,
+      KMReaderSchemaV1.SavedFilter.self,
+      KMReaderSchemaV1.EpubThemePreset.self,
     ]
+  }
+
+  @Model
+  final class KomgaInstance {
+    @Attribute(.unique) var id: UUID = UUID()
+    var name: String = ""
+    var serverURL: String = ""
+    var username: String = ""
+    var authToken: String = ""
+    var isAdmin: Bool = false
+    var authMethod: AuthenticationMethod? = AuthenticationMethod.basicAuth
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var lastUsedAt: Date = Date(timeIntervalSince1970: 0)
+    var seriesLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
+    var booksLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
+
+    init() {}
+  }
+
+  @Model
+  final class KomgaLibrary {
+    @Attribute(.unique) var id: UUID = UUID()
+    var instanceId: String = ""
+    var libraryId: String = ""
+    var name: String = ""
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+
+    var fileSize: Double?
+    var booksCount: Double?
+    var seriesCount: Double?
+    var sidecarsCount: Double?
+    var collectionsCount: Double?
+    var readlistsCount: Double?
+
+    init() {}
   }
 
   @Model
@@ -214,6 +249,53 @@ enum KMReaderSchemaV1: VersionedSchema {
     var downloadedSize: Int64 = 0
     var downloadedBooks: Int = 0
     var pendingBooks: Int = 0
+
+    init() {}
+  }
+
+  @Model
+  final class CustomFont {
+    @Attribute(.unique) var name: String = ""
+    var path: String?
+    var fileName: String?
+    var fileSize: Int64?
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+
+    init() {}
+  }
+
+  @Model
+  final class PendingProgress {
+    @Attribute(.unique) var id: String = ""
+    var instanceId: String = ""
+    var bookId: String = ""
+    var page: Int = 0
+    var completed: Bool = false
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var progressionData: Data?
+
+    init() {}
+  }
+
+  @Model
+  final class SavedFilter {
+    @Attribute(.unique) var id: UUID = UUID()
+    var name: String = ""
+    var filterTypeRaw: String = ""
+    var filterDataJSON: String = ""
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var updatedAt: Date = Date(timeIntervalSince1970: 0)
+
+    init() {}
+  }
+
+  @Model
+  final class EpubThemePreset {
+    @Attribute(.unique) var id: UUID = UUID()
+    var name: String = ""
+    var preferencesJSON: String = ""
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var updatedAt: Date = Date(timeIntervalSince1970: 0)
 
     init() {}
   }

--- a/KMReader/Core/Storage/Schema/KMReaderSchemaV2.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderSchemaV2.swift
@@ -13,17 +13,52 @@ enum KMReaderSchemaV2: VersionedSchema {
 
   static var models: [any PersistentModel.Type] {
     [
-      KomgaInstance.self,
-      KomgaLibrary.self,
+      KMReaderSchemaV2.KomgaInstance.self,
+      KMReaderSchemaV2.KomgaLibrary.self,
       KMReaderSchemaV2.KomgaSeries.self,
       KMReaderSchemaV2.KomgaBook.self,
       KMReaderSchemaV2.KomgaCollection.self,
       KMReaderSchemaV2.KomgaReadList.self,
-      CustomFont.self,
-      PendingProgress.self,
-      SavedFilter.self,
-      EpubThemePreset.self,
+      KMReaderSchemaV2.CustomFont.self,
+      KMReaderSchemaV2.PendingProgress.self,
+      KMReaderSchemaV2.SavedFilter.self,
+      KMReaderSchemaV2.EpubThemePreset.self,
     ]
+  }
+
+  @Model
+  final class KomgaInstance {
+    @Attribute(.unique) var id: UUID = UUID()
+    var name: String = ""
+    var serverURL: String = ""
+    var username: String = ""
+    var authToken: String = ""
+    var isAdmin: Bool = false
+    var authMethod: AuthenticationMethod? = AuthenticationMethod.basicAuth
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var lastUsedAt: Date = Date(timeIntervalSince1970: 0)
+    var seriesLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
+    var booksLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
+
+    init() {}
+  }
+
+  @Model
+  final class KomgaLibrary {
+    @Attribute(.unique) var id: UUID = UUID()
+    var instanceId: String = ""
+    var libraryId: String = ""
+    var name: String = ""
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+
+    var fileSize: Double?
+    var booksCount: Double?
+    var seriesCount: Double?
+    var sidecarsCount: Double?
+    var collectionsCount: Double?
+    var readlistsCount: Double?
+
+    init() {}
   }
 
   @Model
@@ -196,6 +231,53 @@ enum KMReaderSchemaV2: VersionedSchema {
     var downloadedSize: Int64 = 0
     var downloadedBooks: Int = 0
     var pendingBooks: Int = 0
+
+    init() {}
+  }
+
+  @Model
+  final class CustomFont {
+    @Attribute(.unique) var name: String = ""
+    var path: String?
+    var fileName: String?
+    var fileSize: Int64?
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+
+    init() {}
+  }
+
+  @Model
+  final class PendingProgress {
+    @Attribute(.unique) var id: String = ""
+    var instanceId: String = ""
+    var bookId: String = ""
+    var page: Int = 0
+    var completed: Bool = false
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var progressionData: Data?
+
+    init() {}
+  }
+
+  @Model
+  final class SavedFilter {
+    @Attribute(.unique) var id: UUID = UUID()
+    var name: String = ""
+    var filterTypeRaw: String = ""
+    var filterDataJSON: String = ""
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var updatedAt: Date = Date(timeIntervalSince1970: 0)
+
+    init() {}
+  }
+
+  @Model
+  final class EpubThemePreset {
+    @Attribute(.unique) var id: UUID = UUID()
+    var name: String = ""
+    var preferencesJSON: String = ""
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var updatedAt: Date = Date(timeIntervalSince1970: 0)
 
     init() {}
   }

--- a/KMReader/Core/Storage/Schema/KMReaderSchemaV3.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderSchemaV3.swift
@@ -13,17 +13,52 @@ enum KMReaderSchemaV3: VersionedSchema {
 
   static var models: [any PersistentModel.Type] {
     [
-      KomgaInstance.self,
-      KomgaLibrary.self,
+      KMReaderSchemaV3.KomgaInstance.self,
+      KMReaderSchemaV3.KomgaLibrary.self,
       KMReaderSchemaV3.KomgaSeries.self,
       KMReaderSchemaV3.KomgaBook.self,
-      KomgaCollection.self,
-      KomgaReadList.self,
-      CustomFont.self,
-      PendingProgress.self,
-      SavedFilter.self,
-      EpubThemePreset.self,
+      KMReaderSchemaV3.KomgaCollection.self,
+      KMReaderSchemaV3.KomgaReadList.self,
+      KMReaderSchemaV3.CustomFont.self,
+      KMReaderSchemaV3.PendingProgress.self,
+      KMReaderSchemaV3.SavedFilter.self,
+      KMReaderSchemaV3.EpubThemePreset.self,
     ]
+  }
+
+  @Model
+  final class KomgaInstance {
+    @Attribute(.unique) var id: UUID = UUID()
+    var name: String = ""
+    var serverURL: String = ""
+    var username: String = ""
+    var authToken: String = ""
+    var isAdmin: Bool = false
+    var authMethod: AuthenticationMethod? = AuthenticationMethod.basicAuth
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var lastUsedAt: Date = Date(timeIntervalSince1970: 0)
+    var seriesLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
+    var booksLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
+
+    init() {}
+  }
+
+  @Model
+  final class KomgaLibrary {
+    @Attribute(.unique) var id: UUID = UUID()
+    var instanceId: String = ""
+    var libraryId: String = ""
+    var name: String = ""
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+
+    var fileSize: Double?
+    var booksCount: Double?
+    var seriesCount: Double?
+    var sidecarsCount: Double?
+    var collectionsCount: Double?
+    var readlistsCount: Double?
+
+    init() {}
   }
 
   @Model
@@ -123,6 +158,99 @@ enum KMReaderSchemaV3: VersionedSchema {
     var offlinePolicyLimit: Int = 0
 
     var collectionIdsRaw: Data?
+
+    init() {}
+  }
+
+  @Model
+  final class KomgaCollection {
+    @Attribute(.unique) var id: String = ""
+
+    var collectionId: String = ""
+    var instanceId: String = ""
+
+    var name: String = ""
+    var ordered: Bool = false
+    var createdDate: Date = Date(timeIntervalSince1970: 0)
+    var lastModifiedDate: Date = Date(timeIntervalSince1970: 0)
+    var filtered: Bool = false
+    var isPinned: Bool = false
+
+    var seriesIdsRaw: Data?
+
+    init() {}
+  }
+
+  @Model
+  final class KomgaReadList {
+    @Attribute(.unique) var id: String = ""
+
+    var readListId: String = ""
+    var instanceId: String = ""
+
+    var name: String = ""
+    var summary: String = ""
+    var ordered: Bool = false
+    var createdDate: Date = Date(timeIntervalSince1970: 0)
+    var lastModifiedDate: Date = Date(timeIntervalSince1970: 0)
+    var filtered: Bool = false
+    var isPinned: Bool = false
+
+    var bookIdsRaw: Data?
+
+    var downloadStatusRaw: String = "notDownloaded"
+    var downloadError: String?
+    var downloadAt: Date?
+    var downloadedSize: Int64 = 0
+    var downloadedBooks: Int = 0
+    var pendingBooks: Int = 0
+
+    init() {}
+  }
+
+  @Model
+  final class CustomFont {
+    @Attribute(.unique) var name: String = ""
+    var path: String?
+    var fileName: String?
+    var fileSize: Int64?
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+
+    init() {}
+  }
+
+  @Model
+  final class PendingProgress {
+    @Attribute(.unique) var id: String = ""
+    var instanceId: String = ""
+    var bookId: String = ""
+    var page: Int = 0
+    var completed: Bool = false
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var progressionData: Data?
+
+    init() {}
+  }
+
+  @Model
+  final class SavedFilter {
+    @Attribute(.unique) var id: UUID = UUID()
+    var name: String = ""
+    var filterTypeRaw: String = ""
+    var filterDataJSON: String = ""
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var updatedAt: Date = Date(timeIntervalSince1970: 0)
+
+    init() {}
+  }
+
+  @Model
+  final class EpubThemePreset {
+    @Attribute(.unique) var id: UUID = UUID()
+    var name: String = ""
+    var preferencesJSON: String = ""
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var updatedAt: Date = Date(timeIntervalSince1970: 0)
 
     init() {}
   }

--- a/KMReader/Core/Storage/Schema/KMReaderSchemaV4.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderSchemaV4.swift
@@ -13,17 +13,52 @@ enum KMReaderSchemaV4: VersionedSchema {
 
   static var models: [any PersistentModel.Type] {
     [
-      KomgaInstance.self,
-      KomgaLibrary.self,
-      KomgaSeries.self,
+      KMReaderSchemaV4.KomgaInstance.self,
+      KMReaderSchemaV4.KomgaLibrary.self,
+      KMReaderSchemaV4.KomgaSeries.self,
       KMReaderSchemaV4.KomgaBook.self,
-      KomgaCollection.self,
-      KomgaReadList.self,
-      CustomFont.self,
-      PendingProgress.self,
-      SavedFilter.self,
-      EpubThemePreset.self,
+      KMReaderSchemaV4.KomgaCollection.self,
+      KMReaderSchemaV4.KomgaReadList.self,
+      KMReaderSchemaV4.CustomFont.self,
+      KMReaderSchemaV4.PendingProgress.self,
+      KMReaderSchemaV4.SavedFilter.self,
+      KMReaderSchemaV4.EpubThemePreset.self,
     ]
+  }
+
+  @Model
+  final class KomgaInstance {
+    @Attribute(.unique) var id: UUID = UUID()
+    var name: String = ""
+    var serverURL: String = ""
+    var username: String = ""
+    var authToken: String = ""
+    var isAdmin: Bool = false
+    var authMethod: AuthenticationMethod? = AuthenticationMethod.basicAuth
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var lastUsedAt: Date = Date(timeIntervalSince1970: 0)
+    var seriesLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
+    var booksLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
+
+    init() {}
+  }
+
+  @Model
+  final class KomgaLibrary {
+    @Attribute(.unique) var id: UUID = UUID()
+    var instanceId: String = ""
+    var libraryId: String = ""
+    var name: String = ""
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+
+    var fileSize: Double?
+    var booksCount: Double?
+    var seriesCount: Double?
+    var sidecarsCount: Double?
+    var collectionsCount: Double?
+    var readlistsCount: Double?
+
+    init() {}
   }
 
   @Model
@@ -78,6 +113,146 @@ enum KMReaderSchemaV4: VersionedSchema {
 
     var isolatePagesRaw: Data?
     var epubPreferencesRaw: String?
+
+    init() {}
+  }
+
+  @Model
+  final class KomgaSeries {
+    @Attribute(.unique) var id: String = ""
+
+    var seriesId: String = ""
+    var libraryId: String = ""
+    var instanceId: String = ""
+
+    var name: String = ""
+    var url: String = ""
+    var created: Date = Date(timeIntervalSince1970: 0)
+    var lastModified: Date = Date(timeIntervalSince1970: 0)
+
+    var booksCount: Int = 0
+    var booksReadCount: Int = 0
+    var booksUnreadCount: Int = 0
+    var booksInProgressCount: Int = 0
+
+    // API-aligned raw storage
+    var metadataRaw: Data?
+    var booksMetadataRaw: Data?
+
+    var metaTitle: String = ""
+    var metaTitleSort: String = ""
+    var metaPublisherIndex: String = "|"
+    var metaAuthorsIndex: String = "|"
+    var metaGenresIndex: String = "|"
+    var metaTagsIndex: String = "|"
+    var metaLanguageIndex: String = "|"
+
+    var isUnavailable: Bool = false
+    var oneshot: Bool = false
+
+    var downloadStatusRaw: String = "notDownloaded"
+    var downloadError: String?
+    var downloadAt: Date?
+    var downloadedSize: Int64 = 0
+    var downloadedBooks: Int = 0
+    var pendingBooks: Int = 0
+    var offlinePolicyRaw: String = "manual"
+    var offlinePolicyLimit: Int = 0
+
+    var collectionIdsRaw: Data?
+
+    init() {}
+  }
+
+  @Model
+  final class KomgaCollection {
+    @Attribute(.unique) var id: String = ""
+
+    var collectionId: String = ""
+    var instanceId: String = ""
+
+    var name: String = ""
+    var ordered: Bool = false
+    var createdDate: Date = Date(timeIntervalSince1970: 0)
+    var lastModifiedDate: Date = Date(timeIntervalSince1970: 0)
+    var filtered: Bool = false
+    var isPinned: Bool = false
+
+    var seriesIdsRaw: Data?
+
+    init() {}
+  }
+
+  @Model
+  final class KomgaReadList {
+    @Attribute(.unique) var id: String = ""
+
+    var readListId: String = ""
+    var instanceId: String = ""
+
+    var name: String = ""
+    var summary: String = ""
+    var ordered: Bool = false
+    var createdDate: Date = Date(timeIntervalSince1970: 0)
+    var lastModifiedDate: Date = Date(timeIntervalSince1970: 0)
+    var filtered: Bool = false
+    var isPinned: Bool = false
+
+    var bookIdsRaw: Data?
+
+    var downloadStatusRaw: String = "notDownloaded"
+    var downloadError: String?
+    var downloadAt: Date?
+    var downloadedSize: Int64 = 0
+    var downloadedBooks: Int = 0
+    var pendingBooks: Int = 0
+
+    init() {}
+  }
+
+  @Model
+  final class CustomFont {
+    @Attribute(.unique) var name: String = ""
+    var path: String?
+    var fileName: String?
+    var fileSize: Int64?
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+
+    init() {}
+  }
+
+  @Model
+  final class PendingProgress {
+    @Attribute(.unique) var id: String = ""
+    var instanceId: String = ""
+    var bookId: String = ""
+    var page: Int = 0
+    var completed: Bool = false
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var progressionData: Data?
+
+    init() {}
+  }
+
+  @Model
+  final class SavedFilter {
+    @Attribute(.unique) var id: UUID = UUID()
+    var name: String = ""
+    var filterTypeRaw: String = ""
+    var filterDataJSON: String = ""
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var updatedAt: Date = Date(timeIntervalSince1970: 0)
+
+    init() {}
+  }
+
+  @Model
+  final class EpubThemePreset {
+    @Attribute(.unique) var id: UUID = UUID()
+    var name: String = ""
+    var preferencesJSON: String = ""
+    var createdAt: Date = Date(timeIntervalSince1970: 0)
+    var updatedAt: Date = Date(timeIntervalSince1970: 0)
 
     init() {}
   }


### PR DESCRIPTION
## Problem
TestFlight build 4.10 could crash during startup while SwiftData upgraded an older store. The V3-to-V4 migration replayed raw book snapshots by fetching the current runtime `KomgaBook`/`KomgaSeries` models from a V4 migration context, which can trip SwiftData's typed model assertion when the app target schema has already advanced to V5.

## Approach
Keep migration code pinned to the schema version that owns each migration context. The raw snapshot replay now fetches V4-local book and series models, and historical V1-V4 schemas now define their persisted model snapshots locally instead of reusing runtime model types.

## Scope
- Freeze all persisted models inside `KMReaderSchemaV1` through `KMReaderSchemaV4`
- Update V3-to-V4 raw snapshot replay to use `KMReaderSchemaV4` model types
- Leave `KMReaderSchemaV5` as the current runtime schema

## Validation
- [x] `make format`
- [x] `make build-ios`
- [x] `make build-macos`
- [x] Confirmed V1-V4 schema model lists no longer contain bare runtime model `.self` references
