### PR TITLE
feat: add offline-first reading

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 435;
+				CURRENT_PROJECT_VERSION = 436;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 435;
+				CURRENT_PROJECT_VERSION = 436;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 435;
+				CURRENT_PROJECT_VERSION = 436;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 435;
+				CURRENT_PROJECT_VERSION = 436;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -365,6 +365,11 @@ enum AppConfig {
     set { UserDefaults.standard.set(newValue, forKey: "offlineAutoDeleteRead") }
   }
 
+  static nonisolated var offlineFirstReading: Bool {
+    get { UserDefaults.standard.bool(forKey: "offlineFirstReading") }
+    set { UserDefaults.standard.set(newValue, forKey: "offlineFirstReading") }
+  }
+
   static nonisolated var backgroundDownloadTasksData: Data? {
     get { UserDefaults.standard.data(forKey: "BackgroundDownloadTasks") }
     set {

--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -2209,6 +2209,54 @@ actor DatabaseOperator {
     }
   }
 
+  @discardableResult
+  func queueBooksOffline(bookIds: [String], instanceId: String) -> Int {
+    guard !bookIds.isEmpty else { return 0 }
+
+    let bookIdSet = Set(bookIds)
+    let descriptor = FetchDescriptor<KomgaBook>(
+      predicate: #Predicate { $0.instanceId == instanceId }
+    )
+    let books = ((try? modelContext.fetch(descriptor)) ?? [])
+      .filter { bookIdSet.contains($0.bookId) }
+
+    let orderedBooks = books.sorted { lhs, rhs in
+      let lhsIndex = bookIds.firstIndex(of: lhs.bookId) ?? Int.max
+      let rhsIndex = bookIds.firstIndex(of: rhs.bookId) ?? Int.max
+      return lhsIndex < rhsIndex
+    }
+
+    let now = Date.now
+    var queuedCount = 0
+    var affectedSeriesIds = Set<String>()
+    var affectedBookIds: [String] = []
+
+    for (index, book) in orderedBooks.enumerated() {
+      if AppConfig.offlineAutoDeleteRead && book.progressCompleted == true {
+        continue
+      }
+      if book.downloadStatusRaw == "downloaded" || book.downloadStatusRaw == "pending" {
+        continue
+      }
+      book.downloadStatusRaw = "pending"
+      book.downloadError = nil
+      book.downloadAt = now.addingTimeInterval(Double(index) * 0.001)
+      queuedCount += 1
+      affectedSeriesIds.insert(book.seriesId)
+      affectedBookIds.append(book.bookId)
+    }
+
+    for seriesId in affectedSeriesIds {
+      syncSeriesDownloadStatus(seriesId: seriesId, instanceId: instanceId)
+    }
+    syncReadListsContainingBooks(bookIds: affectedBookIds, instanceId: instanceId)
+
+    if queuedCount > 0 {
+      commit()
+    }
+    return queuedCount
+  }
+
   func fetchDownloadQueueSummary(instanceId: String) -> DownloadQueueSummary {
     let downloadingCount = fetchBooksCount(
       instanceId: instanceId,

--- a/KMReader/Features/Dashboard/Views/DashboardView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardView.swift
@@ -17,6 +17,7 @@ struct DashboardView: View {
   @State private var showLibraryPicker = false
   @State private var shouldRefreshAfterReading = false
   @State private var isCheckingConnection = false
+  @State private var offlineQueueingSections: Set<DashboardSection> = []
 
   @AppStorage("dashboard") private var dashboard: DashboardConfiguration = DashboardConfiguration()
   @AppStorage("currentAccount") private var current: Current = .init()
@@ -38,6 +39,10 @@ struct DashboardView: View {
       get: { GridDensity.closest(to: gridDensity) },
       set: { gridDensity = $0.rawValue }
     )
+  }
+
+  private var isQueueingDashboardOffline: Bool {
+    !offlineQueueingSections.isEmpty
   }
 
   @ViewBuilder
@@ -390,6 +395,33 @@ struct DashboardView: View {
 
               Divider()
 
+              Menu {
+                Button {
+                  queueDashboardSectionOffline(.keepReading)
+                } label: {
+                  Label(
+                    DashboardSection.keepReading.displayName,
+                    systemImage: DashboardSection.keepReading.icon
+                  )
+                }
+                .disabled(isQueueingDashboardOffline)
+
+                Button {
+                  queueDashboardSectionOffline(.onDeck)
+                } label: {
+                  Label(
+                    DashboardSection.onDeck.displayName,
+                    systemImage: DashboardSection.onDeck.icon
+                  )
+                }
+                .disabled(isQueueingDashboardOffline)
+              } label: {
+                Label(String(localized: "Queue Offline"), systemImage: "arrow.down.circle")
+              }
+              .disabled(isOffline || isQueueingDashboardOffline)
+
+              Divider()
+
               Button {
                 refreshDashboard(reason: "Manual toolbar button")
               } label: {
@@ -440,6 +472,61 @@ struct DashboardView: View {
       await sseService.connect()
       ErrorManager.shared.notify(message: String(localized: "settings.connection_restored"))
       refreshDashboard(reason: "Reconnected")
+    }
+  }
+
+  private func queueDashboardSectionOffline(_ section: DashboardSection) {
+    guard !current.instanceId.isEmpty, !isOffline else { return }
+    guard !offlineQueueingSections.contains(section) else { return }
+
+    offlineQueueingSections.insert(section)
+    let instanceId = current.instanceId
+    let libraryIds = dashboard.libraryIds
+
+    Task {
+      defer {
+        Task { @MainActor in
+          offlineQueueingSections.remove(section)
+        }
+      }
+
+      do {
+        guard
+          let page = try await section.fetchBooks(
+            libraryIds: libraryIds,
+            page: 0,
+            size: 20
+          )
+        else {
+          ErrorManager.shared.notify(
+            message: String(localized: "No books found to queue for offline reading.")
+          )
+          return
+        }
+
+        let ids = page.content.map(\.id)
+        let queuedCount =
+          await DatabaseOperator.databaseIfConfigured()?.queueBooksOffline(
+            bookIds: ids,
+            instanceId: instanceId
+          ) ?? 0
+
+        if queuedCount > 0 {
+          OfflineManager.shared.triggerSync(instanceId: instanceId)
+          ErrorManager.shared.notify(
+            message: String(
+              format: String(localized: "Queued %lld books for offline reading."),
+              Int64(queuedCount)
+            )
+          )
+        } else {
+          ErrorManager.shared.notify(
+            message: String(localized: "No new books were added to the offline queue.")
+          )
+        }
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
     }
   }
 

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -56,6 +56,8 @@ actor OfflineManager {
   static let shared = OfflineManager()
 
   private var activeTasks: [String: Task<Void, Never>] = [:]
+  private var readingDownloadRequests: [String: (instanceId: String, info: DownloadInfo)] = [:]
+  private var readingDownloadRequestOrder: [String] = []
   private var syncTask: Task<Void, Never>?
   private var syncTaskID: UUID?
   private var isProcessingQueue = false
@@ -316,6 +318,30 @@ actor OfflineManager {
     try? await DatabaseOperator.database().commit()
     await refreshQueueStatus(instanceId: instanceId)
     await syncDownloadQueue(instanceId: instanceId)
+  }
+
+  func downloadForReading(instanceId: String, info: DownloadInfo) async {
+    let status = await getDownloadStatus(bookId: info.bookId)
+
+    switch status {
+    case .downloaded:
+      removeReadingDownloadRequest(bookId: info.bookId)
+      return
+    case .notDownloaded, .failed:
+      try? await DatabaseOperator.database().updateBookDownloadStatus(
+        bookId: info.bookId,
+        instanceId: instanceId,
+        status: .pending,
+        downloadAt: .now
+      )
+      try? await DatabaseOperator.database().commit()
+    case .pending:
+      break
+    }
+
+    addReadingDownloadRequest(instanceId: instanceId, info: info)
+    await refreshQueueStatus(instanceId: instanceId)
+    _ = await startNextReadingDownload(instanceId: instanceId)
   }
 
   func deleteBook(
@@ -621,6 +647,10 @@ actor OfflineManager {
     // Check if offline
     guard !AppConfig.isOffline else { return }
 
+    if await startNextReadingDownload(instanceId: instanceId) {
+      return
+    }
+
     // Check if paused
     guard !AppConfig.offlinePaused else { return }
     guard !isProcessingQueue else { return }
@@ -668,6 +698,44 @@ actor OfflineManager {
 
     // Proceed to download even if it's read, as it was likely manually requested or reader is opening it.
     await startDownload(instanceId: instanceId, info: nextBook.downloadInfo)
+  }
+
+  private func addReadingDownloadRequest(instanceId: String, info: DownloadInfo) {
+    if readingDownloadRequests[info.bookId] == nil {
+      readingDownloadRequestOrder.append(info.bookId)
+    }
+    readingDownloadRequests[info.bookId] = (instanceId: instanceId, info: info)
+  }
+
+  private func removeReadingDownloadRequest(bookId: String) {
+    readingDownloadRequests.removeValue(forKey: bookId)
+    readingDownloadRequestOrder.removeAll { $0 == bookId }
+  }
+
+  private func startNextReadingDownload(instanceId: String) async -> Bool {
+    guard !AppConfig.isOffline else { return false }
+    guard activeTasks.isEmpty else { return false }
+
+    while let bookId = readingDownloadRequestOrder.first(where: {
+      readingDownloadRequests[$0]?.instanceId == instanceId
+    }) {
+      guard let request = readingDownloadRequests[bookId] else {
+        readingDownloadRequestOrder.removeAll { $0 == bookId }
+        continue
+      }
+
+      let status = await getDownloadStatus(bookId: bookId)
+      switch status {
+      case .pending:
+        removeReadingDownloadRequest(bookId: bookId)
+        await startDownload(instanceId: request.instanceId, info: request.info)
+        return true
+      case .downloaded, .notDownloaded, .failed:
+        removeReadingDownloadRequest(bookId: bookId)
+      }
+    }
+
+    return false
   }
 
   private func syncMissingOfflineEpubProgressions(instanceId: String) async {

--- a/KMReader/Features/Offline/Views/OfflineTasksView.swift
+++ b/KMReader/Features/Offline/Views/OfflineTasksView.swift
@@ -12,6 +12,7 @@ struct OfflineTasksView: View {
   private var instanceId: String { current.instanceId }
   @AppStorage("offlinePaused") private var isPaused: Bool = false
   @AppStorage("offlineAutoDeleteRead") private var autoDeleteRead: Bool = false
+  @AppStorage("offlineFirstReading") private var offlineFirstReading: Bool = false
   @State private var showingBulkAlert = false
   @State private var showingAutoDeleteAlert = false
   @State private var pendingBulkAction: BulkAction?
@@ -62,16 +63,18 @@ struct OfflineTasksView: View {
   var body: some View {
     Form {
       Section {
-        Toggle(
-          isOn: Binding(
-            get: { !isPaused },
-            set: { newValue in
-              isPaused = !newValue
+        Toggle(isOn: $offlineFirstReading) {
+          VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+              Image(systemName: offlineFirstReading ? "arrow.down.circle.fill" : "arrow.down.circle")
+              Text(String(localized: "Offline-first Reading"))
             }
-          )
-        ) {
-          Label(currentStatus.label, systemImage: currentStatus.icon)
-            .foregroundColor(currentStatus.color)
+            Text(
+              String(localized: "Download books before opening them, then read from local storage.")
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+          }
         }
 
         Toggle(
@@ -86,10 +89,31 @@ struct OfflineTasksView: View {
             }
           )
         ) {
-          Label(
-            String(localized: "settings.offline.auto_delete_read"),
-            systemImage: autoDeleteRead ? "checkmark.circle" : "circle"
+          VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+              Image(systemName: autoDeleteRead ? "checkmark.circle.fill" : "circle")
+              Text(String(localized: "settings.offline.auto_delete_read"))
+            }
+            Text(String(localized: "settings.offline.auto_delete_read.message"))
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+      } header: {
+        Text(String(localized: "Offline Reading"))
+      }
+
+      Section {
+        Toggle(
+          isOn: Binding(
+            get: { !isPaused },
+            set: { newValue in
+              isPaused = !newValue
+            }
           )
+        ) {
+          Label(currentStatus.label, systemImage: currentStatus.icon)
+            .foregroundColor(currentStatus.color)
         }
       }
 
@@ -244,18 +268,21 @@ struct OfflineTaskRow: View {
         switch book.downloadStatus {
         case .pending:
           if let progress = progress {
-            let isProcessing = progress >= 1
-            ProgressView(value: isProcessing ? nil : progress) {
-              Text(
-                isProcessing
-                  ? String(localized: "Processing offline files...")
-                  : String(
+            if progress >= 1 {
+              Text(String(localized: "Processing offline files..."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            } else {
+              ProgressView(value: progress) {
+                Text(
+                  String(
                     format: String(localized: "Downloading %lld%%"),
                     Int64(progress * 100)
                   )
-              )
-              .font(.caption)
-              .foregroundColor(.secondary)
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+              }
             }
           } else {
             Text("Pending in queue...")

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -322,15 +322,11 @@
       downloadBytesExpected = nil
 
       switch status {
-      case .notDownloaded:
-        await OfflineManager.shared.toggleDownload(
+      case .notDownloaded, .failed, .pending:
+        await OfflineManager.shared.downloadForReading(
           instanceId: instanceId,
           info: downloadInfo
         )
-      case .failed:
-        await OfflineManager.shared.retryDownload(instanceId: instanceId, bookId: bookId)
-      case .pending:
-        break
       case .downloaded:
         return
       }
@@ -349,7 +345,7 @@
           throw AppErrorType.operationFailed(message: error)
         case .notDownloaded:
           throw AppErrorType.operationFailed(
-            message: "Download did not start. Please try again."
+            message: String(localized: "Download did not start. Please try again.")
           )
         case .pending:
           if let progress = DownloadProgressTracker.shared.progress[bookId] {
@@ -389,7 +385,7 @@
         case .notDownloaded:
           errorMessage =
             AppErrorType.operationFailed(
-              message: "Download did not start. Please try again."
+              message: String(localized: "Download did not start. Please try again.")
             ).localizedDescription
           loadingStage = .idle
           isLoading = false

--- a/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
@@ -305,12 +305,8 @@
       downloadBytesExpected = nil
 
       switch status {
-      case .notDownloaded:
-        await OfflineManager.shared.toggleDownload(instanceId: instanceId, info: downloadInfo)
-      case .failed:
-        await OfflineManager.shared.retryDownload(instanceId: instanceId, bookId: bookId)
-      case .pending:
-        break
+      case .notDownloaded, .failed, .pending:
+        await OfflineManager.shared.downloadForReading(instanceId: instanceId, info: downloadInfo)
       case .downloaded:
         downloadProgress = 1.0
         return
@@ -330,7 +326,7 @@
           throw AppErrorType.operationFailed(message: error)
         case .notDownloaded:
           throw AppErrorType.operationFailed(
-            message: "Download did not start. Please try again."
+            message: String(localized: "Download did not start. Please try again.")
           )
         case .pending:
           if let progress = DownloadProgressTracker.shared.progress[bookId] {

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -563,6 +563,18 @@ class ReaderViewModel {
 
   private func fetchSegmentPages(for book: Book) async -> [BookPage]? {
     let database = await DatabaseOperator.databaseIfConfigured()
+
+    if AppConfig.offlineFirstReading {
+      do {
+        try await ensureOfflineReady(book: book, updatesLoadingState: false)
+      } catch {
+        logger.error("❌ Failed to prepare offline segment for book \(book.id): \(error)")
+        return nil
+      }
+
+      return await database?.fetchPages(id: book.id)
+    }
+
     if let cachedPages = await database?.fetchPages(id: book.id) {
       return cachedPages
     }
@@ -740,6 +752,9 @@ class ReaderViewModel {
     resetStateForBookLoad()
 
     do {
+      if AppConfig.offlineFirstReading {
+        try await ensureOfflineReady(book: book, updatesLoadingState: true)
+      }
       await prepareOfflinePDFForDivina(book: book)
       let database = await DatabaseOperator.databaseIfConfigured()
 
@@ -781,6 +796,67 @@ class ReaderViewModel {
     }
 
     isLoading = false
+  }
+
+  private func ensureOfflineReady(book: Book, updatesLoadingState: Bool) async throws {
+    let downloadInfo = book.downloadInfo
+    let status = await OfflineManager.shared.getDownloadStatus(bookId: book.id)
+    if case .downloaded = status {
+      if updatesLoadingState {
+        loadingProgress = 1.0
+      }
+      return
+    }
+
+    if AppConfig.isOffline {
+      throw AppErrorType.networkUnavailable
+    }
+
+    if updatesLoadingState {
+      loadingTitle = String(localized: "Downloading book...")
+      loadingDetail = nil
+      loadingProgress = 0.0
+    }
+
+    switch status {
+    case .notDownloaded, .failed, .pending:
+      await OfflineManager.shared.downloadForReading(
+        instanceId: AppConfig.current.instanceId,
+        info: downloadInfo
+      )
+    case .downloaded:
+      loadingProgress = 1.0
+      return
+    }
+
+    while true {
+      if AppConfig.isOffline {
+        throw AppErrorType.networkUnavailable
+      }
+
+      let currentStatus = await OfflineManager.shared.getDownloadStatus(bookId: book.id)
+      switch currentStatus {
+      case .downloaded:
+        if updatesLoadingState {
+          loadingProgress = 1.0
+        }
+        return
+      case .failed(let error):
+        throw AppErrorType.operationFailed(message: error)
+      case .notDownloaded:
+        throw AppErrorType.operationFailed(
+          message: String(localized: "Download did not start. Please try again.")
+        )
+      case .pending:
+        if updatesLoadingState,
+          let progress = DownloadProgressTracker.shared.progress[book.id]
+        {
+          loadingProgress = progress
+        }
+      }
+
+      try await Task.sleep(for: .milliseconds(200))
+    }
   }
 
   private func prepareOfflinePDFForDivina(book: Book) async {

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -18144,6 +18144,134 @@
         }
       }
     },
+    "Download books before opening them, then read from local storage." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bücher vor dem Öffnen herunterladen und dann aus dem lokalen Speicher lesen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download books before opening them, then read from local storage."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Descarga los libros antes de abrirlos y léelos desde el almacenamiento local."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Télécharge les livres avant de les ouvrir, puis lis-les depuis le stockage local."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scarica i libri prima di aprirli, poi leggili dall'archivio locale."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開く前に本をダウンロードし、ローカルストレージから読みます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "책을 열기 전에 다운로드한 다음 로컬 저장소에서 읽습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загружайте книги перед открытием, затем читайте их из локального хранилища."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开书籍前先下载，然后从本地存储阅读。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開啟書籍前先下載，然後從本機儲存空間閱讀。"
+          }
+        }
+      }
+    },
+    "Download did not start. Please try again." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Download wurde nicht gestartet. Bitte versuche es erneut."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download did not start. Please try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La descarga no se inició. Inténtalo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le téléchargement n'a pas démarré. Réessaie."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il download non è iniziato. Riprova."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードを開始できませんでした。もう一度お試しください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드가 시작되지 않았습니다. 다시 시도하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загрузка не началась. Повторите попытку."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载未开始，请重试。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下載未開始，請再試一次。"
+          }
+        }
+      }
+    },
     "Download finished with failures" : {
       "localizations" : {
         "de" : {
@@ -39968,6 +40096,70 @@
         }
       }
     },
+    "No books found to queue for offline reading." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Bücher zum Einreihen für das Offline-Lesen gefunden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No books found to queue for offline reading."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se encontraron libros para añadir a la cola de lectura sin conexión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun livre trouvé à ajouter à la file de lecture hors ligne."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun libro trovato da aggiungere alla coda per la lettura offline."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフライン読書用にキューへ追加できる本が見つかりません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 읽기 대기열에 추가할 책을 찾을 수 없습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не найдены книги для добавления в очередь офлайн-чтения."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有找到可加入离线阅读队列的书籍。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "找不到可加入離線閱讀佇列的書籍。"
+          }
+        }
+      }
+    },
     "No collections found" : {
       "localizations" : {
         "de" : {
@@ -40860,6 +41052,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "沒有缺少的海報"
+          }
+        }
+      }
+    },
+    "No new books were added to the offline queue." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Es wurden keine neuen Bücher zur Offline-Warteschlange hinzugefügt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No new books were added to the offline queue."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se añadieron libros nuevos a la cola sin conexión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun nouveau livre n'a été ajouté à la file hors ligne."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessun nuovo libro è stato aggiunto alla coda offline."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインキューに新しい本は追加されませんでした。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 대기열에 새 책이 추가되지 않았습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Новые книги не были добавлены в офлайн-очередь."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有新的书籍加入离线队列。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "沒有新的書籍加入離線佇列。"
           }
         }
       }
@@ -46688,6 +46944,134 @@
         }
       }
     },
+    "Offline Reading" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Lesen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline Reading"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lectura sin conexión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture hors ligne"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettura offline"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフライン読書"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 읽기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Офлайн-чтение"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "离线阅读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "離線閱讀"
+          }
+        }
+      }
+    },
+    "Offline-first Reading" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline zuerst lesen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-first Reading"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lectura primero sin conexión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture hors ligne d'abord"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettura prima offline"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフライン優先読書"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 우선 읽기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чтение сначала офлайн"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "优先离线阅读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "優先離線閱讀"
+          }
+        }
+      }
+    },
     "offline.shortcuts.books.subtitle" : {
       "localizations" : {
         "de" : {
@@ -51358,6 +51742,134 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "購買請求超時。請稍後再試。"
+          }
+        }
+      }
+    },
+    "Queue Offline" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline einreihen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Queue Offline"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir a la cola sin conexión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter à la file hors ligne"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi alla coda offline"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインキューに追加"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 대기열에 추가"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Добавить в офлайн-очередь"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入离线队列"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入離線佇列"
+          }
+        }
+      }
+    },
+    "Queued %lld books for offline reading." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld Bücher für das Offline-Lesen eingereiht."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Queued %lld books for offline reading."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se añadieron %lld libros a la cola de lectura sin conexión."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld livres ajoutés à la file de lecture hors ligne."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld libri aggiunti alla coda per la lettura offline."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld冊の本をオフライン読書用にキューへ追加しました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld권의 책을 오프라인 읽기 대기열에 추가했습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld книг добавлено в очередь офлайн-чтения."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已将 %lld 本书加入离线阅读队列。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已將 %lld 本書加入離線閱讀佇列。"
           }
         }
       }


### PR DESCRIPTION
## Problem
Opening a book while offline downloads are paused could leave the reader waiting forever when offline-first reading needs the book to be prepared before display. The paused queue also had no quick way to queue common dashboard sections for offline reading.

## Approach
Treat reader-triggered downloads as a priority lane inside `OfflineManager`: they still reuse the single active download model, but they bypass the normal queue pause gate without resuming the whole queue. Add an offline-first reading preference and wire the reader view models to wait for local preparation before loading content when the preference is enabled.

## Scope
- Add the offline-first reading setting in Offline Tasks
- Add reader-priority download requests that bypass paused queue processing
- Add dashboard actions to queue Keep Reading and On Deck books offline
- Localize the new offline reading strings across supported languages
- Bump the build version to 436

## Validation
- [x] `make format`
- [x] `make build`
- [x] `make localize`
- [x] `./misc/translate.py list`
- [x] `python3 -m json.tool KMReader/Localizable.xcstrings`
- [x] `git diff --check`
