### PR TITLE
fix(dashboard): reduce offline queue lag

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 436;
+				CURRENT_PROJECT_VERSION = 437;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 436;
+				CURRENT_PROJECT_VERSION = 437;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 436;
+				CURRENT_PROJECT_VERSION = 437;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 436;
+				CURRENT_PROJECT_VERSION = 437;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -2213,16 +2213,20 @@ actor DatabaseOperator {
   func queueBooksOffline(bookIds: [String], instanceId: String) -> Int {
     guard !bookIds.isEmpty else { return 0 }
 
-    let bookIdSet = Set(bookIds)
-    let descriptor = FetchDescriptor<KomgaBook>(
-      predicate: #Predicate { $0.instanceId == instanceId }
+    let compositeIds = Set(
+      bookIds.map { CompositeID.generate(instanceId: instanceId, id: $0) }
     )
-    let books = ((try? modelContext.fetch(descriptor)) ?? [])
-      .filter { bookIdSet.contains($0.bookId) }
+    let descriptor = FetchDescriptor<KomgaBook>(
+      predicate: #Predicate { compositeIds.contains($0.id) }
+    )
+    let books = (try? modelContext.fetch(descriptor)) ?? []
+    let orderByBookId = Dictionary(
+      uniqueKeysWithValues: bookIds.enumerated().map { ($0.element, $0.offset) }
+    )
 
     let orderedBooks = books.sorted { lhs, rhs in
-      let lhsIndex = bookIds.firstIndex(of: lhs.bookId) ?? Int.max
-      let rhsIndex = bookIds.firstIndex(of: rhs.bookId) ?? Int.max
+      let lhsIndex = orderByBookId[lhs.bookId] ?? Int.max
+      let rhsIndex = orderByBookId[rhs.bookId] ?? Int.max
       return lhsIndex < rhsIndex
     }
 

--- a/KMReader/Features/Dashboard/Views/DashboardView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardView.swift
@@ -27,6 +27,7 @@ struct DashboardView: View {
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
 
   private let sseService = SSEService.shared
+  private let sectionCacheStore = DashboardSectionCacheStore.shared
   private let debounceInterval: TimeInterval = 5.0  // 5 seconds debounce
   private let logger = AppLogger(.dashboard)
 
@@ -491,20 +492,14 @@ struct DashboardView: View {
       }
 
       do {
-        guard
-          let page = try await section.fetchBooks(
-            libraryIds: libraryIds,
-            page: 0,
-            size: 20
-          )
-        else {
+        let ids = try await bookIdsForOfflineQueue(section: section, libraryIds: libraryIds)
+        guard !ids.isEmpty else {
           ErrorManager.shared.notify(
             message: String(localized: "No books found to queue for offline reading.")
           )
           return
         }
 
-        let ids = page.content.map(\.id)
         let queuedCount =
           await DatabaseOperator.databaseIfConfigured()?.queueBooksOffline(
             bookIds: ids,
@@ -528,6 +523,30 @@ struct DashboardView: View {
         ErrorManager.shared.alert(error: error)
       }
     }
+  }
+
+  private func bookIdsForOfflineQueue(
+    section: DashboardSection,
+    libraryIds: [String]
+  ) async throws -> [String] {
+    let cachedIds = sectionCacheStore.ids(for: section)
+    if !cachedIds.isEmpty {
+      return cachedIds
+    }
+
+    guard
+      let page = try await section.fetchBooks(
+        libraryIds: libraryIds,
+        page: 0,
+        size: 20
+      )
+    else {
+      return []
+    }
+
+    let ids = page.content.map(\.id)
+    _ = sectionCacheStore.updateIfChanged(section: section, ids: ids)
+    return ids
   }
 
   private func enterOfflineMode() {


### PR DESCRIPTION
## Problem
Queueing a dashboard section for offline reading could briefly stall the UI because the action path refreshed the section from the server and then scanned local storage broadly, even when only one new book was added.

## Approach
Use the dashboard section cache as the fast path for offline queue IDs, falling back to the existing server fetch only when the cache is empty. Narrow the local database lookup to the requested composite book IDs so queueing work scales with the selected section rather than the whole instance.

## Scope
- Reuse cached dashboard section IDs for Queue Offline actions
- Cache fallback fetch results for later dashboard queue actions
- Query only requested books when marking offline queue entries pending
- Bump build version to 437

## Validation
- [x] make format
- [x] make build-macos
