### PR TITLE
fix: normalize EPUB extraction permissions

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -688,7 +688,7 @@
 			repositoryURL = "https://github.com/everpcpc/libarchive-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.5;
+				minimumVersion = 0.1.7;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/KMReader/Features/Offline/Services/ArchiveExtractionService.swift
+++ b/KMReader/Features/Offline/Services/ArchiveExtractionService.swift
@@ -24,7 +24,7 @@ nonisolated enum ArchiveExtractionService {
       try? FileManager.default.removeItem(at: stagingDirectory)
     }
 
-    try ArchiveReader().extract(archiveFile, to: stagingDirectory)
+    try ArchiveReader().extract(archiveFile, to: stagingDirectory, permissionMode: .normalized)
 
     let extractedFiles = try regularFiles(in: stagingDirectory)
     var remainingDestinations = destinationsByArchivePath

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -14945,18 +14945,17 @@
       }
     },
     "dashboard.downloadAll" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download All"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alle herunterladen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download All"
           }
         },
         "es" : {
@@ -15010,18 +15009,17 @@
       }
     },
     "dashboard.downloadLatest" : {
-      "extractionState" : "extracted_with_value",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download Latest"
-          }
-        },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Neueste herunterladen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download Latest"
           }
         },
         "es" : {


### PR DESCRIPTION
## Problem
Background EPUB downloads could fail during extraction when an EPUB archive contains read-only directory modes. Libarchive could stage files under non-writable directories, and the later move step would fail with a permission error.

## Approach
Update KMReader to require libarchive-swift 0.1.7 and use its normalized extraction permission mode. This preserves the single-pass libarchive extraction path while ensuring staged regular files and directories are writable before KMReader moves matched resources into their offline destinations.

## Scope
- Require libarchive-swift 0.1.7
- Use normalized permissions for archive staging during offline extraction
- Include the pending Localizable.xcstrings sync for dashboard download labels

## Validation
- [x] make build-ios
