### PR TITLE
fix: limit dashboard bulk download actions

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 438;
+				CURRENT_PROJECT_VERSION = 439;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 438;
+				CURRENT_PROJECT_VERSION = 439;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 438;
+				CURRENT_PROJECT_VERSION = 439;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 438;
+				CURRENT_PROJECT_VERSION = 439;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Dashboard/Models/DashboardSection.swift
+++ b/KMReader/Features/Dashboard/Models/DashboardSection.swift
@@ -95,6 +95,28 @@ enum DashboardSection: String, CaseIterable, Identifiable, Codable {
     }
   }
 
+  static var latestOfflineQueueSections: [DashboardSection] {
+    allCases.filter(\.supportsDownloadLatest)
+  }
+
+  var supportsDownloadLatest: Bool {
+    switch self {
+    case .keepReading, .onDeck, .recentlyReleasedBooks, .recentlyAddedBooks:
+      return true
+    default:
+      return false
+    }
+  }
+
+  var supportsDownloadAll: Bool {
+    switch self {
+    case .keepReading, .onDeck:
+      return true
+    default:
+      return false
+    }
+  }
+
   func fetchBooks(libraryIds: [String], page: Int, size: Int) async throws -> Page<Book>? {
     switch self {
     case .keepReading:

--- a/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
@@ -43,7 +43,7 @@ struct DashboardSectionDetailView: View {
           .pickerStyle(.segmented)
           .padding()
 
-          if section.contentKind == .books {
+          if section.supportsDownloadAll {
             Button {
               queueAllBooksOffline()
             } label: {
@@ -75,7 +75,7 @@ struct DashboardSectionDetailView: View {
       .toolbar {
         ToolbarItem(placement: .automatic) {
           Menu {
-            if section.contentKind == .books {
+            if section.supportsDownloadAll {
               Button {
                 queueAllBooksOffline()
               } label: {
@@ -262,7 +262,7 @@ struct DashboardSectionDetailView: View {
   }
 
   private func queueAllBooksOffline() {
-    guard section.contentKind == .books, !isOffline else { return }
+    guard section.supportsDownloadAll, !isOffline else { return }
     guard !isQueueingAllOffline else { return }
 
     isQueueingAllOffline = true

--- a/KMReader/Features/Dashboard/Views/DashboardView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardView.swift
@@ -46,15 +46,6 @@ struct DashboardView: View {
     !offlineQueueingSections.isEmpty
   }
 
-  private var latestOfflineQueueSections: [DashboardSection] {
-    [
-      .keepReading,
-      .onDeck,
-      .recentlyReleasedBooks,
-      .recentlyAddedBooks,
-    ]
-  }
-
   @ViewBuilder
   private var dashboardHeader: some View {
     HStack {
@@ -406,7 +397,7 @@ struct DashboardView: View {
               Divider()
 
               Menu {
-                ForEach(latestOfflineQueueSections) { section in
+                ForEach(DashboardSection.latestOfflineQueueSections) { section in
                   Button {
                     queueDashboardSectionOffline(section)
                   } label: {
@@ -481,7 +472,7 @@ struct DashboardView: View {
   }
 
   private func queueDashboardSectionOffline(_ section: DashboardSection) {
-    guard !current.instanceId.isEmpty, !isOffline else { return }
+    guard section.supportsDownloadLatest, !current.instanceId.isEmpty, !isOffline else { return }
     guard !offlineQueueingSections.contains(section) else { return }
 
     offlineQueueingSections.insert(section)


### PR DESCRIPTION
## Problem
Dashboard section detail pages exposed Download All for book sections where bulk queuing can be unexpectedly large or no longer useful, such as Recently Released, Recently Added, and Recently Read.

## Approach
Move dashboard download capability checks onto DashboardSection and separate Download All from Download Latest so each action can use the right allowlist.

## Scope
- Limit section detail Download All to Keep Reading and On Deck
- Keep dashboard Download Latest available for Keep Reading, On Deck, Recently Released, and Recently Added
- Add guard checks so unsupported sections cannot be queued through these actions
- Bump build version to 439

## Validation
- [x] make format
