### PR TITLE
docs: refresh 4.10 store copy

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,12 +1,17 @@
-Reader Controls
-- Tap zone layout presets make it easier to choose how page turns and controls respond while reading.
-- Reader tap zones now stay separate from buttons and controls, reducing accidental actions.
-- Live Activity options have been moved to a more appropriate Settings location.
+New
+- Added offline-first reading so downloaded books can be prepared locally before the reader opens.
+- Added dashboard download actions for recent, on-deck, and keep-reading sections, with clearer Download Latest and Download All choices where available.
+- Added per-page rotation for DIVINA pages.
+- Added reader progress options for DIVINA and PDF so lightweight progress can stay visible while controls are hidden.
 
-Reader Reliability
-- Webtoon navigation is more consistent across scrolling and page-turn actions.
-- Webtoon books now preserve progress more reliably when reaching the final page.
+Improvements
+- PDF reading now uses supported page presentation modes, including an Auto mode that adapts between portrait and landscape.
+- Automatic offline mode can now recover when your configured Komga server becomes reachable again, while manual offline mode stays under your control.
+- Reader opening is faster because adjacent-book loading no longer blocks the first page.
+- Webtoon spacing, history rows, reader menus, and reading stats controls have been tightened for cleaner scanning.
 
-Offline and Library Reliability
-- Downloaded archives with mixed path styles open more reliably.
-- Library details refresh more consistently after changes made on the server.
+Fixes
+- Progress is flushed when the app backgrounds, reducing the chance of losing the last pages you read.
+- Stale offline progress is skipped when the server already has newer progress, preventing older queued updates from moving books backward.
+- EPUB downloads with read-only archive folders extract more reliably.
+- Dashboard offline queue actions are faster and avoid unsupported bulk downloads.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -6,12 +6,13 @@ IMPORTANT FEATURES
 
 - Native readers
 Read comics and books with DIVINA on iOS, macOS, and tvOS, plus EPUB and PDF on iOS and macOS. Readers support LTR, RTL, vertical, Webtoon, spreads, zoom, page curl or cover transitions, custom EPUB fonts and typography, nested EPUB tables of contents, PDF search, keyboard shortcuts, per-book preferences, animated pages, and incognito reading.
+Rotate individual pages, keep lightweight progress visible while reading, and choose native PDF presentation modes that adapt cleanly between portrait and landscape.
 
 - Browse and discover
 Use Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/read lists, reading history, saved filters, advanced metadata filters with all/any matching, optional unread-cover blur, Spotlight indexing, widgets, and Home Screen quick actions.
 
 - Offline and sync
-Download books for offline reading, set per-series download policies, browse downloaded items, keep reading with iOS background downloads and Live Activities, and sync progress when you reconnect.
+Download books for offline reading, set per-series download policies, browse downloaded items, queue dashboard sections, keep reading with iOS background downloads and Live Activities, prepare books before opening with offline-first reading, and sync progress when you reconnect.
 
 - Multi-server and admin tools
 Save multiple Komga servers and switch instantly.

--- a/README.md
+++ b/README.md
@@ -22,23 +22,23 @@
 
 ### Readers
 
-- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl on iOS, cover transitions, tap zone layout presets, keyboard support, and per-book preferences.
+- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl on iOS, cover transitions, tap zone layout presets, keyboard support, per-page rotation, and per-book preferences.
 - EPUB reader on iOS/macOS with paged, scrolled, or cover layouts, custom fonts, themes, typography controls, status/footer overlays, multi-column reading, and nested table of contents.
-- PDF reader on iOS/macOS with native PDF or DIVINA mode, search, table of contents, page jump, spread layouts, configurable render quality, and optional continuous scrolling.
-- Animated GIF and WebP pages play inline. Incognito mode, page image actions, reader progress overlays, and iOS Live Text are supported where available.
+- PDF reader on iOS/macOS with native PDF or DIVINA mode, search, table of contents, page jump, automatic or explicit page presentation modes, spread layouts, configurable render quality, and continuous reading options.
+- Animated GIF and WebP pages play inline. Incognito mode, page image actions, persistent reader progress overlays, and iOS Live Text are supported where available.
 
 ### Browse and Discovery
 
-- Dashboard sections for Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists.
+- Dashboard sections for Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists, with quick offline actions for current or full book sections where supported.
 - Browse Series, Books, Collections, and Read Lists with metadata filters, all/any matching, saved filters, reading history, and optional unread-cover blur.
 - Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
 
 ### Offline and Sync
 
-- Download books for offline reading across DIVINA, EPUB, and PDF workflows.
+- Download books for offline reading across DIVINA, EPUB, and PDF workflows, with optional offline-first reading that prepares local content before opening the reader.
 - Per-series policies support manual, unread-only, unread + cleanup, and all-books downloads.
 - Large downloads stream to disk, and CBZ, CBR, PDF, and supported EPUB offline flows use local extraction or storage.
-- Progress and offline changes sync when reconnecting. Cache controls cover pages and thumbnails.
+- Progress and offline changes sync when reconnecting, with stale progress protection and automatic recovery from server outages when offline mode was entered automatically. Cache controls cover pages and thumbnails.
 - iOS background downloads and Live Activities show reader progress, incognito status, download progress, and processing state.
 
 ### Multi-Server and Management

--- a/static/index.html
+++ b/static/index.html
@@ -28,9 +28,9 @@
                 <p class="tagline">
                     Read, download, browse, and manage your Komga library with
                     native DIVINA, EPUB, and PDF readers, Webtoon and spread
-                    layouts, offline sync, advanced filtering, multi-server
-                    support, and Apple-platform integrations on iPhone, iPad,
-                    Mac, and Apple TV.
+                    layouts, offline-first reading, dashboard download actions,
+                    advanced filtering, multi-server support, and Apple-platform
+                    integrations on iPhone, iPad, Mac, and Apple TV.
                 </p>
                 <div class="cta">
                     <a
@@ -64,7 +64,7 @@
                     </div>
                     <div class="meta-card">
                         <span>Productivity</span>
-                        <strong>Widgets + Spotlight + Live Activities</strong>
+                        <strong>Widgets · Spotlight · Live Activities</strong>
                     </div>
                 </div>
             </header>
@@ -83,9 +83,11 @@
                             plus EPUB and PDF on iOS and macOS. Readers support
                             LTR, RTL, vertical, Webtoon, spreads, zoom,
                             page curl or cover transitions, tap zone presets,
-                            keyboard shortcuts, per-book preferences, custom EPUB fonts and
-                            typography, nested EPUB table of contents, PDF
-                            search, animated pages, and incognito reading.
+                            keyboard shortcuts, per-page rotation, persistent
+                            progress, per-book preferences, custom EPUB fonts
+                            and typography, nested EPUB table of contents, PDF
+                            search, adaptive PDF presentation, animated pages,
+                            and incognito reading.
                         </p>
                     </article>
                     <article class="card">
@@ -95,9 +97,10 @@
                             Keep Reading, On Deck, Recently Added, Recently
                             Updated, pinned collections/read lists, reading
                             history, metadata filters with all/any matching,
-                            saved filters, optional unread-cover blur, widgets,
-                            quick actions, and Spotlight indexing keep the
-                            useful parts of your library close.
+                            saved filters, optional unread-cover blur,
+                            dashboard download actions, widgets, quick actions,
+                            and Spotlight indexing keep the useful parts of your
+                            library close.
                         </p>
                     </article>
                     <article class="card">
@@ -105,7 +108,8 @@
                         <h3>Download and keep reading anywhere</h3>
                         <p>
                             Download books for offline reading, set per-series
-                            download policies, browse downloaded items, use iOS
+                            download policies, prepare local content before the
+                            reader opens, browse downloaded items, use iOS
                             background downloads and Live Activities, and sync
                             progress when you reconnect.
                         </p>
@@ -208,9 +212,11 @@
                     <article class="faq-item">
                         <h4>How does offline mode work?</h4>
                         <p>
-                            Downloaded books stay readable offline, per-series
-                            policies help decide what stays on device, and
-                            reading progress syncs when you reconnect.
+                            Downloaded books stay readable offline, offline-first
+                            reading can prepare local content before the reader
+                            opens, per-series policies help decide what stays on
+                            device, and reading progress syncs when you
+                            reconnect.
                         </p>
                     </article>
                     <article class="faq-item">


### PR DESCRIPTION
## Problem
The public README, static landing page, and App Store metadata still reflected the previous release focus. The 4.10 release adds several user-visible reader and offline improvements, so the published copy and release notes need to describe the same product surface.

## Approach
Refresh the durable product docs around current core capabilities, and keep the App Store changelog focused on user-facing changes from the 4.10 cycle instead of implementation or release workflow details.

## Scope
- Update README reader, dashboard, and offline feature summaries
- Update App Store description with 4.10 reader and offline highlights
- Update static landing page copy to match the same feature priorities
- Replace the App Store changelog with sectioned 4.10 release notes

## Validation
- [x] Ran `git diff --check`
- [x] Updated the App Store Connect 4.10 en-US description and changelog for iOS, macOS, and tvOS
