### PR TITLE
refactor(storage): move SwiftData models into active schema

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 442;
+				CURRENT_PROJECT_VERSION = 443;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 442;
+				CURRENT_PROJECT_VERSION = 443;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 442;
+				CURRENT_PROJECT_VERSION = 443;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 442;
+				CURRENT_PROJECT_VERSION = 443;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/Schema/KMReaderMigrationPlan.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderMigrationPlan.swift
@@ -152,7 +152,7 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
       KMReaderSchemaV2.self,
       KMReaderSchemaV3.self,
       KMReaderSchemaV4.self,
-      KMReaderSchemaV5.self,
+      KMReaderSchemaV6.self,
     ]
   }
 
@@ -161,7 +161,7 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
       migrateV1toV2,
       migrateV2toV3,
       migrateV3toV4,
-      migrateV4toV5,
+      migrateV4toV6,
     ]
   }
 
@@ -539,11 +539,12 @@ enum KMReaderMigrationPlan: SchemaMigrationPlan {
     return try? JSONDecoder().decode(type, from: data)
   }
 
-  // V4 → V5: v4.10 shipped V5 using runtime model types, so keep V5 stable
-  // and use an explicit staged migration for direct v4.9 → v4.11 upgrades.
-  static let migrateV4toV5 = MigrationStage.custom(
+  // V4 → V6: bridge the historical snapshot chain to the schema-owned active
+  // model graph. Runtime-backed V4/V5 stores from shipped builds do not match
+  // these snapshot source schemas and are handled by MainApp's inferred fallback.
+  static let migrateV4toV6 = MigrationStage.custom(
     fromVersion: KMReaderSchemaV4.self,
-    toVersion: KMReaderSchemaV5.self,
+    toVersion: KMReaderSchemaV6.self,
     willMigrate: { _ in },
     didMigrate: { context in
       if context.hasChanges {

--- a/KMReader/Core/Storage/Schema/KMReaderSchemaV5.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderSchemaV5.swift
@@ -1,7 +1,6 @@
 //
 // KMReaderSchemaV5.swift
 //
-//
 
 import Foundation
 import SwiftData

--- a/KMReader/Core/Storage/Schema/KMReaderSchemaV6.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderSchemaV6.swift
@@ -1,0 +1,533 @@
+//
+// KMReaderSchemaV6.swift
+//
+//
+
+import Foundation
+import SwiftData
+
+enum KMReaderSchemaV6: VersionedSchema {
+  static var versionIdentifier: Schema.Version {
+    Schema.Version(6, 0, 0)
+  }
+
+  static var models: [any PersistentModel.Type] {
+    [
+      KMReaderSchemaV6.KomgaInstance.self,
+      KMReaderSchemaV6.KomgaLibrary.self,
+      KMReaderSchemaV6.KomgaSeries.self,
+      KMReaderSchemaV6.KomgaBook.self,
+      KMReaderSchemaV6.KomgaCollection.self,
+      KMReaderSchemaV6.KomgaReadList.self,
+      KMReaderSchemaV6.CustomFontV1.self,
+      KMReaderSchemaV6.PendingProgress.self,
+      KMReaderSchemaV6.SavedFilterV1.self,
+      KMReaderSchemaV6.EpubThemePresetV1.self,
+    ]
+  }
+
+  @Model
+  final class KomgaInstance {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var serverURL: String
+    var username: String
+    var authToken: String
+    var isAdmin: Bool
+    var authMethod: AuthenticationMethod? = AuthenticationMethod.basicAuth
+    var createdAt: Date
+    var lastUsedAt: Date
+    var seriesLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
+    var booksLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
+
+    init(
+      id: UUID = UUID(),
+      name: String,
+      serverURL: String,
+      username: String,
+      authToken: String,
+      isAdmin: Bool,
+      authMethod: AuthenticationMethod = .basicAuth,
+      createdAt: Date = Date(),
+      lastUsedAt: Date = Date(),
+      seriesLastSyncedAt: Date = Date(timeIntervalSince1970: 0),
+      booksLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
+    ) {
+      self.id = id
+      self.name = name
+      self.serverURL = serverURL
+      self.username = username
+      self.authToken = authToken
+      self.isAdmin = isAdmin
+      self.authMethod = authMethod
+      self.createdAt = createdAt
+      self.lastUsedAt = lastUsedAt
+      self.seriesLastSyncedAt = seriesLastSyncedAt
+      self.booksLastSyncedAt = booksLastSyncedAt
+    }
+  }
+
+  @Model
+  final class KomgaLibrary {
+    static let allLibrariesId = "__all_libraries__"
+
+    @Attribute(.unique) var id: UUID
+    var instanceId: String
+    var libraryId: String
+    var name: String
+    var createdAt: Date
+
+    // Metrics
+    var fileSize: Double?
+    var booksCount: Double?
+    var seriesCount: Double?
+    var sidecarsCount: Double?
+    var collectionsCount: Double?
+    var readlistsCount: Double?
+
+    init(
+      id: UUID = UUID(),
+      instanceId: String,
+      libraryId: String,
+      name: String,
+      createdAt: Date = Date(),
+      fileSize: Double? = nil,
+      booksCount: Double? = nil,
+      seriesCount: Double? = nil,
+      sidecarsCount: Double? = nil,
+      collectionsCount: Double? = nil,
+      readlistsCount: Double? = nil
+    ) {
+      self.id = id
+      self.instanceId = instanceId
+      self.libraryId = libraryId
+      self.name = name
+      self.createdAt = createdAt
+      self.fileSize = fileSize
+      self.booksCount = booksCount
+      self.seriesCount = seriesCount
+      self.sidecarsCount = sidecarsCount
+      self.collectionsCount = collectionsCount
+      self.readlistsCount = readlistsCount
+    }
+  }
+
+  @Model
+  final class KomgaSeries {
+    @Attribute(.unique) var id: String  // Composite: CompositeID.generate
+
+    var seriesId: String
+    var libraryId: String
+    var instanceId: String
+
+    var name: String
+    var url: String
+    var created: Date
+    var lastModified: Date
+
+    var booksCount: Int
+    var booksReadCount: Int
+    var booksUnreadCount: Int
+    var booksInProgressCount: Int
+
+    // API-aligned raw storage
+    var metadataRaw: Data?
+    var booksMetadataRaw: Data?
+
+    // Query fields
+    var metaTitle: String
+    var metaTitleSort: String
+    var metaPublisherIndex: String = "|"
+    var metaAuthorsIndex: String = "|"
+    var metaGenresIndex: String = "|"
+    var metaTagsIndex: String = "|"
+    var metaLanguageIndex: String = "|"
+
+    var isUnavailable: Bool = false
+    var oneshot: Bool
+
+    // Track offline download status (managed locally)
+    var downloadStatusRaw: String = "notDownloaded"
+    var downloadError: String?
+    var downloadAt: Date?
+    var downloadedSize: Int64 = 0
+    var downloadedBooks: Int = 0
+    var pendingBooks: Int = 0
+    var offlinePolicyRaw: String = "manual"
+    var offlinePolicyLimit: Int = 0
+
+    // Cached collection IDs containing this series
+    var collectionIdsRaw: Data?
+
+    init(
+      id: String? = nil,
+      seriesId: String,
+      libraryId: String,
+      instanceId: String,
+      name: String,
+      url: String,
+      created: Date,
+      lastModified: Date,
+      booksCount: Int,
+      booksReadCount: Int,
+      booksUnreadCount: Int,
+      booksInProgressCount: Int,
+      metadata: SeriesMetadata,
+      booksMetadata: SeriesBooksMetadata,
+      isUnavailable: Bool,
+      oneshot: Bool,
+      downloadedBooks: Int = 0,
+      pendingBooks: Int = 0,
+      downloadedSize: Int64 = 0,
+      offlinePolicy: SeriesOfflinePolicy = .manual,
+      offlinePolicyLimit: Int = 0
+    ) {
+      self.id = id ?? CompositeID.generate(instanceId: instanceId, id: seriesId)
+      self.seriesId = seriesId
+      self.libraryId = libraryId
+      self.instanceId = instanceId
+      self.name = name
+      self.url = url
+      self.created = created
+      self.lastModified = lastModified
+      self.booksCount = booksCount
+      self.booksReadCount = booksReadCount
+      self.booksUnreadCount = booksUnreadCount
+      self.booksInProgressCount = booksInProgressCount
+
+      self.metadataRaw = RawCodableStore.encode(metadata)
+      self.booksMetadataRaw = RawCodableStore.encode(booksMetadata)
+      self.metaTitle = metadata.title
+      self.metaTitleSort = metadata.titleSort
+      self.metaPublisherIndex = MetadataIndex.encode(value: metadata.publisher)
+      self.metaAuthorsIndex = MetadataIndex.encode(values: booksMetadata.authors?.map(\.name) ?? [])
+      self.metaGenresIndex = MetadataIndex.encode(values: metadata.genres ?? [])
+      self.metaTagsIndex = MetadataIndex.encode(values: metadata.tags ?? [])
+      self.metaLanguageIndex = MetadataIndex.encode(value: metadata.language)
+
+      self.isUnavailable = isUnavailable
+      self.oneshot = oneshot
+      self.downloadedBooks = downloadedBooks
+      self.pendingBooks = pendingBooks
+      self.downloadedSize = downloadedSize
+      self.offlinePolicyRaw = offlinePolicy.rawValue
+      self.offlinePolicyLimit = offlinePolicyLimit
+      self.collectionIdsRaw = try? JSONEncoder().encode([] as [String])
+    }
+  }
+
+  @Model
+  final class KomgaBook {
+    @Attribute(.unique) var id: String  // Composite: CompositeID.generate
+
+    var bookId: String
+    var seriesId: String
+    var libraryId: String
+    var instanceId: String
+
+    var name: String
+    var url: String
+    var number: Double
+    var created: Date
+    var lastModified: Date
+    var sizeBytes: Int64
+    var size: String
+
+    // API-aligned raw storage
+    var mediaRaw: Data?
+    var metadataRaw: Data?
+    var readProgressRaw: Data?
+
+    // Query fields
+    var mediaPagesCount: Int
+    var mediaProfile: String?
+    var metaTitle: String
+    var metaNumber: String
+    var metaNumberSort: Double
+    var metaReleaseDate: String?
+    var progressPage: Int?
+    var progressCompleted: Bool?
+    var progressReadDate: Date?
+    var metaAuthorsIndex: String = "|"
+    var metaTagsIndex: String = "|"
+
+    var isUnavailable: Bool = false
+    var oneshot: Bool
+    var seriesTitle: String = ""
+
+    // Metadata storage
+    var pagesRaw: Data?
+    var tocRaw: Data?
+    var webPubManifestRaw: Data?
+    var epubProgressionRaw: Data?
+
+    // Track offline download status (managed locally)
+    var downloadStatusRaw: String = "notDownloaded"
+    var downloadError: String?
+    var downloadAt: Date?
+    var downloadedSize: Int64 = 0
+
+    // Cached read list IDs containing this book
+    var readListIdsRaw: Data?
+
+    var isolatePagesRaw: Data?
+    var pageRotationsRaw: Data?
+    var epubPreferencesRaw: String?
+
+    init(
+      id: String? = nil,
+      bookId: String,
+      seriesId: String,
+      libraryId: String,
+      instanceId: String,
+      name: String,
+      url: String,
+      number: Double,
+      created: Date,
+      lastModified: Date,
+      sizeBytes: Int64,
+      size: String,
+      media: Media,
+      metadata: BookMetadata,
+      readProgress: ReadProgress?,
+      isUnavailable: Bool,
+      oneshot: Bool,
+      seriesTitle: String = "",
+      downloadedSize: Int64 = 0
+    ) {
+      self.id = id ?? CompositeID.generate(instanceId: instanceId, id: bookId)
+      self.bookId = bookId
+      self.seriesId = seriesId
+      self.libraryId = libraryId
+      self.instanceId = instanceId
+      self.name = name
+      self.url = url
+      self.number = number
+      self.created = created
+      self.lastModified = lastModified
+      self.sizeBytes = sizeBytes
+      self.size = size
+
+      self.mediaRaw = RawCodableStore.encode(media)
+      self.metadataRaw = RawCodableStore.encode(metadata)
+      self.readProgressRaw = RawCodableStore.encodeOptional(readProgress)
+
+      self.mediaPagesCount = media.pagesCount
+      self.mediaProfile = media.mediaProfile
+      self.metaTitle = metadata.title
+      self.metaNumber = metadata.number
+      self.metaNumberSort = metadata.numberSort
+      self.metaReleaseDate = metadata.releaseDate
+      self.progressPage = readProgress?.page
+      self.progressCompleted = readProgress?.completed
+      self.progressReadDate = readProgress?.readDate
+      self.metaAuthorsIndex = MetadataIndex.encode(values: metadata.authors?.map(\.name) ?? [])
+      self.metaTagsIndex = MetadataIndex.encode(values: metadata.tags ?? [])
+
+      self.seriesTitle = seriesTitle
+      self.isUnavailable = isUnavailable
+      self.oneshot = oneshot
+      self.downloadedSize = downloadedSize
+      self.readListIdsRaw = try? JSONEncoder().encode([] as [String])
+      self.isolatePagesRaw = try? JSONEncoder().encode([] as [Int])
+      self.pageRotationsRaw = nil
+      self.epubPreferencesRaw = nil
+      self.epubProgressionRaw = nil
+    }
+  }
+
+  @Model
+  final class KomgaCollection {
+    @Attribute(.unique) var id: String  // Composite: CompositeID.generate
+
+    var collectionId: String
+    var instanceId: String
+
+    var name: String
+    var ordered: Bool
+    var createdDate: Date
+    var lastModifiedDate: Date
+    var filtered: Bool
+    var isPinned: Bool = false
+
+    var seriesIdsRaw: Data?
+
+    init(
+      id: String? = nil,
+      collectionId: String,
+      instanceId: String,
+      name: String,
+      ordered: Bool,
+      createdDate: Date,
+      lastModifiedDate: Date,
+      filtered: Bool,
+      isPinned: Bool = false,
+      seriesIds: [String] = []
+    ) {
+      self.id = id ?? CompositeID.generate(instanceId: instanceId, id: collectionId)
+      self.collectionId = collectionId
+      self.instanceId = instanceId
+      self.name = name
+      self.ordered = ordered
+      self.createdDate = createdDate
+      self.lastModifiedDate = lastModifiedDate
+      self.filtered = filtered
+      self.isPinned = isPinned
+      self.seriesIdsRaw = try? JSONEncoder().encode(seriesIds)
+    }
+  }
+
+  @Model
+  final class KomgaReadList {
+    @Attribute(.unique) var id: String  // Composite: CompositeID.generate
+
+    var readListId: String
+    var instanceId: String
+
+    var name: String
+    var summary: String
+    var ordered: Bool
+    var createdDate: Date
+    var lastModifiedDate: Date
+    var filtered: Bool
+    var isPinned: Bool = false
+
+    var bookIdsRaw: Data?
+
+    // Track offline download status (managed locally, manual only)
+    var downloadStatusRaw: String = "notDownloaded"
+    var downloadError: String?
+    var downloadAt: Date?
+    var downloadedSize: Int64 = 0
+    var downloadedBooks: Int = 0
+    var pendingBooks: Int = 0
+
+    init(
+      id: String? = nil,
+      readListId: String,
+      instanceId: String,
+      name: String,
+      summary: String,
+      ordered: Bool,
+      createdDate: Date,
+      lastModifiedDate: Date,
+      filtered: Bool,
+      isPinned: Bool = false,
+      bookIds: [String] = [],
+      downloadedBooks: Int = 0,
+      pendingBooks: Int = 0,
+      downloadedSize: Int64 = 0
+    ) {
+      self.id = id ?? CompositeID.generate(instanceId: instanceId, id: readListId)
+      self.readListId = readListId
+      self.instanceId = instanceId
+      self.name = name
+      self.summary = summary
+      self.ordered = ordered
+      self.createdDate = createdDate
+      self.lastModifiedDate = lastModifiedDate
+      self.filtered = filtered
+      self.isPinned = isPinned
+      self.bookIdsRaw = try? JSONEncoder().encode(bookIds)
+      self.downloadedBooks = downloadedBooks
+      self.pendingBooks = pendingBooks
+      self.downloadedSize = downloadedSize
+    }
+  }
+
+  @Model
+  final class CustomFontV1 {
+    @Attribute(.unique) var name: String
+    var path: String?  // File path for imported fonts, nil for system/manual fonts
+    var fileName: String?  // Original file name for imported fonts
+    var fileSize: Int64?  // File size in bytes for imported fonts
+    var createdAt: Date
+
+    init(name: String, path: String? = nil, fileName: String? = nil, fileSize: Int64? = nil, createdAt: Date = Date()) {
+      self.name = name
+      self.path = path
+      self.fileName = fileName
+      self.fileSize = fileSize
+      self.createdAt = createdAt
+    }
+  }
+
+  @Model
+  final class PendingProgress {
+    @Attribute(.unique) var id: String  // Composite: "instanceId_bookId"
+
+    var instanceId: String
+    var bookId: String
+    var page: Int
+    var completed: Bool
+    var createdAt: Date
+    var progressionData: Data?  // For EPUB R2Progression
+
+    init(
+      instanceId: String,
+      bookId: String,
+      page: Int,
+      completed: Bool,
+      progressionData: Data? = nil
+    ) {
+      self.id = CompositeID.generate(instanceId: instanceId, id: bookId)
+      self.instanceId = instanceId
+      self.bookId = bookId
+      self.page = page
+      self.completed = completed
+      self.createdAt = Date()
+      self.progressionData = progressionData
+    }
+  }
+
+  @Model
+  final class SavedFilterV1 {
+    @Attribute(.unique) var id: UUID
+
+    var name: String
+    var filterTypeRaw: String
+    var filterDataJSON: String
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(
+      id: UUID = UUID(),
+      name: String,
+      filterType: SavedFilterType,
+      filterDataJSON: String,
+      createdAt: Date = Date(),
+      updatedAt: Date = Date()
+    ) {
+      self.id = id
+      self.name = name
+      self.filterTypeRaw = filterType.rawValue
+      self.filterDataJSON = filterDataJSON
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+    }
+  }
+
+  @Model
+  final class EpubThemePresetV1 {
+    @Attribute(.unique) var id: UUID
+
+    var name: String
+    var preferencesJSON: String
+    var createdAt: Date
+    var updatedAt: Date
+
+    init(
+      id: UUID = UUID(),
+      name: String,
+      preferencesJSON: String,
+      createdAt: Date = Date(),
+      updatedAt: Date = Date()
+    ) {
+      self.id = id
+      self.name = name
+      self.preferencesJSON = preferencesJSON
+      self.createdAt = createdAt
+      self.updatedAt = updatedAt
+    }
+  }
+}

--- a/KMReader/Features/Auth/Models/KomgaInstance.swift
+++ b/KMReader/Features/Auth/Models/KomgaInstance.swift
@@ -1,51 +1,13 @@
 //
 // KomgaInstance.swift
 //
-//
 
 import Foundation
 import SwiftData
 
-@Model
-final class KomgaInstance {
-  @Attribute(.unique) var id: UUID
-  var name: String
-  var serverURL: String
-  var username: String
-  var authToken: String
-  var isAdmin: Bool
-  var authMethod: AuthenticationMethod? = AuthenticationMethod.basicAuth
-  var createdAt: Date
-  var lastUsedAt: Date
-  var seriesLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
-  var booksLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
+typealias KomgaInstance = KMReaderSchemaV6.KomgaInstance
 
-  init(
-    id: UUID = UUID(),
-    name: String,
-    serverURL: String,
-    username: String,
-    authToken: String,
-    isAdmin: Bool,
-    authMethod: AuthenticationMethod = .basicAuth,
-    createdAt: Date = Date(),
-    lastUsedAt: Date = Date(),
-    seriesLastSyncedAt: Date = Date(timeIntervalSince1970: 0),
-    booksLastSyncedAt: Date = Date(timeIntervalSince1970: 0)
-  ) {
-    self.id = id
-    self.name = name
-    self.serverURL = serverURL
-    self.username = username
-    self.authToken = authToken
-    self.isAdmin = isAdmin
-    self.authMethod = authMethod
-    self.createdAt = createdAt
-    self.lastUsedAt = lastUsedAt
-    self.seriesLastSyncedAt = seriesLastSyncedAt
-    self.booksLastSyncedAt = booksLastSyncedAt
-  }
-
+extension KomgaInstance {
   var displayName: String {
     name.isEmpty ? serverURL : name
   }

--- a/KMReader/Features/Book/Models/KomgaBook.swift
+++ b/KMReader/Features/Book/Models/KomgaBook.swift
@@ -1,69 +1,13 @@
 //
 // KomgaBook.swift
 //
-//
 
 import Foundation
 import SwiftData
 
-@Model
-final class KomgaBook {
-  @Attribute(.unique) var id: String  // Composite: CompositeID.generate
+typealias KomgaBook = KMReaderSchemaV6.KomgaBook
 
-  var bookId: String
-  var seriesId: String
-  var libraryId: String
-  var instanceId: String
-
-  var name: String
-  var url: String
-  var number: Double
-  var created: Date
-  var lastModified: Date
-  var sizeBytes: Int64
-  var size: String
-
-  // API-aligned raw storage
-  var mediaRaw: Data?
-  var metadataRaw: Data?
-  var readProgressRaw: Data?
-
-  // Query fields
-  var mediaPagesCount: Int
-  var mediaProfile: String?
-  var metaTitle: String
-  var metaNumber: String
-  var metaNumberSort: Double
-  var metaReleaseDate: String?
-  var progressPage: Int?
-  var progressCompleted: Bool?
-  var progressReadDate: Date?
-  var metaAuthorsIndex: String = "|"
-  var metaTagsIndex: String = "|"
-
-  var isUnavailable: Bool = false
-  var oneshot: Bool
-  var seriesTitle: String = ""
-
-  // Metadata storage
-  var pagesRaw: Data?
-  var tocRaw: Data?
-  var webPubManifestRaw: Data?
-  var epubProgressionRaw: Data?
-
-  // Track offline download status (managed locally)
-  var downloadStatusRaw: String = "notDownloaded"
-  var downloadError: String?
-  var downloadAt: Date?
-  var downloadedSize: Int64 = 0
-
-  // Cached read list IDs containing this book
-  var readListIdsRaw: Data?
-
-  var isolatePagesRaw: Data?
-  var pageRotationsRaw: Data?
-  var epubPreferencesRaw: String?
-
+extension KomgaBook {
   var readListIds: [String] {
     get { readListIdsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? [] }
     set { readListIdsRaw = try? JSONEncoder().encode(newValue) }
@@ -147,67 +91,6 @@ final class KomgaBook {
 
   var isInProgress: Bool {
     hasStartedReading && !isCompleted
-  }
-
-  init(
-    id: String? = nil,
-    bookId: String,
-    seriesId: String,
-    libraryId: String,
-    instanceId: String,
-    name: String,
-    url: String,
-    number: Double,
-    created: Date,
-    lastModified: Date,
-    sizeBytes: Int64,
-    size: String,
-    media: Media,
-    metadata: BookMetadata,
-    readProgress: ReadProgress?,
-    isUnavailable: Bool,
-    oneshot: Bool,
-    seriesTitle: String = "",
-    downloadedSize: Int64 = 0
-  ) {
-    self.id = id ?? CompositeID.generate(instanceId: instanceId, id: bookId)
-    self.bookId = bookId
-    self.seriesId = seriesId
-    self.libraryId = libraryId
-    self.instanceId = instanceId
-    self.name = name
-    self.url = url
-    self.number = number
-    self.created = created
-    self.lastModified = lastModified
-    self.sizeBytes = sizeBytes
-    self.size = size
-
-    self.mediaRaw = RawCodableStore.encode(media)
-    self.metadataRaw = RawCodableStore.encode(metadata)
-    self.readProgressRaw = RawCodableStore.encodeOptional(readProgress)
-
-    self.mediaPagesCount = media.pagesCount
-    self.mediaProfile = media.mediaProfile
-    self.metaTitle = metadata.title
-    self.metaNumber = metadata.number
-    self.metaNumberSort = metadata.numberSort
-    self.metaReleaseDate = metadata.releaseDate
-    self.progressPage = readProgress?.page
-    self.progressCompleted = readProgress?.completed
-    self.progressReadDate = readProgress?.readDate
-    self.metaAuthorsIndex = MetadataIndex.encode(values: metadata.authors?.map(\.name) ?? [])
-    self.metaTagsIndex = MetadataIndex.encode(values: metadata.tags ?? [])
-
-    self.seriesTitle = seriesTitle
-    self.isUnavailable = isUnavailable
-    self.oneshot = oneshot
-    self.downloadedSize = downloadedSize
-    self.readListIdsRaw = try? JSONEncoder().encode([] as [String])
-    self.isolatePagesRaw = try? JSONEncoder().encode([] as [Int])
-    self.pageRotationsRaw = nil
-    self.epubPreferencesRaw = nil
-    self.epubProgressionRaw = nil
   }
 
   func updateMedia(_ media: Media, raw: Data?) {

--- a/KMReader/Features/Browse/Models/SavedFilter.swift
+++ b/KMReader/Features/Browse/Models/SavedFilter.swift
@@ -32,18 +32,9 @@ enum SavedFilterType: String, CaseIterable, Identifiable {
   }
 }
 
-typealias SavedFilter = SavedFilterV1
+typealias SavedFilter = KMReaderSchemaV6.SavedFilterV1
 
-@Model
-final class SavedFilterV1 {
-  @Attribute(.unique) var id: UUID
-
-  var name: String
-  var filterTypeRaw: String
-  var filterDataJSON: String
-  var createdAt: Date
-  var updatedAt: Date
-
+extension SavedFilter {
   var filterType: SavedFilterType {
     get {
       SavedFilterType(rawValue: filterTypeRaw) ?? .series
@@ -51,22 +42,6 @@ final class SavedFilterV1 {
     set {
       filterTypeRaw = newValue.rawValue
     }
-  }
-
-  init(
-    id: UUID = UUID(),
-    name: String,
-    filterType: SavedFilterType,
-    filterDataJSON: String,
-    createdAt: Date = Date(),
-    updatedAt: Date = Date()
-  ) {
-    self.id = id
-    self.name = name
-    self.filterTypeRaw = filterType.rawValue
-    self.filterDataJSON = filterDataJSON
-    self.createdAt = createdAt
-    self.updatedAt = updatedAt
   }
 
   @MainActor

--- a/KMReader/Features/Collection/Models/KomgaCollection.swift
+++ b/KMReader/Features/Collection/Models/KomgaCollection.swift
@@ -1,54 +1,16 @@
 //
 // KomgaCollection.swift
 //
-//
 
 import Foundation
 import SwiftData
 
-@Model
-final class KomgaCollection {
-  @Attribute(.unique) var id: String  // Composite: CompositeID.generate
+typealias KomgaCollection = KMReaderSchemaV6.KomgaCollection
 
-  var collectionId: String
-  var instanceId: String
-
-  var name: String
-  var ordered: Bool
-  var createdDate: Date
-  var lastModifiedDate: Date
-  var filtered: Bool
-  var isPinned: Bool = false
-
-  var seriesIdsRaw: Data?
-
+extension KomgaCollection {
   var seriesIds: [String] {
     get { seriesIdsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? [] }
     set { seriesIdsRaw = try? JSONEncoder().encode(newValue) }
-  }
-
-  init(
-    id: String? = nil,
-    collectionId: String,
-    instanceId: String,
-    name: String,
-    ordered: Bool,
-    createdDate: Date,
-    lastModifiedDate: Date,
-    filtered: Bool,
-    isPinned: Bool = false,
-    seriesIds: [String] = []
-  ) {
-    self.id = id ?? CompositeID.generate(instanceId: instanceId, id: collectionId)
-    self.collectionId = collectionId
-    self.instanceId = instanceId
-    self.name = name
-    self.ordered = ordered
-    self.createdDate = createdDate
-    self.lastModifiedDate = lastModifiedDate
-    self.filtered = filtered
-    self.isPinned = isPinned
-    self.seriesIdsRaw = try? JSONEncoder().encode(seriesIds)
   }
 
   func toCollection() -> SeriesCollection {

--- a/KMReader/Features/Library/Models/KomgaLibrary.swift
+++ b/KMReader/Features/Library/Models/KomgaLibrary.swift
@@ -1,52 +1,8 @@
 //
 // KomgaLibrary.swift
 //
-//
 
 import Foundation
 import SwiftData
 
-@Model
-final class KomgaLibrary {
-  static let allLibrariesId = "__all_libraries__"
-
-  @Attribute(.unique) var id: UUID
-  var instanceId: String
-  var libraryId: String
-  var name: String
-  var createdAt: Date
-
-  // Metrics
-  var fileSize: Double?
-  var booksCount: Double?
-  var seriesCount: Double?
-  var sidecarsCount: Double?
-  var collectionsCount: Double?
-  var readlistsCount: Double?
-
-  init(
-    id: UUID = UUID(),
-    instanceId: String,
-    libraryId: String,
-    name: String,
-    createdAt: Date = Date(),
-    fileSize: Double? = nil,
-    booksCount: Double? = nil,
-    seriesCount: Double? = nil,
-    sidecarsCount: Double? = nil,
-    collectionsCount: Double? = nil,
-    readlistsCount: Double? = nil
-  ) {
-    self.id = id
-    self.instanceId = instanceId
-    self.libraryId = libraryId
-    self.name = name
-    self.createdAt = createdAt
-    self.fileSize = fileSize
-    self.booksCount = booksCount
-    self.seriesCount = seriesCount
-    self.sidecarsCount = sidecarsCount
-    self.collectionsCount = collectionsCount
-    self.readlistsCount = readlistsCount
-  }
-}
+typealias KomgaLibrary = KMReaderSchemaV6.KomgaLibrary

--- a/KMReader/Features/ReadList/Models/KomgaReadList.swift
+++ b/KMReader/Features/ReadList/Models/KomgaReadList.swift
@@ -1,40 +1,17 @@
 //
 // KomgaReadList.swift
 //
-//
 
 import Foundation
 import SwiftData
 
-@Model
-final class KomgaReadList {
-  @Attribute(.unique) var id: String  // Composite: CompositeID.generate
+typealias KomgaReadList = KMReaderSchemaV6.KomgaReadList
 
-  var readListId: String
-  var instanceId: String
-
-  var name: String
-  var summary: String
-  var ordered: Bool
-  var createdDate: Date
-  var lastModifiedDate: Date
-  var filtered: Bool
-  var isPinned: Bool = false
-
-  var bookIdsRaw: Data?
-
+extension KomgaReadList {
   var bookIds: [String] {
     get { bookIdsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? [] }
     set { bookIdsRaw = try? JSONEncoder().encode(newValue) }
   }
-
-  // Track offline download status (managed locally, manual only)
-  var downloadStatusRaw: String = "notDownloaded"
-  var downloadError: String?
-  var downloadAt: Date?
-  var downloadedSize: Int64 = 0
-  var downloadedBooks: Int = 0
-  var pendingBooks: Int = 0
 
   /// Computed property for download status.
   var downloadStatus: SeriesDownloadStatus {
@@ -55,38 +32,6 @@ final class KomgaReadList {
     }
 
     return .notDownloaded
-  }
-
-  init(
-    id: String? = nil,
-    readListId: String,
-    instanceId: String,
-    name: String,
-    summary: String,
-    ordered: Bool,
-    createdDate: Date,
-    lastModifiedDate: Date,
-    filtered: Bool,
-    isPinned: Bool = false,
-    bookIds: [String] = [],
-    downloadedBooks: Int = 0,
-    pendingBooks: Int = 0,
-    downloadedSize: Int64 = 0
-  ) {
-    self.id = id ?? CompositeID.generate(instanceId: instanceId, id: readListId)
-    self.readListId = readListId
-    self.instanceId = instanceId
-    self.name = name
-    self.summary = summary
-    self.ordered = ordered
-    self.createdDate = createdDate
-    self.lastModifiedDate = lastModifiedDate
-    self.filtered = filtered
-    self.isPinned = isPinned
-    self.bookIdsRaw = try? JSONEncoder().encode(bookIds)
-    self.downloadedBooks = downloadedBooks
-    self.pendingBooks = pendingBooks
-    self.downloadedSize = downloadedSize
   }
 
   func toReadList() -> ReadList {

--- a/KMReader/Features/Reader/Models/CustomFont.swift
+++ b/KMReader/Features/Reader/Models/CustomFont.swift
@@ -1,26 +1,8 @@
 //
 // CustomFont.swift
 //
-//
 
 import Foundation
 import SwiftData
 
-typealias CustomFont = CustomFontV1
-
-@Model
-final class CustomFontV1 {
-  @Attribute(.unique) var name: String
-  var path: String?  // File path for imported fonts, nil for system/manual fonts
-  var fileName: String?  // Original file name for imported fonts
-  var fileSize: Int64?  // File size in bytes for imported fonts
-  var createdAt: Date
-
-  init(name: String, path: String? = nil, fileName: String? = nil, fileSize: Int64? = nil, createdAt: Date = Date()) {
-    self.name = name
-    self.path = path
-    self.fileName = fileName
-    self.fileSize = fileSize
-    self.createdAt = createdAt
-  }
-}
+typealias CustomFont = KMReaderSchemaV6.CustomFontV1

--- a/KMReader/Features/Reader/Models/EpubThemePreset.swift
+++ b/KMReader/Features/Reader/Models/EpubThemePreset.swift
@@ -1,36 +1,13 @@
 //
 // EpubThemePreset.swift
 //
-//
 
 import Foundation
 import SwiftData
 
-typealias EpubThemePreset = EpubThemePresetV1
+typealias EpubThemePreset = KMReaderSchemaV6.EpubThemePresetV1
 
-@Model
-final class EpubThemePresetV1 {
-  @Attribute(.unique) var id: UUID
-
-  var name: String
-  var preferencesJSON: String
-  var createdAt: Date
-  var updatedAt: Date
-
-  init(
-    id: UUID = UUID(),
-    name: String,
-    preferencesJSON: String,
-    createdAt: Date = Date(),
-    updatedAt: Date = Date()
-  ) {
-    self.id = id
-    self.name = name
-    self.preferencesJSON = preferencesJSON
-    self.createdAt = createdAt
-    self.updatedAt = updatedAt
-  }
-
+extension EpubThemePreset {
   @MainActor
   func getPreferences() -> EpubReaderPreferences? {
     return EpubReaderPreferences(rawValue: preferencesJSON)

--- a/KMReader/Features/Series/Models/KomgaSeries.swift
+++ b/KMReader/Features/Series/Models/KomgaSeries.swift
@@ -1,58 +1,13 @@
 //
 // KomgaSeries.swift
 //
-//
 
 import Foundation
 import SwiftData
 
-@Model
-final class KomgaSeries {
-  @Attribute(.unique) var id: String  // Composite: CompositeID.generate
+typealias KomgaSeries = KMReaderSchemaV6.KomgaSeries
 
-  var seriesId: String
-  var libraryId: String
-  var instanceId: String
-
-  var name: String
-  var url: String
-  var created: Date
-  var lastModified: Date
-
-  var booksCount: Int
-  var booksReadCount: Int
-  var booksUnreadCount: Int
-  var booksInProgressCount: Int
-
-  // API-aligned raw storage
-  var metadataRaw: Data?
-  var booksMetadataRaw: Data?
-
-  // Query fields
-  var metaTitle: String
-  var metaTitleSort: String
-  var metaPublisherIndex: String = "|"
-  var metaAuthorsIndex: String = "|"
-  var metaGenresIndex: String = "|"
-  var metaTagsIndex: String = "|"
-  var metaLanguageIndex: String = "|"
-
-  var isUnavailable: Bool = false
-  var oneshot: Bool
-
-  // Track offline download status (managed locally)
-  var downloadStatusRaw: String = "notDownloaded"
-  var downloadError: String?
-  var downloadAt: Date?
-  var downloadedSize: Int64 = 0
-  var downloadedBooks: Int = 0
-  var pendingBooks: Int = 0
-  var offlinePolicyRaw: String = "manual"
-  var offlinePolicyLimit: Int = 0
-
-  // Cached collection IDs containing this series
-  var collectionIdsRaw: Data?
-
+extension KomgaSeries {
   var collectionIds: [String] {
     get {
       collectionIdsRaw.flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? []
@@ -108,62 +63,6 @@ final class KomgaSeries {
     set {
       offlinePolicyRaw = newValue.rawValue
     }
-  }
-
-  init(
-    id: String? = nil,
-    seriesId: String,
-    libraryId: String,
-    instanceId: String,
-    name: String,
-    url: String,
-    created: Date,
-    lastModified: Date,
-    booksCount: Int,
-    booksReadCount: Int,
-    booksUnreadCount: Int,
-    booksInProgressCount: Int,
-    metadata: SeriesMetadata,
-    booksMetadata: SeriesBooksMetadata,
-    isUnavailable: Bool,
-    oneshot: Bool,
-    downloadedBooks: Int = 0,
-    pendingBooks: Int = 0,
-    downloadedSize: Int64 = 0,
-    offlinePolicy: SeriesOfflinePolicy = .manual,
-    offlinePolicyLimit: Int = 0
-  ) {
-    self.id = id ?? CompositeID.generate(instanceId: instanceId, id: seriesId)
-    self.seriesId = seriesId
-    self.libraryId = libraryId
-    self.instanceId = instanceId
-    self.name = name
-    self.url = url
-    self.created = created
-    self.lastModified = lastModified
-    self.booksCount = booksCount
-    self.booksReadCount = booksReadCount
-    self.booksUnreadCount = booksUnreadCount
-    self.booksInProgressCount = booksInProgressCount
-
-    self.metadataRaw = RawCodableStore.encode(metadata)
-    self.booksMetadataRaw = RawCodableStore.encode(booksMetadata)
-    self.metaTitle = metadata.title
-    self.metaTitleSort = metadata.titleSort
-    self.metaPublisherIndex = MetadataIndex.encode(value: metadata.publisher)
-    self.metaAuthorsIndex = MetadataIndex.encode(values: booksMetadata.authors?.map(\.name) ?? [])
-    self.metaGenresIndex = MetadataIndex.encode(values: metadata.genres ?? [])
-    self.metaTagsIndex = MetadataIndex.encode(values: metadata.tags ?? [])
-    self.metaLanguageIndex = MetadataIndex.encode(value: metadata.language)
-
-    self.isUnavailable = isUnavailable
-    self.oneshot = oneshot
-    self.downloadedBooks = downloadedBooks
-    self.pendingBooks = pendingBooks
-    self.downloadedSize = downloadedSize
-    self.offlinePolicyRaw = offlinePolicy.rawValue
-    self.offlinePolicyLimit = offlinePolicyLimit
-    self.collectionIdsRaw = try? JSONEncoder().encode([] as [String])
   }
 
   func updateMetadata(_ metadata: SeriesMetadata, raw: Data?) {

--- a/KMReader/Features/Sync/Models/PendingProgress.swift
+++ b/KMReader/Features/Sync/Models/PendingProgress.swift
@@ -1,35 +1,8 @@
 //
 // PendingProgress.swift
 //
-//
 
 import Foundation
 import SwiftData
 
-@Model
-final class PendingProgress {
-  @Attribute(.unique) var id: String  // Composite: "instanceId_bookId"
-
-  var instanceId: String
-  var bookId: String
-  var page: Int
-  var completed: Bool
-  var createdAt: Date
-  var progressionData: Data?  // For EPUB R2Progression
-
-  init(
-    instanceId: String,
-    bookId: String,
-    page: Int,
-    completed: Bool,
-    progressionData: Data? = nil
-  ) {
-    self.id = CompositeID.generate(instanceId: instanceId, id: bookId)
-    self.instanceId = instanceId
-    self.bookId = bookId
-    self.page = page
-    self.completed = completed
-    self.createdAt = Date()
-    self.progressionData = progressionData
-  }
-}
+typealias PendingProgress = KMReaderSchemaV6.PendingProgress

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -76,13 +76,75 @@ struct MainApp: App {
   }
 
   private func makeModelContainer() throws -> ModelContainer {
-    let schema = Schema(versionedSchema: KMReaderSchemaV5.self)
+    let schema = Schema(versionedSchema: KMReaderSchemaV6.self)
     let configuration = ModelConfiguration(schema: schema)
-    return try ModelContainer(
-      for: schema,
-      migrationPlan: KMReaderMigrationPlan.self,
-      configurations: [configuration]
-    )
+
+    do {
+      return try ModelContainer(
+        for: schema,
+        migrationPlan: KMReaderMigrationPlan.self,
+        configurations: [configuration]
+      )
+    } catch {
+      guard Self.isUnknownModelVersionError(error) else {
+        throw error
+      }
+
+      AppLogger(.database).warning(
+        "Staged SwiftData migration could not identify the source model version; retrying with inferred lightweight migration for legacy runtime-backed V4/V5 stores"
+      )
+      return try ModelContainer(for: schema, configurations: [configuration])
+    }
+  }
+
+  private static func isUnknownModelVersionError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    return containsUnknownModelVersion(in: nsError, visited: [])
+  }
+
+  private static func containsUnknownModelVersion(
+    in error: NSError,
+    visited: Set<String>
+  ) -> Bool {
+    let key = "\(error.domain):\(error.code):\(Unmanaged.passUnretained(error).toOpaque())"
+    guard !visited.contains(key) else { return false }
+    var visited = visited
+    visited.insert(key)
+
+    let messages = [
+      error.localizedDescription,
+      error.localizedFailureReason,
+      error.localizedRecoverySuggestion,
+      String(describing: error),
+    ]
+    if messages.contains(where: { message in
+      message?.localizedCaseInsensitiveContains("unknown model version") == true
+        || message?.localizedCaseInsensitiveContains("Cannot use staged migration") == true
+    }) {
+      return true
+    }
+
+    if error.domain == NSCocoaErrorDomain, error.code == 134_504 {
+      return true
+    }
+
+    for value in error.userInfo.values {
+      if let nested = value as? NSError,
+        containsUnknownModelVersion(in: nested, visited: visited)
+      {
+        return true
+      }
+      if let nestedErrors = value as? [NSError],
+        nestedErrors.contains(where: { containsUnknownModelVersion(in: $0, visited: visited) })
+      {
+        return true
+      }
+      if String(describing: value).localizedCaseInsensitiveContains("unknown model version") {
+        return true
+      }
+    }
+
+    return false
   }
 
   @MainActor


### PR DESCRIPTION
## Problem
The previous SwiftData schema history mixed runtime-backed model declarations with later schema snapshots. That makes direct upgrades from shipped runtime-backed stores fragile: build 428/V4 and v4.10-v4.11/V5 stores can fail staged migration with an unknown model version, while pointing the active schema at nested snapshot models without changing runtime type usage can crash on model casts.

## Approach
Move the active SwiftData model graph into a new schema-owned `KMReaderSchemaV6`, then expose those active models through top-level typealiases so existing app code fetches and inserts the same types that the active schema owns.

Model behavior now lives in extensions next to each typealias, while `KMReaderSchemaV6` keeps the persistence shape focused on stored fields and initializers. The staged migration graph handles the snapshot-backed history through V4, and `MainApp` keeps an inferred lightweight fallback for legacy runtime-backed V4/V5 stores that staged migration cannot identify.

## Scope
- Add schema-owned `KMReaderSchemaV6` as the active model graph
- Replace top-level `@Model` declarations with typealiases to V6 models
- Move computed properties and helper methods into extensions colocated with the typealiases
- Update the migration plan to target V6 and avoid matching polluted runtime-backed V5 in staged migration
- Retain fallback inferred migration for legacy runtime-backed V4/V5 stores
- Bump build number to 443

## Validation
- [x] `make build-ios-ci`
