### PR TITLE
fix(storage): retry inferred migration after staged failures

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 443;
+				CURRENT_PROJECT_VERSION = 444;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 443;
+				CURRENT_PROJECT_VERSION = 444;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 443;
+				CURRENT_PROJECT_VERSION = 444;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 443;
+				CURRENT_PROJECT_VERSION = 444;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -86,65 +86,12 @@ struct MainApp: App {
         configurations: [configuration]
       )
     } catch {
-      guard Self.isUnknownModelVersionError(error) else {
-        throw error
-      }
-
+      let stagedErrorMessage = String(describing: error)
       AppLogger(.database).warning(
-        "Staged SwiftData migration could not identify the source model version; retrying with inferred lightweight migration for legacy runtime-backed V4/V5 stores"
+        "Staged SwiftData migration failed; retrying with inferred lightweight migration for legacy runtime-backed V4/V5 stores: \(stagedErrorMessage)"
       )
       return try ModelContainer(for: schema, configurations: [configuration])
     }
-  }
-
-  private static func isUnknownModelVersionError(_ error: Error) -> Bool {
-    let nsError = error as NSError
-    return containsUnknownModelVersion(in: nsError, visited: [])
-  }
-
-  private static func containsUnknownModelVersion(
-    in error: NSError,
-    visited: Set<String>
-  ) -> Bool {
-    let key = "\(error.domain):\(error.code):\(Unmanaged.passUnretained(error).toOpaque())"
-    guard !visited.contains(key) else { return false }
-    var visited = visited
-    visited.insert(key)
-
-    let messages = [
-      error.localizedDescription,
-      error.localizedFailureReason,
-      error.localizedRecoverySuggestion,
-      String(describing: error),
-    ]
-    if messages.contains(where: { message in
-      message?.localizedCaseInsensitiveContains("unknown model version") == true
-        || message?.localizedCaseInsensitiveContains("Cannot use staged migration") == true
-    }) {
-      return true
-    }
-
-    if error.domain == NSCocoaErrorDomain, error.code == 134_504 {
-      return true
-    }
-
-    for value in error.userInfo.values {
-      if let nested = value as? NSError,
-        containsUnknownModelVersion(in: nested, visited: visited)
-      {
-        return true
-      }
-      if let nestedErrors = value as? [NSError],
-        nestedErrors.contains(where: { containsUnknownModelVersion(in: $0, visited: visited) })
-      {
-        return true
-      }
-      if String(describing: value).localizedCaseInsensitiveContains("unknown model version") {
-        return true
-      }
-    }
-
-    return false
   }
 
   @MainActor


### PR DESCRIPTION
## Problem
Build 428 upgrades can still fail with a generic `loadIssueModelContainer` error instead of exposing the underlying unknown model version message. That means the previous fallback gate can skip inferred lightweight migration even though the legacy runtime-backed V4/V5 store needs it.

## Approach
Retry opening the active SwiftData schema without the staged migration plan whenever the staged path fails. This lets legacy runtime-backed V4/V5 stores attempt Core Data's inferred lightweight migration even when SwiftData wraps the staged failure in a generic container-load error.

## Scope
- Broaden the SwiftData fallback path after staged migration failure
- Keep the active schema-owned V6 model graph unchanged
- Bump build number to 444

## Validation
- [x] `make build-ios-ci`
