### PR TITLE
chore(ci): upgrade GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Show Xcode version
         run: xcodebuild -version
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Show Xcode version
         run: xcodebuild -version
@@ -40,7 +40,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Show Xcode version
         run: xcodebuild -version

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,16 +26,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: static
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       marketing_changed: ${{ steps.changed.outputs.marketing_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -108,7 +108,7 @@ jobs:
     if: needs.detect.outputs.marketing_changed == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Ensure GitHub release exists
         env:
@@ -134,7 +134,7 @@ jobs:
         platform: [ios, macos, tvos]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare App Store Connect API key
         id: prepare
@@ -152,7 +152,7 @@ jobs:
           echo "APP_STORE_CONNECT_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Import codesign certs
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@v7
         with:
           p12-file-base64: ${{ secrets.APPSTORE_CERTIFICATES_FILE_BASE64 }}
           p12-password: ${{ secrets.APPSTORE_CERTIFICATES_PASSWORD }}


### PR DESCRIPTION
## Problem
The CI and release workflows are still pinned to older major versions of the GitHub Actions they use, including checkout v4, Pages v4/v3 actions, and import-codesign-certs v3.

## Approach
Update the workflow action references to the latest available major versions while keeping the existing workflow structure and inputs unchanged.

## Scope
- Upgrade `actions/checkout` to v6 across CI, Pages, and publish workflows
- Upgrade GitHub Pages actions to `configure-pages@v6`, `upload-pages-artifact@v5`, and `deploy-pages@v5`
- Upgrade `apple-actions/import-codesign-certs` to v7

## Validation
- [x] Workflow YAML files parse successfully with Ruby/Psych
- [x] Confirmed old action references are removed
