### PR TITLE
fix(reader): sync presented book on Divina cross-volume continuation

### DIFF
--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -1419,7 +1419,39 @@ struct DivinaReaderView: View {
       return false
     }
     viewModel.requestNavigation(toViewItem: adjacentItem)
+    syncPresentedBookIfCrossedSegmentBoundary(to: adjacentItem)
     return true
+  }
+
+  /// Sync presented-book identity with the segment the user just navigated
+  /// into. Without this, `session.book` stays pinned to the originally-opened
+  /// book; a later rebuild of the reader cover (memory pressure, parent
+  /// dependency churn) re-initializes `currentBookId` from `session.book.id`,
+  /// reruns `loadBook` for the stale book, lands the user at its stale
+  /// `readProgress.page`, and regresses its server-side completed state via
+  /// the ensuing ambient `updateProgress` write. PR #785's body explicitly
+  /// calls out this multi-segment reader scenario as a gap not covered by
+  /// the pending-progress conflict-resolution work.
+  ///
+  /// `currentBookId` is intentionally left untouched so the seamless
+  /// cross-volume UX is preserved — changing it retriggers `.task(id:)` and
+  /// shows a loading overlay mid-flip. Post-cross-boundary invariant:
+  ///   - `currentBookId` is the reader's load anchor (only changed by the
+  ///     explicit Next/Previous Book entry points or a fresh cover init).
+  ///   - `currentBook` / `session.book` follow the segment under the current
+  ///     reader page.
+  private func syncPresentedBookIfCrossedSegmentBoundary(to adjacentItem: ReaderViewItem) {
+    let newSegmentBookId = adjacentItem.pageID.bookId
+    guard newSegmentBookId != currentBook?.id,
+      let newBook = viewModel.currentBook(forSegmentBookId: newSegmentBookId)
+    else {
+      return
+    }
+    // Flush the outgoing book's progress so any pending terminal state
+    // (e.g. freshly-completed) is durable before further writes for the
+    // new book.
+    viewModel.flushProgress()
+    currentBook = newBook
   }
 
   private func jumpToPageID(_ pageID: ReaderPageID) {

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -1419,7 +1419,7 @@ struct DivinaReaderView: View {
       return false
     }
     viewModel.requestNavigation(toViewItem: adjacentItem)
-    syncPresentedBookIfCrossedSegmentBoundary(to: adjacentItem)
+    syncPresentedBookIfCrossedSegmentBoundary(toSegmentBookId: adjacentItem.pageID.bookId)
     return true
   }
 
@@ -1440,8 +1440,15 @@ struct DivinaReaderView: View {
   ///     explicit Next/Previous Book entry points or a fresh cover init).
   ///   - `currentBook` / `session.book` follow the segment under the current
   ///     reader page.
-  private func syncPresentedBookIfCrossedSegmentBoundary(to adjacentItem: ReaderViewItem) {
-    let newSegmentBookId = adjacentItem.pageID.bookId
+  ///
+  /// Must be invoked from every view-level call site that hands a navigation
+  /// request to the viewmodel (`requestNavigation(toViewItem:)` /
+  /// `requestNavigation(toPageID:)`), because once the next/previous segment
+  /// has been proactively preloaded by `preloadNextSegmentForCurrentPositionIfNeeded`,
+  /// the common-case page turn near a boundary goes through the direct
+  /// adjacent-item branch in `goToPagedReaderPosition` rather than
+  /// `navigateAcrossBoundaryIfNeeded`.
+  private func syncPresentedBookIfCrossedSegmentBoundary(toSegmentBookId newSegmentBookId: String) {
     guard newSegmentBookId != currentBook?.id,
       let newBook = viewModel.currentBook(forSegmentBookId: newSegmentBookId)
     else {
@@ -1457,6 +1464,7 @@ struct DivinaReaderView: View {
   private func jumpToPageID(_ pageID: ReaderPageID) {
     guard pageID != viewModel.currentReaderPage?.id else { return }
     viewModel.requestNavigation(toPageID: pageID)
+    syncPresentedBookIfCrossedSegmentBoundary(toSegmentBookId: pageID.bookId)
   }
 
   private func displayPageNumber(for pageID: ReaderPageID) -> Int {
@@ -1660,6 +1668,7 @@ struct DivinaReaderView: View {
 
     if let item = viewModel.adjacentViewItem(offset: offset) {
       viewModel.requestNavigation(toViewItem: item)
+      syncPresentedBookIfCrossedSegmentBoundary(toSegmentBookId: item.pageID.bookId)
     } else {
       Task { @MainActor in
         _ = await navigateAcrossBoundaryIfNeeded(offset: offset)


### PR DESCRIPTION
Closes #817

## Problem

While reading manga in a single uninterrupted foreground session, a user finished volume 1, continued past the end into volume 2 by flipping pages, read ~50 pages of volume 2, then mid-page-flip saw a loading screen and was teleported into the middle of volume 1. Closing the book revealed that volume 1's progress had regressed from "completed" to "in-progress at mid-page", while volume 2's progress was correct.

Reproduces on v4.12 / build 444. Likely also reproduces on macOS / tvOS.

## Root cause

Two contributing mechanisms compose:

**1. Cross-volume continuation doesn't update book identity.** `DivinaReaderView` has two paths from vol N → vol N+1:

- **Explicit** (tap the Next Book button): `openNextBook(nextBookId:)` at `DivinaReaderView.swift:1761`. Flushes progress, sets `currentBookId = nextBookId` (triggers `.task(id: currentBookId)` → `loadBook`), resets the viewmodel. Establishes new book identity correctly.
- **Silent** (just keep flipping): `navigateAcrossBoundaryIfNeeded(offset:)` at `DivinaReaderView.swift:1403`. Calls `viewModel.requestNavigation(toViewItem: adjacentItem)` and stops. The user is now reading vol N+1's pixels, but three pieces of book-identity state are still pointing at vol N:
  - `@State currentBookId` (only written at lines 105, 1769, 1790)
  - `@State currentBook` (only written at line 1063 inside `loadBook`)
  - `ReaderPresentationManager.currentSession.book` (driven by `.onChange(of: currentBook)` at 594–597, which never fires)

**2. Reader-cover rebuild re-inits from the stale session book.** The iOS reader is a `fullScreenCover` (`Shared/UI/ReaderOverlay.swift:18-33`) conditioned only on `currentSession != nil` with no `.id(session.id)` modifier. If SwiftUI rebuilds `DivinaReaderView` for any reason (memory pressure, parent dependency churn), the new init runs `self._currentBookId = State(initialValue: book.id)` where `book = session.book = vol N`. `.task(id: currentBookId)` then fires `loadBook(vol N)`, the loading screen shows, and the user lands at vol N's stale `readProgress.page` (either the completion PATCH hadn't fully propagated server-side or the cached `currentBook.readProgress` snapshot still holds the pre-completion value). The ensuing `.onChange(of: viewModel.currentReaderPage?.id)` (lines 741–751) fires `updateProgress()` → `submitPageProgress(bookId: vol N, page: midpage, completed: false)`, regressing vol N's completed state.

This is the gap explicitly called out as out-of-scope in PR #785's body:

> Direct online PATCHes from other client paths (e.g., the multi-segment reader navigating into an adjacent previously-completed book) regress the server without ever going through PendingProgress. Those would need a reader-layer guard, also out of scope.

## Fix

In `navigateAcrossBoundaryIfNeeded`, after `requestNavigation`, sync `currentBook` to the new segment's book. The existing `.onChange(of: currentBook)` propagates to `session.book`. Also flush the outgoing book's progress so any pending terminal state (e.g. freshly-completed) is durable before further writes for the new book.

`currentBookId` is intentionally left untouched so the seamless cross-volume UX is preserved — changing it retriggers `.task(id:)` and shows a loading overlay mid-flip. New invariant:

- `currentBookId` is the reader's load anchor (only changed by the explicit Next/Previous Book entry points or a fresh cover init).
- `currentBook` / `session.book` follow the segment under the current reader page.

After this fix, a cover rebuild while in vol N+1 seeds the new init from `session.book = vol N+1`, `.task` runs `loadBook(vol N+1)`, and the user recovers in vol N+1 at server-known progress — benign.

## Scope

- Add `syncPresentedBookIfCrossedSegmentBoundary(to:)` helper in `DivinaReaderView`.
- Invoke it from `navigateAcrossBoundaryIfNeeded` after `requestNavigation`.
- No-op when `adjacentItem.pageID.bookId == currentBook?.id` (no boundary crossed; e.g., navigation to the in-segment end-page view item).
- PDF and EPUB readers do not have a silent multi-segment cross-boundary path, so no change there.

## Open question (not blocking the fix)

The specific trigger for the iOS reader-cover rebuild in this user's session is not pinned down from static reading. Memory pressure is the most likely candidate (heavy CBZ pages can be megabytes each, and the multi-segment design keeps the previous volume's segment resident in the viewmodel during cross-boundary continuation). Doesn't affect the fix — the identity sync makes the rebuild benign regardless of trigger.

## Repro context

The user-reported session involved two manga TPB volumes at the heavy end of typical CBZ memory weight:

| | Vol N | Vol N+1 |
|---|---|---|
| Archive size | 186 MB | 207 MB |
| Page count | 203 | 212 |
| Average page (compressed PNG) | 936 KB | 997 KB |
| Max single page | 2.49 MB | 3.74 MB |
| Pages > 2 MB | 2 (both end-of-volume spreads) | 4 (one early spread, three end-of-volume spreads) |

A typical manga page at 1500×2200 px decodes to ~13 MB RGBA in memory (~26 MB at 2× retina); double-page spreads double that. The teleport-and-regress symptom occurred ~50 pages into vol N+1, by which point the reader holds a sliding window of decoded vol N+1 pages around p050 (each 700–1300 KB compressed → 15–40 MB decoded) plus the vol N segment still resident in the viewmodel from the silent boundary crossing. That's a plausible memory-pressure peak on iPhones with smaller heap budgets, leading to `didReceiveMemoryWarning` → SwiftUI view-body eviction → the unkeyed `fullScreenCover` rebuild path described above. Archives themselves are structurally clean (`unzip -t` reports no errors; PNG-only entries; zero-padded `pNNN` filenames that lexsort correctly; no ComicInfo.xml or junk entries).

## Testing

**Not tested.** I do not have an Xcode build environment for this project, so the change has not been built or run. The reasoning is purely static:

- One-line behavioral addition at the call site (`syncPresentedBookIfCrossedSegmentBoundary(to: adjacentItem)`) plus a self-contained helper.
- The helper short-circuits when no boundary is crossed (`newSegmentBookId == currentBook?.id`), preserving existing behavior for intra-segment navigation (including transitions to the in-segment `.end(...)` view item).
- The helper short-circuits when the new segment's book is not resolvable in the viewmodel (`viewModel.currentBook(forSegmentBookId:) == nil`), preserving existing behavior in any unexpected race state.
- `viewModel.flushProgress()` is idempotent in incognito mode (early-returns) and otherwise simply enqueues a flush of the currently-tracked book's progress — same call already issued at `closeReader` and `openNextBook`.
- Assigning `currentBook` engages the existing `.onChange(of: currentBook)` at lines 594–597, which is already exercised whenever `loadBook` resolves a book — no new code path in the presentation manager or downstream.

A maintainer with the build environment should verify:

1. Continuous-flip cross-volume reading still feels seamless (no loading screen at the boundary).
2. After crossing into vol N+1 by flipping, force a memory-pressure remount or rebuild — the reader recovers in vol N+1 (at server-known progress), not in vol N.
3. After crossing into vol N+1 by flipping, vol N's server-side progress remains `completed=true` (no regression on close).
4. Backward cross-boundary (flipping from vol N+1 page 0 backward into vol N's end page) also updates `currentBook` correctly.
5. The explicit Next/Previous Book button path still works (it always did — it goes through `openNextBook` / `openPreviousBook`, unchanged).
