### PR TITLE
feat(ui): move browse tab to trailing position

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 445;
+				CURRENT_PROJECT_VERSION = 446;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 445;
+				CURRENT_PROJECT_VERSION = 446;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 445;
+				CURRENT_PROJECT_VERSION = 446;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 445;
+				CURRENT_PROJECT_VERSION = 446;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/OldTabView.swift
+++ b/KMReader/OldTabView.swift
@@ -20,12 +20,6 @@ struct OldTabView: View {
       .tag(TabItem.home)
 
       NavigationStack {
-        rootContent(for: .browse)
-      }
-      .tabItem { TabItem.browse.label }
-      .tag(TabItem.browse)
-
-      NavigationStack {
         rootContent(for: .offline)
       }
       .tabItem { TabItem.offline.label }
@@ -42,6 +36,12 @@ struct OldTabView: View {
       }
       .tabItem { TabItem.settings.label }
       .tag(TabItem.settings)
+
+      NavigationStack {
+        rootContent(for: .browse)
+      }
+      .tabItem { TabItem.browse.label }
+      .tag(TabItem.browse)
     }
     .onAppear {
       if let link = deepLinkRouter.pendingDeepLink {

--- a/KMReader/PhoneTabView.swift
+++ b/KMReader/PhoneTabView.swift
@@ -21,12 +21,6 @@ import SwiftUI
           }
         }
 
-        Tab(TabItem.browse.title, systemImage: TabItem.browse.icon, value: TabItem.browse) {
-          NavigationStack {
-            rootContent(for: .browse)
-          }
-        }
-
         Tab(TabItem.offline.title, systemImage: TabItem.offline.icon, value: TabItem.offline) {
           NavigationStack {
             rootContent(for: .offline)
@@ -39,12 +33,18 @@ import SwiftUI
           }
         }
 
+        Tab(TabItem.settings.title, systemImage: TabItem.settings.icon, value: TabItem.settings) {
+          NavigationStack {
+            rootContent(for: .settings)
+          }
+        }
+
         Tab(
-          TabItem.settings.title, systemImage: TabItem.settings.icon, value: TabItem.settings,
+          TabItem.browse.title, systemImage: TabItem.browse.icon, value: TabItem.browse,
           role: .search
         ) {
           NavigationStack {
-            rootContent(for: .settings)
+            rootContent(for: .browse)
           }
         }
       }

--- a/KMReader/Shared/Foundation/Models/TabItem.swift
+++ b/KMReader/Shared/Foundation/Models/TabItem.swift
@@ -42,7 +42,7 @@ enum TabItem: Hashable, Identifiable {
     case .home:
       return "house"
     case .browse:
-      return ContentIcon.browse
+      return "magnifyingglass"
     case .offline:
       return "tray.and.arrow.down"
     case .server:

--- a/KMReader/TVTabView.swift
+++ b/KMReader/TVTabView.swift
@@ -21,12 +21,6 @@ import SwiftUI
           }
         }
 
-        Tab(TabItem.browse.title, systemImage: TabItem.browse.icon, value: TabItem.browse) {
-          NavigationStack {
-            rootContent(for: .browse)
-          }
-        }
-
         Tab(TabItem.offline.title, systemImage: TabItem.offline.icon, value: TabItem.offline) {
           NavigationStack {
             rootContent(for: .offline)
@@ -44,6 +38,12 @@ import SwiftUI
             NavigationStack {
               rootContent(for: .settings)
             }
+          }
+        }
+
+        Tab(TabItem.browse.title, systemImage: TabItem.browse.icon, value: TabItem.browse) {
+          NavigationStack {
+            rootContent(for: .browse)
           }
         }
       }


### PR DESCRIPTION
## Problem
The iPhone and tvOS tab order placed Browse near the primary tabs while the search-style entry point is better treated as a trailing utility tab. On iOS 18, the search role was also attached to Settings instead of the Browse destination.

## Approach
Move the Browse tab to the trailing position across the SwiftUI tab shells and attach the iOS 18 search role to Browse instead of Settings. Keep the existing Browse wording so the UI text remains unchanged.

## Scope
- Reorder Browse after Settings in the phone, legacy, and tvOS tab shells
- Move the iOS 18 `role: .search` from Settings to Browse
- Increment the build number to 446

## Validation
- [x] `make format`
- [x] `make build-ios`
