### PR TITLE
fix(reader): harden pagecurl controller state

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 446;
+				CURRENT_PROJECT_VERSION = 447;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 446;
+				CURRENT_PROJECT_VERSION = 447;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 446;
+				CURRENT_PROJECT_VERSION = 447;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 446;
+				CURRENT_PROJECT_VERSION = 447;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/CurlDualPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlDualPageView.swift
@@ -74,6 +74,16 @@
           direction: .forward,
           animated: false
         )
+      } else {
+        PageCurlControllerPlanner.safeSetViewControllers(
+          PageCurlControllerPlanner.placeholderControllers(
+            in: pageVC,
+            backgroundColor: UIColor(renderConfig.readerBackground.color)
+          ),
+          on: pageVC,
+          direction: .forward,
+          animated: false
+        )
       }
 
       return pageVC
@@ -508,6 +518,7 @@
       }
 
       func refreshVisibleControllerConfiguration() {
+        guard !isTransitioning else { return }
         guard let pageViewController else { return }
         guard let visibleControllers = pageViewController.viewControllers else { return }
         guard let spreadIndex = resolvedVisibleSpreadIndex() else { return }
@@ -639,11 +650,7 @@
         _ pageViewController: UIPageViewController,
         spineLocationFor orientation: UIInterfaceOrientation
       ) -> UIPageViewController.SpineLocation {
-        PageCurlControllerPlanner.configure(
-          pageViewController: pageViewController,
-          semanticContentAttribute: parent.mode.isRTL ? .forceRightToLeft : .forceLeftToRight
-        )
-        return .mid
+        .mid
       }
 
       @objc private func handleSingleTap(_ gesture: UITapGestureRecognizer) {

--- a/KMReader/Features/Reader/Views/CurlPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlPageView.swift
@@ -66,6 +66,16 @@
           direction: .forward,
           animated: false
         )
+      } else {
+        PageCurlControllerPlanner.safeSetViewControllers(
+          PageCurlControllerPlanner.placeholderControllers(
+            in: pageVC,
+            backgroundColor: UIColor(renderConfig.readerBackground.color)
+          ),
+          on: pageVC,
+          direction: .forward,
+          animated: false
+        )
       }
 
       return pageVC
@@ -311,6 +321,7 @@
       }
 
       func refreshVisibleControllerConfiguration() {
+        guard !isTransitioning else { return }
         guard let pageViewController else { return }
         guard let visibleController = pageViewController.viewControllers?.first else { return }
         guard let index = resolvedIndex(for: visibleController) else { return }
@@ -488,11 +499,7 @@
         _ pageViewController: UIPageViewController,
         spineLocationFor orientation: UIInterfaceOrientation
       ) -> UIPageViewController.SpineLocation {
-        PageCurlControllerPlanner.configure(
-          pageViewController: pageViewController,
-          semanticContentAttribute: parent.mode.isRTL ? .forceRightToLeft : .forceLeftToRight
-        )
-        return parent.mode.isRTL ? .max : .min
+        parent.mode.isRTL ? .max : .min
       }
 
       // MARK: - UIGestureRecognizerDelegate

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
@@ -89,10 +89,24 @@
           direction: .forward,
           animated: false
         )
+        context.coordinator.commitInstalledLocation(
+          chapterIndex: initialChapterIndex,
+          pageIndex: initialPageIndex
+        )
         if let initialVC = initialVC as? EpubPageViewController {
           context.coordinator.preloadAdjacentPages(for: initialVC, in: pageVC)
           context.coordinator.storeBacksideSnapshotIfReady(from: initialVC)
         }
+      } else {
+        PageCurlControllerPlanner.safeSetViewControllers(
+          PageCurlControllerPlanner.placeholderControllers(
+            in: pageVC,
+            backgroundColor: preferences.resolvedTheme(for: colorScheme).uiColorBackground
+          ),
+          on: pageVC,
+          direction: .forward,
+          animated: false
+        )
       }
 
       return pageVC
@@ -108,7 +122,12 @@
       let initialPageCount = viewModel.chapterPageCount(at: initialChapterIndex) ?? 1
       let initialPageIndex = max(0, min(viewModel.currentPageIndex, initialPageCount - 1))
 
-      if uiViewController.viewControllers?.isEmpty ?? true,
+      let visibleController = uiViewController.viewControllers?.first
+      let needsInitialControllers =
+        !context.coordinator.isAnimating
+        && !(visibleController is EpubPageViewController)
+        && !(visibleController is PageCurlBacksideViewController)
+      if needsInitialControllers,
         initialChapterIndex >= 0,
         initialChapterIndex < viewModel.chapterCount,
         let initialVC = context.coordinator.pageViewController(
@@ -130,17 +149,30 @@
           direction: .forward,
           animated: false
         )
-        context.coordinator.currentChapterIndex = initialChapterIndex
-        context.coordinator.currentPageIndex = initialPageIndex
+        context.coordinator.commitInstalledLocation(
+          chapterIndex: initialChapterIndex,
+          pageIndex: initialPageIndex
+        )
         if let initialVC = initialVC as? EpubPageViewController {
           context.coordinator.preloadAdjacentPages(for: initialVC, in: uiViewController)
           context.coordinator.storeBacksideSnapshotIfReady(from: initialVC)
         }
+      } else if needsInitialControllers {
+        PageCurlControllerPlanner.safeSetViewControllers(
+          PageCurlControllerPlanner.placeholderControllers(
+            in: uiViewController,
+            backgroundColor: preferences.resolvedTheme(for: colorScheme).uiColorBackground
+          ),
+          on: uiViewController,
+          direction: .forward,
+          animated: false
+        )
       }
 
       if let targetChapterIndex = viewModel.targetChapterIndex,
         let targetPageIndex = viewModel.targetPageIndex,
         !context.coordinator.isAnimating,
+        !(uiViewController.transitionCoordinator?.isAnimated ?? false),
         targetChapterIndex >= 0,
         targetChapterIndex < viewModel.chapterCount,
         targetChapterIndex != context.coordinator.currentChapterIndex
@@ -356,6 +388,23 @@
 
       private func cacheKey(chapterIndex: Int, pageIndex: Int) -> String {
         "\(chapterIndex)-\(pageIndex)"
+      }
+
+      func commitInstalledLocation(chapterIndex: Int, pageIndex: Int) {
+        currentChapterIndex = chapterIndex
+        currentPageIndex = pageIndex
+        if parent.viewModel.currentChapterIndex != chapterIndex {
+          parent.viewModel.currentChapterIndex = chapterIndex
+        }
+        if parent.viewModel.currentPageIndex != pageIndex {
+          parent.viewModel.currentPageIndex = pageIndex
+        }
+        if parent.viewModel.targetChapterIndex == chapterIndex,
+          parent.viewModel.targetPageIndex == pageIndex
+        {
+          parent.viewModel.targetChapterIndex = nil
+          parent.viewModel.targetPageIndex = nil
+        }
       }
 
       func storeBacksideSnapshotIfReady(from controller: EpubPageViewController) {
@@ -657,6 +706,7 @@
         willTransitionTo pendingViewControllers: [UIViewController]
       ) {
         guard !pendingViewControllers.isEmpty else { return }
+        isAnimating = true
         clearReservedControllers()
 
         for controller in pendingViewControllers {
@@ -698,6 +748,7 @@
         previousViewControllers: [UIViewController],
         transitionCompleted completed: Bool
       ) {
+        isAnimating = false
         pendingControllers.removeAll()
         clearReservedControllers()
 
@@ -740,8 +791,7 @@
         _ pageViewController: UIPageViewController,
         spineLocationFor orientation: UIInterfaceOrientation
       ) -> UIPageViewController.SpineLocation {
-        PageCurlControllerPlanner.configure(pageViewController: pageViewController)
-        return .min
+        .min
       }
 
       @objc func handleTap(_ recognizer: UITapGestureRecognizer) {

--- a/KMReader/Features/Reader/Views/PageCurlControllerPlanner.swift
+++ b/KMReader/Features/Reader/Views/PageCurlControllerPlanner.swift
@@ -53,14 +53,28 @@
       )
     }
 
+    static func placeholderControllers(
+      in pageViewController: UIPageViewController,
+      backgroundColor: UIColor = .clear
+    ) -> [UIViewController] {
+      normalizedControllers(
+        [placeholderController(backgroundColor: backgroundColor)],
+        in: pageViewController,
+        animated: false
+      )
+    }
+
     private static func requiredControllerCount(
       in pageViewController: UIPageViewController,
       animated: Bool
     ) -> Int {
+      if pageViewController.spineLocation == .mid {
+        return 2
+      }
       if animated && pageViewController.isDoubleSided {
         return 2
       }
-      return pageViewController.spineLocation == .mid ? 2 : 1
+      return 1
     }
 
     private static func normalizedControllers(
@@ -82,6 +96,12 @@
       let fallback = UIViewController()
       fallback.view.backgroundColor = primary.isViewLoaded ? primary.view.backgroundColor : .clear
       return fallback
+    }
+
+    private static func placeholderController(backgroundColor: UIColor) -> UIViewController {
+      let placeholder = UIViewController()
+      placeholder.view.backgroundColor = backgroundColor
+      return placeholder
     }
   }
 #endif


### PR DESCRIPTION
## Problem
Page curl readers could crash when UIKit received an inconsistent `UIPageViewController` state during SwiftUI mount or active page transitions. The highest-risk path was Divina dual-page curl with a middle spine, but EPUB page curl also had a fragile initial-open path when restoring directly to a middle page.

## Approach
Keep spine-location delegate callbacks side-effect-free, normalize controller sets before passing them to UIKit, and install safe placeholder controllers whenever the reader is not ready to provide real content yet. The EPUB page curl initial install now commits the coordinator state immediately, so the first SwiftUI update does not re-enter navigation from a stale chapter/page index.

## Scope
- Harden Divina single and dual page curl controller setup.
- Harden EPUB paged curl initial setup and transition guards.
- Add shared placeholder controller support in the page curl planner.
- Bump build version to 447 via the project `make bump` target.

## Validation
- [x] swift-format on changed Swift files
- [x] make build-ios-ci
- [x] xcodebuild generic iOS Simulator build with code signing disabled
- [x] git diff --check
