### PR TITLE
fix(reader): respond to iOS memory warnings by pruning decoded bitmaps

### DIFF
--- a/KMReader/Core/Storage/MemoryWarningCenter.swift
+++ b/KMReader/Core/Storage/MemoryWarningCenter.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+#if os(iOS) || os(tvOS)
+  import UIKit
+
+  @MainActor
+  protocol MemoryWarningListener: AnyObject {
+    func handleMemoryWarning()
+  }
+
+  @MainActor
+  final class MemoryWarningCenter {
+    static let shared = MemoryWarningCenter()
+
+    private struct WeakListener {
+      weak var value: (any MemoryWarningListener)?
+    }
+
+    private let logger = AppLogger(.app)
+    private var listeners: [WeakListener] = []
+
+    private init() {
+      Task { @MainActor [weak self] in
+        for await _ in NotificationCenter.default.notifications(
+          named: UIApplication.didReceiveMemoryWarningNotification
+        ) {
+          self?.notifyListeners()
+        }
+      }
+    }
+
+    func addListener(_ listener: any MemoryWarningListener) {
+      compactListeners()
+      guard !listeners.contains(where: { $0.value === listener }) else { return }
+      listeners.append(WeakListener(value: listener))
+    }
+
+    func removeListener(_ listener: any MemoryWarningListener) {
+      listeners.removeAll { $0.value == nil || $0.value === listener }
+    }
+
+    private func notifyListeners() {
+      compactListeners()
+      let liveListeners = listeners.compactMap(\.value)
+      logger.warning("⚠️ [Memory] Received memory warning; notifying \(liveListeners.count) listener(s)")
+      for listener in liveListeners {
+        listener.handleMemoryWarning()
+      }
+    }
+
+    private func compactListeners() {
+      listeners.removeAll { $0.value == nil }
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
+++ b/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
@@ -46,14 +46,6 @@ final class ReaderPageLoadScheduler {
   private var preloadTask: Task<Void, Never>?
   private var visiblePageIDs: [ReaderPageID] = []
 
-  #if os(iOS) || os(tvOS)
-    // `Task<Void, Never>` is Sendable, so this property is reachable from
-    // the nonisolated `deinit` even though the class is `@MainActor`. The
-    // older `addObserver(forName:object:queue:using:)` pattern returns a
-    // non-Sendable `NSObjectProtocol`, which would not be.
-    private nonisolated let memoryWarningObservation: Task<Void, Never>
-  #endif
-
   init(
     preloadBefore: Int = ReaderConstants.preloadBefore,
     preloadAfter: Int = ReaderConstants.preloadAfter,
@@ -66,30 +58,7 @@ final class ReaderPageLoadScheduler {
     self.keepRangeAfter = keepRangeAfter
 
     #if os(iOS) || os(tvOS)
-      // `UIApplication.didReceiveMemoryWarningNotification` is posted by
-      // UIKit when the system needs memory back. Without this observation,
-      // iOS's only recourse is to evict view bodies / hosting controllers —
-      // which forces a full `DivinaReaderView` rebuild and exercises the
-      // exact path PR #818 fixed against. Responding explicitly lets us
-      // release the in-memory bitmap cache (~10 decoded pages, frequently
-      // tens of MB each) gracefully without disturbing the view tree.
-      //
-      // The Task suspends on the AsyncSequence until a notification fires;
-      // `deinit` cancels the task, which terminates the iteration.
-      self.memoryWarningObservation = Task { @MainActor [weak self] in
-        for await _ in NotificationCenter.default.notifications(
-          named: UIApplication.didReceiveMemoryWarningNotification
-        ) {
-          guard !Task.isCancelled else { break }
-          self?.handleMemoryWarning()
-        }
-      }
-    #endif
-  }
-
-  deinit {
-    #if os(iOS) || os(tvOS)
-      memoryWarningObservation.cancel()
+      installMemoryWarningObservation()
     #endif
   }
 
@@ -245,6 +214,42 @@ final class ReaderPageLoadScheduler {
   }
 
   #if os(iOS) || os(tvOS)
+    /// Start the memory-warning observation Task. Called from `init` once
+    /// all stored properties are initialized — capturing `[weak self]`
+    /// inside an init-property initializer would trip Swift 6's "self
+    /// used before init" rule, so the capture is hoisted into a method.
+    ///
+    /// The Task is intentionally fire-and-forget. It is held only by the
+    /// AsyncSequence iteration; the closure captures `[weak self]`. When
+    /// the scheduler deinits, the Task remains suspended until the next
+    /// memory warning fires, at which point `guard let self else { … }`
+    /// causes the Task to complete. The leak is bounded — at most one
+    /// suspended Task (a few kilobytes of task control block) per
+    /// scheduler instance between scheduler deinit and the next system
+    /// memory warning. Trying to store the Task on `self` for explicit
+    /// cancellation would either (a) hit the init-order rule above, or
+    /// (b) require accessing a non-Sendable property from nonisolated
+    /// deinit. The trade-off — a small bounded leak in exchange for a
+    /// simple Swift 6-clean implementation — is acceptable for a
+    /// per-reader-session scheduler.
+    private func installMemoryWarningObservation() {
+      // `UIApplication.didReceiveMemoryWarningNotification` is posted by
+      // UIKit when the system needs memory back. Without this observation,
+      // iOS's only recourse is to evict view bodies / hosting controllers
+      // — which forces a full `DivinaReaderView` rebuild and exercises the
+      // exact path PR #818 fixed against. Responding explicitly lets us
+      // release the in-memory bitmap cache (~10 decoded pages, frequently
+      // tens of MB each) gracefully without disturbing the view tree.
+      Task { @MainActor [weak self] in
+        for await _ in NotificationCenter.default.notifications(
+          named: UIApplication.didReceiveMemoryWarningNotification
+        ) {
+          guard let self else { return }
+          self.handleMemoryWarning()
+        }
+      }
+    }
+
     private func handleMemoryWarning() {
       logger.warning("⚠️ [Reader/Memory] Received memory warning; pruning to visible pages only")
       pruneToVisiblePagesOnly()

--- a/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
+++ b/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
@@ -47,17 +47,6 @@ final class ReaderPageLoadScheduler {
   private var preloadTask: Task<Void, Never>?
   private var visiblePageIDs: [ReaderPageID] = []
 
-  #if os(iOS) || os(tvOS)
-    // Sendable container holding the memory-warning observation Task.
-    // `OSAllocatedUnfairLock<State>` is Sendable when `State` is Sendable
-    // (`Task<Void, Never>?` is), so the property is reachable from the
-    // nonisolated `deinit` even though the class is `@MainActor`.
-    // Initialization via a stored-property initializer runs before the
-    // init body, sidestepping Swift 6's "self used before init" rule
-    // that blocks `[weak self]` capture inside a property initializer.
-    private let memoryWarningTaskBox = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
-  #endif
-
   init(
     preloadBefore: Int = ReaderConstants.preloadBefore,
     preloadAfter: Int = ReaderConstants.preloadAfter,
@@ -70,16 +59,7 @@ final class ReaderPageLoadScheduler {
     self.keepRangeAfter = keepRangeAfter
 
     #if os(iOS) || os(tvOS)
-      installMemoryWarningObservation()
-    #endif
-  }
-
-  deinit {
-    #if os(iOS) || os(tvOS)
-      memoryWarningTaskBox.withLock { task in
-        task?.cancel()
-        task = nil
-      }
+      MemoryWarningCenter.shared.addListener(self)
     #endif
   }
 
@@ -233,43 +213,6 @@ final class ReaderPageLoadScheduler {
       "🧹 [Reader/Memory] Pruned to visible pages: kept=\(keepPageIDs.count), removed=\(imageKeysToRemove.count)"
     )
   }
-
-  #if os(iOS) || os(tvOS)
-    /// Start the memory-warning observation Task. Called from `init` once
-    /// all stored properties are initialized — capturing `[weak self]`
-    /// inside an init-property initializer trips Swift 6's "self used
-    /// before init" rule, so the capture is hoisted into a method.
-    ///
-    /// The Task is stored in `memoryWarningTaskBox` (an
-    /// `OSAllocatedUnfairLock<Task<Void, Never>?>`, which is Sendable)
-    /// so `deinit` can cancel it regardless of which thread the deinit
-    /// runs on. Cancellation terminates the AsyncSequence iteration and
-    /// releases the Task immediately rather than waiting for the next
-    /// memory warning to wake it.
-    private func installMemoryWarningObservation() {
-      // `UIApplication.didReceiveMemoryWarningNotification` is posted by
-      // UIKit when the system needs memory back. Without this observation,
-      // iOS's only recourse is to evict view bodies / hosting controllers
-      // — which forces a full `DivinaReaderView` rebuild and exercises the
-      // exact path PR #818 fixed against. Responding explicitly lets us
-      // release the in-memory bitmap cache (~10 decoded pages, frequently
-      // tens of MB each) gracefully without disturbing the view tree.
-      let task = Task { @MainActor [weak self] in
-        for await _ in NotificationCenter.default.notifications(
-          named: UIApplication.didReceiveMemoryWarningNotification
-        ) {
-          guard !Task.isCancelled, let self else { return }
-          self.handleMemoryWarning()
-        }
-      }
-      memoryWarningTaskBox.withLock { $0 = task }
-    }
-
-    private func handleMemoryWarning() {
-      logger.warning("⚠️ [Reader/Memory] Received memory warning; pruning to visible pages only")
-      pruneToVisiblePagesOnly()
-    }
-  #endif
 
   func isAnimatedPage(for pageID: ReaderPageID) -> Bool {
     animatedPageStates[pageID] == true
@@ -969,3 +912,12 @@ final class ReaderPageLoadScheduler {
     return BookService.shared.getBookPageURL(bookId: bookId, page: page.number)
   }
 }
+
+#if os(iOS) || os(tvOS)
+  extension ReaderPageLoadScheduler: MemoryWarningListener {
+    func handleMemoryWarning() {
+      logger.warning("⚠️ [Reader/Memory] Received memory warning; pruning to visible pages only")
+      pruneToVisiblePagesOnly()
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
+++ b/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
@@ -3,7 +3,9 @@ import ImageIO
 import SwiftUI
 import UniformTypeIdentifiers
 
-#if os(macOS)
+#if os(iOS) || os(tvOS)
+  import UIKit
+#elseif os(macOS)
   import AppKit
 #endif
 
@@ -44,6 +46,10 @@ final class ReaderPageLoadScheduler {
   private var preloadTask: Task<Void, Never>?
   private var visiblePageIDs: [ReaderPageID] = []
 
+  #if os(iOS) || os(tvOS)
+    private var memoryWarningObserver: NSObjectProtocol?
+  #endif
+
   init(
     preloadBefore: Int = ReaderConstants.preloadBefore,
     preloadAfter: Int = ReaderConstants.preloadAfter,
@@ -54,6 +60,18 @@ final class ReaderPageLoadScheduler {
     self.preloadAfter = preloadAfter
     self.keepRangeBefore = keepRangeBefore
     self.keepRangeAfter = keepRangeAfter
+
+    #if os(iOS) || os(tvOS)
+      installMemoryWarningObserver()
+    #endif
+  }
+
+  deinit {
+    #if os(iOS) || os(tvOS)
+      if let memoryWarningObserver {
+        NotificationCenter.default.removeObserver(memoryWarningObserver)
+      }
+    #endif
   }
 
   func setPresentationInvalidationHandler(_ handler: PresentationInvalidationHandler?) {
@@ -170,6 +188,68 @@ final class ReaderPageLoadScheduler {
       updateAnimatedPresentation(knownAnimatedState: nil, sourceFileURL: nil, for: key)
     }
   }
+
+  /// Drop decoded bitmaps for every page outside the visible set, keeping
+  /// only what's strictly required to render the current screen. More
+  /// aggressive than `cleanupDistantImagesAroundCurrentPage` (which keeps
+  /// the full `keepRangeBefore`/`keepRangeAfter` keep-window of ~10 pages)
+  /// because this is invoked under memory pressure, when iOS would
+  /// otherwise reclaim the view tree and force a full reader rebuild.
+  ///
+  /// The on-disk image cache survives this prune untouched; the next
+  /// preload cycle (driven by the next page change) re-decodes the keep
+  /// window from disk transparently. Falls back to keeping `currentPageID`
+  /// when `visiblePageIDs` is unexpectedly empty so the user never loses
+  /// the page they're actively reading.
+  func pruneToVisiblePagesOnly() {
+    var keepPageIDs = Set(visiblePageIDs)
+    if keepPageIDs.isEmpty, let currentPageID {
+      keepPageIDs.insert(currentPageID)
+    }
+
+    let imageKeysToRemove = preloadedImagesByID.keys.filter { !keepPageIDs.contains($0) }
+    for key in imageKeysToRemove {
+      clearPreloadedImage(for: key)
+    }
+
+    let animatedKeysToRemove = Set(animatedPageStates.keys)
+      .union(animatedPageSourceFileURLs.keys)
+      .filter { !keepPageIDs.contains($0) }
+
+    for key in animatedKeysToRemove {
+      updateAnimatedPresentation(knownAnimatedState: nil, sourceFileURL: nil, for: key)
+    }
+
+    logger.debug(
+      "🧹 [Reader/Memory] Pruned to visible pages: kept=\(keepPageIDs.count), removed=\(imageKeysToRemove.count)"
+    )
+  }
+
+  #if os(iOS) || os(tvOS)
+    private func installMemoryWarningObserver() {
+      // `UIApplication.didReceiveMemoryWarningNotification` is posted by
+      // UIKit when the system needs memory back. Without a hook here, iOS's
+      // only recourse is to evict view bodies / hosting controllers —
+      // which forces a full `DivinaReaderView` rebuild and exercises the
+      // exact path PR #818 fixed against. Responding explicitly lets us
+      // release the in-memory bitmap cache (~10 decoded pages, frequently
+      // tens of MB each) gracefully without disturbing the view tree.
+      memoryWarningObserver = NotificationCenter.default.addObserver(
+        forName: UIApplication.didReceiveMemoryWarningNotification,
+        object: nil,
+        queue: nil
+      ) { [weak self] _ in
+        Task { @MainActor [weak self] in
+          self?.handleMemoryWarning()
+        }
+      }
+    }
+
+    private func handleMemoryWarning() {
+      logger.warning("⚠️ [Reader/Memory] Received memory warning; pruning to visible pages only")
+      pruneToVisiblePagesOnly()
+    }
+  #endif
 
   func isAnimatedPage(for pageID: ReaderPageID) -> Bool {
     animatedPageStates[pageID] == true

--- a/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
+++ b/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
@@ -47,7 +47,11 @@ final class ReaderPageLoadScheduler {
   private var visiblePageIDs: [ReaderPageID] = []
 
   #if os(iOS) || os(tvOS)
-    private var memoryWarningObserver: NSObjectProtocol?
+    // `Task<Void, Never>` is Sendable, so this property is reachable from
+    // the nonisolated `deinit` even though the class is `@MainActor`. The
+    // older `addObserver(forName:object:queue:using:)` pattern returns a
+    // non-Sendable `NSObjectProtocol`, which would not be.
+    private nonisolated let memoryWarningObservation: Task<Void, Never>
   #endif
 
   init(
@@ -62,15 +66,30 @@ final class ReaderPageLoadScheduler {
     self.keepRangeAfter = keepRangeAfter
 
     #if os(iOS) || os(tvOS)
-      installMemoryWarningObserver()
+      // `UIApplication.didReceiveMemoryWarningNotification` is posted by
+      // UIKit when the system needs memory back. Without this observation,
+      // iOS's only recourse is to evict view bodies / hosting controllers —
+      // which forces a full `DivinaReaderView` rebuild and exercises the
+      // exact path PR #818 fixed against. Responding explicitly lets us
+      // release the in-memory bitmap cache (~10 decoded pages, frequently
+      // tens of MB each) gracefully without disturbing the view tree.
+      //
+      // The Task suspends on the AsyncSequence until a notification fires;
+      // `deinit` cancels the task, which terminates the iteration.
+      self.memoryWarningObservation = Task { @MainActor [weak self] in
+        for await _ in NotificationCenter.default.notifications(
+          named: UIApplication.didReceiveMemoryWarningNotification
+        ) {
+          guard !Task.isCancelled else { break }
+          self?.handleMemoryWarning()
+        }
+      }
     #endif
   }
 
   deinit {
     #if os(iOS) || os(tvOS)
-      if let memoryWarningObserver {
-        NotificationCenter.default.removeObserver(memoryWarningObserver)
-      }
+      memoryWarningObservation.cancel()
     #endif
   }
 
@@ -226,25 +245,6 @@ final class ReaderPageLoadScheduler {
   }
 
   #if os(iOS) || os(tvOS)
-    private func installMemoryWarningObserver() {
-      // `UIApplication.didReceiveMemoryWarningNotification` is posted by
-      // UIKit when the system needs memory back. Without a hook here, iOS's
-      // only recourse is to evict view bodies / hosting controllers —
-      // which forces a full `DivinaReaderView` rebuild and exercises the
-      // exact path PR #818 fixed against. Responding explicitly lets us
-      // release the in-memory bitmap cache (~10 decoded pages, frequently
-      // tens of MB each) gracefully without disturbing the view tree.
-      memoryWarningObserver = NotificationCenter.default.addObserver(
-        forName: UIApplication.didReceiveMemoryWarningNotification,
-        object: nil,
-        queue: nil
-      ) { [weak self] _ in
-        Task { @MainActor [weak self] in
-          self?.handleMemoryWarning()
-        }
-      }
-    }
-
     private func handleMemoryWarning() {
       logger.warning("⚠️ [Reader/Memory] Received memory warning; pruning to visible pages only")
       pruneToVisiblePagesOnly()

--- a/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
+++ b/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
@@ -2,6 +2,7 @@ import Foundation
 import ImageIO
 import SwiftUI
 import UniformTypeIdentifiers
+import os
 
 #if os(iOS) || os(tvOS)
   import UIKit
@@ -46,6 +47,17 @@ final class ReaderPageLoadScheduler {
   private var preloadTask: Task<Void, Never>?
   private var visiblePageIDs: [ReaderPageID] = []
 
+  #if os(iOS) || os(tvOS)
+    // Sendable container holding the memory-warning observation Task.
+    // `OSAllocatedUnfairLock<State>` is Sendable when `State` is Sendable
+    // (`Task<Void, Never>?` is), so the property is reachable from the
+    // nonisolated `deinit` even though the class is `@MainActor`.
+    // Initialization via a stored-property initializer runs before the
+    // init body, sidestepping Swift 6's "self used before init" rule
+    // that blocks `[weak self]` capture inside a property initializer.
+    private let memoryWarningTaskBox = OSAllocatedUnfairLock<Task<Void, Never>?>(initialState: nil)
+  #endif
+
   init(
     preloadBefore: Int = ReaderConstants.preloadBefore,
     preloadAfter: Int = ReaderConstants.preloadAfter,
@@ -59,6 +71,15 @@ final class ReaderPageLoadScheduler {
 
     #if os(iOS) || os(tvOS)
       installMemoryWarningObservation()
+    #endif
+  }
+
+  deinit {
+    #if os(iOS) || os(tvOS)
+      memoryWarningTaskBox.withLock { task in
+        task?.cancel()
+        task = nil
+      }
     #endif
   }
 
@@ -216,22 +237,15 @@ final class ReaderPageLoadScheduler {
   #if os(iOS) || os(tvOS)
     /// Start the memory-warning observation Task. Called from `init` once
     /// all stored properties are initialized — capturing `[weak self]`
-    /// inside an init-property initializer would trip Swift 6's "self
-    /// used before init" rule, so the capture is hoisted into a method.
+    /// inside an init-property initializer trips Swift 6's "self used
+    /// before init" rule, so the capture is hoisted into a method.
     ///
-    /// The Task is intentionally fire-and-forget. It is held only by the
-    /// AsyncSequence iteration; the closure captures `[weak self]`. When
-    /// the scheduler deinits, the Task remains suspended until the next
-    /// memory warning fires, at which point `guard let self else { … }`
-    /// causes the Task to complete. The leak is bounded — at most one
-    /// suspended Task (a few kilobytes of task control block) per
-    /// scheduler instance between scheduler deinit and the next system
-    /// memory warning. Trying to store the Task on `self` for explicit
-    /// cancellation would either (a) hit the init-order rule above, or
-    /// (b) require accessing a non-Sendable property from nonisolated
-    /// deinit. The trade-off — a small bounded leak in exchange for a
-    /// simple Swift 6-clean implementation — is acceptable for a
-    /// per-reader-session scheduler.
+    /// The Task is stored in `memoryWarningTaskBox` (an
+    /// `OSAllocatedUnfairLock<Task<Void, Never>?>`, which is Sendable)
+    /// so `deinit` can cancel it regardless of which thread the deinit
+    /// runs on. Cancellation terminates the AsyncSequence iteration and
+    /// releases the Task immediately rather than waiting for the next
+    /// memory warning to wake it.
     private func installMemoryWarningObservation() {
       // `UIApplication.didReceiveMemoryWarningNotification` is posted by
       // UIKit when the system needs memory back. Without this observation,
@@ -240,14 +254,15 @@ final class ReaderPageLoadScheduler {
       // exact path PR #818 fixed against. Responding explicitly lets us
       // release the in-memory bitmap cache (~10 decoded pages, frequently
       // tens of MB each) gracefully without disturbing the view tree.
-      Task { @MainActor [weak self] in
+      let task = Task { @MainActor [weak self] in
         for await _ in NotificationCenter.default.notifications(
           named: UIApplication.didReceiveMemoryWarningNotification
         ) {
-          guard let self else { return }
+          guard !Task.isCancelled, let self else { return }
           self.handleMemoryWarning()
         }
       }
+      memoryWarningTaskBox.withLock { $0 = task }
     }
 
     private func handleMemoryWarning() {


### PR DESCRIPTION
## Problem
Decoded reader page bitmaps can consume a large amount of memory, but iOS memory pressure was not visible to the reader cache. This could leave the system to reclaim larger UI/view state instead of letting the reader release decoded pages gracefully.

Closes #821

## Approach
Keep the aggressive memory-pressure behavior, but centralize UIKit memory warning observation in a shared `MemoryWarningCenter`. The center observes the system notification once, dispatches on the main actor, and keeps weak listeners so reader schedulers can register without being retained.

`ReaderPageLoadScheduler` now only implements the reader-specific response: prune decoded images and animated presentation state down to the visible pages, falling back to the current page if visibility is temporarily empty.

## Notes
- `MemoryWarningCenter` is main-actor isolated intentionally because current listeners mutate reader/UI cache state.
- Weak listener storage avoids explicit lifecycle cancellation and keeps stale entries cleanup-only.
- The on-disk image cache is unchanged; pages can be decoded again from disk after memory pressure.

## Validation
- [x] `make format`
- [x] `git diff --check`
- [x] `python3 misc/xcode.py build ios --ci`
