### PR TITLE
fix(reader): avoid offline download for backward preloads

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 448;
+				CURRENT_PROJECT_VERSION = 449;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 448;
+				CURRENT_PROJECT_VERSION = 449;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 448;
+				CURRENT_PROJECT_VERSION = 449;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 448;
+				CURRENT_PROJECT_VERSION = 449;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -39,6 +39,20 @@ class ReaderViewModel {
   @ObservationIgnored
   private var pagePresentationInvalidationHandlers: [UUID: PagePresentationInvalidationHandler] = [:]
 
+  private enum SegmentFetchPurpose {
+    case nextPreload
+    case previousPreload
+
+    var shouldEnsureOfflineReady: Bool {
+      switch self {
+      case .nextPreload:
+        return true
+      case .previousPreload:
+        return false
+      }
+    }
+  }
+
   private let logger = AppLogger(.reader)
   private let pageLoadScheduler: ReaderPageLoadScheduler
   private var bookMediaProfile: MediaProfile = .unknown
@@ -567,10 +581,10 @@ class ReaderViewModel {
     rebuildReaderPages()
   }
 
-  private func fetchSegmentPages(for book: Book) async -> [BookPage]? {
+  private func fetchSegmentPages(for book: Book, purpose: SegmentFetchPurpose) async -> [BookPage]? {
     let database = await DatabaseOperator.databaseIfConfigured()
 
-    if AppConfig.offlineFirstReading {
+    if AppConfig.offlineFirstReading, purpose.shouldEnsureOfflineReady {
       do {
         try await ensureOfflineReady(book: book, updatesLoadingState: false)
       } catch {
@@ -674,7 +688,7 @@ class ReaderViewModel {
       return
     }
 
-    guard let fetchedPages = await fetchSegmentPages(for: nextBook) else {
+    guard let fetchedPages = await fetchSegmentPages(for: nextBook, purpose: .nextPreload) else {
       regenerateViewState()
       return
     }
@@ -719,7 +733,7 @@ class ReaderViewModel {
       return
     }
 
-    guard let fetchedPages = await fetchSegmentPages(for: previousBook) else {
+    guard let fetchedPages = await fetchSegmentPages(for: previousBook, purpose: .previousPreload) else {
       regenerateViewState()
       return
     }


### PR DESCRIPTION
## Problem
Offline-first reading currently treats every adjacent segment preload as a reason to prepare the whole book offline. When a reader opens a new book at the beginning, that also triggers the previous segment preload path, so the app downloads the previous book even though most readers continue forward and only rarely go back.

## Approach
Make adjacent segment fetches directional internally. Forward preloads keep the existing offline-first behavior so the next book can be ready near the end of the current one. Backward preloads skip the whole-book offline preparation and use the existing cached-page or streaming fallback instead.

## Scope
- Add an internal segment fetch purpose for previous vs next preloads.
- Preserve offline-first download behavior for the current book and forward preloads.
- Avoid enqueueing whole previous-book downloads for backward/previous preloads.
- Bump build version to 449.

## Validation
- [x] make format
- [x] make build-macos-ci
