### PR TITLE
feat(reader): add Divina border cropping

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 449;
+				CURRENT_PROJECT_VERSION = 450;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 449;
+				CURRENT_PROJECT_VERSION = 450;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 449;
+				CURRENT_PROJECT_VERSION = 450;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 449;
+				CURRENT_PROJECT_VERSION = 450;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -985,6 +985,21 @@ enum AppConfig {
       UserDefaults.standard.set(max(newValue, 1.0), forKey: "imageUpscaleAlwaysMaxScreenScale")
     }
   }
+
+  static nonisolated var divinaPageBorderCropMode: ReaderPageBorderCropMode {
+    get {
+      if let stored = UserDefaults.standard.string(forKey: "divinaPageBorderCropMode"),
+        let mode = ReaderPageBorderCropMode(rawValue: stored)
+      {
+        return mode
+      }
+      return .disabled
+    }
+    set {
+      UserDefaults.standard.set(newValue.rawValue, forKey: "divinaPageBorderCropMode")
+    }
+  }
+
   static nonisolated var shakeToOpenLiveText: Bool {
     get {
       if UserDefaults.standard.object(forKey: "shakeToOpenLiveText") != nil {

--- a/KMReader/Features/Reader/Models/ReaderPageBorderCropMode.swift
+++ b/KMReader/Features/Reader/Models/ReaderPageBorderCropMode.swift
@@ -1,0 +1,23 @@
+//
+// ReaderPageBorderCropMode.swift
+//
+//
+
+import Foundation
+
+enum ReaderPageBorderCropMode: String, CaseIterable, Hashable, Sendable {
+  case disabled
+  case conservative
+  case aggressive
+
+  var displayName: String {
+    switch self {
+    case .disabled:
+      return String(localized: "Disabled")
+    case .conservative:
+      return String(localized: "Conservative", defaultValue: "Conservative")
+    case .aggressive:
+      return String(localized: "Aggressive", defaultValue: "Aggressive")
+    }
+  }
+}

--- a/KMReader/Features/Reader/Services/ImageProcessing/ReaderPageBorderCropper.swift
+++ b/KMReader/Features/Reader/Services/ImageProcessing/ReaderPageBorderCropper.swift
@@ -1,0 +1,193 @@
+//
+// ReaderPageBorderCropper.swift
+//
+//
+
+import CoreGraphics
+import Foundation
+
+nonisolated enum ReaderPageBorderCropper {
+  static func crop(_ image: CGImage, mode: ReaderPageBorderCropMode) -> CGImage? {
+    guard mode != .disabled else { return nil }
+    guard let cropRect = cropRect(for: image, mode: mode) else { return nil }
+    return image.cropping(to: cropRect)
+  }
+
+  static func cropRect(for image: CGImage, mode: ReaderPageBorderCropMode) -> CGRect? {
+    guard mode != .disabled else { return nil }
+
+    let sourceWidth = image.width
+    let sourceHeight = image.height
+    guard sourceWidth >= 64, sourceHeight >= 64 else { return nil }
+
+    let parameters = parameters(for: mode)
+    let analysisScale = min(1.0, parameters.downscale)
+    let analysisWidth = max(1, Int((Double(sourceWidth) * analysisScale).rounded()))
+    let analysisHeight = max(1, Int((Double(sourceHeight) * analysisScale).rounded()))
+    guard let pixels = argbPixels(from: image, width: analysisWidth, height: analysisHeight) else { return nil }
+
+    var minX = analysisWidth
+    var minY = analysisHeight
+    var maxX = -1
+    var maxY = -1
+
+    for y in 0..<analysisHeight {
+      for x in 0..<analysisWidth {
+        let index = (y * analysisWidth + x) * 4
+        let alpha = Int(pixels[index])
+        let red = Int(pixels[index + 1])
+        let green = Int(pixels[index + 2])
+        let blue = Int(pixels[index + 3])
+
+        guard
+          !isCropBackgroundPixel(
+            alpha: alpha,
+            red: red,
+            green: green,
+            blue: blue,
+            parameters: parameters
+          )
+        else {
+          continue
+        }
+
+        minX = min(minX, x)
+        minY = min(minY, y)
+        maxX = max(maxX, x)
+        maxY = max(maxY, y)
+      }
+    }
+
+    guard maxX >= minX, maxY >= minY else { return nil }
+
+    let paddingX = max(0, Int((Double(analysisWidth) * parameters.paddingRatio).rounded()))
+    let paddingY = max(0, Int((Double(analysisHeight) * parameters.paddingRatio).rounded()))
+    let paddedMinX = max(0, minX - paddingX)
+    let paddedMinY = max(0, minY - paddingY)
+    let paddedMaxX = min(analysisWidth - 1, maxX + paddingX)
+    let paddedMaxY = min(analysisHeight - 1, maxY + paddingY)
+
+    let cropWidth = paddedMaxX - paddedMinX + 1
+    let cropHeight = paddedMaxY - paddedMinY + 1
+    guard cropWidth > 0, cropHeight > 0 else { return nil }
+
+    let retainedWidthRatio = Double(cropWidth) / Double(analysisWidth)
+    let retainedHeightRatio = Double(cropHeight) / Double(analysisHeight)
+    guard retainedWidthRatio >= parameters.minimumRetainedRatio,
+      retainedHeightRatio >= parameters.minimumRetainedRatio
+    else {
+      return nil
+    }
+
+    let maxCropRatio = parameters.maxCropRatio
+    let cropLeftRatio = Double(paddedMinX) / Double(analysisWidth)
+    let cropRightRatio = Double(analysisWidth - 1 - paddedMaxX) / Double(analysisWidth)
+    let cropTopRatio = Double(paddedMinY) / Double(analysisHeight)
+    let cropBottomRatio = Double(analysisHeight - 1 - paddedMaxY) / Double(analysisHeight)
+    guard [cropLeftRatio, cropRightRatio, cropTopRatio, cropBottomRatio].allSatisfy({ $0 <= maxCropRatio }) else {
+      return nil
+    }
+
+    let sourceScaleX = Double(sourceWidth) / Double(analysisWidth)
+    let sourceScaleY = Double(sourceHeight) / Double(analysisHeight)
+    let sourceX = max(0, Int((Double(paddedMinX) * sourceScaleX).rounded(.down)))
+    let sourceY = max(0, Int((Double(paddedMinY) * sourceScaleY).rounded(.down)))
+    let sourceRight = min(sourceWidth, Int((Double(paddedMaxX + 1) * sourceScaleX).rounded(.up)))
+    let sourceBottom = min(sourceHeight, Int((Double(paddedMaxY + 1) * sourceScaleY).rounded(.up)))
+
+    guard sourceRight > sourceX, sourceBottom > sourceY else { return nil }
+    guard sourceX > 0 || sourceY > 0 || sourceRight < sourceWidth || sourceBottom < sourceHeight else {
+      return nil
+    }
+
+    return CGRect(x: sourceX, y: sourceY, width: sourceRight - sourceX, height: sourceBottom - sourceY)
+  }
+
+  private static func isCropBackgroundPixel(
+    alpha: Int,
+    red: Int,
+    green: Int,
+    blue: Int,
+    parameters: CropParameters
+  ) -> Bool {
+    if alpha <= parameters.alphaThreshold { return true }
+    if red >= parameters.whiteThreshold, green >= parameters.whiteThreshold, blue >= parameters.whiteThreshold {
+      return true
+    }
+    if red <= parameters.blackThreshold, green <= parameters.blackThreshold, blue <= parameters.blackThreshold {
+      return true
+    }
+    return false
+  }
+
+  private static func parameters(for mode: ReaderPageBorderCropMode) -> CropParameters {
+    switch mode {
+    case .disabled:
+      return CropParameters(
+        whiteThreshold: 238,
+        blackThreshold: 5,
+        alphaThreshold: 0,
+        downscale: 0.4,
+        paddingRatio: 0.018,
+        maxCropRatio: 0.2,
+        minimumRetainedRatio: 0.75
+      )
+    case .conservative:
+      return CropParameters(
+        whiteThreshold: 238,
+        blackThreshold: 5,
+        alphaThreshold: 0,
+        downscale: 0.4,
+        paddingRatio: 0.018,
+        maxCropRatio: 0.2,
+        minimumRetainedRatio: 0.75
+      )
+    case .aggressive:
+      return CropParameters(
+        whiteThreshold: 170,
+        blackThreshold: 32,
+        alphaThreshold: 0,
+        downscale: 0.4,
+        paddingRatio: 0,
+        maxCropRatio: 0.6,
+        minimumRetainedRatio: 0.35
+      )
+    }
+  }
+
+  private static func argbPixels(from image: CGImage, width: Int, height: Int) -> [UInt8]? {
+    let bytesPerPixel = 4
+    let bytesPerRow = width * bytesPerPixel
+    var pixels = [UInt8](repeating: 0, count: height * bytesPerRow)
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let bitmapInfo = CGImageAlphaInfo.premultipliedFirst.rawValue
+
+    guard
+      let context = CGContext(
+        data: &pixels,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: bytesPerRow,
+        space: colorSpace,
+        bitmapInfo: bitmapInfo
+      )
+    else {
+      return nil
+    }
+
+    context.interpolationQuality = .low
+    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+    return pixels
+  }
+
+  private struct CropParameters {
+    let whiteThreshold: Int
+    let blackThreshold: Int
+    let alphaThreshold: Int
+    let downscale: Double
+    let paddingRatio: Double
+    let maxCropRatio: Double
+    let minimumRetainedRatio: Double
+  }
+}

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
@@ -259,8 +259,17 @@
     private func preparedImage(from image: UIImage?, splitMode: PageSplitMode, rotationDegrees: Int) -> UIImage? {
       guard let image else { return nil }
       let rotatedImage = rotateImage(image, degrees: rotationDegrees)
-      guard splitMode != .none else { return rotatedImage }
-      return cropImageForSplitMode(image: rotatedImage, splitMode: splitMode)
+      let splitImage =
+        splitMode == .none ? rotatedImage : cropImageForSplitMode(image: rotatedImage, splitMode: splitMode)
+      return cropBordersIfNeeded(splitImage)
+    }
+
+    private func cropBordersIfNeeded(_ image: UIImage?) -> UIImage? {
+      guard let image else { return nil }
+      let mode = AppConfig.divinaPageBorderCropMode
+      guard mode != .disabled, let cgImage = image.cgImage else { return image }
+      guard let cropped = ReaderPageBorderCropper.crop(cgImage, mode: mode) else { return image }
+      return UIImage(cgImage: cropped, scale: image.scale, orientation: image.imageOrientation)
     }
 
     private func rotateImage(_ image: UIImage, degrees: Int) -> UIImage {

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_macOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_macOS.swift
@@ -280,8 +280,21 @@
     private func preparedImage(from image: NSImage?, splitMode: PageSplitMode, rotationDegrees: Int) -> NSImage? {
       guard let image else { return nil }
       let rotatedImage = rotateImage(image, degrees: rotationDegrees)
-      guard splitMode != .none else { return rotatedImage }
-      return cropImageForSplitMode(image: rotatedImage, splitMode: splitMode)
+      let splitImage =
+        splitMode == .none ? rotatedImage : cropImageForSplitMode(image: rotatedImage, splitMode: splitMode)
+      return cropBordersIfNeeded(splitImage)
+    }
+
+    private func cropBordersIfNeeded(_ image: NSImage?) -> NSImage? {
+      guard let image else { return nil }
+      let mode = AppConfig.divinaPageBorderCropMode
+      guard mode != .disabled,
+        let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil),
+        let cropped = ReaderPageBorderCropper.crop(cgImage, mode: mode)
+      else {
+        return image
+      }
+      return NSImage(cgImage: cropped, size: NSSize(width: cropped.width, height: cropped.height))
     }
 
     private func rotateImage(_ image: NSImage, degrees: Int) -> NSImage {

--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -32,6 +32,8 @@ struct ReaderSettingsSheet: View {
   @AppStorage("imageUpscaleAlwaysMaxScreenScale")
   private var imageUpscaleAlwaysMaxScreenScale: Double =
     AppConfig.imageUpscaleAlwaysMaxScreenScale
+  @AppStorage("divinaPageBorderCropMode") private var divinaPageBorderCropMode: ReaderPageBorderCropMode =
+    AppConfig.divinaPageBorderCropMode
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
   @AppStorage("enableDivinaImageContextMenu")
   private var enableDivinaImageContextMenu: Bool = AppConfig.enableDivinaImageContextMenu
@@ -210,7 +212,14 @@ struct ReaderSettingsSheet: View {
         #endif
 
         #if os(iOS) || os(macOS)
-          Section(header: Text("Image Upscaling")) {
+          Section(header: Text("Image Processing")) {
+            Picker("Border Cropping", selection: $divinaPageBorderCropMode) {
+              ForEach(ReaderPageBorderCropMode.allCases, id: \.self) { mode in
+                Text(mode.displayName).tag(mode)
+              }
+            }
+            .pickerStyle(.menu)
+
             VStack(alignment: .leading, spacing: 8) {
               Picker("Waifu2x Mode", selection: $imageUpscalingMode) {
                 ForEach(ReaderImageUpscalingMode.allCases, id: \.self) { mode in
@@ -282,6 +291,7 @@ struct ReaderSettingsSheet: View {
     .animation(.default, value: tapZoneMode)
     .animation(.default, value: doubleTapZoomMode)
     .animation(.default, value: imageUpscalingMode)
+    .animation(.default, value: divinaPageBorderCropMode)
     .animation(.default, value: pageTransitionStyle)
     .animation(.default, value: readingDirection)
     .presentationDragIndicator(.visible)

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -32,6 +32,8 @@ struct DivinaPreferencesView: View {
   @AppStorage("imageUpscaleAlwaysMaxScreenScale")
   private var imageUpscaleAlwaysMaxScreenScale: Double =
     AppConfig.imageUpscaleAlwaysMaxScreenScale
+  @AppStorage("divinaPageBorderCropMode") private var divinaPageBorderCropMode: ReaderPageBorderCropMode =
+    AppConfig.divinaPageBorderCropMode
   @AppStorage("enableLiveText") private var enableLiveText: Bool = false
   @AppStorage("enableDivinaImageContextMenu")
   private var enableDivinaImageContextMenu: Bool = AppConfig.enableDivinaImageContextMenu
@@ -350,7 +352,19 @@ struct DivinaPreferencesView: View {
       }
 
       #if os(iOS) || os(macOS)
-        Section(header: Text("Image Upscaling")) {
+        Section(header: Text("Image Processing")) {
+          VStack(alignment: .leading, spacing: 8) {
+            Picker("Border Cropping", selection: $divinaPageBorderCropMode) {
+              ForEach(ReaderPageBorderCropMode.allCases, id: \.self) { mode in
+                Text(mode.displayName).tag(mode)
+              }
+            }
+            .pickerStyle(.menu)
+            Text("Automatically trim empty page borders.")
+              .font(.caption)
+              .foregroundColor(.secondary)
+          }
+
           VStack(alignment: .leading, spacing: 8) {
             Picker("Waifu2x Mode", selection: $imageUpscalingMode) {
               ForEach(ReaderImageUpscalingMode.allCases, id: \.self) { mode in
@@ -449,6 +463,7 @@ struct DivinaPreferencesView: View {
     .animation(.default, value: tapZoneMode)
     .animation(.default, value: doubleTapZoomMode)
     .animation(.default, value: imageUpscalingMode)
+    .animation(.default, value: divinaPageBorderCropMode)
     .animation(.default, value: pageTransitionStyle)
     .animation(.default, value: forceDefaultReadingDirection)
     .animation(.default, value: readDirection)

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -3936,6 +3936,70 @@
         }
       }
     },
+    "Aggressive" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggressiv"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggressive"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agresivo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agressif"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggressivo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "積極的"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "적극적"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Агрессивный"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "激进"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "激進"
+          }
+        }
+      }
+    },
     "All" : {
       "localizations" : {
         "de" : {
@@ -7264,6 +7328,70 @@
         }
       }
     },
+    "Automatically trim empty page borders." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leere Seitenränder automatisch zuschneiden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatically trim empty page borders."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recorta automáticamente los bordes vacíos de la página."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rogne automatiquement les marges vides de la page."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ritaglia automaticamente i bordi vuoti della pagina."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページの空白余白を自動的にトリミングします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지의 빈 테두리를 자동으로 잘라냅니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Автоматически обрезает пустые поля страницы."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动裁剪页面空白边距。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動裁剪頁面空白邊距。"
+          }
+        }
+      }
+    },
     "Avg Pages / Book" : {
       "localizations" : {
         "de" : {
@@ -9180,6 +9308,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "系列"
+          }
+        }
+      }
+    },
+    "Border Cropping" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ränder zuschneiden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Border Cropping"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recorte de bordes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rognage des bordures"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ritaglio bordi"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "余白のトリミング"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "테두리 자르기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обрезка полей"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "裁剪页边"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "裁剪頁邊"
           }
         }
       }
@@ -13404,6 +13596,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "連線驗證成功"
+          }
+        }
+      }
+    },
+    "Conservative" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konservativ"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conservative"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conservador"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conservateur"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conservativo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控えめ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보수적"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Консервативный"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保守"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保守"
           }
         }
       }
@@ -29344,66 +29600,66 @@
         }
       }
     },
-    "Image Upscaling" : {
+    "Image Processing" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bild-Hochskalierung"
+            "value" : "Bildverarbeitung"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Image Upscaling"
+            "value" : "Image Processing"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Escalado de imagen"
+            "value" : "Procesamiento de imagen"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Suréchantillonnage d’image"
+            "value" : "Traitement de l’image"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Upscaling immagine"
+            "value" : "Elaborazione immagine"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "画像アップスケーリング"
+            "value" : "画像処理"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "이미지 업스케일링"
+            "value" : "이미지 처리"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Масштабирование изображения"
+            "value" : "Обработка изображений"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "图像超分辨率"
+            "value" : "图像处理"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "影像超解析度"
+            "value" : "影像處理"
           }
         }
       }


### PR DESCRIPTION
## Problem
Large empty borders around comic pages waste screen space in the DIVINA reader, especially on iPadOS, where users expect the page image to expand closer to the available viewport.

## Approach
Add a default-disabled DIVINA image processing option for border cropping. The cropper analyzes a downscaled copy of the page and removes transparent, near-white, or near-black border pixels, with conservative and aggressive modes for different tolerance levels.

## Scope
- Add a `Border Cropping` setting under `Image Processing` in both global DIVINA preferences and the in-reader settings sheet
- Apply cropping after rotation and split-page handling in native iOS/tvOS and macOS page renderers
- Add localized strings through the project localization workflow
- Bump build number to 450

## Validation
- [x] `make localize`
- [x] `make format`
- [x] `make build-ios`

Closes #825
