### PR TITLE
feat(reader): auto-hide overlay after resume to soften PR #682 force-show

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 450;
+				CURRENT_PROJECT_VERSION = 451;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 450;
+				CURRENT_PROJECT_VERSION = 451;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 450;
+				CURRENT_PROJECT_VERSION = 451;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 450;
+				CURRENT_PROJECT_VERSION = 451;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -269,7 +269,8 @@ struct DivinaReaderView: View {
     // the overlay hidden (and therefore wants it back hidden after a glance)
     // or with it visible (and wants it to stay visible).
     if oldPhase == .active && newPhase != .active {
-      wasShowingControlsBeforeBackground = shouldShowControls
+      wasShowingControlsBeforeBackground = autoHideAfterResumeTask == nil && shouldShowControls
+      cancelAutoHideAfterResume()
     }
 
     // PR #682 force-show — unchanged. Keeps iOS's status-bar / safe-area state
@@ -304,7 +305,7 @@ struct DivinaReaderView: View {
   private func scheduleAutoHideAfterResume() {
     autoHideAfterResumeTask?.cancel()
     autoHideAfterResumeTask = Task { @MainActor in
-      try? await Task.sleep(for: .seconds(3))
+      try? await Task.sleep(for: .seconds(1))
       guard !Task.isCancelled else { return }
       withAnimation {
         showingControls = false

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -56,6 +56,16 @@ struct DivinaReaderView: View {
   @State private var currentBookId: String
   @State private var viewModel: ReaderViewModel
   @State private var showingControls = false
+  // Captures `shouldShowControls` on the active → non-active scene-phase
+  // transition (before the PR #682 force-show flips `showingControls`), so the
+  // subsequent resume can decide whether to auto-hide the overlay or leave it
+  // visible. See `handleScenePhaseChange(from:to:)`.
+  @State private var wasShowingControlsBeforeBackground: Bool = false
+  // Task that fades the resume-triggered overlay back to hidden after a brief
+  // glance window. Reset on user interaction (page change) to act as an idle
+  // timeout; cancelled on tap-toggle and reader close. Nil when no auto-hide
+  // is pending.
+  @State private var autoHideAfterResumeTask: Task<Void, Never>?
   @State private var currentSeries: Series?
   @State private var currentBook: Book?
   @State private var seriesId: String?
@@ -241,6 +251,7 @@ struct DivinaReaderView: View {
   #endif
 
   private func closeReader() {
+    cancelAutoHideAfterResume()
     logger.debug(
       "🚪 Closing DIVINA reader for book \(currentBookId), currentPage=\(viewModel.currentPage?.number ?? -1), totalPages=\(viewModel.pageCount)"
     )
@@ -251,18 +262,71 @@ struct DivinaReaderView: View {
     }
   }
 
-  private func handleScenePhaseChange(_ phase: ScenePhase) {
-    if phase != .active || !shouldShowControls {
+  private func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase) {
+    // Capture pre-background overlay state once, on the active → non-active
+    // edge, BEFORE the force-show below flips `showingControls`. This is what
+    // tells `scheduleAutoHideAfterResume` whether the user was reading with
+    // the overlay hidden (and therefore wants it back hidden after a glance)
+    // or with it visible (and wants it to stay visible).
+    if oldPhase == .active && newPhase != .active {
+      wasShowingControlsBeforeBackground = shouldShowControls
+    }
+
+    // PR #682 force-show — unchanged. Keeps iOS's status-bar / safe-area state
+    // in a known configuration across the background → foreground cycle so the
+    // dashboard inherits a clean safe-area on subsequent close. The historical
+    // UX cost (overlay flashing visible on every lock/unlock until tapped) is
+    // what the auto-hide below mitigates.
+    if newPhase != .active || !shouldShowControls {
       showingControls = true
+    }
+
+    // On returning to .active: if pre-background was hidden, schedule a brief
+    // auto-hide so the user gets a glance at title/progress and the overlay
+    // fades back to where it was.
+    if oldPhase != .active, newPhase == .active, !wasShowingControlsBeforeBackground {
+      scheduleAutoHideAfterResume()
     }
 
     #if os(iOS)
       // Flush in-flight read progress to the server before iOS suspends the app, so
       // the trailing pages of the reading session are not lost to URLSession cancellation.
-      if phase == .background {
+      if newPhase == .background {
         readerPresentation.flushForBackgrounding()
       }
     #endif
+  }
+
+  /// Fade the overlay back to hidden after a brief glance window. Used only
+  /// on the resume path when the user had the overlay hidden before going to
+  /// background; preserves visible-overlay sessions untouched. Sub-tasks are
+  /// idempotent — re-scheduling cancels and replaces.
+  private func scheduleAutoHideAfterResume() {
+    autoHideAfterResumeTask?.cancel()
+    autoHideAfterResumeTask = Task { @MainActor in
+      try? await Task.sleep(for: .seconds(3))
+      guard !Task.isCancelled else { return }
+      withAnimation {
+        showingControls = false
+      }
+      autoHideAfterResumeTask = nil
+    }
+  }
+
+  private func cancelAutoHideAfterResume() {
+    autoHideAfterResumeTask?.cancel()
+    autoHideAfterResumeTask = nil
+  }
+
+  /// Restart the auto-hide timer if one is currently pending. Called from
+  /// existing user-interaction observers (e.g., page changes) so the auto-
+  /// hide acts as an idle timeout: any interaction within the window resets
+  /// the clock, and the overlay only fades when the user actually stops
+  /// engaging. Does nothing when no auto-hide is pending (normal reading
+  /// outside the post-resume window).
+  private func resetAutoHideAfterResumeIfPending() {
+    guard autoHideAfterResumeTask != nil else { return }
+    scheduleAutoHideAfterResume()
   }
 
   private func schedulePageMaintenanceAfterPageChange() {
@@ -626,8 +690,8 @@ struct DivinaReaderView: View {
         readerPresentation.clearReaderCommands()
       #endif
     }
-    .onChange(of: scenePhase) { _, newPhase in
-      handleScenePhaseChange(newPhase)
+    .onChange(of: scenePhase) { oldPhase, newPhase in
+      handleScenePhaseChange(from: oldPhase, to: newPhase)
     }
     .onChange(of: viewModel.isZoomed) { _, newValue in
       if newValue {
@@ -753,6 +817,11 @@ struct DivinaReaderView: View {
             await viewModel.updateProgress()
           }
           schedulePageMaintenanceAfterPageChange()
+          // Treat page changes as user activity: if we're inside the post-
+          // resume auto-hide window, restart the timer so the overlay stays
+          // visible while the user is actively flipping pages and only fades
+          // after a real pause.
+          resetAutoHideAfterResumeIfPending()
         }
         #if os(tvOS)
           .onChange(of: isShowingEndPage) { oldValue, newValue in
@@ -1684,12 +1753,14 @@ struct DivinaReaderView: View {
   #if os(tvOS)
     private func toggleControls() {
       // On tvOS, allow toggling controls even at endpage to enable navigation back
+      cancelAutoHideAfterResume()
       withAnimation {
         showingControls.toggle()
       }
     }
   #else
     private func toggleControls() {
+      cancelAutoHideAfterResume()
       withAnimation {
         showingControls.toggle()
       }

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -30,6 +30,15 @@
     @State private var activePreferences: EpubReaderPreferences
     @State private var bookPreferences: EpubReaderPreferences?
     @State private var showingControls = false
+    // Captures `shouldShowControls` on the active → non-active scene-phase
+    // transition (before the PR #682 force-show flips `showingControls`), so
+    // the subsequent resume can decide whether to auto-hide the overlay or
+    // leave it visible. See `handleScenePhaseChange(from:to:)`.
+    @State private var wasShowingControlsBeforeBackground: Bool = false
+    // Task that fades the resume-triggered overlay back to hidden after a
+    // brief glance window. Reset on user interaction (location change) to act
+    // as an idle timeout; cancelled on tap-toggle and reader close.
+    @State private var autoHideAfterResumeTask: Task<Void, Never>?
     @State private var currentSeries: Series?
     @State private var currentBook: Book?
     @State private var showingChapterSheet = false
@@ -63,6 +72,7 @@
     }
 
     private func closeReader() {
+      cancelAutoHideAfterResume()
       logger.debug(
         "🚪 Closing EPUB reader for book \(handoffBookId), chapter=\(viewModel.currentChapterIndex), page=\(viewModel.currentPageIndex)"
       )
@@ -73,18 +83,68 @@
       }
     }
 
-    private func handleScenePhaseChange(_ phase: ScenePhase) {
-      if phase != .active || !shouldShowControls {
+    private func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase) {
+      // Capture pre-background overlay state on the active → non-active edge,
+      // BEFORE the force-show below flips `showingControls`. Tells the
+      // subsequent resume whether to auto-hide the overlay or leave it
+      // visible.
+      if oldPhase == .active && newPhase != .active {
+        wasShowingControlsBeforeBackground = shouldShowControls
+      }
+
+      // PR #682 force-show — unchanged. Keeps iOS's status-bar / safe-area
+      // state in a known configuration across background → foreground so the
+      // dashboard inherits a clean safe-area on subsequent close. The
+      // historical UX cost (overlay flashing visible on every lock/unlock) is
+      // what the auto-hide below mitigates.
+      if newPhase != .active || !shouldShowControls {
         showingControls = true
+      }
+
+      // On returning to .active: if pre-background was hidden, schedule a
+      // brief auto-hide so the user gets a glance and the overlay fades back
+      // to where it was.
+      if oldPhase != .active, newPhase == .active, !wasShowingControlsBeforeBackground {
+        scheduleAutoHideAfterResume()
       }
 
       #if os(iOS)
         // Flush in-flight read progress to the server before iOS suspends the app, so
         // the trailing pages of the reading session are not lost to URLSession cancellation.
-        if phase == .background {
+        if newPhase == .background {
           readerPresentation.flushForBackgrounding()
         }
       #endif
+    }
+
+    /// Fade the overlay back to hidden after a brief glance window. Used only
+    /// on the resume path when the user had the overlay hidden before going
+    /// to background; preserves visible-overlay sessions untouched.
+    private func scheduleAutoHideAfterResume() {
+      autoHideAfterResumeTask?.cancel()
+      autoHideAfterResumeTask = Task { @MainActor in
+        try? await Task.sleep(for: .seconds(3))
+        guard !Task.isCancelled else { return }
+        withAnimation {
+          showingControls = false
+        }
+        autoHideAfterResumeTask = nil
+      }
+    }
+
+    private func cancelAutoHideAfterResume() {
+      autoHideAfterResumeTask?.cancel()
+      autoHideAfterResumeTask = nil
+    }
+
+    /// Restart the auto-hide timer if one is currently pending. Called from
+    /// existing user-interaction observers (e.g., location changes) so the
+    /// auto-hide acts as an idle timeout: interaction within the window
+    /// resets the clock, and the overlay only fades when the user actually
+    /// pauses.
+    private func resetAutoHideAfterResumeIfPending() {
+      guard autoHideAfterResumeTask != nil else { return }
+      scheduleAutoHideAfterResume()
     }
 
     var shouldShowControls: Bool {
@@ -202,6 +262,11 @@
         #endif
         .onChange(of: viewModel.currentLocation) { _, _ in
           updateReaderLiveActivityProgress()
+          // Treat location changes as user activity: if we're inside the post-
+          // resume auto-hide window, restart the timer so the overlay stays
+          // visible while the user is actively navigating and only fades after
+          // a real pause.
+          resetAutoHideAfterResumeIfPending()
         }
         .onChange(of: viewModel.hasContent) { oldValue, newValue in
           if !oldValue && newValue {
@@ -239,8 +304,8 @@
             readerPresentation.clearReaderCommands()
           #endif
         }
-        .onChange(of: scenePhase) { _, newPhase in
-          handleScenePhaseChange(newPhase)
+        .onChange(of: scenePhase) { oldPhase, newPhase in
+          handleScenePhaseChange(from: oldPhase, to: newPhase)
         }
         #if os(iOS)
           .readerDismissGesture(readingDirection: dismissGestureReadingDirection)
@@ -759,6 +824,7 @@
     }
 
     private func toggleControls() {
+      cancelAutoHideAfterResume()
       withAnimation(animation) {
         showingControls.toggle()
       }

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -89,7 +89,8 @@
       // subsequent resume whether to auto-hide the overlay or leave it
       // visible.
       if oldPhase == .active && newPhase != .active {
-        wasShowingControlsBeforeBackground = shouldShowControls
+        wasShowingControlsBeforeBackground = autoHideAfterResumeTask == nil && shouldShowControls
+        cancelAutoHideAfterResume()
       }
 
       // PR #682 force-show — unchanged. Keeps iOS's status-bar / safe-area
@@ -123,7 +124,7 @@
     private func scheduleAutoHideAfterResume() {
       autoHideAfterResumeTask?.cancel()
       autoHideAfterResumeTask = Task { @MainActor in
-        try? await Task.sleep(for: .seconds(3))
+        try? await Task.sleep(for: .seconds(1))
         guard !Task.isCancelled else { return }
         withAnimation {
           showingControls = false

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -34,6 +34,15 @@
     @State private var currentBook: Book?
     @State private var currentSeries: Series?
     @State private var showingControls = false
+    // Captures `shouldShowControls` on the active → non-active scene-phase
+    // transition (before the PR #682 force-show flips `showingControls`), so
+    // the subsequent resume can decide whether to auto-hide the overlay or
+    // leave it visible. See `handleScenePhaseChange(from:to:)`.
+    @State private var wasShowingControlsBeforeBackground: Bool = false
+    // Task that fades the resume-triggered overlay back to hidden after a
+    // brief glance window. Reset on user interaction (page change) to act as
+    // an idle timeout; cancelled on tap-toggle and reader close.
+    @State private var autoHideAfterResumeTask: Task<Void, Never>?
     @State private var showingPageJumpSheet = false
     @State private var showingSearchSheet = false
     @State private var showingTOCSheet = false
@@ -165,6 +174,11 @@
       }
       .onChange(of: viewModel.currentPageNumber) { _, _ in
         updateHandoff()
+        // Treat page changes as user activity: if we're inside the post-
+        // resume auto-hide window, restart the timer so the overlay stays
+        // visible while the user is actively flipping pages and only fades
+        // after a real pause.
+        resetAutoHideAfterResumeIfPending()
       }
       .onChange(of: viewModel.documentURL) { _, newURL in
         guard newURL != nil else { return }
@@ -186,8 +200,8 @@
           readerPresentation.clearReaderCommands()
         #endif
       }
-      .onChange(of: scenePhase) { _, newPhase in
-        handleScenePhaseChange(newPhase)
+      .onChange(of: scenePhase) { oldPhase, newPhase in
+        handleScenePhaseChange(from: oldPhase, to: newPhase)
       }
       .background(
         KeyboardEventHandler(
@@ -217,18 +231,67 @@
       return showingControls
     }
 
-    private func handleScenePhaseChange(_ phase: ScenePhase) {
-      if phase != .active || !shouldShowControls {
+    private func handleScenePhaseChange(from oldPhase: ScenePhase, to newPhase: ScenePhase) {
+      // Capture pre-background overlay state on the active → non-active edge,
+      // BEFORE the force-show below flips `showingControls`. Tells the
+      // subsequent resume whether to auto-hide the overlay or leave it
+      // visible.
+      if oldPhase == .active && newPhase != .active {
+        wasShowingControlsBeforeBackground = shouldShowControls
+      }
+
+      // PR #682 force-show — unchanged. Keeps iOS's status-bar / safe-area
+      // state in a known configuration across background → foreground so the
+      // dashboard inherits a clean safe-area on subsequent close. The
+      // historical UX cost (overlay flashing visible on every lock/unlock) is
+      // what the auto-hide below mitigates.
+      if newPhase != .active || !shouldShowControls {
         showingControls = true
+      }
+
+      // On returning to .active: if pre-background was hidden, schedule a
+      // brief auto-hide so the user gets a glance and the overlay fades back
+      // to where it was.
+      if oldPhase != .active, newPhase == .active, !wasShowingControlsBeforeBackground {
+        scheduleAutoHideAfterResume()
       }
 
       #if os(iOS)
         // Flush in-flight read progress to the server before iOS suspends the app, so
         // the trailing pages of the reading session are not lost to URLSession cancellation.
-        if phase == .background {
+        if newPhase == .background {
           readerPresentation.flushForBackgrounding()
         }
       #endif
+    }
+
+    /// Fade the overlay back to hidden after a brief glance window. Used only
+    /// on the resume path when the user had the overlay hidden before going
+    /// to background; preserves visible-overlay sessions untouched.
+    private func scheduleAutoHideAfterResume() {
+      autoHideAfterResumeTask?.cancel()
+      autoHideAfterResumeTask = Task { @MainActor in
+        try? await Task.sleep(for: .seconds(3))
+        guard !Task.isCancelled else { return }
+        withAnimation {
+          showingControls = false
+        }
+        autoHideAfterResumeTask = nil
+      }
+    }
+
+    private func cancelAutoHideAfterResume() {
+      autoHideAfterResumeTask?.cancel()
+      autoHideAfterResumeTask = nil
+    }
+
+    /// Restart the auto-hide timer if one is currently pending. Called from
+    /// existing user-interaction observers (e.g., page changes) so the auto-
+    /// hide acts as an idle timeout: interaction within the window resets
+    /// the clock, and the overlay only fades when the user actually pauses.
+    private func resetAutoHideAfterResumeIfPending() {
+      guard autoHideAfterResumeTask != nil else { return }
+      scheduleAutoHideAfterResume()
     }
 
     private var animation: Animation {
@@ -414,6 +477,7 @@
     }
 
     private func toggleControls() {
+      cancelAutoHideAfterResume()
       withAnimation(animation) {
         showingControls.toggle()
       }
@@ -468,6 +532,7 @@
     }
 
     private func closeReader() {
+      cancelAutoHideAfterResume()
       logger.debug(
         "🚪 Closing PDF reader for book \(book.id), page=\(viewModel.currentPageNumber)/\(viewModel.pageCount)"
       )

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -237,7 +237,8 @@
       // subsequent resume whether to auto-hide the overlay or leave it
       // visible.
       if oldPhase == .active && newPhase != .active {
-        wasShowingControlsBeforeBackground = shouldShowControls
+        wasShowingControlsBeforeBackground = autoHideAfterResumeTask == nil && shouldShowControls
+        cancelAutoHideAfterResume()
       }
 
       // PR #682 force-show — unchanged. Keeps iOS's status-bar / safe-area
@@ -271,7 +272,7 @@
     private func scheduleAutoHideAfterResume() {
       autoHideAfterResumeTask?.cancel()
       autoHideAfterResumeTask = Task { @MainActor in
-        try? await Task.sleep(for: .seconds(3))
+        try? await Task.sleep(for: .seconds(1))
         guard !Task.isCancelled else { return }
         withAnimation {
           showingControls = false


### PR DESCRIPTION
Closes #828

## Problem

PR #682 ("restore reader status bar ownership") forces the reader overlay visible on every non-active scene-phase transition as a workaround for an iPad safe-area quirk. The UX cost: locking the iPad while reading with the overlay hidden, then unlocking, leaves the overlay visible and sticky until tapped. Same flash on notification banners, the app switcher, and other brief inactive cycles. Adds up over a reading session.

(Full repro and rationale in the linked issue.)

## Approach

Keep the PR #682 force-show intact — it's still doing real work on every close path, particularly the swipe-down dismiss (which routes through `fullScreenCover`'s binding setter and bypasses `DivinaReaderView.closeReader()` entirely, so close-time reassertion alone doesn't cover it). Layer a graceful auto-hide on top: when returning to `.active` after the force-show fired because the user had the overlay hidden before going to background, schedule a brief fade-out so the overlay glances at the user (showing title, progress) and then settles back to where it was.

Nothing in the PR #682 path changes shape — the safe-area protection is preserved on every close path. The auto-hide is purely additive.

## State machine

Two new `@State` per reader:

- `wasShowingControlsBeforeBackground: Bool` — captured **once**, on the `.active → non-active` edge, **before** the force-show flips `showingControls`. This is the signal that says "the user was reading with the overlay hidden; restore that on unlock."
- `autoHideAfterResumeTask: Task<Void, Never>?` — the pending fade-out timer. Non-nil while a timer is in flight; nil otherwise. The nil-check doubles as "are we inside the post-resume window?" for the idle-reset behavior.

The handler updates from a single-arg `_ phase: ScenePhase` to `from oldPhase: ScenePhase, to newPhase: ScenePhase` so it can detect the `.active → non-active` edge (for capture) and `non-active → .active` edge (for scheduling) cleanly without state outside the function.

## Interaction model

| Event | Behavior |
|---|---|
| Pre-lock overlay hidden → unlock | Force-show fires (PR #682), auto-hide scheduled for 3s, overlay fades back to hidden |
| Pre-lock overlay visible → unlock | Force-show is a no-op (already visible), no auto-hide scheduled, overlay stays visible (user's preference preserved) |
| Tap-toggle during the 3s window | Cancel auto-hide, toggle as normal (explicit user signal, no double-action) |
| Page change during the 3s window | Reset auto-hide (idle-timeout: overlay stays visible while user is actively flipping pages, only fades after a real pause) |
| Reader close during the 3s window | Cancel auto-hide (cleanup, no stray fade after reader is gone) |
| Notification banner / app switcher | Same shape — brief inactive cycle, glance + fade on return |

## UX trade-off summary

| Path | Before this PR | After this PR |
|---|---|---|
| Lock/unlock with hidden overlay | Overlay visible until tap | Overlay glances 3s then fades — no tap needed |
| Lock/unlock with visible overlay | Overlay stays visible | Overlay stays visible (unchanged) |
| Notification banner with hidden overlay | Overlay visible until tap | Overlay glances 3s then fades |
| PR #682 safe-area protection (close after background) | Protected | Protected (force-show unchanged) |
| Tap-close from any state | Status bar correct, no flash | Same |
| Swipe-close from any state | Status bar correct via force-show staying applied | Same (force-show still runs the same way) |

## Scope

Same shape applied uniformly to all three readers:
- `DivinaReaderView` (DIVINA / comics)
- `PdfReaderView` (PDF)
- `EpubReaderView` (EPUB)

All three had identical PR #682 scene-phase logic; all three get identical auto-hide layering.

## Test plan

- [ ] iPad: read with overlay hidden, lock screen, unlock — overlay appears for ~3s then fades back automatically. No tap needed.
- [ ] iPad: read with overlay visible, lock screen, unlock — overlay stays visible (pre-lock state preserved).
- [ ] iPad: read with overlay hidden, swipe down notification center or pull up app switcher — same brief glance + fade behavior.
- [ ] iPad: **PR #682 repro path** — open reader with overlay hidden, background, resume, close via tap. Dashboard toolbar should not overlap status bar.
- [ ] iPad: **PR #682 repro path with swipe-close** — open reader with overlay hidden, background, resume, swipe down to dismiss. Dashboard toolbar should not overlap status bar (this is the path that bypasses `closeReader`, protected by the unchanged force-show).
- [ ] iPad: during the 3s post-resume window, flip a page via slider or tap — auto-hide timer should reset, overlay stays visible.
- [ ] iPad: during the 3s post-resume window, tap to dismiss overlay manually — should hide immediately, no double-action artifact.
- [ ] iPad: close reader during the 3s window — should not see the overlay flash hidden after the reader is gone.
- [ ] Each of the above on iPhone for completeness.

## Validation

**Not tested** — no Xcode environment available. All three readers follow the same shape, so behavior should be consistent across them. The full test plan above is the suggested verification path.

## Design notes

- **Why 3 seconds?** Long enough to read the title and glance at progress (the same value Apple Books uses is closer to 5s; we can tune later if needed).
- **Why fire-and-forget Task instead of a stored cancellable?** The Task IS stored as `autoHideAfterResumeTask` for cancel/reset semantics. The completion path sets `autoHideAfterResumeTask = nil` after the fade so the nil-check accurately reflects "is an auto-hide pending?" Cancellation paths in the helpers also set it to nil. Within a single main-actor tick the assignments are race-free — `Task.sleep` is the only suspension point, and everything after the sleep runs to completion before the next main-actor yield.
- **Why hook into existing `onChange` observers** for page changes rather than adding new ones? Avoids duplicating observers on the same property, and keeps the diff smaller and easier to audit. The reset call is a single line addition to each existing handler.
