### PR TITLE
fix(epub): load spine documents with manifest media types

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 451;
+				CURRENT_PROJECT_VERSION = 452;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 451;
+				CURRENT_PROJECT_VERSION = 452;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 451;
+				CURRENT_PROJECT_VERSION = 452;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 451;
+				CURRENT_PROJECT_VERSION = 452;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -1000,8 +1000,36 @@
           )
           throw AppErrorType.unknown(message: offlineEpubRecoveryMessage())
         }
+        try normalizeKoboScriptedChapterIfNeeded(at: cachedURL)
         chapterURLCache[index] = cachedURL
       }
+    }
+
+    private func normalizeKoboScriptedChapterIfNeeded(at url: URL) throws {
+      guard url.pathExtension.lowercased() == "html" || url.pathExtension.lowercased() == "xhtml" else {
+        return
+      }
+
+      let data = try Data(contentsOf: url)
+      guard var html = String(data: data, encoding: .utf8) else { return }
+      guard html.range(of: "kobo.js", options: .caseInsensitive) != nil else { return }
+      guard
+        html.range(of: "koboSpan", options: .caseInsensitive) != nil
+          || html.range(of: "book-inner", options: .caseInsensitive) != nil
+      else {
+        return
+      }
+
+      let originalHTML = html
+      html = html.replacingOccurrences(
+        of: #"<script\b(?=[^>]*\bsrc\s*=\s*["'][^"']*kobo\.js(?:[?#][^"']*)?["'])[^>]*(?:/>|>\s*</script\s*>)"#,
+        with: "",
+        options: [.regularExpression, .caseInsensitive]
+      )
+
+      guard html != originalHTML else { return }
+      try html.data(using: .utf8)?.write(to: url, options: .atomic)
+      logger.debug("Normalized Kobo scripted EPUB chapter before WebView load: \(url.lastPathComponent)")
     }
 
     private func offlineEpubRecoveryMessage() -> String {

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -606,6 +606,11 @@
       chapterURLCache[index]
     }
 
+    func chapterMediaType(at index: Int) -> String? {
+      guard index >= 0, index < readingOrder.count else { return nil }
+      return readingOrder[index].type
+    }
+
     func chapterPageCount(at index: Int) -> Int? {
       chapterPageCounts[index]
     }
@@ -1000,36 +1005,8 @@
           )
           throw AppErrorType.unknown(message: offlineEpubRecoveryMessage())
         }
-        try normalizeKoboScriptedChapterIfNeeded(at: cachedURL)
         chapterURLCache[index] = cachedURL
       }
-    }
-
-    private func normalizeKoboScriptedChapterIfNeeded(at url: URL) throws {
-      guard url.pathExtension.lowercased() == "html" || url.pathExtension.lowercased() == "xhtml" else {
-        return
-      }
-
-      let data = try Data(contentsOf: url)
-      guard var html = String(data: data, encoding: .utf8) else { return }
-      guard html.range(of: "kobo.js", options: .caseInsensitive) != nil else { return }
-      guard
-        html.range(of: "koboSpan", options: .caseInsensitive) != nil
-          || html.range(of: "book-inner", options: .caseInsensitive) != nil
-      else {
-        return
-      }
-
-      let originalHTML = html
-      html = html.replacingOccurrences(
-        of: #"<script\b(?=[^>]*\bsrc\s*=\s*["'][^"']*kobo\.js(?:[?#][^"']*)?["'])[^>]*(?:/>|>\s*</script\s*>)"#,
-        with: "",
-        options: [.regularExpression, .caseInsensitive]
-      )
-
-      guard html != originalHTML else { return }
-      try html.data(using: .utf8)?.write(to: url, options: .atomic)
-      logger.debug("Normalized Kobo scripted EPUB chapter before WebView load: \(url.lastPathComponent)")
     }
 
     private func offlineEpubRecoveryMessage() -> String {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
@@ -235,6 +235,7 @@
           CustomFontStore.shared.getFontPath(for: $0)
         }
         let chapterURL = parent.viewModel.chapterURL(at: chapterIndex)
+        let chapterMediaType = parent.viewModel.chapterMediaType(at: chapterIndex)
         let rootURL = parent.viewModel.resourceRootURL
         let readiumPayload = parent.preferences.makeReadiumPayload(
           theme: theme,
@@ -268,6 +269,7 @@
         if let cached = cachedControllers[key] {
           cached.configure(
             chapterURL: chapterURL,
+            chapterMediaType: chapterMediaType,
             rootURL: rootURL,
             containerInsets: containerInsets,
             theme: theme,
@@ -303,6 +305,7 @@
         }) {
           reusable.configure(
             chapterURL: chapterURL,
+            chapterMediaType: chapterMediaType,
             rootURL: rootURL,
             containerInsets: containerInsets,
             theme: theme,
@@ -335,6 +338,7 @@
 
         let controller = EpubPageViewController(
           chapterURL: chapterURL,
+          chapterMediaType: chapterMediaType,
           rootURL: rootURL,
           containerInsets: containerInsets,
           theme: theme,
@@ -416,6 +420,7 @@
 
         controller.configure(
           chapterURL: parent.viewModel.chapterURL(at: chapterIndex),
+          chapterMediaType: parent.viewModel.chapterMediaType(at: chapterIndex),
           rootURL: parent.viewModel.resourceRootURL,
           containerInsets: containerInsets,
           theme: theme,

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView_macOS.swift
@@ -63,6 +63,7 @@
       let pageIndex: Int
       let rawPageIndex: Int
       let chapterURL: URL?
+      let chapterMediaType: String?
       let rootURL: URL?
       let contentCSS: String
       let readiumProperties: [String: String?]
@@ -100,6 +101,7 @@
     private var currentSubPageIndex: Int = 0
     private var totalPagesInChapter: Int = 1
     private var chapterURL: URL?
+    private var chapterMediaType: String?
     private var rootURL: URL?
     private var contentCSS: String = ""
     private var readiumProperties: [String: String?] = [:]
@@ -162,8 +164,10 @@
       )
 
       let nextChapterURL = parent.viewModel.chapterURL(at: requestedChapterIndex)
+      let nextChapterMediaType = parent.viewModel.chapterMediaType(at: requestedChapterIndex)
       let nextRootURL = parent.viewModel.resourceRootURL
-      let shouldReload = nextChapterURL != chapterURL || nextRootURL != rootURL
+      let shouldReload =
+        nextChapterURL != chapterURL || nextChapterMediaType != chapterMediaType || nextRootURL != rootURL
       let appearanceChanged =
         contentCSS != readiumPayload.css
         || readiumProperties != readiumPayload.properties
@@ -198,6 +202,7 @@
           pageIndex: requestedPageIndex,
           rawPageIndex: requestedRawPageIndex,
           chapterURL: nextChapterURL,
+          chapterMediaType: nextChapterMediaType,
           rootURL: nextRootURL,
           contentCSS: readiumPayload.css,
           readiumProperties: readiumPayload.properties,
@@ -219,6 +224,7 @@
         chapterIndex: requestedChapterIndex,
         pageIndex: requestedPageIndex,
         chapterURL: nextChapterURL,
+        chapterMediaType: nextChapterMediaType,
         rootURL: nextRootURL,
         contentCSS: readiumPayload.css,
         readiumProperties: readiumPayload.properties,
@@ -278,6 +284,7 @@
         chapterIndex: request.chapterIndex,
         pageIndex: request.pageIndex,
         chapterURL: request.chapterURL,
+        chapterMediaType: request.chapterMediaType,
         rootURL: request.rootURL,
         contentCSS: request.contentCSS,
         readiumProperties: request.readiumProperties,
@@ -433,6 +440,7 @@
       chapterIndex: Int,
       pageIndex: Int,
       chapterURL: URL?,
+      chapterMediaType: String?,
       rootURL: URL?,
       contentCSS: String,
       readiumProperties: [String: String?],
@@ -444,6 +452,7 @@
       self.chapterIndex = chapterIndex
       self.currentSubPageIndex = pageIndex
       self.chapterURL = chapterURL
+      self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
       self.contentCSS = contentCSS
       self.readiumProperties = readiumProperties
@@ -459,7 +468,7 @@
       totalPagesInChapter = 1
       isAwaitingPaginationReady = true
       webView.alphaValue = 0.01
-      webView.loadFileURL(chapterURL, allowingReadAccessTo: rootURL)
+      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL, mediaType: chapterMediaType)
     }
 
     private func installOverlayIfNeeded() {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
@@ -1622,122 +1622,13 @@
       readingProgression: WebPubReadingProgression?,
       completion: (() -> Void)? = nil
     ) {
-      let readiumAssets = ReadiumCSSLoader.cssAssets(
+      let js = WebPubPagedJavaScriptBuilder.makeInjectCSSScript(
+        contentCSS: css,
+        readiumProperties: readiumProperties,
+        readiumPropertyKeys: readiumPropertyKeys,
         language: language,
         readingProgression: readingProgression
       )
-      let readiumVariant = ReadiumCSSLoader.resolveVariantSubdirectory(
-        language: language,
-        readingProgression: readingProgression
-      )
-      let shouldSetDir = readiumVariant == "rtl"
-
-      let readiumBefore = Data(readiumAssets.before.utf8).base64EncodedString()
-      let readiumDefault = Data(readiumAssets.defaultCSS.utf8).base64EncodedString()
-      let readiumAfter = Data(readiumAssets.after.utf8).base64EncodedString()
-      let customCSS = Data(css.utf8).base64EncodedString()
-
-      var properties: [String: Any] = [:]
-      for (key, value) in readiumProperties {
-        properties[key] = value ?? NSNull()
-      }
-      let propertiesJSON: String = {
-        guard
-          let data = try? JSONSerialization.data(withJSONObject: properties, options: []),
-          let json = String(data: data, encoding: .utf8)
-        else {
-          return "{}"
-        }
-        return json
-      }()
-      let propertyKeysJSON: String = {
-        guard
-          let data = try? JSONSerialization.data(withJSONObject: readiumPropertyKeys, options: []),
-          let json = String(data: data, encoding: .utf8)
-        else {
-          return "[]"
-        }
-        return json
-      }()
-      let languageJSON: String = {
-        guard let language else { return "null" }
-        var escaped = language
-        escaped = escaped.replacingOccurrences(of: "\\", with: "\\\\")
-        escaped = escaped.replacingOccurrences(of: "\"", with: "\\\"")
-        escaped = escaped.replacingOccurrences(of: "\n", with: "\\n")
-        escaped = escaped.replacingOccurrences(of: "\r", with: "\\r")
-        escaped = escaped.replacingOccurrences(of: "\t", with: "\\t")
-        return "\"\(escaped)\""
-      }()
-
-      let js = """
-          (function() {
-            var root = document.documentElement;
-            var lang = \(languageJSON);
-            if (lang) {
-              if (!root.hasAttribute('lang')) {
-                root.setAttribute('lang', lang);
-              }
-              if (!root.hasAttribute('xml:lang')) {
-                root.setAttribute('xml:lang', lang);
-              }
-              if (document.body) {
-                if (!document.body.hasAttribute('lang')) {
-                  document.body.setAttribute('lang', lang);
-                }
-                if (!document.body.hasAttribute('xml:lang')) {
-                  document.body.setAttribute('xml:lang', lang);
-                }
-              }
-            }
-            if (\(shouldSetDir ? "true" : "false")) {
-              root.setAttribute('dir', 'rtl');
-              if (document.body) {
-                document.body.setAttribute('dir', 'rtl');
-              }
-            }
-
-            var props = \(propertiesJSON);
-            Object.keys(props).forEach(function(key) {
-              var value = props[key];
-              if (value === null || value === undefined) {
-                root.style.removeProperty(key);
-              } else {
-                root.style.setProperty(key, value, 'important');
-              }
-            });
-            var knownKeys = \(propertyKeysJSON);
-            knownKeys.forEach(function(key) {
-              if (!(key in props)) {
-                root.style.removeProperty(key);
-              }
-            });
-
-            var meta = document.querySelector('meta[name=viewport]');
-            if (!meta) {
-              meta = document.createElement('meta');
-              meta.name = 'viewport';
-              document.head.appendChild(meta);
-            }
-            meta.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no');
-
-            var style = document.getElementById('kmreader-style');
-            if (!style) {
-              style = document.createElement('style');
-              style.id = 'kmreader-style';
-              document.head.appendChild(style);
-            }
-            var hasStyles = document.querySelector("link[rel~='stylesheet'], style:not(#kmreader-style)") !== null;
-            var css = atob('\(readiumBefore)') + "\\n"
-              + (hasStyles ? "" : atob('\(readiumDefault)') + "\\n")
-              + atob('\(readiumAfter)') + "\\n"
-              + atob('\(customCSS)');
-            style.textContent = css;
-
-            return true;
-          })();
-        """
-
       webView.evaluateJavaScript(js) { _, _ in
         completion?()
       }

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
@@ -276,6 +276,7 @@
 
         currentVC.configure(
           chapterURL: viewModel.chapterURL(at: chapterIndex),
+          chapterMediaType: viewModel.chapterMediaType(at: chapterIndex),
           rootURL: viewModel.resourceRootURL,
           containerInsets: containerInsets,
           theme: theme,
@@ -480,6 +481,7 @@
 
         let fontPath = parent.preferences.fontFamily.fontName.flatMap { CustomFontStore.shared.getFontPath(for: $0) }
         let chapterURL = parent.viewModel.chapterURL(at: chapterIndex)
+        let chapterMediaType = parent.viewModel.chapterMediaType(at: chapterIndex)
         let rootURL = parent.viewModel.resourceRootURL
         let readiumPayload = parent.preferences.makeReadiumPayload(
           theme: theme,
@@ -512,6 +514,7 @@
         if let cached = cachedControllers[key] {
           cached.configure(
             chapterURL: chapterURL,
+            chapterMediaType: chapterMediaType,
             rootURL: rootURL,
             containerInsets: containerInsets,
             theme: theme,
@@ -545,6 +548,7 @@
         }) {
           reusable.configure(
             chapterURL: chapterURL,
+            chapterMediaType: chapterMediaType,
             rootURL: rootURL,
             containerInsets: containerInsets,
             theme: theme,
@@ -577,6 +581,7 @@
 
         let controller = EpubPageViewController(
           chapterURL: chapterURL,
+          chapterMediaType: chapterMediaType,
           rootURL: rootURL,
           containerInsets: containerInsets,
           theme: theme,
@@ -1133,6 +1138,7 @@
     private var publicationLanguage: String?
     private var publicationReadingProgression: WebPubReadingProgression?
     private var chapterURL: URL?
+    private var chapterMediaType: String?
     private var rootURL: URL?
     private var lastLayoutSize: CGSize = .zero
     private var isContentLoaded = false
@@ -1158,6 +1164,7 @@
 
     init(
       chapterURL: URL?,
+      chapterMediaType: String?,
       rootURL: URL?,
       containerInsets: UIEdgeInsets,
       theme: ReaderTheme,
@@ -1178,6 +1185,7 @@
       onPageCountReady: ((Int) -> Void)?
     ) {
       self.chapterURL = chapterURL
+      self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
       self.containerInsets = containerInsets
       self.theme = theme
@@ -1266,6 +1274,7 @@
 
     func configure(
       chapterURL: URL?,
+      chapterMediaType: String?,
       rootURL: URL?,
       containerInsets: UIEdgeInsets,
       theme: ReaderTheme,
@@ -1287,7 +1296,8 @@
       targetProgressionOnReady: Double? = nil,
       onPageCountReady: ((Int) -> Void)?
     ) {
-      let shouldReload = chapterURL != self.chapterURL || rootURL != self.rootURL
+      let shouldReload =
+        chapterURL != self.chapterURL || chapterMediaType != self.chapterMediaType || rootURL != self.rootURL
       let appearanceChanged =
         theme != self.theme
         || containerInsets != self.containerInsets
@@ -1305,6 +1315,7 @@
       }
 
       self.chapterURL = chapterURL
+      self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
       self.containerInsets = containerInsets
       self.theme = theme
@@ -1533,7 +1544,7 @@
         loadingIndicator?.startAnimating()
       }
 
-      webView.loadFileURL(chapterURL, allowingReadAccessTo: rootURL)
+      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL, mediaType: chapterMediaType)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
@@ -41,6 +41,7 @@
 
       let vc = PagedScrollEpubViewController(
         chapterURL: viewModel.chapterURL(at: chapterIndex),
+        chapterMediaType: viewModel.chapterMediaType(at: chapterIndex),
         rootURL: viewModel.resourceRootURL,
         containerInsets: viewModel.containerInsetsForLabels().uiEdgeInsets,
         theme: theme,
@@ -198,6 +199,7 @@
 
       uiViewController.configure(
         chapterURL: viewModel.chapterURL(at: chapterIndex),
+        chapterMediaType: viewModel.chapterMediaType(at: chapterIndex),
         rootURL: viewModel.resourceRootURL,
         containerInsets: containerInsets,
         theme: theme,
@@ -247,6 +249,7 @@
     private var publicationReadingProgression: WebPubReadingProgression?
     private var animatePageTransitions: Bool
     private var chapterURL: URL?
+    private var chapterMediaType: String?
     private var rootURL: URL?
     private var lastLayoutSize: CGSize = .zero
     private var isContentLoaded = false
@@ -300,6 +303,7 @@
 
     init(
       chapterURL: URL?,
+      chapterMediaType: String?,
       rootURL: URL?,
       containerInsets: UIEdgeInsets,
       theme: ReaderTheme,
@@ -321,6 +325,7 @@
       useSafeArea: Bool
     ) {
       self.chapterURL = chapterURL
+      self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
       self.containerInsets = containerInsets
       self.theme = theme
@@ -718,6 +723,7 @@
 
     func configure(
       chapterURL: URL?,
+      chapterMediaType: String?,
       rootURL: URL?,
       containerInsets: UIEdgeInsets,
       theme: ReaderTheme,
@@ -736,7 +742,8 @@
       labelBottomOffset: CGFloat,
       useSafeArea: Bool
     ) {
-      let shouldReload = chapterURL != self.chapterURL || rootURL != self.rootURL
+      let shouldReload =
+        chapterURL != self.chapterURL || chapterMediaType != self.chapterMediaType || rootURL != self.rootURL
       let appearanceChanged =
         theme != self.theme
         || containerInsets != self.containerInsets
@@ -749,6 +756,7 @@
         || useSafeArea != self.useSafeArea
 
       self.chapterURL = chapterURL
+      self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
       self.containerInsets = containerInsets
       self.theme = theme
@@ -801,7 +809,7 @@
       webView.alpha = 0.01
       loadingIndicator?.startAnimating()
 
-      webView.loadFileURL(chapterURL, allowingReadAccessTo: rootURL)
+      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL, mediaType: chapterMediaType)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView_macOS.swift
@@ -64,6 +64,7 @@
     private var currentSubPageIndex: Int = 0
     private var totalPagesInChapter: Int = 1
     private var chapterURL: URL?
+    private var chapterMediaType: String?
     private var rootURL: URL?
     private var contentCSS: String = ""
     private var readiumProperties: [String: String?] = [:]
@@ -114,8 +115,10 @@
       )
 
       let nextChapterURL = parent.viewModel.chapterURL(at: selectedChapterIndex)
+      let nextChapterMediaType = parent.viewModel.chapterMediaType(at: selectedChapterIndex)
       let nextRootURL = parent.viewModel.resourceRootURL
-      let shouldReload = nextChapterURL != chapterURL || nextRootURL != rootURL
+      let shouldReload =
+        nextChapterURL != chapterURL || nextChapterMediaType != chapterMediaType || nextRootURL != rootURL
       let appearanceChanged =
         contentCSS != readiumPayload.css
         || readiumProperties != readiumPayload.properties
@@ -124,6 +127,7 @@
 
       chapterIndex = selectedChapterIndex
       chapterURL = nextChapterURL
+      chapterMediaType = nextChapterMediaType
       rootURL = nextRootURL
       contentCSS = readiumPayload.css
       readiumProperties = readiumPayload.properties
@@ -168,7 +172,7 @@
       totalPagesInChapter = 1
       isAwaitingPaginationReady = true
       webView.alphaValue = 0.01
-      webView.loadFileURL(chapterURL, allowingReadAccessTo: rootURL)
+      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL, mediaType: chapterMediaType)
     }
 
     private func installOverlayIfNeeded() {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPlatformSupport.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPlatformSupport.swift
@@ -54,6 +54,26 @@
     }
   }
 
+  extension WKWebView {
+    func loadEPUBDocument(
+      url: URL,
+      rootURL: URL,
+      mediaType: String?
+    ) {
+      guard let mediaType, let data = try? Data(contentsOf: url) else {
+        loadFileURL(url, allowingReadAccessTo: rootURL)
+        return
+      }
+
+      load(
+        data,
+        mimeType: mediaType,
+        characterEncodingName: "utf-8",
+        baseURL: url.deletingLastPathComponent()
+      )
+    }
+  }
+
   extension URL {
     var deletingFragment: URL {
       guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
@@ -1279,122 +1279,13 @@
       readingProgression: WebPubReadingProgression?,
       completion: (() -> Void)? = nil
     ) {
-      let readiumAssets = ReadiumCSSLoader.cssAssets(
+      let js = WebPubPagedJavaScriptBuilder.makeInjectCSSScript(
+        contentCSS: css,
+        readiumProperties: readiumProperties,
+        readiumPropertyKeys: readiumPropertyKeys,
         language: language,
         readingProgression: readingProgression
       )
-      let readiumVariant = ReadiumCSSLoader.resolveVariantSubdirectory(
-        language: language,
-        readingProgression: readingProgression
-      )
-      let shouldSetDir = readiumVariant == "rtl"
-
-      let readiumBefore = Data(readiumAssets.before.utf8).base64EncodedString()
-      let readiumDefault = Data(readiumAssets.defaultCSS.utf8).base64EncodedString()
-      let readiumAfter = Data(readiumAssets.after.utf8).base64EncodedString()
-      let customCSS = Data(css.utf8).base64EncodedString()
-
-      var properties: [String: Any] = [:]
-      for (key, value) in readiumProperties {
-        properties[key] = value ?? NSNull()
-      }
-      let propertiesJSON: String = {
-        guard
-          let data = try? JSONSerialization.data(withJSONObject: properties, options: []),
-          let json = String(data: data, encoding: .utf8)
-        else {
-          return "{}"
-        }
-        return json
-      }()
-      let propertyKeysJSON: String = {
-        guard
-          let data = try? JSONSerialization.data(withJSONObject: readiumPropertyKeys, options: []),
-          let json = String(data: data, encoding: .utf8)
-        else {
-          return "[]"
-        }
-        return json
-      }()
-      let languageJSON: String = {
-        guard let language else { return "null" }
-        var escaped = language
-        escaped = escaped.replacingOccurrences(of: "\\", with: "\\\\")
-        escaped = escaped.replacingOccurrences(of: "\"", with: "\\\"")
-        escaped = escaped.replacingOccurrences(of: "\n", with: "\\n")
-        escaped = escaped.replacingOccurrences(of: "\r", with: "\\r")
-        escaped = escaped.replacingOccurrences(of: "\t", with: "\\t")
-        return "\"\(escaped)\""
-      }()
-
-      let js = """
-          (function() {
-            var root = document.documentElement;
-            var lang = \(languageJSON);
-            if (lang) {
-              if (!root.hasAttribute('lang')) {
-                root.setAttribute('lang', lang);
-              }
-              if (!root.hasAttribute('xml:lang')) {
-                root.setAttribute('xml:lang', lang);
-              }
-              if (document.body) {
-                if (!document.body.hasAttribute('lang')) {
-                  document.body.setAttribute('lang', lang);
-                }
-                if (!document.body.hasAttribute('xml:lang')) {
-                  document.body.setAttribute('xml:lang', lang);
-                }
-              }
-            }
-            if (\(shouldSetDir ? "true" : "false")) {
-              root.setAttribute('dir', 'rtl');
-              if (document.body) {
-                document.body.setAttribute('dir', 'rtl');
-              }
-            }
-
-            var props = \(propertiesJSON);
-            Object.keys(props).forEach(function(key) {
-              var value = props[key];
-              if (value === null || value === undefined) {
-                root.style.removeProperty(key);
-              } else {
-                root.style.setProperty(key, value, 'important');
-              }
-            });
-            var knownKeys = \(propertyKeysJSON);
-            knownKeys.forEach(function(key) {
-              if (!(key in props)) {
-                root.style.removeProperty(key);
-              }
-            });
-
-            var meta = document.querySelector('meta[name=viewport]');
-            if (!meta) {
-              meta = document.createElement('meta');
-              meta.name = 'viewport';
-              document.head.appendChild(meta);
-            }
-            meta.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no');
-
-            var style = document.getElementById('kmreader-style');
-            if (!style) {
-              style = document.createElement('style');
-              style.id = 'kmreader-style';
-              document.head.appendChild(style);
-            }
-            var hasStyles = document.querySelector("link[rel~='stylesheet'], style:not(#kmreader-style)") !== null;
-            var css = atob('\(readiumBefore)') + "\\n"
-              + (hasStyles ? "" : atob('\(readiumDefault)') + "\\n")
-              + atob('\(readiumAfter)') + "\\n"
-              + atob('\(customCSS)');
-            style.textContent = css;
-
-            return true;
-          })();
-        """
-
       webView.evaluateJavaScript(js) { _, _ in
         completion?()
       }

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
@@ -40,6 +40,7 @@
 
       let vc = ScrolledEpubViewController(
         chapterURL: viewModel.chapterURL(at: chapterIndex),
+        chapterMediaType: viewModel.chapterMediaType(at: chapterIndex),
         rootURL: viewModel.resourceRootURL,
         containerInsets: viewModel.containerInsetsForLabels().uiEdgeInsets,
         tapScrollPercentage: preferences.tapScrollPercentage,
@@ -198,6 +199,7 @@
 
       uiViewController.configure(
         chapterURL: viewModel.chapterURL(at: chapterIndex),
+        chapterMediaType: viewModel.chapterMediaType(at: chapterIndex),
         rootURL: viewModel.resourceRootURL,
         containerInsets: containerInsets,
         tapScrollPercentage: preferences.tapScrollPercentage,
@@ -254,6 +256,7 @@
     private var publicationLanguage: String?
     private var publicationReadingProgression: WebPubReadingProgression?
     private var chapterURL: URL?
+    private var chapterMediaType: String?
     private var rootURL: URL?
     private var lastLayoutSize: CGSize = .zero
     private var isContentLoaded = false
@@ -316,6 +319,7 @@
 
     init(
       chapterURL: URL?,
+      chapterMediaType: String?,
       rootURL: URL?,
       containerInsets: UIEdgeInsets,
       tapScrollPercentage: Double,
@@ -338,6 +342,7 @@
       useSafeArea: Bool
     ) {
       self.chapterURL = chapterURL
+      self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
       self.containerInsets = containerInsets
       self.tapScrollPercentage = Self.normalizedTapScrollPercentage(tapScrollPercentage)
@@ -684,6 +689,7 @@
 
     func configure(
       chapterURL: URL?,
+      chapterMediaType: String?,
       rootURL: URL?,
       containerInsets: UIEdgeInsets,
       tapScrollPercentage: Double,
@@ -703,7 +709,8 @@
       labelBottomOffset: CGFloat,
       useSafeArea: Bool
     ) {
-      let shouldReload = chapterURL != self.chapterURL || rootURL != self.rootURL
+      let shouldReload =
+        chapterURL != self.chapterURL || chapterMediaType != self.chapterMediaType || rootURL != self.rootURL
       let normalizedTapScrollPercentage = Self.normalizedTapScrollPercentage(tapScrollPercentage)
       let appearanceChanged =
         theme != self.theme
@@ -719,6 +726,7 @@
         || useSafeArea != self.useSafeArea
 
       self.chapterURL = chapterURL
+      self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
       self.containerInsets = containerInsets
       self.tapScrollPercentage = normalizedTapScrollPercentage
@@ -780,7 +788,7 @@
       webView.alpha = 0.01
       loadingIndicator?.startAnimating()
 
-      webView.loadFileURL(chapterURL, allowingReadAccessTo: rootURL)
+      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL, mediaType: chapterMediaType)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
@@ -596,97 +596,13 @@
     }
 
     private func injectCSS(on webView: WKWebView, completion: (() -> Void)? = nil) {
-      let readiumAssets = ReadiumCSSLoader.cssAssets(
+      let js = WebPubPagedJavaScriptBuilder.makeInjectCSSScript(
+        contentCSS: contentCSS,
+        readiumProperties: readiumProperties,
+        readiumPropertyKeys: EpubReaderPreferences.readiumPropertyKeys,
         language: publicationLanguage,
         readingProgression: publicationReadingProgression
       )
-      let readiumVariant = ReadiumCSSLoader.resolveVariantSubdirectory(
-        language: publicationLanguage,
-        readingProgression: publicationReadingProgression
-      )
-      let shouldSetDir = readiumVariant == "rtl"
-
-      let readiumBefore = Data(readiumAssets.before.utf8).base64EncodedString()
-      let readiumDefault = Data(readiumAssets.defaultCSS.utf8).base64EncodedString()
-      let readiumAfter = Data(readiumAssets.after.utf8).base64EncodedString()
-      let customCSS = Data(contentCSS.utf8).base64EncodedString()
-
-      var properties: [String: Any] = [:]
-      for (key, value) in readiumProperties {
-        properties[key] = value ?? NSNull()
-      }
-      let propertiesJSON = WebPubJavaScriptSupport.encodeJSON(properties, fallback: "{}")
-      let propertyKeysJSON = WebPubJavaScriptSupport.encodeJSON(
-        EpubReaderPreferences.readiumPropertyKeys, fallback: "[]")
-      let languageJSON = WebPubJavaScriptSupport.escapedJSONString(publicationLanguage)
-
-      let js = """
-          (function() {
-            var root = document.documentElement;
-            var lang = \(languageJSON);
-            if (lang) {
-              if (!root.hasAttribute('lang')) {
-                root.setAttribute('lang', lang);
-              }
-              if (!root.hasAttribute('xml:lang')) {
-                root.setAttribute('xml:lang', lang);
-              }
-              if (document.body) {
-                if (!document.body.hasAttribute('lang')) {
-                  document.body.setAttribute('lang', lang);
-                }
-                if (!document.body.hasAttribute('xml:lang')) {
-                  document.body.setAttribute('xml:lang', lang);
-                }
-              }
-            }
-            if (\(shouldSetDir ? "true" : "false")) {
-              root.setAttribute('dir', 'rtl');
-              if (document.body) {
-                document.body.setAttribute('dir', 'rtl');
-              }
-            }
-
-            var props = \(propertiesJSON);
-            Object.keys(props).forEach(function(key) {
-              var value = props[key];
-              if (value === null || value === undefined) {
-                root.style.removeProperty(key);
-              } else {
-                root.style.setProperty(key, value, 'important');
-              }
-            });
-            var knownKeys = \(propertyKeysJSON);
-            knownKeys.forEach(function(key) {
-              if (!(key in props)) {
-                root.style.removeProperty(key);
-              }
-            });
-
-            var meta = document.querySelector('meta[name=viewport]');
-            if (!meta) {
-              meta = document.createElement('meta');
-              meta.name = 'viewport';
-              document.head.appendChild(meta);
-            }
-            meta.setAttribute('content', 'width=device-width, initial-scale=1.0');
-
-            var style = document.getElementById('kmreader-style');
-            if (!style) {
-              style = document.createElement('style');
-              style.id = 'kmreader-style';
-              document.head.appendChild(style);
-            }
-            var hasStyles = document.querySelector("link[rel~='stylesheet'], style:not(#kmreader-style)") !== null;
-            var css = atob('\(readiumBefore)') + "\\n"
-              + (hasStyles ? "" : atob('\(readiumDefault)') + "\\n")
-              + atob('\(readiumAfter)') + "\\n"
-              + atob('\(customCSS)');
-            style.textContent = css;
-            return true;
-          })();
-        """
-
       webView.evaluateJavaScript(js) { _, _ in
         completion?()
       }

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
@@ -61,6 +61,7 @@
     private var currentSubPageIndex: Int = 0
     private var totalPagesInChapter: Int = 1
     private var chapterURL: URL?
+    private var chapterMediaType: String?
     private var rootURL: URL?
     private var contentCSS: String = ""
     private var readiumProperties: [String: String?] = [:]
@@ -114,8 +115,10 @@
       )
 
       let nextChapterURL = parent.viewModel.chapterURL(at: selectedChapterIndex)
+      let nextChapterMediaType = parent.viewModel.chapterMediaType(at: selectedChapterIndex)
       let nextRootURL = parent.viewModel.resourceRootURL
-      let shouldReload = nextChapterURL != chapterURL || nextRootURL != rootURL
+      let shouldReload =
+        nextChapterURL != chapterURL || nextChapterMediaType != chapterMediaType || nextRootURL != rootURL
       let appearanceChanged =
         contentCSS != readiumPayload.css
         || readiumProperties != readiumPayload.properties
@@ -125,6 +128,7 @@
 
       chapterIndex = selectedChapterIndex
       chapterURL = nextChapterURL
+      chapterMediaType = nextChapterMediaType
       rootURL = nextRootURL
       contentCSS = readiumPayload.css
       readiumProperties = readiumPayload.properties
@@ -172,7 +176,7 @@
       lastKnownDocumentContentHeight = 0
       lastKnownDocumentViewportHeight = 0
       totalPagesInChapter = 1
-      webView.loadFileURL(chapterURL, allowingReadAccessTo: rootURL)
+      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL, mediaType: chapterMediaType)
     }
 
     private func installOverlayIfNeeded() {


### PR DESCRIPTION
## Problem
Some EPUBs store XHTML spine documents with `.html` filenames while the manifest correctly declares those reading order items as `application/xhtml+xml`. Loading those files through `WKWebView.loadFileURL` lets WebKit infer the type from the local file URL, so `.html` documents can be parsed as regular HTML instead of XHTML.

For Kobo scripted exports, this breaks chapters containing XHTML-style self-closing script tags such as `<script src="../js/kobo.js"/>`. In HTML parsing mode, WebKit treats that tag as an unclosed script element and consumes the following style/body markup as script text. The chapter DOM is effectively empty, so pagination reports a single blank page.

## Approach
Load EPUB spine documents from `Data` with the media type supplied by the reading order manifest instead of relying on file extension inference. This preserves `application/xhtml+xml` parsing for XHTML documents even when their filenames end in `.html`, while still falling back to `loadFileURL` when no media type or data is available.

The implementation also reuses the shared Readium CSS injection builder across the remaining EPUB reader paths, so language escaping, Readium asset assembly, and property serialization stay in one place.

## Scope
- Add a shared `WKWebView.loadEPUBDocument` helper that accepts a manifest media type.
- Pass each chapter's reading order `type` through the EPUB reader views.
- Use the helper across paged scroll, scrolled, page curl, and macOS cover flows.
- Remove the Kobo-specific chapter normalization workaround in favor of standards-based MIME handling.
- Consolidate remaining manual Readium CSS injection paths through the shared builder.

## Release
This fix is planned to be included in the next KMReader release.

## Validation
- [x] `make format`
- [x] `make build`

Refs #827
