### PR TITLE
fix(epub): split tap zone settings

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 452;
+				CURRENT_PROJECT_VERSION = 453;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 452;
+				CURRENT_PROJECT_VERSION = 453;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 452;
+				CURRENT_PROJECT_VERSION = 453;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 452;
+				CURRENT_PROJECT_VERSION = 453;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -694,9 +694,7 @@ enum AppConfig {
         return mode
       }
 
-      let migratedMode = tapZoneMode
-      UserDefaults.standard.set(migratedMode.rawValue, forKey: "epubTapZoneMode")
-      return migratedMode
+      return .defaultLayout
     }
     set {
       UserDefaults.standard.set(newValue.rawValue, forKey: "epubTapZoneMode")
@@ -711,9 +709,7 @@ enum AppConfig {
         return mode
       }
 
-      let migratedMode = tapZoneInversionMode
-      UserDefaults.standard.set(migratedMode.rawValue, forKey: "epubTapZoneInversionMode")
-      return migratedMode
+      return .auto
     }
     set {
       UserDefaults.standard.set(newValue.rawValue, forKey: "epubTapZoneInversionMode")

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -686,6 +686,40 @@ enum AppConfig {
     }
   }
 
+  static nonisolated var epubTapZoneMode: TapZoneMode {
+    get {
+      if let stored = UserDefaults.standard.string(forKey: "epubTapZoneMode"),
+        let mode = TapZoneMode(rawValue: stored)
+      {
+        return mode
+      }
+
+      let migratedMode = tapZoneMode
+      UserDefaults.standard.set(migratedMode.rawValue, forKey: "epubTapZoneMode")
+      return migratedMode
+    }
+    set {
+      UserDefaults.standard.set(newValue.rawValue, forKey: "epubTapZoneMode")
+    }
+  }
+
+  static nonisolated var epubTapZoneInversionMode: TapZoneInversionMode {
+    get {
+      if let stored = UserDefaults.standard.string(forKey: "epubTapZoneInversionMode"),
+        let mode = TapZoneInversionMode(rawValue: stored)
+      {
+        return mode
+      }
+
+      let migratedMode = tapZoneInversionMode
+      UserDefaults.standard.set(migratedMode.rawValue, forKey: "epubTapZoneInversionMode")
+      return migratedMode
+    }
+    set {
+      UserDefaults.standard.set(newValue.rawValue, forKey: "epubTapZoneInversionMode")
+    }
+  }
+
   static nonisolated var showKeyboardHelpOverlay: Bool {
     get {
       if UserDefaults.standard.object(forKey: "showKeyboardHelpOverlay") != nil {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
@@ -1047,8 +1047,8 @@
         let action = TapZoneHelper.action(
           normalizedX: normalizedX,
           normalizedY: normalizedY,
-          tapZoneMode: AppConfig.tapZoneMode,
-          tapZoneInversionMode: AppConfig.tapZoneInversionMode,
+          tapZoneMode: AppConfig.epubTapZoneMode,
+          tapZoneInversionMode: AppConfig.epubTapZoneInversionMode,
           readingDirection: tapReadingDirection()
         )
 

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
@@ -815,8 +815,8 @@
         let action = TapZoneHelper.action(
           normalizedX: normalizedX,
           normalizedY: normalizedY,
-          tapZoneMode: AppConfig.tapZoneMode,
-          tapZoneInversionMode: AppConfig.tapZoneInversionMode,
+          tapZoneMode: AppConfig.epubTapZoneMode,
+          tapZoneInversionMode: AppConfig.epubTapZoneInversionMode,
           readingDirection: tapReadingDirection()
         )
 

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
@@ -508,8 +508,8 @@
       let action = TapZoneHelper.action(
         normalizedX: normalizedX,
         normalizedY: normalizedY,
-        tapZoneMode: AppConfig.tapZoneMode,
-        tapZoneInversionMode: AppConfig.tapZoneInversionMode,
+        tapZoneMode: AppConfig.epubTapZoneMode,
+        tapZoneInversionMode: AppConfig.epubTapZoneInversionMode,
         readingDirection: tapReadingDirection()
       )
 

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
@@ -576,8 +576,8 @@
       let action = TapZoneHelper.action(
         normalizedX: normalizedX,
         normalizedY: normalizedY,
-        tapZoneMode: AppConfig.tapZoneMode,
-        tapZoneInversionMode: AppConfig.tapZoneInversionMode,
+        tapZoneMode: AppConfig.epubTapZoneMode,
+        tapZoneInversionMode: AppConfig.epubTapZoneInversionMode,
         readingDirection: tapReadingDirection()
       )
 

--- a/KMReader/Features/Reader/Views/Sheets/EpubPreferencesView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubPreferencesView_macOS.swift
@@ -206,27 +206,31 @@
           }
 
           Section(String(localized: "Tap Zones")) {
-            TapZoneModePicker(
-              selection: $epubTapZoneMode,
-              tapZoneInversionMode: epubTapZoneInversionMode,
-              readingDirection: draft.flowStyle.isPaged ? .ltr : .vertical
-            )
+            VStack(alignment: .leading, spacing: 8) {
+              TapZoneModePicker(
+                selection: $epubTapZoneMode,
+                tapZoneInversionMode: epubTapZoneInversionMode,
+                readingDirection: draft.flowStyle.isPaged ? .ltr : .vertical
+              )
 
-            Text("Choose how tap zones are laid out")
-              .font(.caption)
-              .foregroundStyle(.secondary)
-
-            if !epubTapZoneMode.isDisabled {
-              Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
-                ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in
-                  Text(mode.displayName).tag(mode)
-                }
-              }
-              .pickerStyle(.menu)
-
-              Text("Mirror left and right tap zones manually or automatically for RTL reading")
+              Text("Choose how tap zones are laid out")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+            }
+
+            if !epubTapZoneMode.isDisabled {
+              VStack(alignment: .leading, spacing: 8) {
+                Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
+                  ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in
+                    Text(mode.displayName).tag(mode)
+                  }
+                }
+                .pickerStyle(.menu)
+
+                Text("Mirror left and right tap zones manually or automatically for RTL reading")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+              }
             }
           }
 

--- a/KMReader/Features/Reader/Views/Sheets/EpubPreferencesView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubPreferencesView_macOS.swift
@@ -189,19 +189,21 @@
             }
 
             if draft.flowStyle.isPaged {
-              Picker(
-                String(localized: "Page Transition Style"),
-                selection: $epubPageTransitionStyle
-              ) {
-                ForEach(PageTransitionStyle.epubAvailableCases, id: \.self) { style in
-                  Text(style.displayName).tag(style)
+              VStack(alignment: .leading, spacing: 8) {
+                Picker(
+                  String(localized: "Page Transition Style"),
+                  selection: $epubPageTransitionStyle
+                ) {
+                  ForEach(PageTransitionStyle.epubAvailableCases, id: \.self) { style in
+                    Text(style.displayName).tag(style)
+                  }
                 }
-              }
-              .pickerStyle(.menu)
+                .pickerStyle(.menu)
 
-              Text(epubPageTransitionStyle.description)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                Text(epubPageTransitionStyle.description)
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+              }
             }
           }
 
@@ -290,21 +292,23 @@
               }
             }
 
-            HStack {
-              Text(fontWeightLabelText)
-              Spacer()
-              Toggle("", isOn: fontWeightEnabled)
-                .labelsHidden()
-            }
+            VStack(alignment: .leading, spacing: 8) {
+              HStack {
+                Text(fontWeightLabelText)
+                Spacer()
+                Toggle("", isOn: fontWeightEnabled)
+                  .labelsHidden()
+              }
 
-            Text(
-              String(
-                localized:
-                  "Font weight support depends on the current font. Some fonts may ignore this setting or only support part of the range."
+              Text(
+                String(
+                  localized:
+                    "Font weight support depends on the current font. Some fonts may ignore this setting or only support part of the range."
+                )
               )
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
+              .font(.caption)
+              .foregroundStyle(.secondary)
+            }
 
             if draft.fontWeight != nil {
               Slider(
@@ -388,25 +392,27 @@
             }
 
             Section(String(localized: "Line & Paragraph")) {
-              Picker(
-                String(localized: "epub.text_alignment.title", defaultValue: "Text Alignment"),
-                selection: $draft.textAlignment
-              ) {
-                ForEach(EpubTextAlignment.allCases) { alignment in
-                  Text(alignment.displayName)
-                    .tag(alignment)
+              VStack(alignment: .leading, spacing: 8) {
+                Picker(
+                  String(localized: "epub.text_alignment.title", defaultValue: "Text Alignment"),
+                  selection: $draft.textAlignment
+                ) {
+                  ForEach(EpubTextAlignment.allCases) { alignment in
+                    Text(alignment.displayName)
+                      .tag(alignment)
+                  }
                 }
-              }
-              .pickerStyle(.menu)
+                .pickerStyle(.menu)
 
-              Text(
-                String(
-                  localized: "epub.text_alignment.justify.description",
-                  defaultValue: "Justify automatically enables hyphenation."
+                Text(
+                  String(
+                    localized: "epub.text_alignment.justify.description",
+                    defaultValue: "Justify automatically enables hyphenation."
+                  )
                 )
-              )
-              .font(.caption)
-              .foregroundStyle(.secondary)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+              }
 
               VStack(alignment: .leading) {
                 Slider(value: $draft.lineHeight, in: 0.5...2.5, step: 0.1)

--- a/KMReader/Features/Reader/Views/Sheets/EpubPreferencesView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubPreferencesView_macOS.swift
@@ -21,6 +21,9 @@
     @AppStorage("epubShowsProgressFooter") private var epubShowsProgressFooter: Bool = false
     @AppStorage("epubShowKeyboardHelpOverlay")
     private var showKeyboardHelpOverlay: Bool = AppConfig.epubShowKeyboardHelpOverlay
+    @AppStorage("epubTapZoneMode") private var epubTapZoneMode: TapZoneMode = AppConfig.epubTapZoneMode
+    @AppStorage("epubTapZoneInversionMode")
+    private var epubTapZoneInversionMode: TapZoneInversionMode = AppConfig.epubTapZoneInversionMode
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
@@ -197,6 +200,31 @@
               .pickerStyle(.menu)
 
               Text(epubPageTransitionStyle.description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+          }
+
+          Section(String(localized: "Tap Zones")) {
+            TapZoneModePicker(
+              selection: $epubTapZoneMode,
+              tapZoneInversionMode: epubTapZoneInversionMode,
+              readingDirection: draft.flowStyle.isPaged ? .ltr : .vertical
+            )
+
+            Text("Choose how tap zones are laid out")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+
+            if !epubTapZoneMode.isDisabled {
+              Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
+                ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in
+                  Text(mode.displayName).tag(mode)
+                }
+              }
+              .pickerStyle(.menu)
+
+              Text("Mirror left and right tap zones manually or automatically for RTL reading")
                 .font(.caption)
                 .foregroundStyle(.secondary)
             }

--- a/KMReader/Features/Reader/Views/Sheets/EpubPreferencesView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubPreferencesView_macOS.swift
@@ -207,55 +207,6 @@
             }
           }
 
-          Section(String(localized: "Tap Zones")) {
-            VStack(alignment: .leading, spacing: 8) {
-              TapZoneModePicker(
-                selection: $epubTapZoneMode,
-                tapZoneInversionMode: epubTapZoneInversionMode,
-                readingDirection: draft.flowStyle.isPaged ? .ltr : .vertical
-              )
-
-              Text("Choose how tap zones are laid out")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-
-            if !epubTapZoneMode.isDisabled {
-              VStack(alignment: .leading, spacing: 8) {
-                Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
-                  ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in
-                    Text(mode.displayName).tag(mode)
-                  }
-                }
-                .pickerStyle(.menu)
-
-                Text("Mirror left and right tap zones manually or automatically for RTL reading")
-                  .font(.caption)
-                  .foregroundStyle(.secondary)
-              }
-            }
-          }
-
-          Section(String(localized: "Reader Overlay")) {
-            Toggle(isOn: $epubShowsProgressFooter) {
-              VStack(alignment: .leading, spacing: 4) {
-                Text(String(localized: "Show Progress Footer"))
-                Text(String(localized: "Show book progress at the bottom while reading."))
-                  .font(.caption)
-                  .foregroundStyle(.secondary)
-              }
-            }
-
-            Toggle(isOn: $showKeyboardHelpOverlay) {
-              VStack(alignment: .leading, spacing: 4) {
-                Text("Auto-Show Keyboard Help")
-                Text("Briefly show keyboard shortcuts when opening the reader")
-                  .font(.caption)
-                  .foregroundStyle(.secondary)
-              }
-            }
-          }
-
           Section(String(localized: "Presets")) {
             Button(String(localized: "Load Preset")) {
               showPresetsSheet = true
@@ -437,6 +388,55 @@
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)
+              }
+            }
+          }
+
+          Section(String(localized: "Tap Zones")) {
+            VStack(alignment: .leading, spacing: 8) {
+              TapZoneModePicker(
+                selection: $epubTapZoneMode,
+                tapZoneInversionMode: epubTapZoneInversionMode,
+                readingDirection: draft.flowStyle.isPaged ? .ltr : .vertical
+              )
+
+              Text("Choose how tap zones are laid out")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+
+            if !epubTapZoneMode.isDisabled {
+              VStack(alignment: .leading, spacing: 8) {
+                Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
+                  ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in
+                    Text(mode.displayName).tag(mode)
+                  }
+                }
+                .pickerStyle(.menu)
+
+                Text("Mirror left and right tap zones manually or automatically for RTL reading")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+              }
+            }
+          }
+
+          Section(String(localized: "Reader Overlay")) {
+            Toggle(isOn: $epubShowsProgressFooter) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text(String(localized: "Show Progress Footer"))
+                Text(String(localized: "Show book progress at the bottom while reading."))
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+              }
+            }
+
+            Toggle(isOn: $showKeyboardHelpOverlay) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Auto-Show Keyboard Help")
+                Text("Briefly show keyboard shortcuts when opening the reader")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
               }
             }
           }

--- a/KMReader/Features/Settings/EpubPreferencesView.swift
+++ b/KMReader/Features/Settings/EpubPreferencesView.swift
@@ -191,27 +191,31 @@
         }
 
         Section(String(localized: "Tap Zones")) {
-          TapZoneModePicker(
-            selection: $epubTapZoneMode,
-            tapZoneInversionMode: epubTapZoneInversionMode,
-            readingDirection: draft.flowStyle.isPaged ? .ltr : .vertical
-          )
+          VStack(alignment: .leading, spacing: 8) {
+            TapZoneModePicker(
+              selection: $epubTapZoneMode,
+              tapZoneInversionMode: epubTapZoneInversionMode,
+              readingDirection: draft.flowStyle.isPaged ? .ltr : .vertical
+            )
 
-          Text("Choose how tap zones are laid out")
-            .font(.caption)
-            .foregroundStyle(.secondary)
-
-          if !epubTapZoneMode.isDisabled {
-            Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
-              ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in
-                Text(mode.displayName).tag(mode)
-              }
-            }
-            .pickerStyle(.menu)
-
-            Text("Mirror left and right tap zones manually or automatically for RTL reading")
+            Text("Choose how tap zones are laid out")
               .font(.caption)
               .foregroundStyle(.secondary)
+          }
+
+          if !epubTapZoneMode.isDisabled {
+            VStack(alignment: .leading, spacing: 8) {
+              Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
+                ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in
+                  Text(mode.displayName).tag(mode)
+                }
+              }
+              .pickerStyle(.menu)
+
+              Text("Mirror left and right tap zones manually or automatically for RTL reading")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
           }
         }
 

--- a/KMReader/Features/Settings/EpubPreferencesView.swift
+++ b/KMReader/Features/Settings/EpubPreferencesView.swift
@@ -192,64 +192,6 @@
           }
         }
 
-        Section(String(localized: "Tap Zones")) {
-          VStack(alignment: .leading, spacing: 8) {
-            TapZoneModePicker(
-              selection: $epubTapZoneMode,
-              tapZoneInversionMode: epubTapZoneInversionMode,
-              readingDirection: draft.flowStyle.isPaged ? .ltr : .vertical
-            )
-
-            Text("Choose how tap zones are laid out")
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-
-          if !epubTapZoneMode.isDisabled {
-            VStack(alignment: .leading, spacing: 8) {
-              Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
-                ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in
-                  Text(mode.displayName).tag(mode)
-                }
-              }
-              .pickerStyle(.menu)
-
-              Text("Mirror left and right tap zones manually or automatically for RTL reading")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-          }
-        }
-
-        Section(String(localized: "Reader Overlay")) {
-          Toggle(isOn: $epubShowsStatusBarWhileReading) {
-            VStack(alignment: .leading, spacing: 4) {
-              Text(String(localized: "Show Status Bar While Reading"))
-              Text(String(localized: "Keep time and battery visible when controls are hidden."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-          }
-
-          Toggle(isOn: $epubShowsProgressFooter) {
-            VStack(alignment: .leading, spacing: 4) {
-              Text(String(localized: "Show Progress Footer"))
-              Text(String(localized: "Show book progress at the bottom while reading."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-          }
-
-          Toggle(isOn: $showKeyboardHelpOverlay) {
-            VStack(alignment: .leading, spacing: 4) {
-              Text("Auto-Show Keyboard Help")
-              Text("Briefly show keyboard shortcuts when opening the reader")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-          }
-        }
-
         Section(String(localized: "Presets")) {
           Button {
             showPresetsSheet = true
@@ -445,6 +387,64 @@
               )
               .font(.caption)
               .foregroundStyle(.secondary)
+            }
+          }
+        }
+
+        Section(String(localized: "Tap Zones")) {
+          VStack(alignment: .leading, spacing: 8) {
+            TapZoneModePicker(
+              selection: $epubTapZoneMode,
+              tapZoneInversionMode: epubTapZoneInversionMode,
+              readingDirection: draft.flowStyle.isPaged ? .ltr : .vertical
+            )
+
+            Text("Choose how tap zones are laid out")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+
+          if !epubTapZoneMode.isDisabled {
+            VStack(alignment: .leading, spacing: 8) {
+              Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
+                ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in
+                  Text(mode.displayName).tag(mode)
+                }
+              }
+              .pickerStyle(.menu)
+
+              Text("Mirror left and right tap zones manually or automatically for RTL reading")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+          }
+        }
+
+        Section(String(localized: "Reader Overlay")) {
+          Toggle(isOn: $epubShowsStatusBarWhileReading) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text(String(localized: "Show Status Bar While Reading"))
+              Text(String(localized: "Keep time and battery visible when controls are hidden."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+          }
+
+          Toggle(isOn: $epubShowsProgressFooter) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text(String(localized: "Show Progress Footer"))
+              Text(String(localized: "Show book progress at the bottom while reading."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+          }
+
+          Toggle(isOn: $showKeyboardHelpOverlay) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Auto-Show Keyboard Help")
+              Text("Briefly show keyboard shortcuts when opening the reader")
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
           }
         }

--- a/KMReader/Features/Settings/EpubPreferencesView.swift
+++ b/KMReader/Features/Settings/EpubPreferencesView.swift
@@ -177,16 +177,18 @@
           }
 
           if draft.flowStyle.isPaged {
-            Picker(String(localized: "Page Transition Style"), selection: $epubPageTransitionStyle) {
-              ForEach(PageTransitionStyle.epubAvailableCases, id: \.self) { style in
-                Text(style.displayName).tag(style)
+            VStack(alignment: .leading, spacing: 8) {
+              Picker(String(localized: "Page Transition Style"), selection: $epubPageTransitionStyle) {
+                ForEach(PageTransitionStyle.epubAvailableCases, id: \.self) { style in
+                  Text(style.displayName).tag(style)
+                }
               }
-            }
-            .pickerStyle(.menu)
+              .pickerStyle(.menu)
 
-            Text(epubPageTransitionStyle.description)
-              .font(.caption)
-              .foregroundStyle(.secondary)
+              Text(epubPageTransitionStyle.description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
           }
         }
 
@@ -279,21 +281,23 @@
           }
           .id(fontListRefreshId)
 
-          HStack {
-            Text(fontWeightLabelText)
-            Spacer()
-            Toggle("", isOn: fontWeightEnabled)
-              .labelsHidden()
-          }
+          VStack(alignment: .leading, spacing: 8) {
+            HStack {
+              Text(fontWeightLabelText)
+              Spacer()
+              Toggle("", isOn: fontWeightEnabled)
+                .labelsHidden()
+            }
 
-          Text(
-            String(
-              localized:
-                "Font weight support depends on the current font. Some fonts may ignore this setting or only support part of the range."
+            Text(
+              String(
+                localized:
+                  "Font weight support depends on the current font. Some fonts may ignore this setting or only support part of the range."
+              )
             )
-          )
-          .font(.caption)
-          .foregroundStyle(.secondary)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+          }
 
           if draft.fontWeight != nil {
             Slider(
@@ -393,25 +397,27 @@
           }
 
           Section(String(localized: "Line & Paragraph")) {
-            Picker(
-              String(localized: "epub.text_alignment.title", defaultValue: "Text Alignment"),
-              selection: $draft.textAlignment
-            ) {
-              ForEach(EpubTextAlignment.allCases) { alignment in
-                Text(alignment.displayName)
-                  .tag(alignment)
+            VStack(alignment: .leading, spacing: 8) {
+              Picker(
+                String(localized: "epub.text_alignment.title", defaultValue: "Text Alignment"),
+                selection: $draft.textAlignment
+              ) {
+                ForEach(EpubTextAlignment.allCases) { alignment in
+                  Text(alignment.displayName)
+                    .tag(alignment)
+                }
               }
-            }
-            .pickerStyle(.menu)
+              .pickerStyle(.menu)
 
-            Text(
-              String(
-                localized: "epub.text_alignment.justify.description",
-                defaultValue: "Justify automatically enables hyphenation."
+              Text(
+                String(
+                  localized: "epub.text_alignment.justify.description",
+                  defaultValue: "Justify automatically enables hyphenation."
+                )
               )
-            )
-            .font(.caption)
-            .foregroundStyle(.secondary)
+              .font(.caption)
+              .foregroundStyle(.secondary)
+            }
 
             VStack(alignment: .leading) {
               Slider(value: $draft.lineHeight, in: 0.5...2.5, step: 0.1)

--- a/KMReader/Features/Settings/EpubPreferencesView.swift
+++ b/KMReader/Features/Settings/EpubPreferencesView.swift
@@ -28,6 +28,9 @@
     @AppStorage("epubShowsProgressFooter") private var epubShowsProgressFooter: Bool = false
     @AppStorage("epubShowKeyboardHelpOverlay")
     private var showKeyboardHelpOverlay: Bool = AppConfig.epubShowKeyboardHelpOverlay
+    @AppStorage("epubTapZoneMode") private var epubTapZoneMode: TapZoneMode = AppConfig.epubTapZoneMode
+    @AppStorage("epubTapZoneInversionMode")
+    private var epubTapZoneInversionMode: TapZoneInversionMode = AppConfig.epubTapZoneInversionMode
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) var colorScheme
@@ -182,6 +185,31 @@
             .pickerStyle(.menu)
 
             Text(epubPageTransitionStyle.description)
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+
+        Section(String(localized: "Tap Zones")) {
+          TapZoneModePicker(
+            selection: $epubTapZoneMode,
+            tapZoneInversionMode: epubTapZoneInversionMode,
+            readingDirection: draft.flowStyle.isPaged ? .ltr : .vertical
+          )
+
+          Text("Choose how tap zones are laid out")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+          if !epubTapZoneMode.isDisabled {
+            Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
+              ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in
+                Text(mode.displayName).tag(mode)
+              }
+            }
+            .pickerStyle(.menu)
+
+            Text("Mirror left and right tap zones manually or automatically for RTL reading")
               .font(.caption)
               .foregroundStyle(.secondary)
           }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -73826,7 +73826,70 @@
         }
       }
     },
-    "Tap Zones" : {},
+    "Tap Zones" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tippzonen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap Zones"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zonas táctiles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zones de toucher"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zone di tocco"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タップゾーン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탭 존"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зоны касания"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击区域"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "點擊區域"
+          }
+        }
+      }
+    },
     "Task Queue Status" : {
       "localizations" : {
         "de" : {

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -73826,9 +73826,7 @@
         }
       }
     },
-    "Tap Zones" : {
-
-    },
+    "Tap Zones" : {},
     "Task Queue Status" : {
       "localizations" : {
         "de" : {

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -73826,6 +73826,9 @@
         }
       }
     },
+    "Tap Zones" : {
+
+    },
     "Task Queue Status" : {
       "localizations" : {
         "de" : {

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -73826,70 +73826,7 @@
         }
       }
     },
-    "Tap Zones" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tippzonen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tap Zones"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zonas táctiles"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zones de toucher"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zone di tocco"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "タップゾーン"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "탭 존"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Зоны касания"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "点击区域"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "點擊區域"
-          }
-        }
-      }
-    },
+    "Tap Zones" : {},
     "Task Queue Status" : {
       "localizations" : {
         "de" : {


### PR DESCRIPTION
## Problem
EPUB tap navigation was sharing the same tap zone preferences that are exposed under the DIVINA settings page, which made the controls misleading and coupled two different reader experiences.

## Approach
Add dedicated EPUB tap zone preference keys and wire EPUB tap handling to those settings directly. The EPUB settings pages now expose their own tap zone controls, with helper descriptions grouped inside the relevant setting rows instead of appearing as standalone rows.

## Scope
- Add EPUB-specific tap zone mode and mirroring settings
- Use the EPUB-specific settings in EPUB paged, curl, cover, and scrolled tap handlers
- Add EPUB tap zone controls to iOS and macOS EPUB preferences
- Increment build version to 453

## Testing
- [x] make format
- [x] make build-ios
- [x] make build-macos
