### PR TITLE
fix(offline): update libarchive for UTF-8 archive paths

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -688,7 +688,7 @@
 			repositoryURL = "https://github.com/everpcpc/libarchive-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.7;
+				minimumVersion = 0.1.8;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -1943,7 +1943,7 @@ actor OfflineManager {
           try? FileManager.default.removeItem(at: archiveExtractionFile)
         } catch {
           logger.error(
-            "❌ Background archive extraction failed for book \(bookId), file=\(archiveExtractionFile.lastPathComponent), bookDir=\(bookDir.path), error=\(error.localizedDescription)"
+            "❌ Background archive extraction failed for book \(bookId), file=\(archiveExtractionFile.lastPathComponent), bookDir=\(bookDir.path), error=\(String(describing: error))"
           )
           await failArchiveExtraction(recoveryMessage)
           return


### PR DESCRIPTION
## Summary
- update libarchive-swift requirement to 0.1.8 for UTF-8 archive pathname handling
- preserve richer archive extraction error logging with associated error details

## Context
libarchive-swift 0.1.8 fixes valid CBZ/ZIP archives with UTF-8 pathnames failing under C locale during offline extraction.