### PR TITLE
fix(reader): finish divina scroll turns after animation

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 453;
+				CURRENT_PROJECT_VERSION = 454;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 453;
+				CURRENT_PROJECT_VERSION = 454;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 453;
+				CURRENT_PROJECT_VERSION = 454;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 453;
+				CURRENT_PROJECT_VERSION = 454;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
@@ -245,12 +245,7 @@
           }
         }
 
-        let finishedProgrammaticScroll = finishProgrammaticScrollIfTargetReached(in: collectionView)
-        if finishedProgrammaticScroll {
-          refreshedVisibleContent = true
-        }
-
-        if !finishedProgrammaticScroll, let navigationTarget = parent.viewModel.navigationTarget {
+        if let navigationTarget = parent.viewModel.navigationTarget {
           handleNavigationChange(navigationTarget, in: collectionView)
         } else if renderInputsChanged && !refreshedVisibleContent {
           refreshVisibleCells(in: collectionView)
@@ -661,30 +656,6 @@
         return true
       }
 
-      @discardableResult
-      private func finishProgrammaticScrollIfTargetReached(in collectionView: UICollectionView) -> Bool {
-        guard engine.isProgrammaticScrolling || engine.hasPendingProgrammaticCommit else {
-          return false
-        }
-        guard engine.programmaticTargetItem != nil else {
-          clearProgrammaticScrollState()
-          return false
-        }
-
-        let reachedTargetOffset =
-          pendingProgrammaticTargetOffset.map {
-            isEquivalentContentOffset($0, to: collectionView.contentOffset)
-          }
-          ?? false
-
-        guard reachedTargetOffset else {
-          return false
-        }
-
-        finishProgrammaticScroll(in: collectionView)
-        return true
-      }
-
       private func commitPendingProgrammaticItemIfNeeded(in collectionView: UICollectionView) -> Bool {
         guard let resolvedItem = engine.consumePendingProgrammaticCommit() else {
           return false
@@ -1082,7 +1053,6 @@
         if let item = centeredItem(in: collectionView) {
           preloadVisiblePages(for: item)
         }
-        _ = finishProgrammaticScrollIfTargetReached(in: collectionView)
       }
 
       func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
@@ -1090,13 +1060,11 @@
         if !decelerate {
           finishScrollInteractionIfNeeded()
         }
-        _ = finishProgrammaticScrollIfTargetReached(in: collectionView)
       }
 
       func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         guard let collectionView else { return }
         finishScrollInteractionIfNeeded()
-        _ = finishProgrammaticScrollIfTargetReached(in: collectionView)
       }
 
       func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {


### PR DESCRIPTION
## Problem
Programmatic DIVINA scroll turns could commit the target page as soon as the content offset reached the destination, before UIKit had reported the animated scroll as finished. Near segment boundaries, that early commit could trigger progress, preloading, and adjacent segment updates while the page-turn animation was still settling, causing occasional stutter around the final pages of a segment.

## Approach
Make iOS scroll-mode programmatic turns finish only from `scrollViewDidEndScrollingAnimation`, and remove the offset-based early completion helper. Scroll updates still keep visible page preloads responsive, but current-page and segment mutations now wait for the actual animation completion callback.

## Scope
- Remove offset-based programmatic scroll completion from the iOS DIVINA scroll coordinator
- Keep visible-page preloading during scroll without committing page state mid-animation
- Bump the project build number to 454

## Validation
- [x] `make format`
- [x] `git diff --check`
