### PR TITLE
fix(epub): serve publication resources through custom scheme

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 455;
+				CURRENT_PROJECT_VERSION = 456;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 455;
+				CURRENT_PROJECT_VERSION = 456;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 455;
+				CURRENT_PROJECT_VERSION = 456;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 455;
+				CURRENT_PROJECT_VERSION = 456;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Services/EpubResourceSchemeHandler.swift
+++ b/KMReader/Features/Reader/Services/EpubResourceSchemeHandler.swift
@@ -1,66 +1,71 @@
+import Foundation
+import UniformTypeIdentifiers
+
+nonisolated enum EpubResourceScheme {
+  static let scheme = "kmreader-resource"
+  static let host = "epub"
+  static let virtualFontsPrefix = "__fonts__"
+
+  static func url(for fileURL: URL, rootURL: URL) -> URL? {
+    let root = rootURL.standardizedFileURL.resolvingSymlinksInPath()
+    let file = deletingFragment(from: fileURL).standardizedFileURL.resolvingSymlinksInPath()
+    let rootPath = root.path.hasSuffix("/") ? root.path : root.path + "/"
+    guard file.path.hasPrefix(rootPath) || file.path == root.path else { return nil }
+
+    let relativePath = file.path == root.path ? "" : String(file.path.dropFirst(rootPath.count))
+    guard !relativePath.isEmpty else { return nil }
+    return url(forRelativePath: relativePath)
+  }
+
+  static func url(forRelativePath relativePath: String) -> URL? {
+    guard let safePath = EpubResourceSafeRelativePath(relativePath) else { return nil }
+    var components = URLComponents()
+    components.scheme = scheme
+    components.host = host
+    components.path =
+      "/"
+      + safePath.split(separator: "/").map {
+        String($0).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? String($0)
+      }.joined(separator: "/")
+    return components.url
+  }
+
+  static func fontURL(fileName: String) -> URL? {
+    url(forRelativePath: "\(virtualFontsPrefix)/\(fileName)")
+  }
+
+  static func relativePath(from url: URL) -> String? {
+    guard url.scheme == scheme, url.host == host else { return nil }
+    let path = deletingFragment(from: url).path
+    let trimmed = path.hasPrefix("/") ? String(path.dropFirst()) : path
+    return EpubResourceSafeRelativePath(trimmed.removingPercentEncoding ?? trimmed)
+  }
+
+  private static func deletingFragment(from url: URL) -> URL {
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      return url
+    }
+    components.fragment = nil
+    return components.url ?? url
+  }
+}
+
+nonisolated func EpubResourceSafeRelativePath(_ path: String) -> String? {
+  let normalized = path.replacingOccurrences(of: "\\", with: "/")
+  guard !normalized.isEmpty, !normalized.hasPrefix("/") else { return nil }
+  var components: [String] = []
+  for component in normalized.split(separator: "/", omittingEmptySubsequences: true) {
+    let part = String(component)
+    if part == "." { continue }
+    guard part != ".." else { return nil }
+    components.append(part)
+  }
+  guard !components.isEmpty else { return nil }
+  return components.joined(separator: "/")
+}
+
 #if os(iOS) || os(macOS)
-  import Foundation
   import WebKit
-  import UniformTypeIdentifiers
-
-  nonisolated enum EpubResourceScheme {
-    static let scheme = "kmreader-resource"
-    static let host = "epub"
-    static let virtualFontsPrefix = "__fonts__"
-
-    static func url(for fileURL: URL, rootURL: URL) -> URL? {
-      let root = rootURL.standardizedFileURL.resolvingSymlinksInPath()
-      let file = deletingFragment(from: fileURL).standardizedFileURL.resolvingSymlinksInPath()
-      let rootPath = root.path.hasSuffix("/") ? root.path : root.path + "/"
-      guard file.path.hasPrefix(rootPath) || file.path == root.path else { return nil }
-
-      let relativePath = file.path == root.path ? "" : String(file.path.dropFirst(rootPath.count))
-      guard !relativePath.isEmpty else { return nil }
-      return url(forRelativePath: relativePath)
-    }
-
-    static func url(forRelativePath relativePath: String) -> URL? {
-      guard let safePath = EpubResourceSafeRelativePath(relativePath) else { return nil }
-      var components = URLComponents()
-      components.scheme = scheme
-      components.host = host
-      components.path = "/" + safePath.split(separator: "/").map { String($0).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? String($0) }.joined(separator: "/")
-      return components.url
-    }
-
-    static func fontURL(fileName: String) -> URL? {
-      url(forRelativePath: "\(virtualFontsPrefix)/\(fileName)")
-    }
-
-    static func relativePath(from url: URL) -> String? {
-      guard url.scheme == scheme, url.host == host else { return nil }
-      let path = deletingFragment(from: url).path
-      let trimmed = path.hasPrefix("/") ? String(path.dropFirst()) : path
-      return EpubResourceSafeRelativePath(trimmed.removingPercentEncoding ?? trimmed)
-    }
-
-    private static func deletingFragment(from url: URL) -> URL {
-      guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-        return url
-      }
-      components.fragment = nil
-      return components.url ?? url
-    }
-  }
-
-  nonisolated func EpubResourceSafeRelativePath(_ path: String) -> String? {
-    let normalized = path.replacingOccurrences(of: "\\", with: "/")
-    guard !normalized.isEmpty, !normalized.hasPrefix("/") else { return nil }
-    var components: [String] = []
-    for component in normalized.split(separator: "/", omittingEmptySubsequences: true) {
-      let part = String(component)
-      if part == "." { continue }
-      guard part != ".." else { return nil }
-      components.append(part)
-    }
-    guard !components.isEmpty else { return nil }
-    return components.joined(separator: "/")
-  }
 
   final class EpubResourceSchemeHandler: NSObject, WKURLSchemeHandler {
     private let lock = NSLock()
@@ -104,7 +109,8 @@
 
       do {
         let data = try Data(contentsOf: fileURL)
-        let mimeType = mediaType(for: relativePath, fileURL: fileURL, mediaTypesByRelativePath: configuration.mediaTypesByRelativePath)
+        let mimeType = mediaType(
+          for: relativePath, fileURL: fileURL, mediaTypesByRelativePath: configuration.mediaTypesByRelativePath)
         let response = URLResponse(
           url: requestURL,
           mimeType: mimeType,
@@ -139,7 +145,8 @@
       return name
     }
 
-    private func mediaType(for relativePath: String, fileURL: URL, mediaTypesByRelativePath: [String: String]) -> String {
+    private func mediaType(for relativePath: String, fileURL: URL, mediaTypesByRelativePath: [String: String]) -> String
+    {
       if let mappedType = mediaTypesByRelativePath[relativePath], !mappedType.isEmpty { return mappedType }
       return Self.mediaTypeForExtension(fileURL.pathExtension)
     }

--- a/KMReader/Features/Reader/Services/EpubResourceSchemeHandler.swift
+++ b/KMReader/Features/Reader/Services/EpubResourceSchemeHandler.swift
@@ -1,0 +1,193 @@
+#if os(iOS) || os(macOS)
+  import Foundation
+  import WebKit
+  import UniformTypeIdentifiers
+
+  nonisolated enum EpubResourceScheme {
+    static let scheme = "kmreader-resource"
+    static let host = "epub"
+    static let virtualFontsPrefix = "__fonts__"
+
+    static func url(for fileURL: URL, rootURL: URL) -> URL? {
+      let root = rootURL.standardizedFileURL.resolvingSymlinksInPath()
+      let file = deletingFragment(from: fileURL).standardizedFileURL.resolvingSymlinksInPath()
+      let rootPath = root.path.hasSuffix("/") ? root.path : root.path + "/"
+      guard file.path.hasPrefix(rootPath) || file.path == root.path else { return nil }
+
+      let relativePath = file.path == root.path ? "" : String(file.path.dropFirst(rootPath.count))
+      guard !relativePath.isEmpty else { return nil }
+      return url(forRelativePath: relativePath)
+    }
+
+    static func url(forRelativePath relativePath: String) -> URL? {
+      guard let safePath = EpubResourceSafeRelativePath(relativePath) else { return nil }
+      var components = URLComponents()
+      components.scheme = scheme
+      components.host = host
+      components.path = "/" + safePath.split(separator: "/").map { String($0).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? String($0) }.joined(separator: "/")
+      return components.url
+    }
+
+    static func fontURL(fileName: String) -> URL? {
+      url(forRelativePath: "\(virtualFontsPrefix)/\(fileName)")
+    }
+
+    static func relativePath(from url: URL) -> String? {
+      guard url.scheme == scheme, url.host == host else { return nil }
+      let path = deletingFragment(from: url).path
+      let trimmed = path.hasPrefix("/") ? String(path.dropFirst()) : path
+      return EpubResourceSafeRelativePath(trimmed.removingPercentEncoding ?? trimmed)
+    }
+
+    private static func deletingFragment(from url: URL) -> URL {
+      guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        return url
+      }
+      components.fragment = nil
+      return components.url ?? url
+    }
+  }
+
+  nonisolated func EpubResourceSafeRelativePath(_ path: String) -> String? {
+    let normalized = path.replacingOccurrences(of: "\\", with: "/")
+    guard !normalized.isEmpty, !normalized.hasPrefix("/") else { return nil }
+    var components: [String] = []
+    for component in normalized.split(separator: "/", omittingEmptySubsequences: true) {
+      let part = String(component)
+      if part == "." { continue }
+      guard part != ".." else { return nil }
+      components.append(part)
+    }
+    guard !components.isEmpty else { return nil }
+    return components.joined(separator: "/")
+  }
+
+  final class EpubResourceSchemeHandler: NSObject, WKURLSchemeHandler {
+    private let lock = NSLock()
+    private var rootURL: URL?
+    private var mediaTypesByRelativePath: [String: String] = [:]
+
+    func configure(rootURL: URL?, mediaTypesByRelativePath: [String: String]) {
+      lock.lock()
+      self.rootURL = rootURL?.standardizedFileURL.resolvingSymlinksInPath()
+      self.mediaTypesByRelativePath = mediaTypesByRelativePath
+      lock.unlock()
+    }
+
+    private func configurationSnapshot() -> (rootURL: URL?, mediaTypesByRelativePath: [String: String]) {
+      lock.lock()
+      let snapshot = (rootURL, mediaTypesByRelativePath)
+      lock.unlock()
+      return snapshot
+    }
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+      guard let requestURL = urlSchemeTask.request.url,
+        let relativePath = EpubResourceScheme.relativePath(from: requestURL)
+      else {
+        fail(urlSchemeTask, code: NSURLErrorBadURL)
+        return
+      }
+
+      let configuration = configurationSnapshot()
+      let fileURL: URL?
+      if let fontFileName = fontFileName(from: relativePath) {
+        fileURL = FontFileManager.resolveFontFile(named: fontFileName)
+      } else {
+        fileURL = epubFileURL(for: relativePath, rootURL: configuration.rootURL)
+      }
+
+      guard let fileURL else {
+        fail(urlSchemeTask, code: NSURLErrorFileDoesNotExist)
+        return
+      }
+
+      do {
+        let data = try Data(contentsOf: fileURL)
+        let mimeType = mediaType(for: relativePath, fileURL: fileURL, mediaTypesByRelativePath: configuration.mediaTypesByRelativePath)
+        let response = URLResponse(
+          url: requestURL,
+          mimeType: mimeType,
+          expectedContentLength: data.count,
+          textEncodingName: isTextMediaType(mimeType) ? "utf-8" : nil
+        )
+        urlSchemeTask.didReceive(response)
+        urlSchemeTask.didReceive(data)
+        urlSchemeTask.didFinish()
+      } catch {
+        urlSchemeTask.didFailWithError(error)
+      }
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {}
+
+    private func epubFileURL(for relativePath: String, rootURL: URL?) -> URL? {
+      guard let rootURL else { return nil }
+
+      let candidate = rootURL.appendingPathComponent(relativePath).standardizedFileURL.resolvingSymlinksInPath()
+      let rootPath = rootURL.path.hasSuffix("/") ? rootURL.path : rootURL.path + "/"
+      guard candidate.path.hasPrefix(rootPath) || candidate.path == rootURL.path else { return nil }
+      guard FileManager.default.fileExists(atPath: candidate.path) else { return nil }
+      return candidate
+    }
+
+    private func fontFileName(from relativePath: String) -> String? {
+      let prefix = EpubResourceScheme.virtualFontsPrefix + "/"
+      guard relativePath.hasPrefix(prefix) else { return nil }
+      let name = String(relativePath.dropFirst(prefix.count))
+      guard !name.contains("/") else { return nil }
+      return name
+    }
+
+    private func mediaType(for relativePath: String, fileURL: URL, mediaTypesByRelativePath: [String: String]) -> String {
+      if let mappedType = mediaTypesByRelativePath[relativePath], !mappedType.isEmpty { return mappedType }
+      return Self.mediaTypeForExtension(fileURL.pathExtension)
+    }
+
+    private func isTextMediaType(_ mediaType: String) -> Bool {
+      mediaType.hasPrefix("text/")
+        || mediaType == "application/xhtml+xml"
+        || mediaType == "application/xml"
+        || mediaType == "application/javascript"
+        || mediaType == "image/svg+xml"
+    }
+
+    private func fail(_ task: WKURLSchemeTask, code: Int) {
+      task.didFailWithError(NSError(domain: NSURLErrorDomain, code: code))
+    }
+
+    static func mediaTypeForExtension(_ pathExtension: String) -> String {
+      switch pathExtension.lowercased() {
+      case "xhtml", "xht": return "application/xhtml+xml"
+      case "html", "htm": return "text/html"
+      case "css": return "text/css"
+      case "js", "mjs": return "application/javascript"
+      case "jpg", "jpeg": return "image/jpeg"
+      case "png": return "image/png"
+      case "gif": return "image/gif"
+      case "svg", "svgz": return "image/svg+xml"
+      case "webp": return "image/webp"
+      case "ttf": return "font/ttf"
+      case "otf": return "font/otf"
+      case "woff": return "font/woff"
+      case "woff2": return "font/woff2"
+      case "mp3": return "audio/mpeg"
+      case "m4a": return "audio/mp4"
+      case "aac": return "audio/aac"
+      case "oga", "ogg": return "audio/ogg"
+      case "wav": return "audio/wav"
+      case "mp4", "m4v": return "video/mp4"
+      case "webm": return "video/webm"
+      case "ogv": return "video/ogg"
+      case "xml", "opf", "ncx": return "application/xml"
+      default:
+        if let type = UTType(filenameExtension: pathExtension),
+          let mimeType = type.preferredMIMEType
+        {
+          return mimeType
+        }
+        return "application/octet-stream"
+      }
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Services/FontFileManager.swift
+++ b/KMReader/Features/Reader/Services/FontFileManager.swift
@@ -29,9 +29,17 @@ enum FontFileManager {
     return appSupportURL.appendingPathComponent(relativePath).path
   }
 
-  /// Creates a relative path for a font file
-  /// - Parameter fileName: The font file name
-  /// - Returns: Relative path like "CustomFonts/font.ttf"
+  /// Resolves a font file by its stored file name.
+  /// - Parameter fileName: Stored custom font file name.
+  /// - Returns: Absolute file URL, or nil if the file is not available.
+  static func resolveFontFile(named fileName: String) -> URL? {
+    guard !fileName.contains("/"), !fileName.contains("\\") else { return nil }
+    guard let fontsDir = fontsDirectory() else { return nil }
+    let fileURL = fontsDir.appendingPathComponent(fileName).standardizedFileURL
+    guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+    return fileURL
+  }
+
   static func relativePath(for fileName: String) -> String {
     return "CustomFonts/\(fileName)"
   }

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -57,6 +57,7 @@
     var targetPageIndex: Int?
     var currentLocation: WebPubLocation?
     var resourceRootURL: URL?
+    var mediaTypesByRelativePath: [String: String] = [:]
     var publicationLanguage: String?
     var publicationReadingProgression: WebPubReadingProgression?
 
@@ -168,6 +169,7 @@
       targetPageIndex = nil
       currentLocation = nil
       resourceRootURL = nil
+      mediaTypesByRelativePath = [:]
       publicationLanguage = nil
       publicationReadingProgression = nil
       chapterPageCounts = [:]
@@ -222,7 +224,7 @@
         tocTitleByHref = buildTOCTitleMap(from: tableOfContents)
 
         resourceRootURL = offlineRoot
-        copyCustomFontsToResourceDirectory()
+        mediaTypesByRelativePath = Self.mediaTypeMap(from: manifest)
         // Page count cache is memory-only, no file loading needed
         loadTextLengthCache()
         try await cacheChapterURLs()
@@ -301,6 +303,31 @@
         isLoading = false
         logger.error("WebPub load failed: \(message)")
       }
+    }
+
+    private static func mediaTypeMap(from manifest: WebPubPublication) -> [String: String] {
+      var map: [String: String] = [:]
+
+      func collect(_ links: [WebPubLink]) {
+        for link in links {
+          let normalized = normalizedHref(link.href)
+          if let safePath = EpubResourceSafeRelativePath(normalized), let type = link.type {
+            map[safePath] = type
+          }
+          if let children = link.children {
+            collect(children)
+          }
+        }
+      }
+
+      collect(manifest.readingOrder)
+      collect(manifest.resources)
+      collect(manifest.images)
+      collect(manifest.links)
+      collect(manifest.toc)
+      collect(manifest.pageList)
+      collect(manifest.landmarks)
+      return map
     }
 
     private func ensureOfflineReady(
@@ -1039,69 +1066,6 @@
     private func chapterIndexForHref(_ href: String) -> Int? {
       let normalized = Self.normalizedHref(href)
       return readingOrder.firstIndex { Self.normalizedHref($0.href) == normalized }
-    }
-
-    /// Ensures a specific font is copied to the resource directory
-    /// - Parameter fontName: The name of the font to copy
-    func ensureFontCopied(fontName: String) {
-      guard let rootURL = resourceRootURL else { return }
-      guard let sourcePath = CustomFontStore.shared.getFontPath(for: fontName) else { return }
-
-      let sourceURL = URL(fileURLWithPath: sourcePath)
-      guard FileManager.default.fileExists(atPath: sourceURL.path) else { return }
-
-      let fontsDirectory = rootURL.appendingPathComponent(".fonts", isDirectory: true)
-      try? FileManager.default.createDirectory(at: fontsDirectory, withIntermediateDirectories: true)
-
-      let fileName = sourceURL.lastPathComponent
-      let destinationURL = fontsDirectory.appendingPathComponent(fileName)
-
-      // Copy font file if it doesn't already exist
-      if !FileManager.default.fileExists(atPath: destinationURL.path) {
-        try? FileManager.default.copyItem(at: sourceURL, to: destinationURL)
-      }
-    }
-
-    private func copyCustomFontsToResourceDirectory() {
-      guard let rootURL = resourceRootURL else { return }
-
-      // Create .fonts directory
-      let fontsDirectory = rootURL.appendingPathComponent(".fonts", isDirectory: true)
-      do {
-        try FileManager.default.createDirectory(at: fontsDirectory, withIntermediateDirectories: true)
-      } catch {
-        print("⚠️ Failed to create fonts directory: \(error)")
-        return
-      }
-
-      // Get all custom fonts with paths
-      let customFonts = CustomFontStore.shared.fetchCustomFonts()
-
-      for fontName in customFonts {
-        guard let sourcePath = CustomFontStore.shared.getFontPath(for: fontName) else {
-          continue
-        }
-
-        let sourceURL = URL(fileURLWithPath: sourcePath)
-
-        // Check if source file exists
-        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
-          print("⚠️ Font file not found for '\(fontName)': \(sourcePath)")
-          continue
-        }
-
-        let fileName = sourceURL.lastPathComponent
-        let destinationURL = fontsDirectory.appendingPathComponent(fileName)
-
-        // Copy font file if it doesn't already exist
-        if !FileManager.default.fileExists(atPath: destinationURL.path) {
-          do {
-            try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
-          } catch {
-            print("⚠️ Failed to copy font '\(fontName)': \(error)")
-          }
-        }
-      }
     }
 
     private func syncRemoteProgressionToLocal(bookId: String) async {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
@@ -228,9 +228,6 @@
 
         let containerInsets = parent.viewModel.containerInsetsForLabels().uiEdgeInsets
         let theme = parent.preferences.resolvedTheme(for: parent.colorScheme)
-        if let fontName = parent.preferences.fontFamily.fontName {
-          parent.viewModel.ensureFontCopied(fontName: fontName)
-        }
         let fontPath = parent.preferences.fontFamily.fontName.flatMap {
           CustomFontStore.shared.getFontPath(for: $0)
         }
@@ -271,6 +268,7 @@
             chapterURL: chapterURL,
             chapterMediaType: chapterMediaType,
             rootURL: rootURL,
+            mediaTypesByRelativePath: parent.viewModel.mediaTypesByRelativePath,
             containerInsets: containerInsets,
             theme: theme,
             contentCSS: readiumPayload.css,
@@ -307,6 +305,7 @@
             chapterURL: chapterURL,
             chapterMediaType: chapterMediaType,
             rootURL: rootURL,
+            mediaTypesByRelativePath: parent.viewModel.mediaTypesByRelativePath,
             containerInsets: containerInsets,
             theme: theme,
             contentCSS: readiumPayload.css,
@@ -340,6 +339,7 @@
           chapterURL: chapterURL,
           chapterMediaType: chapterMediaType,
           rootURL: rootURL,
+          mediaTypesByRelativePath: parent.viewModel.mediaTypesByRelativePath,
           containerInsets: containerInsets,
           theme: theme,
           contentCSS: readiumPayload.css,
@@ -392,9 +392,6 @@
         let chapterIndex = controller.chapterIndex
         let containerInsets = parent.viewModel.containerInsetsForLabels().uiEdgeInsets
         let theme = parent.preferences.resolvedTheme(for: parent.colorScheme)
-        if let fontName = parent.preferences.fontFamily.fontName {
-          parent.viewModel.ensureFontCopied(fontName: fontName)
-        }
         let fontPath = parent.preferences.fontFamily.fontName.flatMap {
           CustomFontStore.shared.getFontPath(for: $0)
         }
@@ -422,6 +419,7 @@
           chapterURL: parent.viewModel.chapterURL(at: chapterIndex),
           chapterMediaType: parent.viewModel.chapterMediaType(at: chapterIndex),
           rootURL: parent.viewModel.resourceRootURL,
+          mediaTypesByRelativePath: parent.viewModel.mediaTypesByRelativePath,
           containerInsets: containerInsets,
           theme: theme,
           contentCSS: readiumPayload.css,

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView_macOS.swift
@@ -19,6 +19,7 @@
 
     func makeNSView(context: Context) -> NSView {
       let configuration = WKWebViewConfiguration()
+      configuration.registerEpubResourceSchemeHandler(context.coordinator.epubResourceSchemeHandler)
       let userContentController = WKUserContentController()
       userContentController.add(
         WeakWKScriptMessageHandler(delegate: context.coordinator),
@@ -52,6 +53,7 @@
 
   @MainActor
   final class CoverCoordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler, NSGestureRecognizerDelegate {
+    let epubResourceSchemeHandler = EpubResourceSchemeHandler()
     private enum NavigationDirection {
       case forward
       case backward
@@ -135,10 +137,6 @@
       self.parent = parent
       guard let webView else { return }
 
-      if let fontName = parent.preferences.fontFamily.fontName {
-        parent.viewModel.ensureFontCopied(fontName: fontName)
-      }
-
       let requestedChapterIndex = parent.viewModel.targetChapterIndex ?? parent.viewModel.currentChapterIndex
       let requestedRawPageIndex = parent.viewModel.targetPageIndex ?? parent.viewModel.currentPageIndex
       let requestedPageCount = parent.viewModel.chapterPageCount(at: requestedChapterIndex) ?? 1
@@ -166,6 +164,10 @@
       let nextChapterURL = parent.viewModel.chapterURL(at: requestedChapterIndex)
       let nextChapterMediaType = parent.viewModel.chapterMediaType(at: requestedChapterIndex)
       let nextRootURL = parent.viewModel.resourceRootURL
+      epubResourceSchemeHandler.configure(
+        rootURL: nextRootURL,
+        mediaTypesByRelativePath: parent.viewModel.mediaTypesByRelativePath
+      )
       let shouldReload =
         nextChapterURL != chapterURL || nextChapterMediaType != chapterMediaType || nextRootURL != rootURL
       let appearanceChanged =
@@ -468,7 +470,7 @@
       totalPagesInChapter = 1
       isAwaitingPaginationReady = true
       webView.alphaValue = 0.01
-      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL, mediaType: chapterMediaType)
+      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL)
     }
 
     private func installOverlayIfNeeded() {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
@@ -249,11 +249,6 @@
         let containerInsets = viewModel.containerInsetsForLabels().uiEdgeInsets
         let theme = preferences.resolvedTheme(for: colorScheme)
 
-        // Ensure the selected font is copied to the resource directory
-        if let fontName = preferences.fontFamily.fontName {
-          viewModel.ensureFontCopied(fontName: fontName)
-        }
-
         let fontPath = preferences.fontFamily.fontName.flatMap { CustomFontStore.shared.getFontPath(for: $0) }
         let readiumPayload = preferences.makeReadiumPayload(
           theme: theme,
@@ -268,7 +263,8 @@
             pageIndex: currentVC.currentSubPageIndex
           )
         else { return }
-        let chapterProgress = location.pageCount > 0 ? Double(location.pageIndex + 1) / Double(location.pageCount) : nil
+        let chapterProgress =
+          location.pageCount > 0 ? Double(location.pageIndex + 1) / Double(location.pageCount) : nil
         let totalProgression = viewModel.totalProgression(
           location: location,
           chapterProgress: chapterProgress
@@ -278,6 +274,7 @@
           chapterURL: viewModel.chapterURL(at: chapterIndex),
           chapterMediaType: viewModel.chapterMediaType(at: chapterIndex),
           rootURL: viewModel.resourceRootURL,
+          mediaTypesByRelativePath: viewModel.mediaTypesByRelativePath,
           containerInsets: containerInsets,
           theme: theme,
           contentCSS: readiumPayload.css,
@@ -475,9 +472,6 @@
         let theme = parent.preferences.resolvedTheme(for: parent.colorScheme)
 
         // Ensure the selected font is copied to the resource directory
-        if let fontName = parent.preferences.fontFamily.fontName {
-          parent.viewModel.ensureFontCopied(fontName: fontName)
-        }
 
         let fontPath = parent.preferences.fontFamily.fontName.flatMap { CustomFontStore.shared.getFontPath(for: $0) }
         let chapterURL = parent.viewModel.chapterURL(at: chapterIndex)
@@ -503,7 +497,8 @@
             pageIndex: locationPageIndex
           )
         else { return nil }
-        let chapterProgress = location.pageCount > 0 ? Double(location.pageIndex + 1) / Double(location.pageCount) : nil
+        let chapterProgress =
+          location.pageCount > 0 ? Double(location.pageIndex + 1) / Double(location.pageCount) : nil
         let totalProgression = parent.viewModel.totalProgression(
           location: location,
           chapterProgress: chapterProgress
@@ -516,6 +511,7 @@
             chapterURL: chapterURL,
             chapterMediaType: chapterMediaType,
             rootURL: rootURL,
+            mediaTypesByRelativePath: parent.viewModel.mediaTypesByRelativePath,
             containerInsets: containerInsets,
             theme: theme,
             contentCSS: readiumPayload.css,
@@ -550,6 +546,7 @@
             chapterURL: chapterURL,
             chapterMediaType: chapterMediaType,
             rootURL: rootURL,
+            mediaTypesByRelativePath: parent.viewModel.mediaTypesByRelativePath,
             containerInsets: containerInsets,
             theme: theme,
             contentCSS: readiumPayload.css,
@@ -583,6 +580,7 @@
           chapterURL: chapterURL,
           chapterMediaType: chapterMediaType,
           rootURL: rootURL,
+          mediaTypesByRelativePath: parent.viewModel.mediaTypesByRelativePath,
           containerInsets: containerInsets,
           theme: theme,
           contentCSS: readiumPayload.css,
@@ -1140,6 +1138,7 @@
     private var chapterURL: URL?
     private var chapterMediaType: String?
     private var rootURL: URL?
+    private var mediaTypesByRelativePath: [String: String]
     private var lastLayoutSize: CGSize = .zero
     private var isContentLoaded = false
     private var pendingPageIndex: Int?
@@ -1158,6 +1157,8 @@
     private var labelBottomOffset: CGFloat
     private var useSafeArea: Bool
 
+    private let epubResourceSchemeHandler = EpubResourceSchemeHandler()
+
     private var infoOverlay: WebPubInfoOverlaySupport.UIKitOverlay?
 
     private var loadingIndicator: UIActivityIndicatorView?
@@ -1166,6 +1167,7 @@
       chapterURL: URL?,
       chapterMediaType: String?,
       rootURL: URL?,
+      mediaTypesByRelativePath: [String: String],
       containerInsets: UIEdgeInsets,
       theme: ReaderTheme,
       contentCSS: String,
@@ -1187,6 +1189,7 @@
       self.chapterURL = chapterURL
       self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
+      self.mediaTypesByRelativePath = mediaTypesByRelativePath
       self.containerInsets = containerInsets
       self.theme = theme
       self.contentCSS = contentCSS
@@ -1276,6 +1279,7 @@
       chapterURL: URL?,
       chapterMediaType: String?,
       rootURL: URL?,
+      mediaTypesByRelativePath: [String: String],
       containerInsets: UIEdgeInsets,
       theme: ReaderTheme,
       contentCSS: String,
@@ -1297,7 +1301,10 @@
       onPageCountReady: ((Int) -> Void)?
     ) {
       let shouldReload =
-        chapterURL != self.chapterURL || chapterMediaType != self.chapterMediaType || rootURL != self.rootURL
+        chapterURL != self.chapterURL
+        || chapterMediaType != self.chapterMediaType
+        || rootURL != self.rootURL
+        || mediaTypesByRelativePath != self.mediaTypesByRelativePath
       let appearanceChanged =
         theme != self.theme
         || containerInsets != self.containerInsets
@@ -1317,6 +1324,8 @@
       self.chapterURL = chapterURL
       self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
+      self.mediaTypesByRelativePath = mediaTypesByRelativePath
+      epubResourceSchemeHandler.configure(rootURL: rootURL, mediaTypesByRelativePath: mediaTypesByRelativePath)
       self.containerInsets = containerInsets
       self.theme = theme
       self.contentCSS = contentCSS
@@ -1430,6 +1439,8 @@
 
     private func setupWebView() {
       let config = WKWebViewConfiguration()
+      epubResourceSchemeHandler.configure(rootURL: rootURL, mediaTypesByRelativePath: mediaTypesByRelativePath)
+      config.registerEpubResourceSchemeHandler(epubResourceSchemeHandler)
       config.defaultWebpagePreferences.preferredContentMode = .mobile
       let controller = WKUserContentController()
       // Use weak wrapper to avoid retain cycle (WKUserContentController retains handlers strongly)
@@ -1544,7 +1555,7 @@
         loadingIndicator?.startAnimating()
       }
 
-      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL, mediaType: chapterMediaType)
+      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
@@ -43,6 +43,7 @@
         chapterURL: viewModel.chapterURL(at: chapterIndex),
         chapterMediaType: viewModel.chapterMediaType(at: chapterIndex),
         rootURL: viewModel.resourceRootURL,
+        mediaTypesByRelativePath: viewModel.mediaTypesByRelativePath,
         containerInsets: viewModel.containerInsetsForLabels().uiEdgeInsets,
         theme: theme,
         contentCSS: readiumPayload.css,
@@ -173,11 +174,6 @@
       let containerInsets = viewModel.containerInsetsForLabels().uiEdgeInsets
       let theme = preferences.resolvedTheme(for: colorScheme)
 
-      // Ensure the selected font is copied to the resource directory
-      if let fontName = preferences.fontFamily.fontName {
-        viewModel.ensureFontCopied(fontName: fontName)
-      }
-
       let fontPath = preferences.fontFamily.fontName.flatMap { CustomFontStore.shared.getFontPath(for: $0) }
       let readiumPayload = preferences.makeReadiumPayload(
         theme: theme,
@@ -201,6 +197,7 @@
         chapterURL: viewModel.chapterURL(at: chapterIndex),
         chapterMediaType: viewModel.chapterMediaType(at: chapterIndex),
         rootURL: viewModel.resourceRootURL,
+        mediaTypesByRelativePath: viewModel.mediaTypesByRelativePath,
         containerInsets: containerInsets,
         theme: theme,
         contentCSS: readiumPayload.css,
@@ -251,6 +248,7 @@
     private var chapterURL: URL?
     private var chapterMediaType: String?
     private var rootURL: URL?
+    private var mediaTypesByRelativePath: [String: String]
     private var lastLayoutSize: CGSize = .zero
     private var isContentLoaded = false
     private var pendingPageIndex: Int?
@@ -274,6 +272,8 @@
 
     var currentChapterIndex: Int { chapterIndex }
     var currentPageIndex: Int { currentSubPageIndex }
+
+    private let epubResourceSchemeHandler = EpubResourceSchemeHandler()
 
     private var containerView: UIView?
     private var containerConstraints:
@@ -305,6 +305,7 @@
       chapterURL: URL?,
       chapterMediaType: String?,
       rootURL: URL?,
+      mediaTypesByRelativePath: [String: String],
       containerInsets: UIEdgeInsets,
       theme: ReaderTheme,
       contentCSS: String,
@@ -327,6 +328,7 @@
       self.chapterURL = chapterURL
       self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
+      self.mediaTypesByRelativePath = mediaTypesByRelativePath
       self.containerInsets = containerInsets
       self.theme = theme
       self.contentCSS = contentCSS
@@ -385,6 +387,8 @@
 
     private func setupWebView() {
       let config = WKWebViewConfiguration()
+      epubResourceSchemeHandler.configure(rootURL: rootURL, mediaTypesByRelativePath: mediaTypesByRelativePath)
+      config.registerEpubResourceSchemeHandler(epubResourceSchemeHandler)
       config.defaultWebpagePreferences.preferredContentMode = .mobile
       let controller = WKUserContentController()
       // Use weak wrapper to avoid retain cycle
@@ -725,6 +729,7 @@
       chapterURL: URL?,
       chapterMediaType: String?,
       rootURL: URL?,
+      mediaTypesByRelativePath: [String: String],
       containerInsets: UIEdgeInsets,
       theme: ReaderTheme,
       contentCSS: String,
@@ -743,7 +748,10 @@
       useSafeArea: Bool
     ) {
       let shouldReload =
-        chapterURL != self.chapterURL || chapterMediaType != self.chapterMediaType || rootURL != self.rootURL
+        chapterURL != self.chapterURL
+        || chapterMediaType != self.chapterMediaType
+        || rootURL != self.rootURL
+        || mediaTypesByRelativePath != self.mediaTypesByRelativePath
       let appearanceChanged =
         theme != self.theme
         || containerInsets != self.containerInsets
@@ -758,6 +766,8 @@
       self.chapterURL = chapterURL
       self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
+      self.mediaTypesByRelativePath = mediaTypesByRelativePath
+      epubResourceSchemeHandler.configure(rootURL: rootURL, mediaTypesByRelativePath: mediaTypesByRelativePath)
       self.containerInsets = containerInsets
       self.theme = theme
       self.contentCSS = contentCSS
@@ -809,7 +819,7 @@
       webView.alpha = 0.01
       loadingIndicator?.startAnimating()
 
-      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL, mediaType: chapterMediaType)
+      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView_macOS.swift
@@ -19,6 +19,7 @@
 
     func makeNSView(context: Context) -> NSView {
       let configuration = WKWebViewConfiguration()
+      configuration.registerEpubResourceSchemeHandler(context.coordinator.epubResourceSchemeHandler)
       let userContentController = WKUserContentController()
       userContentController.add(
         WeakWKScriptMessageHandler(delegate: context.coordinator),
@@ -50,6 +51,7 @@
 
   @MainActor
   final class PagedCoordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler, NSGestureRecognizerDelegate {
+    let epubResourceSchemeHandler = EpubResourceSchemeHandler()
     private var parent: WebPubPagedScrollView
     private weak var rootView: NSView?
     private weak var webView: WKWebView?
@@ -94,10 +96,6 @@
       self.parent = parent
       guard let webView else { return }
 
-      if let fontName = parent.preferences.fontFamily.fontName {
-        parent.viewModel.ensureFontCopied(fontName: fontName)
-      }
-
       let selectedChapterIndex = parent.viewModel.targetChapterIndex ?? parent.viewModel.currentChapterIndex
       let selectedPageIndex = parent.viewModel.targetPageIndex ?? parent.viewModel.currentPageIndex
       let currentLocation = parent.viewModel.pageLocation(
@@ -117,6 +115,10 @@
       let nextChapterURL = parent.viewModel.chapterURL(at: selectedChapterIndex)
       let nextChapterMediaType = parent.viewModel.chapterMediaType(at: selectedChapterIndex)
       let nextRootURL = parent.viewModel.resourceRootURL
+      epubResourceSchemeHandler.configure(
+        rootURL: nextRootURL,
+        mediaTypesByRelativePath: parent.viewModel.mediaTypesByRelativePath
+      )
       let shouldReload =
         nextChapterURL != chapterURL || nextChapterMediaType != chapterMediaType || nextRootURL != rootURL
       let appearanceChanged =
@@ -172,7 +174,7 @@
       totalPagesInChapter = 1
       isAwaitingPaginationReady = true
       webView.alphaValue = 0.01
-      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL, mediaType: chapterMediaType)
+      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL)
     }
 
     private func installOverlayIfNeeded() {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPlatformSupport.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPlatformSupport.swift
@@ -54,23 +54,19 @@
     }
   }
 
+  extension WKWebViewConfiguration {
+    func registerEpubResourceSchemeHandler(_ handler: EpubResourceSchemeHandler) {
+      setURLSchemeHandler(handler, forURLScheme: EpubResourceScheme.scheme)
+    }
+  }
+
   extension WKWebView {
     func loadEPUBDocument(
       url: URL,
-      rootURL: URL,
-      mediaType: String?
+      rootURL: URL
     ) {
-      guard let mediaType, let data = try? Data(contentsOf: url) else {
-        loadFileURL(url, allowingReadAccessTo: rootURL)
-        return
-      }
-
-      load(
-        data,
-        mimeType: mediaType,
-        characterEncodingName: "utf-8",
-        baseURL: url.deletingLastPathComponent()
-      )
+      guard let schemeURL = EpubResourceScheme.url(for: url, rootURL: rootURL) else { return }
+      load(URLRequest(url: schemeURL))
     }
   }
 

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
@@ -42,6 +42,7 @@
         chapterURL: viewModel.chapterURL(at: chapterIndex),
         chapterMediaType: viewModel.chapterMediaType(at: chapterIndex),
         rootURL: viewModel.resourceRootURL,
+        mediaTypesByRelativePath: viewModel.mediaTypesByRelativePath,
         containerInsets: viewModel.containerInsetsForLabels().uiEdgeInsets,
         tapScrollPercentage: preferences.tapScrollPercentage,
         animateTapTurns: animateTapTurns,
@@ -173,11 +174,6 @@
       let containerInsets = viewModel.containerInsetsForLabels().uiEdgeInsets
       let theme = preferences.resolvedTheme(for: colorScheme)
 
-      // Ensure the selected font is copied to the resource directory
-      if let fontName = preferences.fontFamily.fontName {
-        viewModel.ensureFontCopied(fontName: fontName)
-      }
-
       let fontPath = preferences.fontFamily.fontName.flatMap { CustomFontStore.shared.getFontPath(for: $0) }
       let readiumPayload = preferences.makeReadiumPayload(
         theme: theme,
@@ -201,6 +197,7 @@
         chapterURL: viewModel.chapterURL(at: chapterIndex),
         chapterMediaType: viewModel.chapterMediaType(at: chapterIndex),
         rootURL: viewModel.resourceRootURL,
+        mediaTypesByRelativePath: viewModel.mediaTypesByRelativePath,
         containerInsets: containerInsets,
         tapScrollPercentage: preferences.tapScrollPercentage,
         animateTapTurns: animateTapTurns,
@@ -258,6 +255,7 @@
     private var chapterURL: URL?
     private var chapterMediaType: String?
     private var rootURL: URL?
+    private var mediaTypesByRelativePath: [String: String]
     private var lastLayoutSize: CGSize = .zero
     private var isContentLoaded = false
     private var pendingPageIndex: Int?
@@ -284,6 +282,8 @@
 
     var currentChapterIndex: Int { chapterIndex }
     var currentPageIndex: Int { currentSubPageIndex }
+
+    private let epubResourceSchemeHandler = EpubResourceSchemeHandler()
 
     private var containerView: UIView?
     private var containerConstraints:
@@ -321,6 +321,7 @@
       chapterURL: URL?,
       chapterMediaType: String?,
       rootURL: URL?,
+      mediaTypesByRelativePath: [String: String],
       containerInsets: UIEdgeInsets,
       tapScrollPercentage: Double,
       animateTapTurns: Bool,
@@ -344,6 +345,7 @@
       self.chapterURL = chapterURL
       self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
+      self.mediaTypesByRelativePath = mediaTypesByRelativePath
       self.containerInsets = containerInsets
       self.tapScrollPercentage = Self.normalizedTapScrollPercentage(tapScrollPercentage)
       self.animateTapTurns = animateTapTurns
@@ -403,6 +405,8 @@
 
     private func setupWebView() {
       let config = WKWebViewConfiguration()
+      epubResourceSchemeHandler.configure(rootURL: rootURL, mediaTypesByRelativePath: mediaTypesByRelativePath)
+      config.registerEpubResourceSchemeHandler(epubResourceSchemeHandler)
       config.defaultWebpagePreferences.preferredContentMode = .mobile
       let controller = WKUserContentController()
       // Use weak wrapper to avoid retain cycle
@@ -691,6 +695,7 @@
       chapterURL: URL?,
       chapterMediaType: String?,
       rootURL: URL?,
+      mediaTypesByRelativePath: [String: String],
       containerInsets: UIEdgeInsets,
       tapScrollPercentage: Double,
       animateTapTurns: Bool,
@@ -710,7 +715,10 @@
       useSafeArea: Bool
     ) {
       let shouldReload =
-        chapterURL != self.chapterURL || chapterMediaType != self.chapterMediaType || rootURL != self.rootURL
+        chapterURL != self.chapterURL
+        || chapterMediaType != self.chapterMediaType
+        || rootURL != self.rootURL
+        || mediaTypesByRelativePath != self.mediaTypesByRelativePath
       let normalizedTapScrollPercentage = Self.normalizedTapScrollPercentage(tapScrollPercentage)
       let appearanceChanged =
         theme != self.theme
@@ -728,6 +736,8 @@
       self.chapterURL = chapterURL
       self.chapterMediaType = chapterMediaType
       self.rootURL = rootURL
+      self.mediaTypesByRelativePath = mediaTypesByRelativePath
+      epubResourceSchemeHandler.configure(rootURL: rootURL, mediaTypesByRelativePath: mediaTypesByRelativePath)
       self.containerInsets = containerInsets
       self.tapScrollPercentage = normalizedTapScrollPercentage
       self.animateTapTurns = animateTapTurns
@@ -788,7 +798,7 @@
       webView.alpha = 0.01
       loadingIndicator?.startAnimating()
 
-      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL, mediaType: chapterMediaType)
+      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
@@ -19,6 +19,7 @@
 
     func makeNSView(context: Context) -> NSView {
       let configuration = WKWebViewConfiguration()
+      configuration.registerEpubResourceSchemeHandler(context.coordinator.epubResourceSchemeHandler)
       let userContentController = WKUserContentController()
       userContentController.add(WeakWKScriptMessageHandler(delegate: context.coordinator), name: "readerBridge")
       configuration.userContentController = userContentController
@@ -47,6 +48,7 @@
 
   @MainActor
   final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler, NSGestureRecognizerDelegate {
+    let epubResourceSchemeHandler = EpubResourceSchemeHandler()
     private var parent: WebPubScrolledView
     private weak var rootView: NSView?
     private weak var webView: WKWebView?
@@ -94,10 +96,6 @@
       self.parent = parent
       guard let webView else { return }
 
-      if let fontName = parent.preferences.fontFamily.fontName {
-        parent.viewModel.ensureFontCopied(fontName: fontName)
-      }
-
       let selectedChapterIndex = parent.viewModel.targetChapterIndex ?? parent.viewModel.currentChapterIndex
       let selectedPageIndex = parent.viewModel.targetPageIndex ?? parent.viewModel.currentPageIndex
       let currentLocation = parent.viewModel.pageLocation(
@@ -117,6 +115,10 @@
       let nextChapterURL = parent.viewModel.chapterURL(at: selectedChapterIndex)
       let nextChapterMediaType = parent.viewModel.chapterMediaType(at: selectedChapterIndex)
       let nextRootURL = parent.viewModel.resourceRootURL
+      epubResourceSchemeHandler.configure(
+        rootURL: nextRootURL,
+        mediaTypesByRelativePath: parent.viewModel.mediaTypesByRelativePath
+      )
       let shouldReload =
         nextChapterURL != chapterURL || nextChapterMediaType != chapterMediaType || nextRootURL != rootURL
       let appearanceChanged =
@@ -176,7 +178,7 @@
       lastKnownDocumentContentHeight = 0
       lastKnownDocumentViewportHeight = 0
       totalPagesInChapter = 1
-      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL, mediaType: chapterMediaType)
+      webView.loadEPUBDocument(url: chapterURL, rootURL: rootURL)
     }
 
     private func installOverlayIfNeeded() {

--- a/KMReader/Features/Reader/Views/Models/EpubReaderPreferences.swift
+++ b/KMReader/Features/Reader/Views/Models/EpubReaderPreferences.swift
@@ -339,12 +339,12 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
   }
 
   private func makeFontFaceCSS(fontName: String?, fontPath: String?, rootURL: URL?) -> String {
-    guard let fontName, let path = fontPath, let rootURL else {
+    guard let fontName, let path = fontPath, rootURL != nil else {
       return ""
     }
 
     let fileName = URL(fileURLWithPath: path).lastPathComponent
-    let fontURL = rootURL.appendingPathComponent(".fonts").appendingPathComponent(fileName)
+    guard let fontURL = EpubResourceScheme.fontURL(fileName: fileName) else { return "" }
     let fileURLString = fontURL.absoluteString
     let fontFormat = path.hasSuffix(".otf") ? "opentype" : "truetype"
 


### PR DESCRIPTION
## Problem
The EPUB reader needed manifest media type handling for spine documents, but loading chapters with `WKWebView.load(data:mimeType:baseURL:)` changed WebKit's resource access model. As a result, relative publication assets such as images and custom fonts could stop loading correctly.

## Approach
Serve unpacked EPUB files through an internal `kmreader-resource://epub/...` URL scheme backed by `WKURLSchemeHandler`. Each reader WebView owns its own configurable handler instance, so the current book root and manifest media type map stay isolated across reader modes and windows while still allowing late SwiftUI updates.

Custom fonts are routed through the same origin via `kmreader-resource://epub/__fonts__/<font-file>`, which avoids copying fonts into every unpacked book directory while keeping resource loading consistent. The URL-scheme helpers are available to shared reader preference code, while the WebKit handler remains limited to iOS and macOS.

## Scope
- Add a safe EPUB resource scheme mapper and handler with manifest-backed MIME type lookup and extension fallback.
- Load EPUB chapters through the custom scheme instead of `load(data:mimeType:baseURL:)`.
- Update iOS and macOS EPUB reader views to register per-reader handlers.
- Resolve custom font CSS through the virtual `__fonts__` path.
- Keep shared scheme helpers visible to tvOS builds.
- Bump build version to 456.

## Validation
- [x] `make build-ios-ci`
- [x] `make build-macos-ci`
- [x] `make build-tvos-ci`
- [x] Manual reader check confirmed pages load normally after the handler configuration fix.
