### PR TITLE
refactor(epub): split theme preferences from reader settings

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 456;
+				CURRENT_PROJECT_VERSION = 457;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 456;
+				CURRENT_PROJECT_VERSION = 457;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 456;
+				CURRENT_PROJECT_VERSION = 457;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 456;
+				CURRENT_PROJECT_VERSION = 457;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -926,6 +926,18 @@ enum AppConfig {
     }
   }
 
+  static nonisolated var epubTapScrollPercentage: Double {
+    get {
+      if UserDefaults.standard.object(forKey: "epubTapScrollPercentage") != nil {
+        return UserDefaults.standard.double(forKey: "epubTapScrollPercentage")
+      }
+      return 80.0
+    }
+    set {
+      UserDefaults.standard.set(min(100.0, max(25.0, newValue)), forKey: "epubTapScrollPercentage")
+    }
+  }
+
   static nonisolated var pageTransitionStyle: PageTransitionStyle {
     get {
       if let stored = UserDefaults.standard.string(forKey: "pageTransitionStyle"),
@@ -1042,14 +1054,14 @@ enum AppConfig {
     }
   }
 
-  static nonisolated var epubPreferences: EpubReaderPreferences {
+  static nonisolated var epubThemePreferences: EpubThemePreferences {
     get {
       if let stored = UserDefaults.standard.string(forKey: "epubPreferences"),
-        let prefs = EpubReaderPreferences(rawValue: stored)
+        let prefs = EpubThemePreferences(rawValue: stored)
       {
         return prefs
       }
-      return EpubReaderPreferences()
+      return EpubThemePreferences()
     }
     set {
       UserDefaults.standard.set(newValue.rawValue, forKey: "epubPreferences")

--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -384,22 +384,22 @@ actor DatabaseOperator {
     }
   }
 
-  func fetchBookEpubPreferences(bookId: String) -> EpubReaderPreferences? {
+  func fetchBookEpubThemePreferences(bookId: String) -> EpubThemePreferences? {
     let instanceId = AppConfig.current.instanceId
     let compositeId = CompositeID.generate(instanceId: instanceId, id: bookId)
     let descriptor = FetchDescriptor<KomgaBook>(predicate: #Predicate { $0.id == compositeId })
     guard let raw = try? modelContext.fetch(descriptor).first?.epubPreferencesRaw else {
       return nil
     }
-    return EpubReaderPreferences(rawValue: raw)
+    return EpubThemePreferences(rawValue: raw)
   }
 
-  func updateBookEpubPreferences(bookId: String, preferences: EpubReaderPreferences?) {
+  func updateBookEpubThemePreferences(bookId: String, preferences: EpubThemePreferences?) {
     let instanceId = AppConfig.current.instanceId
     let compositeId = CompositeID.generate(instanceId: instanceId, id: bookId)
     let descriptor = FetchDescriptor<KomgaBook>(predicate: #Predicate { $0.id == compositeId })
     if let book = try? modelContext.fetch(descriptor).first {
-      book.epubPreferences = preferences
+      book.epubThemePreferences = preferences
     }
   }
 

--- a/KMReader/Features/Book/Models/KomgaBook.swift
+++ b/KMReader/Features/Book/Models/KomgaBook.swift
@@ -24,8 +24,8 @@ extension KomgaBook {
     set { pageRotationsRaw = try? JSONEncoder().encode(newValue) }
   }
 
-  var epubPreferences: EpubReaderPreferences? {
-    get { epubPreferencesRaw.flatMap { EpubReaderPreferences(rawValue: $0) } }
+  var epubThemePreferences: EpubThemePreferences? {
+    get { epubPreferencesRaw.flatMap { EpubThemePreferences(rawValue: $0) } }
     set { epubPreferencesRaw = newValue?.rawValue }
   }
 

--- a/KMReader/Features/Reader/Models/EpubThemePreset.swift
+++ b/KMReader/Features/Reader/Models/EpubThemePreset.swift
@@ -9,14 +9,14 @@ typealias EpubThemePreset = KMReaderSchemaV6.EpubThemePresetV1
 
 extension EpubThemePreset {
   @MainActor
-  func getPreferences() -> EpubReaderPreferences? {
-    return EpubReaderPreferences(rawValue: preferencesJSON)
+  func getPreferences() -> EpubThemePreferences? {
+    return EpubThemePreferences(rawValue: preferencesJSON)
   }
 
   @MainActor
   static func create(
     name: String,
-    preferences: EpubReaderPreferences
+    preferences: EpubThemePreferences
   ) -> EpubThemePreset {
     return EpubThemePreset(
       name: name,

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -82,7 +82,7 @@
     private let updateThrottleInterval: TimeInterval = 2.0
     private let logger = AppLogger(.reader)
     private var viewportSize: CGSize = .zero
-    private var preferences: EpubReaderPreferences = .init()
+    private var preferences: EpubThemePreferences = .init()
     private var theme: ReaderTheme = .lightSepia
 
     let incognito: Bool
@@ -107,7 +107,7 @@
       }
     }
 
-    func applyPreferences(_ prefs: EpubReaderPreferences, colorScheme: ColorScheme) {
+    func applyPreferences(_ prefs: EpubThemePreferences, colorScheme: ColorScheme) {
       preferences = prefs
       theme = prefs.resolvedTheme(for: colorScheme)
 

--- a/KMReader/Features/Reader/Views/Epub/EpubEndPageView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubEndPageView.swift
@@ -8,7 +8,7 @@
 
   struct EpubEndPageView: View {
     let bookTitle: String?
-    let preferences: EpubReaderPreferences
+    let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
     let onReturn: () -> Void
     let onClose: () -> Void

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -19,7 +19,10 @@
     @Environment(\.scenePhase) private var scenePhase
 
     @AppStorage("currentAccount") private var current: Current = .init()
-    @AppStorage("epubPreferences") private var globalPreferences: EpubReaderPreferences = .init()
+    @AppStorage("epubPreferences") private var globalThemePreferences: EpubThemePreferences = .init()
+    @AppStorage("epubFlowStyle") private var epubFlowStyle: EpubFlowStyle = .paged
+    @AppStorage("epubTapScrollPercentage") private var epubTapScrollPercentage: Double = AppConfig
+      .epubTapScrollPercentage
     @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
     @AppStorage("epubShowsStatusBarWhileReading") private var epubShowsStatusBarWhileReading: Bool = false
     @AppStorage("animateEpubTapTurns") private var animateEpubTapTurns: Bool = AppConfig.animateEpubTapTurns
@@ -27,8 +30,8 @@
     private var showKeyboardHelpOverlay: Bool = AppConfig.epubShowKeyboardHelpOverlay
 
     @State private var viewModel: EpubReaderViewModel
-    @State private var activePreferences: EpubReaderPreferences
-    @State private var bookPreferences: EpubReaderPreferences?
+    @State private var activeThemePreferences: EpubThemePreferences
+    @State private var bookThemePreferences: EpubThemePreferences?
     @State private var showingControls = false
     // Captures `shouldShowControls` on the active → non-active scene-phase
     // transition (before the PR #682 force-show flips `showingControls`), so
@@ -42,7 +45,8 @@
     @State private var currentSeries: Series?
     @State private var currentBook: Book?
     @State private var showingChapterSheet = false
-    @State private var showingPreferencesSheet = false
+    @State private var showingThemeSheet = false
+    @State private var showingSettingsSheet = false
     @State private var showingDetailSheet = false
     @State private var showingQuickActions = false
     @State private var showingEndPage = false
@@ -66,8 +70,8 @@
       self.readerPresentation = readerPresentation
       self.onClose = onClose
       _viewModel = State(initialValue: EpubReaderViewModel(incognito: incognito))
-      _activePreferences = State(initialValue: AppConfig.epubPreferences)
-      _bookPreferences = State(initialValue: nil)
+      _activeThemePreferences = State(initialValue: AppConfig.epubThemePreferences)
+      _bookThemePreferences = State(initialValue: nil)
       _currentBook = State(initialValue: book)
     }
 
@@ -160,7 +164,8 @@
 
     private var isPresentingModalSheet: Bool {
       showingChapterSheet
-        || showingPreferencesSheet
+        || showingThemeSheet
+        || showingSettingsSheet
         || showingDetailSheet
     }
 
@@ -181,11 +186,11 @@
     }
 
     private var isUsingBookPreferences: Bool {
-      bookPreferences != nil
+      bookThemePreferences != nil
     }
 
     private var dismissGestureReadingDirection: ReadingDirection {
-      switch activePreferences.flowStyle {
+      switch epubFlowStyle {
       case .paged:
         return viewModel.publicationReadingProgression == .rtl ? .rtl : .ltr
       case .scrolled:
@@ -194,7 +199,7 @@
     }
 
     private var readerTheme: ReaderTheme {
-      activePreferences.resolvedTheme(for: colorScheme)
+      activeThemePreferences.resolvedTheme(for: colorScheme)
     }
 
     #if os(macOS)
@@ -245,7 +250,7 @@
         }
         .onAppear {
           updateHandoff()
-          viewModel.applyPreferences(activePreferences, colorScheme: colorScheme)
+          viewModel.applyPreferences(activeThemePreferences, colorScheme: colorScheme)
           #if os(macOS)
             configureReaderCommands()
           #endif
@@ -280,15 +285,15 @@
             ReaderLiveActivityManager.shared.updateReadingProgress(1)
           #endif
         }
-        .onChange(of: activePreferences) { _, newPrefs in
+        .onChange(of: activeThemePreferences) { _, newPrefs in
           viewModel.applyPreferences(newPrefs, colorScheme: colorScheme)
         }
-        .onChange(of: globalPreferences) { _, newPrefs in
+        .onChange(of: globalThemePreferences) { _, newPrefs in
           guard !isUsingBookPreferences else { return }
-          activePreferences = newPrefs
+          activeThemePreferences = newPrefs
         }
         .onChange(of: colorScheme) { _, newScheme in
-          viewModel.applyPreferences(activePreferences, colorScheme: newScheme)
+          viewModel.applyPreferences(activeThemePreferences, colorScheme: newScheme)
         }
         .onReceive(
           NotificationCenter.default.publisher(for: .fileDownloadProgress)
@@ -324,8 +329,8 @@
       viewModel.beginLoading()
 
       currentBook = book
-      bookPreferences = nil
-      activePreferences = globalPreferences
+      bookThemePreferences = nil
+      activeThemePreferences = globalThemePreferences
       do {
         currentBook = try await SyncService.shared.syncBook(bookId: book.id)
       } catch {
@@ -342,7 +347,7 @@
       }
 
       let database = await DatabaseOperator.databaseIfConfigured()
-      let savedPreferences = await database?.fetchBookEpubPreferences(bookId: activeBook.id)
+      let savedThemePreferences = await database?.fetchBookEpubThemePreferences(bookId: activeBook.id)
       if !incognito {
         readerPresentation.trackVisitedBook(
           sessionID: sessionID,
@@ -350,8 +355,8 @@
           seriesId: activeBook.seriesId
         )
       }
-      bookPreferences = savedPreferences
-      activePreferences = savedPreferences ?? globalPreferences
+      bookThemePreferences = savedThemePreferences
+      activeThemePreferences = savedThemePreferences ?? globalThemePreferences
 
       // Refresh WebPub manifest if online
       if !AppConfig.isOffline {
@@ -404,7 +409,7 @@
       if showingEndPage {
         EpubEndPageView(
           bookTitle: currentBook?.metadata.title,
-          preferences: activePreferences,
+          preferences: activeThemePreferences,
           colorScheme: colorScheme,
           onReturn: {
             // Hide end page first, then navigate to last page
@@ -492,13 +497,13 @@
     @ViewBuilder
     private var readerContent: some View {
       #if os(macOS)
-        switch activePreferences.flowStyle {
+        switch epubFlowStyle {
         case .paged:
           switch epubPageTransitionStyle {
           case .cover:
             WebPubPagedCoverView(
               viewModel: viewModel,
-              preferences: activePreferences,
+              preferences: activeThemePreferences,
               colorScheme: colorScheme,
               animateTapTurns: animateEpubTapTurns,
               showingControls: shouldShowControls,
@@ -517,7 +522,7 @@
             WebPubPagedScrollView(
               viewModel: viewModel,
               animatePageTransitions: animateEpubTapTurns,
-              preferences: activePreferences,
+              preferences: activeThemePreferences,
               colorScheme: colorScheme,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
@@ -535,8 +540,9 @@
         case .scrolled:
           WebPubScrolledView(
             viewModel: viewModel,
-            preferences: activePreferences,
+            preferences: activeThemePreferences,
             colorScheme: colorScheme,
+            tapScrollPercentage: epubTapScrollPercentage,
             animateTapTurns: animateEpubTapTurns,
             showingControls: shouldShowControls,
             bookTitle: currentBook?.metadata.title,
@@ -552,14 +558,14 @@
           )
         }
       #else
-        switch activePreferences.flowStyle {
+        switch epubFlowStyle {
         case .paged:
           switch epubPageTransitionStyle {
           case .scroll:
             WebPubPagedScrollView(
               viewModel: viewModel,
               animatePageTransitions: animateEpubTapTurns,
-              preferences: activePreferences,
+              preferences: activeThemePreferences,
               colorScheme: colorScheme,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
@@ -576,7 +582,7 @@
           case .cover:
             WebPubPagedCoverView(
               viewModel: viewModel,
-              preferences: activePreferences,
+              preferences: activeThemePreferences,
               colorScheme: colorScheme,
               animateTapTurns: animateEpubTapTurns,
               showingControls: shouldShowControls,
@@ -594,7 +600,7 @@
           case .pageCurl:
             WebPubPagedCurlView(
               viewModel: viewModel,
-              preferences: activePreferences,
+              preferences: activeThemePreferences,
               colorScheme: colorScheme,
               animateTapTurns: animateEpubTapTurns,
               showingControls: shouldShowControls,
@@ -613,8 +619,9 @@
         case .scrolled:
           WebPubScrolledView(
             viewModel: viewModel,
-            preferences: activePreferences,
+            preferences: activeThemePreferences,
             colorScheme: colorScheme,
+            tapScrollPercentage: epubTapScrollPercentage,
             animateTapTurns: animateEpubTapTurns,
             showingControls: shouldShowControls,
             bookTitle: currentBook?.metadata.title,
@@ -741,23 +748,26 @@
             }
           )
         }
-        .sheet(isPresented: $showingPreferencesSheet) {
+        .sheet(isPresented: $showingThemeSheet) {
           NavigationStack {
-            EpubPreferencesView(
+            EpubThemePreferencesView(
               inSheet: true,
               bookId: currentBook?.id ?? book.id,
-              hasBookPreferences: bookPreferences != nil,
-              initialPreferences: activePreferences,
-              onPreferencesSaved: { newPreferences in
-                activePreferences = newPreferences
-                bookPreferences = newPreferences
+              hasBookThemePreferences: bookThemePreferences != nil,
+              initialThemePreferences: activeThemePreferences,
+              onThemePreferencesSaved: { newPreferences in
+                activeThemePreferences = newPreferences
+                bookThemePreferences = newPreferences
               },
-              onPreferencesCleared: {
-                activePreferences = globalPreferences
-                bookPreferences = nil
+              onThemePreferencesCleared: {
+                activeThemePreferences = globalThemePreferences
+                bookThemePreferences = nil
               }
             )
           }
+        }
+        .sheet(isPresented: $showingSettingsSheet) {
+          EpubReaderSettingsView(inSheet: true)
         }
         .readerDetailSheet(
           isPresented: $showingDetailSheet,
@@ -789,12 +799,12 @@
         }
 
         Button {
-          showingPreferencesSheet = true
+          showingDetailSheet = true
         } label: {
           HStack {
-            Text("Themes & Settings")
+            Text("Book Info")
               .font(.callout)
-            Image(systemName: "textformat")
+            Image(systemName: "info.circle")
           }
           .contentShape(Capsule())
         }
@@ -803,12 +813,26 @@
         .controlSize(.large)
 
         Button {
-          showingDetailSheet = true
+          showingSettingsSheet = true
         } label: {
           HStack {
-            Text("Book Info")
+            Text("Settings")
               .font(.callout)
-            Image(systemName: "info.circle")
+            Image(systemName: "gearshape")
+          }
+          .contentShape(Capsule())
+        }
+        .readerControlButtonStyle()
+        .buttonBorderShape(.capsule)
+        .controlSize(.large)
+
+        Button {
+          showingThemeSheet = true
+        } label: {
+          HStack {
+            Text("Theme")
+              .font(.callout)
+            Image(systemName: "textformat")
           }
           .contentShape(Capsule())
         }
@@ -960,7 +984,7 @@
           state: readerCommandState,
           handlers: ReaderCommandHandlers(
             showReaderSettings: {
-              showingPreferencesSheet = true
+              showingSettingsSheet = true
             },
             showBookDetails: {
               if currentBook != nil && currentSeries != nil {

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
@@ -9,7 +9,7 @@
 
   struct WebPubPagedCoverView: UIViewControllerRepresentable {
     @Bindable var viewModel: EpubReaderViewModel
-    let preferences: EpubReaderPreferences
+    let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
     let animateTapTurns: Bool
     let showingControls: Bool

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView_macOS.swift
@@ -5,7 +5,7 @@
 
   struct WebPubPagedCoverView: NSViewRepresentable {
     @Bindable var viewModel: EpubReaderViewModel
-    let preferences: EpubReaderPreferences
+    let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
     let animateTapTurns: Bool
     let showingControls: Bool
@@ -731,7 +731,7 @@
       let js = WebPubPagedJavaScriptBuilder.makeInjectCSSScript(
         contentCSS: contentCSS,
         readiumProperties: readiumProperties,
-        readiumPropertyKeys: EpubReaderPreferences.readiumPropertyKeys,
+        readiumPropertyKeys: EpubThemePreferences.readiumPropertyKeys,
         language: publicationLanguage,
         readingProgression: publicationReadingProgression
       )

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
@@ -10,7 +10,7 @@
 
   struct WebPubPagedCurlView: UIViewControllerRepresentable {
     @Bindable var viewModel: EpubReaderViewModel
-    let preferences: EpubReaderPreferences
+    let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
     let animateTapTurns: Bool
     let showingControls: Bool
@@ -1617,7 +1617,7 @@
       injectCSS(
         contentCSS,
         readiumProperties: readiumProperties,
-        readiumPropertyKeys: EpubReaderPreferences.readiumPropertyKeys,
+        readiumPropertyKeys: EpubThemePreferences.readiumPropertyKeys,
         language: publicationLanguage,
         readingProgression: publicationReadingProgression
       ) { [weak self] in

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
@@ -13,7 +13,7 @@
   struct WebPubPagedScrollView: UIViewControllerRepresentable {
     @Bindable var viewModel: EpubReaderViewModel
     let animatePageTransitions: Bool
-    let preferences: EpubReaderPreferences
+    let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
     let showingControls: Bool
     let bookTitle: String?
@@ -868,7 +868,7 @@
       injectCSS(
         contentCSS,
         readiumProperties: readiumProperties,
-        readiumPropertyKeys: EpubReaderPreferences.readiumPropertyKeys,
+        readiumPropertyKeys: EpubThemePreferences.readiumPropertyKeys,
         language: publicationLanguage,
         readingProgression: publicationReadingProgression
       ) { [weak self] in

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView_macOS.swift
@@ -6,7 +6,7 @@
   struct WebPubPagedScrollView: NSViewRepresentable {
     @Bindable var viewModel: EpubReaderViewModel
     let animatePageTransitions: Bool
-    let preferences: EpubReaderPreferences
+    let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
     let showingControls: Bool
     let bookTitle: String?
@@ -375,7 +375,7 @@
       let js = WebPubPagedJavaScriptBuilder.makeInjectCSSScript(
         contentCSS: contentCSS,
         readiumProperties: readiumProperties,
-        readiumPropertyKeys: EpubReaderPreferences.readiumPropertyKeys,
+        readiumPropertyKeys: EpubThemePreferences.readiumPropertyKeys,
         language: publicationLanguage,
         readingProgression: publicationReadingProgression
       )

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
@@ -11,8 +11,9 @@
   /// A SwiftUI view that displays EPUB content in continuous vertical scroll mode.
   struct WebPubScrolledView: UIViewControllerRepresentable {
     @Bindable var viewModel: EpubReaderViewModel
-    let preferences: EpubReaderPreferences
+    let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
+    let tapScrollPercentage: Double
     let animateTapTurns: Bool
     let showingControls: Bool
     let bookTitle: String?
@@ -34,6 +35,7 @@
       let readiumPayload = preferences.makeReadiumPayload(
         theme: theme,
         fontPath: fontPath,
+        flowStyle: .scrolled,
         rootURL: viewModel.resourceRootURL,
         viewportSize: viewModel.resolvedViewportSize
       )
@@ -44,7 +46,7 @@
         rootURL: viewModel.resourceRootURL,
         mediaTypesByRelativePath: viewModel.mediaTypesByRelativePath,
         containerInsets: viewModel.containerInsetsForLabels().uiEdgeInsets,
-        tapScrollPercentage: preferences.tapScrollPercentage,
+        tapScrollPercentage: tapScrollPercentage,
         animateTapTurns: animateTapTurns,
         theme: theme,
         contentCSS: readiumPayload.css,
@@ -178,6 +180,7 @@
       let readiumPayload = preferences.makeReadiumPayload(
         theme: theme,
         fontPath: fontPath,
+        flowStyle: .scrolled,
         rootURL: viewModel.resourceRootURL,
         viewportSize: viewModel.resolvedViewportSize
       )
@@ -199,7 +202,7 @@
         rootURL: viewModel.resourceRootURL,
         mediaTypesByRelativePath: viewModel.mediaTypesByRelativePath,
         containerInsets: containerInsets,
-        tapScrollPercentage: preferences.tapScrollPercentage,
+        tapScrollPercentage: tapScrollPercentage,
         animateTapTurns: animateTapTurns,
         theme: theme,
         contentCSS: readiumPayload.css,
@@ -849,7 +852,7 @@
       injectCSS(
         contentCSS,
         readiumProperties: readiumProperties,
-        readiumPropertyKeys: EpubReaderPreferences.readiumPropertyKeys,
+        readiumPropertyKeys: EpubThemePreferences.readiumPropertyKeys,
         language: publicationLanguage,
         readingProgression: publicationReadingProgression
       ) { [weak self] in

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
@@ -5,8 +5,9 @@
 
   struct WebPubScrolledView: NSViewRepresentable {
     @Bindable var viewModel: EpubReaderViewModel
-    let preferences: EpubReaderPreferences
+    let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
+    let tapScrollPercentage: Double
     let animateTapTurns: Bool
     let showingControls: Bool
     let bookTitle: String?
@@ -108,6 +109,7 @@
       let readiumPayload = parent.preferences.makeReadiumPayload(
         theme: theme,
         fontPath: fontPath,
+        flowStyle: .scrolled,
         rootURL: parent.viewModel.resourceRootURL,
         viewportSize: parent.viewModel.resolvedViewportSize
       )
@@ -246,7 +248,7 @@
         }
         return
       }
-      let step = pageHeight * CGFloat(parent.preferences.tapScrollPercentage / 100.0)
+      let step = pageHeight * CGFloat(parent.tapScrollPercentage / 100.0)
       scrollDocument(to: max(0, currentOffset - step))
     }
 
@@ -264,7 +266,7 @@
         }
         return
       }
-      let step = pageHeight * CGFloat(parent.preferences.tapScrollPercentage / 100.0)
+      let step = pageHeight * CGFloat(parent.tapScrollPercentage / 100.0)
       scrollDocument(to: min(maxOffset, currentOffset + step))
     }
 
@@ -601,7 +603,7 @@
       let js = WebPubPagedJavaScriptBuilder.makeInjectCSSScript(
         contentCSS: contentCSS,
         readiumProperties: readiumProperties,
-        readiumPropertyKeys: EpubReaderPreferences.readiumPropertyKeys,
+        readiumPropertyKeys: EpubThemePreferences.readiumPropertyKeys,
         language: publicationLanguage,
         readingProgression: publicationReadingProgression
       )

--- a/KMReader/Features/Reader/Views/Models/EpubThemePreferences.swift
+++ b/KMReader/Features/Reader/Views/Models/EpubThemePreferences.swift
@@ -1,5 +1,5 @@
 //
-// EpubReaderPreferences.swift
+// EpubThemePreferences.swift
 //
 //
 
@@ -23,10 +23,9 @@ nonisolated enum EpubConstants {
   static let minimumFontWeight: Double = 100.0
   static let maximumFontWeight: Double = 1000.0
   static let fontWeightStep: Double = 10.0
-  static let defaultTapScrollPercentage: Double = 80.0
 }
 
-nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable {
+nonisolated struct EpubThemePreferences: RawRepresentable, Equatable, Sendable {
   typealias RawValue = String
 
   // Keep this list in sync with makeReadiumPayload.
@@ -58,7 +57,6 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
   ]
 
   var theme: ThemeChoice
-  var flowStyle: EpubFlowStyle
   var fontFamily: FontFamilyChoice
   var fontWeight: Double?
   var advancedLayout: Bool
@@ -71,11 +69,9 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
   var columnCount: EpubColumnCount
   var textAlignment: EpubTextAlignment
   var pageMargins: Double
-  var tapScrollPercentage: Double
 
   init(
     theme: ThemeChoice = .system,
-    flowStyle: EpubFlowStyle = .paged,
     fontFamily: FontFamilyChoice = .publisher,
     fontWeight: Double? = nil,
     advancedLayout: Bool = false,
@@ -88,10 +84,8 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
     columnCount: EpubColumnCount = .auto,
     textAlignment: EpubTextAlignment = .publisherDefault,
     pageMargins: Double = EpubConstants.defaultPageMargins,
-    tapScrollPercentage: Double = EpubConstants.defaultTapScrollPercentage,
   ) {
     self.theme = theme
-    self.flowStyle = flowStyle
     self.fontFamily = fontFamily
     self.fontSize = fontSize
     self.wordSpacing = wordSpacing
@@ -104,7 +98,6 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
     self.textAlignment = textAlignment
     self.fontWeight = fontWeight
     self.advancedLayout = advancedLayout
-    self.tapScrollPercentage = Self.normalizedTapScrollPercentage(tapScrollPercentage)
   }
 
   init?(rawValue: String) {
@@ -121,8 +114,6 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
     }
 
     let theme = (dict["theme"] as? String).flatMap(ThemeChoice.init) ?? .system
-    let flowStyleRaw = dict["flowStyle"] as? String ?? EpubFlowStyle.paged.rawValue
-    let flowStyle = EpubFlowStyle(rawValue: flowStyleRaw) ?? .paged
     let fontString = dict["fontFamily"] as? String ?? FontFamilyChoice.publisher.rawValue
     let font = FontFamilyChoice(rawValue: fontString)
     let rawFontWeight = dict["fontWeight"] as? Double
@@ -141,13 +132,9 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
     let textAlignment = EpubTextAlignment(rawValue: textAlignmentRaw) ?? .publisherDefault
     let rawPageMargins = dict["pageMargins"] as? Double ?? EpubConstants.defaultPageMargins
     let pageMargins = Self.normalizedPageMargins(rawPageMargins)
-    let rawTapScrollPercentage =
-      dict["tapScrollPercentage"] as? Double ?? EpubConstants.defaultTapScrollPercentage
-    let tapScrollPercentage = Self.normalizedTapScrollPercentage(rawTapScrollPercentage)
 
     self.init(
       theme: theme,
-      flowStyle: flowStyle,
       fontFamily: font,
       fontWeight: fontWeight,
       advancedLayout: advancedLayout,
@@ -160,14 +147,12 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
       columnCount: columnCount,
       textAlignment: textAlignment,
       pageMargins: pageMargins,
-      tapScrollPercentage: tapScrollPercentage,
     )
   }
 
   var rawValue: String {
     var dict: [String: Any] = [
       "theme": theme.rawValue,
-      "flowStyle": flowStyle.rawValue,
       "fontFamily": fontFamily.rawValue,
       "advancedLayout": advancedLayout,
       "fontSize": fontSize,
@@ -179,7 +164,6 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
       "columnCount": columnCount.rawValue,
       "textAlignment": textAlignment.rawValue,
       "pageMargins": pageMargins,
-      "tapScrollPercentage": tapScrollPercentage,
     ]
     if let fontWeight {
       dict["fontWeight"] = fontWeight
@@ -199,6 +183,7 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
   func makeReadiumPayload(
     theme: ReaderTheme,
     fontPath: String? = nil,
+    flowStyle: EpubFlowStyle = .paged,
     rootURL: URL? = nil,
     viewportSize: CGSize? = nil
   ) -> (css: String, properties: [String: String?]) {
@@ -210,8 +195,7 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
       "--RS__backgroundColor": theme.backgroundColorHex,
     ]
     properties["--USER__view"] = flowStyle == .scrolled ? "readium-scroll-on" : nil
-    properties["--RS__disableOverflow"] =
-      flowStyle == .scrolled ? "readium-noOverflow-on" : nil
+    properties["--RS__disableOverflow"] = flowStyle == .scrolled ? "readium-noOverflow-on" : nil
     #if os(iOS)
       properties["--USER__iOSPatch"] = "readium-iOSPatch-on"
       properties["--USER__iPadOSPatch"] = nil
@@ -230,7 +214,7 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
     } else {
       properties["--USER__fontWeight"] = nil
     }
-    properties["--USER__colCount"] = resolvedReadiumColumnCount(for: viewportSize)
+    properties["--USER__colCount"] = resolvedReadiumColumnCount(flowStyle: flowStyle, for: viewportSize)
     properties["--USER__lineLength"] = readiumLineLengthValue(for: pageMargins)
     properties["--USER__textAlign"] = nil
     properties["--USER__bodyHyphens"] = nil
@@ -293,18 +277,20 @@ nonisolated struct EpubReaderPreferences: RawRepresentable, Equatable, Sendable 
   func makeCSS(
     theme: ReaderTheme,
     fontPath: String? = nil,
+    flowStyle: EpubFlowStyle = .paged,
     rootURL: URL? = nil,
     viewportSize: CGSize? = nil
   ) -> String {
     makeReadiumPayload(
       theme: theme,
       fontPath: fontPath,
+      flowStyle: flowStyle,
       rootURL: rootURL,
       viewportSize: viewportSize
     ).css
   }
 
-  private func resolvedReadiumColumnCount(for viewportSize: CGSize?) -> String? {
+  private func resolvedReadiumColumnCount(flowStyle: EpubFlowStyle, for viewportSize: CGSize?) -> String? {
     switch columnCount {
     case .one, .two:
       return columnCount.readiumValue

--- a/KMReader/Features/Reader/Views/Sheets/EpubReaderSettingsView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubReaderSettingsView_macOS.swift
@@ -1,0 +1,140 @@
+//
+//  EpubReaderSettingsView_macOS.swift
+//
+
+#if os(macOS)
+  import SwiftUI
+
+  struct EpubReaderSettingsView: View {
+    let inSheet: Bool
+
+    init(inSheet: Bool = false) {
+      self.inSheet = inSheet
+    }
+
+    @AppStorage("epubFlowStyle") private var flowStyle: EpubFlowStyle = .paged
+    @AppStorage("epubTapScrollPercentage") private var tapScrollPercentage: Double = AppConfig.epubTapScrollPercentage
+    @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
+    @AppStorage("animateEpubTapTurns") private var animateEpubTapTurns: Bool = AppConfig.animateEpubTapTurns
+    @AppStorage("epubShowsProgressFooter") private var epubShowsProgressFooter: Bool = false
+    @AppStorage("epubShowKeyboardHelpOverlay") private var showKeyboardHelpOverlay: Bool = AppConfig
+      .epubShowKeyboardHelpOverlay
+    @AppStorage("epubTapZoneMode") private var epubTapZoneMode: TapZoneMode = AppConfig.epubTapZoneMode
+    @AppStorage("epubTapZoneInversionMode") private var epubTapZoneInversionMode: TapZoneInversionMode = AppConfig
+      .epubTapZoneInversionMode
+
+    var body: some View {
+      if inSheet {
+        SheetView(
+          title: String(localized: "EPUB Settings"),
+          size: .large,
+          applyFormStyle: true
+        ) {
+          settingsForm
+        }
+        .presentationDragIndicator(.visible)
+      } else {
+        settingsForm
+          .inlineNavigationBarTitle(String(localized: "EPUB Settings"))
+      }
+    }
+
+    private var settingsForm: some View {
+      Form { settingsSections }
+        .formStyle(.grouped)
+        .animation(.easeInOut(duration: 0.2), value: flowStyle)
+    }
+
+    @ViewBuilder
+    private var settingsSections: some View {
+      Section(String(localized: "Page Turn")) {
+        Picker(String(localized: "epub.reading_flow"), selection: $flowStyle) {
+          ForEach(EpubFlowStyle.allCases) { style in Text(style.displayName).tag(style) }
+        }
+        .pickerStyle(.menu)
+
+        Toggle(isOn: $animateEpubTapTurns) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Animate Page Turns")
+            Text("Use animation when tapping zones to turn pages")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+
+        if flowStyle.isPaged {
+          VStack(alignment: .leading, spacing: 8) {
+            Picker(String(localized: "Page Transition Style"), selection: $epubPageTransitionStyle) {
+              ForEach(PageTransitionStyle.epubAvailableCases, id: \.self) { style in Text(style.displayName).tag(style)
+              }
+            }
+            .pickerStyle(.menu)
+            Text(epubPageTransitionStyle.description)
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+
+        if flowStyle == .scrolled {
+          VStack(alignment: .leading, spacing: 8) {
+            HStack {
+              Text(String(localized: "epub.scrolled.tap_scroll_height"))
+              Spacer()
+              Text("\(Int(tapScrollPercentage))%")
+                .foregroundStyle(.secondary)
+            }
+            Slider(value: $tapScrollPercentage, in: 25...100, step: 5)
+            Text(String(localized: "epub.scrolled.tap_scroll_height.description"))
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+
+      Section(String(localized: "Tap Zones")) {
+        VStack(alignment: .leading, spacing: 8) {
+          TapZoneModePicker(
+            selection: $epubTapZoneMode,
+            tapZoneInversionMode: epubTapZoneInversionMode,
+            readingDirection: flowStyle.isPaged ? .ltr : .vertical
+          )
+          Text("Choose how tap zones are laid out")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+
+        if !epubTapZoneMode.isDisabled {
+          VStack(alignment: .leading, spacing: 8) {
+            Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
+              ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in Text(mode.displayName).tag(mode) }
+            }
+            .pickerStyle(.menu)
+            Text("Mirror left and right tap zones manually or automatically for RTL reading")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+
+      Section(String(localized: "Reader Overlay")) {
+        Toggle(isOn: $epubShowsProgressFooter) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text(String(localized: "Show Progress Footer"))
+            Text(String(localized: "Show book progress at the bottom while reading."))
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+
+        Toggle(isOn: $showKeyboardHelpOverlay) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Auto-Show Keyboard Help")
+            Text("Briefly show keyboard shortcuts when opening the reader")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Views/Sheets/EpubSettingsPreviewView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubSettingsPreviewView.swift
@@ -5,7 +5,7 @@
   import WebKit
 
   struct EpubSettingsPreviewView: View {
-    let preferences: EpubReaderPreferences
+    let preferences: EpubThemePreferences
 
     @Environment(\.colorScheme) private var colorScheme
     @Query(sort: \CustomFont.name, order: .forward) private var customFonts: [CustomFont]
@@ -54,7 +54,7 @@
   }
 
   private func makePreviewPayload(
-    preferences: EpubReaderPreferences,
+    preferences: EpubThemePreferences,
     colorScheme: ColorScheme,
     customFontPath: String?
   ) -> PreviewPayload {
@@ -168,7 +168,7 @@
 
   #if os(iOS)
     private struct PlatformPreviewWebView: UIViewRepresentable {
-      let preferences: EpubReaderPreferences
+      let preferences: EpubThemePreferences
       let colorScheme: ColorScheme
       let customFontPath: String?
 
@@ -197,7 +197,7 @@
     }
   #elseif os(macOS)
     private struct PlatformPreviewWebView: NSViewRepresentable {
-      let preferences: EpubReaderPreferences
+      let preferences: EpubThemePreferences
       let colorScheme: ColorScheme
       let customFontPath: String?
 
@@ -244,7 +244,7 @@
 
       func update(
         webView: WKWebView,
-        preferences: EpubReaderPreferences,
+        preferences: EpubThemePreferences,
         colorScheme: ColorScheme,
         customFontPath: String?
       ) {

--- a/KMReader/Features/Reader/Views/Sheets/EpubThemePreferencesView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubThemePreferencesView_macOS.swift
@@ -3,27 +3,19 @@
   import SwiftData
   import SwiftUI
 
-  struct EpubPreferencesView: View {
+  struct EpubThemePreferencesView: View {
     let inSheet: Bool
     let bookId: String?
-    let hasBookPreferences: Bool
-    let onPreferencesSaved: ((EpubReaderPreferences) -> Void)?
-    let onPreferencesCleared: (() -> Void)?
+    let hasBookThemePreferences: Bool
+    let onThemePreferencesSaved: ((EpubThemePreferences) -> Void)?
+    let onThemePreferencesCleared: (() -> Void)?
 
-    private let baselinePreferences: EpubReaderPreferences
-    @State private var draft: EpubReaderPreferences
+    private let baselineThemePreferences: EpubThemePreferences
+    @State private var draft: EpubThemePreferences
     @State private var showPresetsSheet: Bool = false
     @State private var showSavePresetAlert: Bool = false
     @State private var newPresetName: String = ""
     @State private var showSystemFontPicker: Bool = false
-    @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
-    @AppStorage("animateEpubTapTurns") private var animateEpubTapTurns: Bool = AppConfig.animateEpubTapTurns
-    @AppStorage("epubShowsProgressFooter") private var epubShowsProgressFooter: Bool = false
-    @AppStorage("epubShowKeyboardHelpOverlay")
-    private var showKeyboardHelpOverlay: Bool = AppConfig.epubShowKeyboardHelpOverlay
-    @AppStorage("epubTapZoneMode") private var epubTapZoneMode: TapZoneMode = AppConfig.epubTapZoneMode
-    @AppStorage("epubTapZoneInversionMode")
-    private var epubTapZoneInversionMode: TapZoneInversionMode = AppConfig.epubTapZoneInversionMode
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
@@ -32,31 +24,31 @@
     init(
       inSheet: Bool = false,
       bookId: String? = nil,
-      hasBookPreferences: Bool = false,
-      initialPreferences: EpubReaderPreferences? = nil,
-      onPreferencesSaved: ((EpubReaderPreferences) -> Void)? = nil,
-      onPreferencesCleared: (() -> Void)? = nil
+      hasBookThemePreferences: Bool = false,
+      initialThemePreferences: EpubThemePreferences? = nil,
+      onThemePreferencesSaved: ((EpubThemePreferences) -> Void)? = nil,
+      onThemePreferencesCleared: (() -> Void)? = nil
     ) {
       self.inSheet = inSheet
       self.bookId = bookId
-      self.hasBookPreferences = hasBookPreferences
-      self.onPreferencesSaved = onPreferencesSaved
-      self.onPreferencesCleared = onPreferencesCleared
-      let baseline = initialPreferences ?? AppConfig.epubPreferences
-      baselinePreferences = baseline
+      self.hasBookThemePreferences = hasBookThemePreferences
+      self.onThemePreferencesSaved = onThemePreferencesSaved
+      self.onThemePreferencesCleared = onThemePreferencesCleared
+      let baseline = initialThemePreferences ?? AppConfig.epubThemePreferences
+      baselineThemePreferences = baseline
       _draft = State(initialValue: baseline)
     }
 
     private var navigationTitle: String {
-      bookId == nil ? SettingsSection.epubReader.title : String(localized: "Current Book")
+      bookId == nil ? String(localized: "EPUB Theme") : String(localized: "Current Book")
     }
 
     private var shouldShowResetToGlobal: Bool {
-      bookId != nil && hasBookPreferences
+      bookId != nil && hasBookThemePreferences
     }
 
     private var isSaveDisabled: Bool {
-      draft == baselinePreferences
+      draft == baselineThemePreferences
     }
 
     private var readerTheme: ReaderTheme {
@@ -171,42 +163,6 @@
           }
 
         Form {
-          Section(String(localized: "Page Turn")) {
-            Picker(String(localized: "epub.reading_flow"), selection: $draft.flowStyle) {
-              ForEach(EpubFlowStyle.allCases) { style in
-                Text(style.displayName).tag(style)
-              }
-            }
-            .pickerStyle(.menu)
-
-            Toggle(isOn: $animateEpubTapTurns) {
-              VStack(alignment: .leading, spacing: 4) {
-                Text("Animate Page Turns")
-                Text("Use animation when tapping zones to turn pages")
-                  .font(.caption)
-                  .foregroundStyle(.secondary)
-              }
-            }
-
-            if draft.flowStyle.isPaged {
-              VStack(alignment: .leading, spacing: 8) {
-                Picker(
-                  String(localized: "Page Transition Style"),
-                  selection: $epubPageTransitionStyle
-                ) {
-                  ForEach(PageTransitionStyle.epubAvailableCases, id: \.self) { style in
-                    Text(style.displayName).tag(style)
-                  }
-                }
-                .pickerStyle(.menu)
-
-                Text(epubPageTransitionStyle.description)
-                  .font(.caption)
-                  .foregroundStyle(.secondary)
-              }
-            }
-          }
-
           Section(String(localized: "Presets")) {
             Button(String(localized: "Load Preset")) {
               showPresetsSheet = true
@@ -271,34 +227,13 @@
           }
 
           Section(String(localized: "Page")) {
-            if draft.flowStyle.isPaged {
-              Picker(String(localized: "Page Layout"), selection: $draft.columnCount) {
-                ForEach(EpubColumnCount.allCases) { option in
-                  Text(option.label)
-                    .tag(option)
-                }
-              }
-              .pickerStyle(.segmented)
-            }
-
-            if draft.flowStyle == .scrolled {
-              VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                  Text(String(localized: "epub.scrolled.tap_scroll_height"))
-                  Spacer()
-                  Text("\(Int(draft.tapScrollPercentage))%")
-                    .foregroundStyle(.secondary)
-                }
-                Slider(
-                  value: $draft.tapScrollPercentage,
-                  in: 25...100,
-                  step: 5
-                )
-                Text(String(localized: "epub.scrolled.tap_scroll_height.description"))
-                  .font(.caption)
-                  .foregroundStyle(.secondary)
+            Picker(String(localized: "Page Layout"), selection: $draft.columnCount) {
+              ForEach(EpubColumnCount.allCases) { option in
+                Text(option.label)
+                  .tag(option)
               }
             }
+            .pickerStyle(.segmented)
 
             VStack(alignment: .leading) {
               Slider(value: $draft.pageMargins, in: 0.25...2.0, step: 0.05)
@@ -392,54 +327,6 @@
             }
           }
 
-          Section(String(localized: "Tap Zones")) {
-            VStack(alignment: .leading, spacing: 8) {
-              TapZoneModePicker(
-                selection: $epubTapZoneMode,
-                tapZoneInversionMode: epubTapZoneInversionMode,
-                readingDirection: draft.flowStyle.isPaged ? .ltr : .vertical
-              )
-
-              Text("Choose how tap zones are laid out")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-
-            if !epubTapZoneMode.isDisabled {
-              VStack(alignment: .leading, spacing: 8) {
-                Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
-                  ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in
-                    Text(mode.displayName).tag(mode)
-                  }
-                }
-                .pickerStyle(.menu)
-
-                Text("Mirror left and right tap zones manually or automatically for RTL reading")
-                  .font(.caption)
-                  .foregroundStyle(.secondary)
-              }
-            }
-          }
-
-          Section(String(localized: "Reader Overlay")) {
-            Toggle(isOn: $epubShowsProgressFooter) {
-              VStack(alignment: .leading, spacing: 4) {
-                Text(String(localized: "Show Progress Footer"))
-                Text(String(localized: "Show book progress at the bottom while reading."))
-                  .font(.caption)
-                  .foregroundStyle(.secondary)
-              }
-            }
-
-            Toggle(isOn: $showKeyboardHelpOverlay) {
-              VStack(alignment: .leading, spacing: 4) {
-                Text("Auto-Show Keyboard Help")
-                Text("Briefly show keyboard shortcuts when opening the reader")
-                  .font(.caption)
-                  .foregroundStyle(.secondary)
-              }
-            }
-          }
         }
       }
       .formStyle(.grouped)
@@ -475,7 +362,6 @@
       }
       .animation(.easeInOut(duration: 0.2), value: draft.advancedLayout)
       .animation(.easeInOut(duration: 0.2), value: draft.fontWeight != nil)
-      .animation(.easeInOut(duration: 0.2), value: draft.flowStyle)
       .onChange(of: draft.advancedLayout) { _, newValue in
         guard !newValue else { return }
         draft.fontSize = EpubConstants.defaultFontScale
@@ -521,7 +407,7 @@
     }
 
     private func resetPreferences() {
-      draft = EpubReaderPreferences()
+      draft = EpubThemePreferences()
       ErrorManager.shared.notify(message: String(localized: "Reset"))
     }
 
@@ -539,15 +425,15 @@
     private func savePreferences() {
       if let bookId {
         Task {
-          try? await DatabaseOperator.database().updateBookEpubPreferences(
+          try? await DatabaseOperator.database().updateBookEpubThemePreferences(
             bookId: bookId,
             preferences: draft
           )
           try? await DatabaseOperator.database().commit()
         }
-        onPreferencesSaved?(draft)
+        onThemePreferencesSaved?(draft)
       } else {
-        AppConfig.epubPreferences = draft
+        AppConfig.epubThemePreferences = draft
       }
       dismiss()
     }
@@ -555,13 +441,13 @@
     private func clearBookPreferences() {
       guard let bookId else { return }
       Task {
-        try? await DatabaseOperator.database().updateBookEpubPreferences(
+        try? await DatabaseOperator.database().updateBookEpubThemePreferences(
           bookId: bookId,
           preferences: nil
         )
         try? await DatabaseOperator.database().commit()
       }
-      onPreferencesCleared?()
+      onThemePreferencesCleared?()
       ErrorManager.shared.notify(message: String(localized: "Reset to Global"))
       dismiss()
     }

--- a/KMReader/Features/Reader/Views/Sheets/EpubThemePresetsView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubThemePresetsView.swift
@@ -7,7 +7,7 @@ import SwiftData
 import SwiftUI
 
 struct EpubThemePresetsView: View {
-  let onApply: ((EpubReaderPreferences) -> Void)?
+  let onApply: ((EpubThemePreferences) -> Void)?
 
   @Environment(\.dismiss) private var dismiss
   @Environment(\.modelContext) private var modelContext
@@ -16,7 +16,7 @@ struct EpubThemePresetsView: View {
   @State private var presetToRename: EpubThemePreset?
   @State private var newName: String = ""
 
-  init(onApply: ((EpubReaderPreferences) -> Void)? = nil) {
+  init(onApply: ((EpubThemePreferences) -> Void)? = nil) {
     self.onApply = onApply
   }
 
@@ -133,7 +133,7 @@ struct EpubThemePresetsView: View {
       if let onApply {
         onApply(preferences)
       } else {
-        AppConfig.epubPreferences = preferences
+        AppConfig.epubThemePreferences = preferences
       }
       ErrorManager.shared.notify(message: String(localized: "Preset applied: \(preset.name)"))
     }

--- a/KMReader/Features/Settings/Components/SettingsSection.swift
+++ b/KMReader/Features/Settings/Components/SettingsSection.swift
@@ -15,7 +15,8 @@ enum SettingsSection: String, CaseIterable {
     case pdfReader
   #endif
   #if os(iOS) || os(macOS)
-    case epubReader
+    case epubTheme
+    case epubSettings
   #endif
   case sse
   case sync
@@ -42,7 +43,9 @@ enum SettingsSection: String, CaseIterable {
         return "doc.richtext"
     #endif
     #if os(iOS) || os(macOS)
-      case .epubReader:
+      case .epubTheme:
+        return "textformat.size"
+      case .epubSettings:
         return "character.book.closed"
     #endif
     case .sse:
@@ -77,8 +80,10 @@ enum SettingsSection: String, CaseIterable {
         return String(localized: "PDF Reader")
     #endif
     #if os(iOS) || os(macOS)
-      case .epubReader:
-        return String(localized: "EPUB Reader")
+      case .epubTheme:
+        return String(localized: "EPUB Theme")
+      case .epubSettings:
+        return String(localized: "EPUB Settings")
     #endif
     case .sse:
       return String(localized: "Real-time Updates")

--- a/KMReader/Features/Settings/EpubReaderSettingsView.swift
+++ b/KMReader/Features/Settings/EpubReaderSettingsView.swift
@@ -1,0 +1,150 @@
+//
+//  EpubReaderSettingsView.swift
+//
+
+#if os(iOS)
+  import SwiftUI
+
+  struct EpubReaderSettingsView: View {
+    let inSheet: Bool
+
+    init(inSheet: Bool = false) {
+      self.inSheet = inSheet
+    }
+
+    @AppStorage("epubFlowStyle") private var flowStyle: EpubFlowStyle = .paged
+    @AppStorage("epubTapScrollPercentage") private var tapScrollPercentage: Double = AppConfig.epubTapScrollPercentage
+    @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
+    @AppStorage("animateEpubTapTurns") private var animateEpubTapTurns: Bool = AppConfig.animateEpubTapTurns
+    @AppStorage("epubShowsStatusBarWhileReading") private var epubShowsStatusBarWhileReading: Bool = false
+    @AppStorage("epubShowsProgressFooter") private var epubShowsProgressFooter: Bool = false
+    @AppStorage("epubShowKeyboardHelpOverlay") private var showKeyboardHelpOverlay: Bool = AppConfig
+      .epubShowKeyboardHelpOverlay
+    @AppStorage("epubTapZoneMode") private var epubTapZoneMode: TapZoneMode = AppConfig.epubTapZoneMode
+    @AppStorage("epubTapZoneInversionMode") private var epubTapZoneInversionMode: TapZoneInversionMode = AppConfig
+      .epubTapZoneInversionMode
+
+    var body: some View {
+      if inSheet {
+        SheetView(
+          title: String(localized: "EPUB Settings"),
+          size: .large,
+          applyFormStyle: true
+        ) {
+          settingsForm
+        }
+        .presentationDragIndicator(.visible)
+      } else {
+        settingsForm
+          .inlineNavigationBarTitle(String(localized: "EPUB Settings"))
+      }
+    }
+
+    private var settingsForm: some View {
+      Form { settingsSections }
+        .formStyle(.grouped)
+        .animation(.easeInOut(duration: 0.2), value: flowStyle)
+    }
+
+    @ViewBuilder
+    private var settingsSections: some View {
+      Section(String(localized: "Page Turn")) {
+        Picker(String(localized: "epub.reading_flow"), selection: $flowStyle) {
+          ForEach(EpubFlowStyle.allCases) { style in Text(style.displayName).tag(style) }
+        }
+        .pickerStyle(.menu)
+
+        Toggle(isOn: $animateEpubTapTurns) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Animate Page Turns")
+            Text("Use animation when tapping zones to turn pages")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+
+        if flowStyle.isPaged {
+          VStack(alignment: .leading, spacing: 8) {
+            Picker(String(localized: "Page Transition Style"), selection: $epubPageTransitionStyle) {
+              ForEach(PageTransitionStyle.epubAvailableCases, id: \.self) { style in Text(style.displayName).tag(style)
+              }
+            }
+            .pickerStyle(.menu)
+            Text(epubPageTransitionStyle.description)
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+
+        if flowStyle == .scrolled {
+          VStack(alignment: .leading, spacing: 8) {
+            HStack {
+              Text(String(localized: "epub.scrolled.tap_scroll_height"))
+              Spacer()
+              Text("\(Int(tapScrollPercentage))%")
+                .foregroundStyle(.secondary)
+            }
+            Slider(value: $tapScrollPercentage, in: 25...100, step: 5)
+            Text(String(localized: "epub.scrolled.tap_scroll_height.description"))
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+
+      Section(String(localized: "Tap Zones")) {
+        VStack(alignment: .leading, spacing: 8) {
+          TapZoneModePicker(
+            selection: $epubTapZoneMode,
+            tapZoneInversionMode: epubTapZoneInversionMode,
+            readingDirection: flowStyle.isPaged ? .ltr : .vertical
+          )
+          Text("Choose how tap zones are laid out")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+
+        if !epubTapZoneMode.isDisabled {
+          VStack(alignment: .leading, spacing: 8) {
+            Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
+              ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in Text(mode.displayName).tag(mode) }
+            }
+            .pickerStyle(.menu)
+            Text("Mirror left and right tap zones manually or automatically for RTL reading")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+
+      Section(String(localized: "Reader Overlay")) {
+        Toggle(isOn: $epubShowsStatusBarWhileReading) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text(String(localized: "Show Status Bar While Reading"))
+            Text(String(localized: "Keep time and battery visible when controls are hidden."))
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+
+        Toggle(isOn: $epubShowsProgressFooter) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text(String(localized: "Show Progress Footer"))
+            Text(String(localized: "Show book progress at the bottom while reading."))
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+
+        Toggle(isOn: $showKeyboardHelpOverlay) {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Auto-Show Keyboard Help")
+            Text("Briefly show keyboard shortcuts when opening the reader")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+    }
+  }
+#endif

--- a/KMReader/Features/Settings/EpubThemePreferencesView.swift
+++ b/KMReader/Features/Settings/EpubThemePreferencesView.swift
@@ -1,5 +1,5 @@
 //
-// EpubPreferencesView.swift
+// EpubThemePreferencesView.swift
 //
 //
 
@@ -8,29 +8,20 @@
   import SwiftData
   import SwiftUI
 
-  struct EpubPreferencesView: View {
+  struct EpubThemePreferencesView: View {
     let inSheet: Bool
     let bookId: String?
-    let hasBookPreferences: Bool
-    let onPreferencesSaved: ((EpubReaderPreferences) -> Void)?
-    let onPreferencesCleared: (() -> Void)?
+    let hasBookThemePreferences: Bool
+    let onThemePreferencesSaved: ((EpubThemePreferences) -> Void)?
+    let onThemePreferencesCleared: (() -> Void)?
 
-    private let baselinePreferences: EpubReaderPreferences
-    @State private var draft: EpubReaderPreferences
+    private let baselineThemePreferences: EpubThemePreferences
+    @State private var draft: EpubThemePreferences
     @State private var showCustomFontsSheet: Bool = false
     @State private var showPresetsSheet: Bool = false
     @State private var showSavePresetAlert: Bool = false
     @State private var newPresetName: String = ""
     @State private var fontListRefreshId: UUID = UUID()
-    @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
-    @AppStorage("animateEpubTapTurns") private var animateEpubTapTurns: Bool = AppConfig.animateEpubTapTurns
-    @AppStorage("epubShowsStatusBarWhileReading") private var epubShowsStatusBarWhileReading: Bool = false
-    @AppStorage("epubShowsProgressFooter") private var epubShowsProgressFooter: Bool = false
-    @AppStorage("epubShowKeyboardHelpOverlay")
-    private var showKeyboardHelpOverlay: Bool = AppConfig.epubShowKeyboardHelpOverlay
-    @AppStorage("epubTapZoneMode") private var epubTapZoneMode: TapZoneMode = AppConfig.epubTapZoneMode
-    @AppStorage("epubTapZoneInversionMode")
-    private var epubTapZoneInversionMode: TapZoneInversionMode = AppConfig.epubTapZoneInversionMode
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) var colorScheme
@@ -41,18 +32,18 @@
     init(
       inSheet: Bool = false,
       bookId: String? = nil,
-      hasBookPreferences: Bool = false,
-      initialPreferences: EpubReaderPreferences? = nil,
-      onPreferencesSaved: ((EpubReaderPreferences) -> Void)? = nil,
-      onPreferencesCleared: (() -> Void)? = nil
+      hasBookThemePreferences: Bool = false,
+      initialThemePreferences: EpubThemePreferences? = nil,
+      onThemePreferencesSaved: ((EpubThemePreferences) -> Void)? = nil,
+      onThemePreferencesCleared: (() -> Void)? = nil
     ) {
       self.inSheet = inSheet
       self.bookId = bookId
-      self.hasBookPreferences = hasBookPreferences
-      self.onPreferencesSaved = onPreferencesSaved
-      self.onPreferencesCleared = onPreferencesCleared
-      let baseline = initialPreferences ?? AppConfig.epubPreferences
-      self.baselinePreferences = baseline
+      self.hasBookThemePreferences = hasBookThemePreferences
+      self.onThemePreferencesSaved = onThemePreferencesSaved
+      self.onThemePreferencesCleared = onThemePreferencesCleared
+      let baseline = initialThemePreferences ?? AppConfig.epubThemePreferences
+      self.baselineThemePreferences = baseline
       self._draft = State(initialValue: baseline)
     }
 
@@ -64,15 +55,15 @@
       if isBookContext {
         return String(localized: "Current Book")
       }
-      return SettingsSection.epubReader.title
+      return String(localized: "EPUB Theme")
     }
 
     private var shouldShowResetToGlobal: Bool {
-      isBookContext && hasBookPreferences
+      isBookContext && hasBookThemePreferences
     }
 
     private var isSaveDisabled: Bool {
-      draft == baselinePreferences
+      draft == baselineThemePreferences
     }
 
     private var readerTheme: ReaderTheme {
@@ -159,39 +150,6 @@
 
     var body: some View {
       Form {
-        Section(String(localized: "Page Turn")) {
-          Picker(String(localized: "epub.reading_flow"), selection: $draft.flowStyle) {
-            ForEach(EpubFlowStyle.allCases) { style in
-              Text(style.displayName).tag(style)
-            }
-          }
-          .pickerStyle(.menu)
-
-          Toggle(isOn: $animateEpubTapTurns) {
-            VStack(alignment: .leading, spacing: 4) {
-              Text("Animate Page Turns")
-              Text("Use animation when tapping zones to turn pages")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-          }
-
-          if draft.flowStyle.isPaged {
-            VStack(alignment: .leading, spacing: 8) {
-              Picker(String(localized: "Page Transition Style"), selection: $epubPageTransitionStyle) {
-                ForEach(PageTransitionStyle.epubAvailableCases, id: \.self) { style in
-                  Text(style.displayName).tag(style)
-                }
-              }
-              .pickerStyle(.menu)
-
-              Text(epubPageTransitionStyle.description)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-          }
-        }
-
         Section(String(localized: "Presets")) {
           Button {
             showPresetsSheet = true
@@ -266,34 +224,13 @@
         }
 
         Section(String(localized: "Page")) {
-          if draft.flowStyle.isPaged {
-            Picker(String(localized: "Page Layout"), selection: $draft.columnCount) {
-              ForEach(EpubColumnCount.allCases) { option in
-                Text(option.label)
-                  .tag(option)
-              }
-            }
-            .pickerStyle(.segmented)
-          }
-
-          if draft.flowStyle == .scrolled {
-            VStack(alignment: .leading, spacing: 8) {
-              HStack {
-                Text(String(localized: "epub.scrolled.tap_scroll_height"))
-                Spacer()
-                Text("\(Int(draft.tapScrollPercentage))%")
-                  .foregroundStyle(.secondary)
-              }
-              Slider(
-                value: $draft.tapScrollPercentage,
-                in: 25...100,
-                step: 5
-              )
-              Text(String(localized: "epub.scrolled.tap_scroll_height.description"))
-                .font(.caption)
-                .foregroundStyle(.secondary)
+          Picker(String(localized: "Page Layout"), selection: $draft.columnCount) {
+            ForEach(EpubColumnCount.allCases) { option in
+              Text(option.label)
+                .tag(option)
             }
           }
+          .pickerStyle(.segmented)
 
           VStack(alignment: .leading) {
             Slider(value: $draft.pageMargins, in: 0.25...2.0, step: 0.05)
@@ -391,68 +328,10 @@
           }
         }
 
-        Section(String(localized: "Tap Zones")) {
-          VStack(alignment: .leading, spacing: 8) {
-            TapZoneModePicker(
-              selection: $epubTapZoneMode,
-              tapZoneInversionMode: epubTapZoneInversionMode,
-              readingDirection: draft.flowStyle.isPaged ? .ltr : .vertical
-            )
-
-            Text("Choose how tap zones are laid out")
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-
-          if !epubTapZoneMode.isDisabled {
-            VStack(alignment: .leading, spacing: 8) {
-              Picker("Tap Zone Mirroring", selection: $epubTapZoneInversionMode) {
-                ForEach(TapZoneInversionMode.allCases, id: \.self) { mode in
-                  Text(mode.displayName).tag(mode)
-                }
-              }
-              .pickerStyle(.menu)
-
-              Text("Mirror left and right tap zones manually or automatically for RTL reading")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-          }
-        }
-
-        Section(String(localized: "Reader Overlay")) {
-          Toggle(isOn: $epubShowsStatusBarWhileReading) {
-            VStack(alignment: .leading, spacing: 4) {
-              Text(String(localized: "Show Status Bar While Reading"))
-              Text(String(localized: "Keep time and battery visible when controls are hidden."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-          }
-
-          Toggle(isOn: $epubShowsProgressFooter) {
-            VStack(alignment: .leading, spacing: 4) {
-              Text(String(localized: "Show Progress Footer"))
-              Text(String(localized: "Show book progress at the bottom while reading."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-          }
-
-          Toggle(isOn: $showKeyboardHelpOverlay) {
-            VStack(alignment: .leading, spacing: 4) {
-              Text("Auto-Show Keyboard Help")
-              Text("Briefly show keyboard shortcuts when opening the reader")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
-          }
-        }
       }
       .formStyle(.grouped)
       .animation(.easeInOut(duration: 0.2), value: draft.advancedLayout)
       .animation(.easeInOut(duration: 0.2), value: draft.fontWeight != nil)
-      .animation(.easeInOut(duration: 0.2), value: draft.flowStyle)
       .onChange(of: draft.advancedLayout) {
         draft.fontSize = EpubConstants.defaultFontScale
         draft.wordSpacing = EpubConstants.defaultWordSpacing
@@ -490,7 +369,7 @@
             }
           }
           Button {
-            draft = EpubReaderPreferences()
+            draft = EpubThemePreferences()
             ErrorManager.shared.notify(message: String(localized: "Reset"))
           } label: {
             Label(String(localized: "Reset"), systemImage: "arrow.counterclockwise")
@@ -535,7 +414,7 @@
         EpubThemePresetsView(onApply: { preferences in
           draft = preferences
           if !isBookContext {
-            AppConfig.epubPreferences = preferences
+            AppConfig.epubThemePreferences = preferences
           }
         })
       }
@@ -573,31 +452,31 @@
     private func savePreferences() {
       if let bookId {
         Task {
-          try? await DatabaseOperator.database().updateBookEpubPreferences(
+          try? await DatabaseOperator.database().updateBookEpubThemePreferences(
             bookId: bookId,
             preferences: draft
           )
           try? await DatabaseOperator.database().commit()
         }
-        onPreferencesSaved?(draft)
+        onThemePreferencesSaved?(draft)
         dismiss()
         return
       }
 
-      AppConfig.epubPreferences = draft
+      AppConfig.epubThemePreferences = draft
       dismiss()
     }
 
     private func clearBookPreferences() {
       guard let bookId else { return }
       Task {
-        try? await DatabaseOperator.database().updateBookEpubPreferences(
+        try? await DatabaseOperator.database().updateBookEpubThemePreferences(
           bookId: bookId,
           preferences: nil
         )
         try? await DatabaseOperator.database().commit()
       }
-      onPreferencesCleared?()
+      onThemePreferencesCleared?()
       ErrorManager.shared.notify(message: String(localized: "Reset to Global"))
       dismiss()
     }

--- a/KMReader/Features/Settings/SettingsView.swift
+++ b/KMReader/Features/Settings/SettingsView.swift
@@ -18,8 +18,11 @@ struct SettingsView: View {
           }
         #endif
         #if os(iOS)
-          NavigationLink(value: NavDestination.settingsEpubReader) {
-            SettingsSectionRow(section: .epubReader)
+          NavigationLink(value: NavDestination.settingsEpubTheme) {
+            SettingsSectionRow(section: .epubTheme)
+          }
+          NavigationLink(value: NavDestination.settingsEpubSettings) {
+            SettingsSectionRow(section: .epubSettings)
           }
         #endif
       }

--- a/KMReader/Features/Settings/SettingsView_macOS.swift
+++ b/KMReader/Features/Settings/SettingsView_macOS.swift
@@ -16,7 +16,8 @@ import SwiftUI
           Section(String(localized: "Reader")) {
             SettingsSectionRow(section: .divinaReader)
             SettingsSectionRow(section: .pdfReader)
-            SettingsSectionRow(section: .epubReader)
+            SettingsSectionRow(section: .epubTheme)
+            SettingsSectionRow(section: .epubSettings)
           }
 
           Section(String(localized: "Display")) {
@@ -74,8 +75,10 @@ import SwiftUI
         DivinaPreferencesView()
       case .pdfReader:
         PdfPreferencesView()
-      case .epubReader:
-        EpubPreferencesView()
+      case .epubTheme:
+        EpubThemePreferencesView()
+      case .epubSettings:
+        EpubReaderSettingsView()
       case .sse:
         SettingsSSEView()
       case .sync:

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -21152,70 +21152,6 @@
         }
       }
     },
-    "EPUB Reader" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "EPUB-Reader"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "EPUB Reader"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lector EPUB"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lecteur EPUB"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lettore EPUB"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "EPUB リーダー"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "EPUB 리더"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ридер EPUB"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "EPUB 阅读器"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "EPUB 閱讀器"
-          }
-        }
-      }
-    },
     "EPUB Reader Not Available" : {
       "localizations" : {
         "de" : {
@@ -21340,6 +21276,134 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "EPUB 閱讀僅支援 iOS 和 macOS。"
+          }
+        }
+      }
+    },
+    "EPUB Settings" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB-Einstellungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB Settings"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes EPUB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réglages EPUB"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impostazioni EPUB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB 設定"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB 설정"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройки EPUB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB 设置"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB 設定"
+          }
+        }
+      }
+    },
+    "EPUB Theme" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB-Design"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB Theme"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tema EPUB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thème EPUB"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tema EPUB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB テーマ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB 테마"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тема EPUB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB 主题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EPUB 主題"
           }
         }
       }
@@ -74590,70 +74654,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "主題預設"
-          }
-        }
-      }
-    },
-    "Themes & Settings" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Themes & Einstellungen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Themes & Settings"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Temas y ajustes"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thèmes et paramètres"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Temi e impostazioni"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "テーマと設定"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "테마 및 설정"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Темы и настройки"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "主题与设置"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "主題與設置"
           }
         }
       }

--- a/KMReader/Shared/Foundation/Models/NavDestination.swift
+++ b/KMReader/Shared/Foundation/Models/NavDestination.swift
@@ -42,7 +42,8 @@ enum NavDestination: Hashable {
     case settingsPdfReader
   #endif
   #if os(iOS)
-    case settingsEpubReader
+    case settingsEpubTheme
+    case settingsEpubSettings
   #endif
   case settingsSSE
   case settingsSync
@@ -163,8 +164,10 @@ enum NavDestination: Hashable {
         PdfPreferencesView()
     #endif
     #if os(iOS)
-      case .settingsEpubReader:
-        EpubPreferencesView()
+      case .settingsEpubTheme:
+        EpubThemePreferencesView()
+      case .settingsEpubSettings:
+        EpubReaderSettingsView()
     #endif
     case .settingsSSE:
       SettingsSSEView()


### PR DESCRIPTION
## Problem
EPUB reader preferences mixed per-book theme/typography choices with global reader behavior settings. That made the settings model and UI ambiguous, especially now that book-specific overrides should only apply to the EPUB theme surface.

## Approach
Separate EPUB theme preferences from global reader settings while preserving existing storage compatibility. Theme preferences keep the current persisted keys and book-level override behavior, while reader behavior such as flow style, tap scrolling, tap zones, page transitions, and overlays moves into dedicated EPUB settings views.

## Scope
- Rename EPUB reader preferences/views to EPUB theme preferences/views
- Add global EPUB settings pages for iOS and macOS
- Split reader quick actions into Contents, Book Info, Settings, and Theme
- Keep existing UserDefaults and database raw keys compatible
- Regenerate localization and add translations for the new EPUB Theme/Settings labels
- Bump the build version

## Validation
- `make format`
- `make localize`
- `make build-macos`
- `make build-ios`
