### PR TITLE
fix(browse): avoid refreshing when returning from detail

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 457;
+				CURRENT_PROJECT_VERSION = 458;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 457;
+				CURRENT_PROJECT_VERSION = 458;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 457;
+				CURRENT_PROJECT_VERSION = 458;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 457;
+				CURRENT_PROJECT_VERSION = 458;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Views/BooksBrowseView.swift
+++ b/KMReader/Features/Book/Views/BooksBrowseView.swift
@@ -22,7 +22,7 @@ struct BooksBrowseView: View {
   @AppStorage("searchIgnoreFilters") private var searchIgnoreFilters: Bool = false
 
   @State private var viewModel = BookViewModel()
-  @State private var hasInitialized = false
+  @State private var initializedKey: String?
 
   var body: some View {
     VStack {
@@ -41,17 +41,17 @@ struct BooksBrowseView: View {
         browseLayout: browseLayout,
         viewModel: viewModel
       )
-      .task {
-        if !hasInitialized {
-          if let metadataFilter = metadataFilter {
-            var opts = BookBrowseOptions()
-            opts.metadataFilter = metadataFilter
-            browseOpts = opts
-          } else {
-            browseOpts = storedBrowseOpts
-          }
-          hasInitialized = true
+      .task(id: initializationKey) {
+        guard initializedKey != initializationKey else { return }
+
+        if let metadataFilter = metadataFilter {
+          var opts = BookBrowseOptions()
+          opts.metadataFilter = metadataFilter
+          browseOpts = opts
+        } else {
+          browseOpts = storedBrowseOpts
         }
+        initializedKey = initializationKey
         await loadBooks(refresh: true)
       }
       .onChange(of: refreshTrigger) { _, _ in
@@ -80,6 +80,13 @@ struct BooksBrowseView: View {
         }
       }
     }
+  }
+
+  private var initializationKey: String {
+    [
+      libraryIds.joined(separator: ","),
+      metadataFilter?.rawValue ?? "",
+    ].joined(separator: "|")
   }
 
   private func loadBooks(refresh: Bool) async {

--- a/KMReader/Features/Browse/Views/BrowseView.swift
+++ b/KMReader/Features/Browse/Views/BrowseView.swift
@@ -23,6 +23,7 @@ struct BrowseView: View {
   @AppStorage("readListBrowseLayout") private var readListBrowseLayout: BrowseLayoutMode = .grid
 
   @State private var refreshTrigger = UUID()
+  @State private var initializedLibraryIdsKey: String?
   @State private var isRefreshDisabled = false
   @State private var searchQuery: String = ""
   @State private var activeSearchText: String = ""
@@ -221,6 +222,8 @@ struct BrowseView: View {
     }
     .task(id: resolvedLibraryIdsKey) {
       guard !authViewModel.isSwitching else { return }
+      guard initializedLibraryIdsKey != resolvedLibraryIdsKey else { return }
+      initializedLibraryIdsKey = resolvedLibraryIdsKey
       refreshBrowse()
     }
   }

--- a/KMReader/Features/Series/Views/SeriesBrowseView.swift
+++ b/KMReader/Features/Series/Views/SeriesBrowseView.swift
@@ -22,7 +22,7 @@ struct SeriesBrowseView: View {
 
   @State private var browseOpts: SeriesBrowseOptions = SeriesBrowseOptions()
   @State private var viewModel = SeriesViewModel()
-  @State private var hasInitialized = false
+  @State private var initializedKey: String?
 
   var body: some View {
     VStack {
@@ -42,17 +42,17 @@ struct SeriesBrowseView: View {
         viewModel: viewModel
       )
     }
-    .task {
-      if !hasInitialized {
-        if let metadataFilter = metadataFilter {
-          var opts = SeriesBrowseOptions()
-          opts.metadataFilter = metadataFilter
-          browseOpts = opts
-        } else {
-          browseOpts = storedBrowseOpts
-        }
-        hasInitialized = true
+    .task(id: initializationKey) {
+      guard initializedKey != initializationKey else { return }
+
+      if let metadataFilter = metadataFilter {
+        var opts = SeriesBrowseOptions()
+        opts.metadataFilter = metadataFilter
+        browseOpts = opts
+      } else {
+        browseOpts = storedBrowseOpts
       }
+      initializedKey = initializationKey
       await loadSeries(refresh: true)
     }
     .onChange(of: refreshTrigger) { _, _ in
@@ -80,6 +80,13 @@ struct SeriesBrowseView: View {
         await loadSeries(refresh: true)
       }
     }
+  }
+
+  private var initializationKey: String {
+    [
+      libraryIds.joined(separator: ","),
+      metadataFilter?.rawValue ?? "",
+    ].joined(separator: "|")
   }
 
   private func loadSeries(refresh: Bool) async {


### PR DESCRIPTION
## Problem
Returning from a series detail page back to browse could still trigger a full browse refresh. The inner browse views were no longer refreshing on every appear, but the outer `BrowseView` could still bump its refresh trigger when the same library scope reappeared.

## Approach
Keep the initial browse refresh tied to a stable library-scope key so returning from detail does not emit a new refresh trigger for the same scope. Series and book browse views now initialize by a stable input key as well, so SwiftUI state reuse still refreshes correctly when the library scope or metadata filter changes.

## Scope
- Avoid repeated outer browse refreshes for the same library scope
- Key series/book browse initialization by library IDs and metadata filter
- Preserve explicit refresh paths for manual refresh, server switch, search, and filter changes
- Bump build version to 458

## Validation
- [x] `make format`
- [x] `make build-macos`
