### PR TITLE
docs: update release notes and product docs

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,17 +1,19 @@
 New
-- Added offline-first reading so downloaded books can be prepared locally before the reader opens.
-- Added dashboard download actions for recent, on-deck, and keep-reading sections, with clearer Download Latest and Download All choices where available.
-- Added per-page rotation for DIVINA pages.
-- Added reader progress options for DIVINA and PDF so lightweight progress can stay visible while controls are hidden.
+- Added optional border cropping for DIVINA pages, helping comics with large empty margins use more of the screen.
+- Added DIVINA image preloading profiles so you can choose between lower memory use and smoother page turns.
+- Added dedicated EPUB settings and EPUB theme controls, separating reading behavior from per-book theme and typography choices.
 
 Improvements
-- PDF reading now uses supported page presentation modes, including an Auto mode that adapts between portrait and landscape.
-- Automatic offline mode can now recover when your configured Komga server becomes reachable again, while manual offline mode stays under your control.
-- Reader opening is faster because adjacent-book loading no longer blocks the first page.
-- Webtoon spacing, history rows, reader menus, and reading stats controls have been tightened for cleaner scanning.
+- EPUB books with custom fonts, images, and mixed HTML/XHTML chapters now load publication resources more reliably.
+- EPUB tap zones now have their own settings instead of sharing DIVINA tap zone preferences.
+- DIVINA scroll and page-curl navigation is more stable, especially around rapid taps, animations, and book boundaries.
+- Reader memory handling is improved on iOS, with decoded pages pruned more gracefully under memory pressure.
+- Browse views avoid unnecessary refreshes when returning from detail pages.
+- The Browse tab is now positioned as the trailing search-style entry point on iPhone and Apple TV.
+- macOS Settings keeps its sidebar stable while using EPUB settings and log search.
 
 Fixes
-- Progress is flushed when the app backgrounds, reducing the chance of losing the last pages you read.
-- Stale offline progress is skipped when the server already has newer progress, preventing older queued updates from moving books backward.
-- EPUB downloads with read-only archive folders extract more reliably.
-- Dashboard offline queue actions are faster and avoid unsupported bulk downloads.
+- Fixed cases where continuing from one volume into the next could jump back or regress progress for the previous volume.
+- Fixed UTF-8 archive path handling for offline CBZ/ZIP extraction.
+- Fixed EPUB chapters that could appear blank when their manifest media type did not match the file extension.
+- Reduced unnecessary offline downloads for previous-book preloads while keeping forward offline-first preparation.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -5,8 +5,8 @@ KMReader helps you read, browse, download, and manage your Komga library with na
 IMPORTANT FEATURES
 
 - Native readers
-Read comics and books with DIVINA on iOS, macOS, and tvOS, plus EPUB and PDF on iOS and macOS. Readers support LTR, RTL, vertical, Webtoon, spreads, zoom, page curl or cover transitions, custom EPUB fonts and typography, nested EPUB tables of contents, PDF search, keyboard shortcuts, per-book preferences, animated pages, and incognito reading.
-Rotate individual pages, keep lightweight progress visible while reading, and choose native PDF presentation modes that adapt cleanly between portrait and landscape.
+Read comics and books with DIVINA on iOS, macOS, and tvOS, plus EPUB and PDF on iOS and macOS. Readers support LTR, RTL, vertical, Webtoon, spreads, zoom, page curl or cover transitions, custom EPUB fonts and typography, dedicated EPUB behavior settings, nested EPUB tables of contents, PDF search, keyboard shortcuts, per-book preferences, animated pages, AI upscaling, and incognito reading.
+Rotate individual pages, crop empty page borders in DIVINA, tune preloading for memory or smoother page turns, keep lightweight progress visible while reading, and choose native PDF presentation modes that adapt cleanly between portrait and landscape.
 
 - Browse and discover
 Use Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/read lists, reading history, saved filters, advanced metadata filters with all/any matching, optional unread-cover blur, Spotlight indexing, widgets, and Home Screen quick actions.

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@
 
 ### Readers
 
-- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl on iOS, cover transitions, tap zone layout presets, keyboard support, per-page rotation, and per-book preferences.
-- EPUB reader on iOS/macOS with paged, scrolled, or cover layouts, custom fonts, themes, typography controls, status/footer overlays, multi-column reading, and nested table of contents.
+- DIVINA reader on iOS, macOS, and tvOS with LTR, RTL, vertical, Webtoon, spreads, zoom, page curl on iOS, cover transitions, tap zone layout presets, keyboard support, per-page rotation, border cropping, preload profiles, and per-book preferences.
+- EPUB reader on iOS/macOS with paged, scrolled, curl, or cover layouts, custom fonts, per-book theme and typography controls, dedicated EPUB behavior settings, status/footer overlays, multi-column reading, and nested table of contents.
 - PDF reader on iOS/macOS with native PDF or DIVINA mode, search, table of contents, page jump, automatic or explicit page presentation modes, spread layouts, configurable render quality, and continuous reading options.
-- Animated GIF and WebP pages play inline. Incognito mode, page image actions, persistent reader progress overlays, and iOS Live Text are supported where available.
+- Animated GIF and WebP pages play inline. Incognito mode, page image actions, persistent reader progress overlays, AI upscaling, and iOS Live Text are supported where available.
 
 ### Browse and Discovery
 

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
         <title>KMReader · Native Komga Client for iOS, macOS & tvOS</title>
         <meta
             name="description"
-            content="KMReader is a native Komga client for iOS, macOS, and tvOS with DIVINA, EPUB, and PDF readers, Webtoon and spread layouts, offline downloads, filtering, multi-server support, and admin tools."
+            content="KMReader is a native Komga client for iOS, macOS, and tvOS with DIVINA, EPUB, and PDF readers, Webtoon and spread layouts, reader image processing, offline downloads, filtering, multi-server support, and admin tools."
         />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -28,7 +28,7 @@
                 <p class="tagline">
                     Read, download, browse, and manage your Komga library with
                     native DIVINA, EPUB, and PDF readers, Webtoon and spread
-                    layouts, offline-first reading, dashboard download actions,
+                    layouts, reader image processing, offline-first reading, dashboard download actions,
                     advanced filtering, multi-server support, and Apple-platform
                     integrations on iPhone, iPad, Mac, and Apple TV.
                 </p>
@@ -83,11 +83,13 @@
                             plus EPUB and PDF on iOS and macOS. Readers support
                             LTR, RTL, vertical, Webtoon, spreads, zoom,
                             page curl or cover transitions, tap zone presets,
-                            keyboard shortcuts, per-page rotation, persistent
-                            progress, per-book preferences, custom EPUB fonts
-                            and typography, nested EPUB table of contents, PDF
-                            search, adaptive PDF presentation, animated pages,
-                            and incognito reading.
+                            keyboard shortcuts, per-page rotation, border
+                            cropping, preload profiles, persistent progress,
+                            per-book preferences, custom EPUB fonts and
+                            typography, dedicated EPUB behavior settings,
+                            nested EPUB table of contents, PDF search, adaptive
+                            PDF presentation, animated pages, AI upscaling, and
+                            incognito reading.
                         </p>
                     </article>
                     <article class="card">


### PR DESCRIPTION
## Problem
The release materials were still describing the previous release highlights and did not reflect the current set of user-facing reader improvements after v4.12.

## Approach
Refresh the App Store changelog from the commits since v4.12, then align the evergreen product copy across the README, App Store description, and landing page with the same current feature emphasis.

## Scope
- Update App Store release notes for the next version
- Mention DIVINA border cropping and preload profiles in product docs
- Mention the separated EPUB settings/theme controls and reader image processing improvements
- Keep the README, App Store description, and landing page messaging consistent

## Validation
- [x] Ran `git diff --check`
