### PR TITLE
fix: Download Unread on a read list ignores the list's order

### DIFF
--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -1812,7 +1812,13 @@ actor DatabaseOperator {
     let allBooks = (try? modelContext.fetch(descriptor)) ?? []
     let books = allBooks.filter { bookIds.contains($0.bookId) }
 
-    let sortedBooks = books.sorted { $0.metaNumberSort < $1.metaNumberSort }
+    // Preserve the read list's curated order, not per-series issue number.
+    let orderByBookId = Dictionary(
+      uniqueKeysWithValues: bookIds.enumerated().map { ($0.element, $0.offset) }
+    )
+    let sortedBooks = books.sorted {
+      (orderByBookId[$0.bookId] ?? Int.max) < (orderByBookId[$1.bookId] ?? Int.max)
+    }
     let unreadBooks = sortedBooks.filter { $0.progressCompleted != true }
     let limitValue = max(0, limit)
     let targetBooks = limitValue > 0 ? Array(unreadBooks.prefix(limitValue)) : unreadBooks


### PR DESCRIPTION
## Problem

On a read list, **Download Unread → N** does not download the next N unread books in the list's order. It downloads the N unread books with the lowest per-series issue numbers, which looks random on any list that interleaves multiple series.

Reproduction (e.g. a "CMRO Main Reading Order" read list that orders issues across Fantastic Four, Tales to Astonish, Hulk, … by story date):

  1. Open the read list. On-screen order is the curated reading order: FF#1, FF#2, Tales to Astonish#27, FF#3, FF#4, Tales to Astonish#29, …
  2. Download → Download Unread → 10.
  3. The 10 queued books are not the first 10 on screen — they're a mix
     sorted by issue number across series.

## Cause

`DatabaseOperator.downloadReadListUnreadOffline(readListId:instanceId:limit:)` sorts by `metaNumberSort` (the book's per-series metadata number) before filtering to unread and taking `prefix(limit)`:

  ```swift
  let sortedBooks = books.sorted { $0.metaNumberSort < $1.metaNumberSort }
```

`metaNumberSort` is the issue number within a series, not the position in the read list. For a single-series list these coincide, so the bug is invisible there; for cross-series curated lists it reorders everything.

##  Fix

Sort by the book's index within `readList.bookIds` (the list's stored order), matching the pattern already used by `queueBooksOffline` in the same file:

  ```swift
  let orderByBookId = Dictionary(
    uniqueKeysWithValues: bookIds.enumerated().map { ($0.element, $0.offset) }
  )
  let sortedBooks = books.sorted {
    (orderByBookId[$0.bookId] ?? Int.max) < (orderByBookId[$1.bookId] ?? Int.max)
  }
```

Both UI entry points (ReadListDownloadActionsSection and ReadListContextMenu) call this method, so both are fixed. No `@Model` changes, so no SwiftData migration. The series-level download paths (metaNumberSort) are intentionally left unchanged — issue-number order  is correct for a single series.