### PR TITLE
feat(reader): add T-Split tap-zone layout

### DIFF
--- a/KMReader/Features/Reader/Models/TapZoneHelper.swift
+++ b/KMReader/Features/Reader/Models/TapZoneHelper.swift
@@ -27,10 +27,19 @@ enum TapZoneHelper {
     normalizedY: CGFloat,
     tapZoneMode: TapZoneMode,
     tapZoneInversionMode: TapZoneInversionMode,
-    readingDirection: ReadingDirection
+    readingDirection: ReadingDirection,
+    stripHeightFraction: CGFloat? = nil
   ) -> TapZoneAction {
     if tapZoneMode.isDisabled {
       return .toggleControls
+    }
+
+    if tapZoneMode == .tSplit {
+      let frac = stripHeightFraction ?? 0.12
+      if normalizedY <= frac { return .toggleControls }
+      let leftHalf = normalizedX < 0.5
+      let inverted = tapZoneInversionMode.isInverted(for: readingDirection)
+      return (leftHalf != inverted) ? .previous : .next
     }
 
     let column = columnIndex(
@@ -91,6 +100,8 @@ enum TapZoneHelper {
         return .previous
       }
       return .next
+    case .tSplit:
+      return .toggleControls
     }
   }
 

--- a/KMReader/Features/Reader/Models/TapZoneMode.swift
+++ b/KMReader/Features/Reader/Models/TapZoneMode.swift
@@ -11,6 +11,7 @@ enum TapZoneMode: String, CaseIterable, Hashable, Sendable {
   case edge = "edge"
   case kindle = "kindle"
   case lShape = "lShape"
+  case tSplit = "tSplit"
 
   var displayName: String {
     switch self {
@@ -19,6 +20,7 @@ enum TapZoneMode: String, CaseIterable, Hashable, Sendable {
     case .edge: return String(localized: "reader.tapZoneMode.edge")
     case .kindle: return String(localized: "reader.tapZoneMode.kindle")
     case .lShape: return String(localized: "reader.tapZoneMode.lShape")
+    case .tSplit: return String(localized: "reader.tapZoneMode.tSplit")
     }
   }
 

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -1707,9 +1707,10 @@ struct DivinaReaderView: View {
   // thin while controls are hidden so the navigation halves stay large; taller
   // while they're shown so a band below the toolbar can toggle them back off (a
   // fixed strip sized to the toolbar leaves no tappable dismiss surface). Tunable;
-  // the shown band clears the ~80-85pt toolbar plus a dismiss margin.
+  // the shown band clears the toolbar (~80pt iPhone, ~105pt iPad) plus a ~44pt
+  // tap row, so dismiss stays comfortable on both.
   private static let tSplitSummonBand: CGFloat = 44
-  private static let tSplitDismissBand: CGFloat = 128
+  private static let tSplitDismissBand: CGFloat = 150
 
   private func handleTapZoneTap(normalizedX: CGFloat, normalizedY: CGFloat) {
     let stripHeightFraction: CGFloat?

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -79,6 +79,8 @@ struct DivinaReaderView: View {
   @State private var preserveReaderOptions = false
   @State private var usesDualPagePresentation = false
   @State private var webtoonScrollController = WebtoonScrollController()
+  @State private var readerSafeAreaTop: CGFloat = 0
+  @State private var readerViewHeight: CGFloat = 0
 
   // UI Panels states
   @State private var showingPageJumpSheet = false
@@ -552,6 +554,8 @@ struct DivinaReaderView: View {
 
         keyboardHelpOverlay
       }
+      .onGeometryChange(for: CGFloat.self) { $0.safeAreaInsets.top } action: { readerSafeAreaTop = $0 }
+      .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { readerViewHeight = $0 }
       .onChange(of: useDualPage, initial: true) { _, newValue in
         usesDualPagePresentation = newValue
         applyDualPagePresentationMode(newValue)
@@ -1699,13 +1703,29 @@ struct DivinaReaderView: View {
     }
   #endif
 
+  // T-Split controls strip height below the safe-area top, in points. Adaptive:
+  // thin while controls are hidden so the navigation halves stay large; taller
+  // while they're shown so a band below the toolbar can toggle them back off (a
+  // fixed strip sized to the toolbar leaves no tappable dismiss surface). Tunable;
+  // the shown band clears the ~80-85pt toolbar plus a dismiss margin.
+  private static let tSplitSummonBand: CGFloat = 44
+  private static let tSplitDismissBand: CGFloat = 128
+
   private func handleTapZoneTap(normalizedX: CGFloat, normalizedY: CGFloat) {
+    let stripHeightFraction: CGFloat?
+    if tapZoneMode == .tSplit, readerViewHeight > 0 {
+      let band = shouldShowControls ? Self.tSplitDismissBand : Self.tSplitSummonBand
+      stripHeightFraction = (readerSafeAreaTop + band) / readerViewHeight
+    } else {
+      stripHeightFraction = nil
+    }
     let action = TapZoneHelper.action(
       normalizedX: normalizedX,
       normalizedY: normalizedY,
       tapZoneMode: tapZoneMode,
       tapZoneInversionMode: tapZoneInversionMode,
-      readingDirection: readingDirection
+      readingDirection: readingDirection,
+      stripHeightFraction: stripHeightFraction
     )
     handleTapZoneAction(action)
   }

--- a/KMReader/Features/Reader/Views/TapZoneOverlay.swift
+++ b/KMReader/Features/Reader/Views/TapZoneOverlay.swift
@@ -33,19 +33,73 @@ struct TapZoneGridOverlayContent: View {
   let tapZoneInversionMode: TapZoneInversionMode
   let readingDirection: ReadingDirection
 
+  // Representative strip height for the hint overlay / preview only. There is no
+  // real page to measure here; runtime tap resolution uses an adaptive fraction.
+  private static let tSplitPreviewStripFraction: CGFloat = 0.12
+
   var body: some View {
     GeometryReader { geometry in
-      VStack(spacing: 0) {
-        ForEach(0..<3, id: \.self) { row in
-          HStack(spacing: 0) {
-            ForEach(0..<3, id: \.self) { column in
-              Rectangle()
-                .fill(color(row: row, column: column).opacity(0.3))
-                .frame(width: geometry.size.width / 3, height: geometry.size.height / 3)
+      if tapZoneMode == .tSplit {
+        tSplitContent(in: geometry.size)
+      } else {
+        VStack(spacing: 0) {
+          ForEach(0..<3, id: \.self) { row in
+            HStack(spacing: 0) {
+              ForEach(0..<3, id: \.self) { column in
+                Rectangle()
+                  .fill(color(row: row, column: column).opacity(0.3))
+                  .frame(width: geometry.size.width / 3, height: geometry.size.height / 3)
+              }
             }
           }
         }
       }
+    }
+  }
+
+  // Top strip (controls) + two halves (previous / next). Colours come from the
+  // real resolver so the preview always matches runtime resolution, including RTL
+  // mirroring; the strip itself does not mirror.
+  @ViewBuilder
+  private func tSplitContent(in size: CGSize) -> some View {
+    let frac = Self.tSplitPreviewStripFraction
+    let stripHeight = size.height * frac
+    let bodyHeight = size.height - stripHeight
+    let bodyY = (1 + frac) / 2
+    VStack(spacing: 0) {
+      Rectangle()
+        .fill(tSplitColor(normalizedX: 0.5, normalizedY: frac / 2).opacity(0.3))
+        .frame(width: size.width, height: stripHeight)
+      HStack(spacing: 0) {
+        Rectangle()
+          .fill(tSplitColor(normalizedX: 0.25, normalizedY: bodyY).opacity(0.3))
+          .frame(width: size.width / 2, height: bodyHeight)
+        Rectangle()
+          .fill(tSplitColor(normalizedX: 0.75, normalizedY: bodyY).opacity(0.3))
+          .frame(width: size.width / 2, height: bodyHeight)
+      }
+    }
+  }
+
+  private func tSplitColor(normalizedX: CGFloat, normalizedY: CGFloat) -> Color {
+    color(for: TapZoneHelper.action(
+      normalizedX: normalizedX,
+      normalizedY: normalizedY,
+      tapZoneMode: tapZoneMode,
+      tapZoneInversionMode: tapZoneInversionMode,
+      readingDirection: readingDirection,
+      stripHeightFraction: Self.tSplitPreviewStripFraction
+    ))
+  }
+
+  private func color(for action: TapZoneAction) -> Color {
+    switch action {
+    case .previous:
+      return .red
+    case .next:
+      return .green
+    case .toggleControls:
+      return .blue
     }
   }
 

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -55138,6 +55138,70 @@
         }
       }
     },
+    "reader.tapZoneMode.tSplit" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "T-Form"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "T-Split"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forma de T"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forme en T"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forma a T"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "T字型"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "T자형"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Т-образный"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "T 形"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "T 形"
+          }
+        }
+      }
+    },
     "reader.tapZoneMode.none" : {
       "localizations" : {
         "de" : {


### PR DESCRIPTION
Adds a new selectable tap-zone layout, T-Split, as agreed on #736. It is a general tap-zone option, available in the tap-zone picker like the existing layouts, and it is not tied to panel mode.

## Layout
A full-width strip along the top resolves to controls. The area below splits 50/50 left and right into back and forward. The two halves mirror by reading direction through the existing `TapZoneInversionMode.isInverted(for:)`. The strip itself does not mirror.

The top strip height is adaptive. While controls are hidden it stays thin so the navigation halves stay large. While controls are shown it grows to clear the toolbar, so there is a tappable band below the buttons to dismiss them. Without this a fixed strip sized to the toolbar leaves no surface to tap, which deadlocks dismissal. The band is derived from safe-area top plus a points value so it stays stable across screen sizes.

## Screenshots

Tap Zone settings with T-Split selected. The controls strip stays on top in both directions and the two halves mirror with the reading direction, the same way the existing layouts do.

<table>
<tr>
<td align="center"><img width="300" src="https://github.com/user-attachments/assets/b3b63d97-89f4-42b3-bf08-70c54a7ff7d0" /><br><sub>LTR</sub></td>
<td width="24"></td>
<td align="center"><img width="300" src="https://github.com/user-attachments/assets/9b13ed79-a254-4c22-8ef3-d7650dc2522b" /><br><sub>RTL</sub></td>
</tr>
</table>

## Scope and constraints
- The existing thirds path is unchanged for none, default, edge, kindle and lShape. The `.tSplit` case takes a separate branch and the shared resolver is otherwise untouched.
- Reuses the existing inversion rule. There is no second RTL rule.
- `.tSplit` emits only the existing actions: `previous`, `next` and `toggleControls`.
- The runtime resolver gains one defaulted parameter (`stripHeightFraction`), so the four EPUB readers compile unchanged and keep the default. `DivinaReaderView` passes the real value.
- The settings preview and the in-reader hint overlay render the strip plus halves by calling the same resolver, so the preview always matches runtime resolution.
- Localised in all supported languages.

## Testing
- Builds on iOS, macOS and tvOS.
- Manually tested on iPhone and macOS, and on iPad in the simulator: the strip resolves to controls, the halves resolve to previous and next, RTL mirroring works, controls dismiss and the existing modes are unchanged.
- Checked across a range of page aspect ratios that the layout is viewport-relative, so very tall or very wide pages do not change the zone geometry.

## Notes
- The iPad feel is not yet confirmed on physical hardware.
- The adaptive strip is DIVINA-specific, so the EPUB readers use the default strip fraction and were not separately hand-tested.
