### PR TITLE
fix(reader): reset zoom state after page turn in cover transition

### DIFF
--- a/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
@@ -547,6 +547,12 @@
         updateSlotLayout()
         applyCurrentItem(targetItem)
         applyPanRecognizerState()
+        // A freshly committed page is never zoomed. Clear any stale scale left on
+        // a slot that was zoomed while the transition animation was in flight
+        // (the animation allows user interaction), then reconcile the shared zoom
+        // flag so the tap zones, controls, and pan recognizer re-enable.
+        containerView?.slotViews.forEach { $0.forceResetZoom() }
+        parent.viewModel.isZoomed = false
       }
 
       private func cancelDragWithAnimation() {

--- a/KMReader/Features/Reader/Views/NativeCoverSlotView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverSlotView_iOS.swift
@@ -46,6 +46,10 @@
       representedItem
     }
 
+    func forceResetZoom() {
+      pageContentView.forceResetZoom()
+    }
+
     override init(frame: CGRect) {
       super.init(frame: frame)
       setupUI()

--- a/KMReader/Features/Reader/Views/NativePagedPageContentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativePagedPageContentView_iOS.swift
@@ -205,6 +205,18 @@
       viewModel.isZoomed = false
     }
 
+    // Reset this slot's scroll view to minimum scale unconditionally, independent
+    // of tracksGlobalZoomState or item identity. Lets the cover coordinator clear
+    // a stale scale left on a slot that was zoomed while a page transition was in
+    // flight. Uses isUpdatingZoomState so it does not re-fire scrollViewDidZoom.
+    func forceResetZoom() {
+      guard scrollView.zoomScale != scrollView.minimumZoomScale else { return }
+      isUpdatingZoomState = true
+      scrollView.setZoomScale(scrollView.minimumZoomScale, animated: false)
+      scrollView.contentOffset = .zero
+      isUpdatingZoomState = false
+    }
+
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
       contentStack
     }


### PR DESCRIPTION
Fixes #846

### Problem

On the Cover page transition (the default), double-tap zooming while a page turn is animating can leave the reader frozen on the next page. The left, right and controls tap zones all stop responding and only the swipe-to-dismiss gesture works.

Tap zones, the controls overlay and the page-pan recognizer are all gated on the shared `ReaderViewModel.isZoomed` flag. The page-turn animation allows user interaction, so a double-tap during the slide zooms a slot that then moves off-screen when the page turn finishes. That slot becomes non-tracking and keeps representing the same page, so its zoom reset never runs, and `completeTransition` never reconciles `isZoomed`. The flag stays `true` and suppresses all input.

### Fix

After a page turn the new page should be back at normal scale, so reconcile zoom state when the page turn finishes.

- `NativePagedPageContentView`: add `forceResetZoom()`, which resets the scroll view to minimum scale unconditionally, independent of the tracking flag or item identity, guarded so it does not re-fire `scrollViewDidZoom`.
- `NativeCoverSlotView`: passthrough to the content view.
- `NativeCoverPageView`: in `completeTransition`, reset all slots and clear `isZoomed`.

### Testing

- Reproduced the freeze on multiple physical iPhones before the change, on both the App Store version and local builds.
- After the change the freeze is gone. The page turns and stays responsive, the tap zones and controls work and double-tap zoom keeps working normally on the new page.
- Also verified on iPad simulator with no freeze.
- Scroll and Page Curl transitions were tested and never froze, before or after. They reset zoom on a different path, so they are unaffected and untouched by this change.
- Builds cleanly for iOS, macOS and tvOS.

### Scope

Cover transition only. No public API or data model changes.

macOS uses native magnification rather than tap-to-zoom, so the reported reproduction does not apply there. The macOS cover engine shares this structure and can take the same reconciliation as a follow-up if wanted.
