### PR TITLE
fix: pair streamed PDF pages in forced dual layout

### DIFF
--- a/KMReader/Features/Reader/Models/PageLayout.swift
+++ b/KMReader/Features/Reader/Models/PageLayout.swift
@@ -32,6 +32,17 @@ enum PageLayout: String, CaseIterable, Hashable, Sendable {
     }
   }
 
+  var detailText: String {
+    switch self {
+    case .single:
+      return String(localized: "reader.pageLayout.single.detail")
+    case .auto:
+      return String(localized: "reader.pageLayout.auto.detail")
+    case .dual:
+      return String(localized: "reader.pageLayout.dual.detail")
+    }
+  }
+
   var supportsDualPageOptions: Bool {
     switch self {
     case .single:

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -1345,8 +1345,21 @@ private func generateViewItems(
 ) -> [ReaderViewItem] {
   guard !segments.isEmpty, !readerPages.isEmpty else { return [] }
 
-  // Helper: determine effective isPortrait considering rotation
-  func effectiveIsPortrait(at index: Int) -> Bool {
+  enum PageOrientation {
+    case portrait
+    case landscape
+    case unknown
+
+    var isKnownLandscape: Bool {
+      self == .landscape
+    }
+
+    var isPairableInForcedDual: Bool {
+      self != .landscape
+    }
+  }
+
+  func effectiveOrientation(at index: Int) -> PageOrientation {
     let page = readerPages[index].page
     let bookId = readerPages[index].bookId
     if let range = segmentPageRangeByBookId[bookId] {
@@ -1354,12 +1367,13 @@ private func generateViewItems(
       let rotation = pageRotationsByBookId[bookId]?[localIndex] ?? 0
       let normalized = ((rotation % 360) + 360) % 360
       if normalized == 90 || normalized == 270 {
-        // Swapped: portrait becomes landscape and vice versa
-        guard let width = page.width, let height = page.height else { return false }
-        return width > height
+        guard let width = page.width, let height = page.height else { return .unknown }
+        return width > height ? .portrait : .landscape
       }
     }
-    return page.isPortrait
+
+    guard let width = page.width, let height = page.height else { return .unknown }
+    return height > width ? .portrait : .landscape
   }
 
   var items: [ReaderViewItem] = []
@@ -1377,12 +1391,12 @@ private func generateViewItems(
 
     while index < segmentEndExclusive {
       if shouldForceDualPairs {
-        let currentIsPortrait = effectiveIsPortrait(at: index)
+        let currentOrientation = effectiveOrientation(at: index)
         let isCoverPage = !noCover && index == segmentStartIndex
-        let isWideCoverPage = isCoverPage && !currentIsPortrait
+        let isWideCoverPage = isCoverPage && currentOrientation.isKnownLandscape
         let isWidePageEligibleForSplit =
           (splitWidePages || pageCurl)
-          && !currentIsPortrait
+          && currentOrientation.isKnownLandscape
           && (noCover || isWideCoverPage || index != segmentStartIndex)
 
         if isWidePageEligibleForSplit {
@@ -1391,17 +1405,20 @@ private func generateViewItems(
           continue
         }
 
-        if !currentIsPortrait && !pageCurl {
+        if currentOrientation.isKnownLandscape && !pageCurl {
           items.append(.page(id: readerPages[index].id))
           index += 1
           continue
         }
 
-        let nextIsPortrait = index + 1 < segmentEndExclusive ? effectiveIsPortrait(at: index + 1) : true
+        let nextIsPairable =
+          index + 1 < segmentEndExclusive
+          ? effectiveOrientation(at: index + 1).isPairableInForcedDual
+          : true
         let shouldShowSingle =
-          (isCoverPage && currentIsPortrait) || index == segmentEndExclusive - 1
+          (isCoverPage && currentOrientation.isPairableInForcedDual) || index == segmentEndExclusive - 1
           || isolatePages.contains(index) || isolatePages.contains(index + 1)
-          || !nextIsPortrait  // next page is wide → keep it for its own item
+          || !nextIsPairable  // next page is wide → keep it for its own item
         if shouldShowSingle {
           items.append(.page(id: readerPages[index].id))
           index += 1
@@ -1413,7 +1430,8 @@ private func generateViewItems(
         continue
       }
 
-      let currentIsPortrait = effectiveIsPortrait(at: index)
+      let currentOrientation = effectiveOrientation(at: index)
+      let currentIsPortrait = currentOrientation == .portrait
 
       var useSinglePage = false
       var shouldSplitPage = false
@@ -1458,7 +1476,7 @@ private func generateViewItems(
         items.append(.page(id: readerPages[index].id))
         index += 1
       } else {
-        let nextIsPortrait = effectiveIsPortrait(at: index + 1)
+        let nextIsPortrait = effectiveOrientation(at: index + 1) == .portrait
         if allowDualPairs && index + 1 < segmentEndExclusive
           && nextIsPortrait
           && !isolatePages.contains(index + 1)

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -101,7 +101,7 @@ struct DivinaPreferencesView: View {
             }
           }
           .pickerStyle(.menu)
-          Text("Opt for single page, auto-detected spreads, or forced dual pages (landscape only)")
+          Text(pageLayout.detailText)
             .font(.caption)
             .foregroundColor(.secondary)
         }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -54370,6 +54370,70 @@
         }
       }
     },
+    "reader.pageLayout.auto.detail" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paart nur Seiten, deren Größe zeigt, dass sie für Doppelseiten geeignet sind."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pairs pages only when page size confirms they are suitable for spreads."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empareja páginas solo cuando su tamaño confirma que son adecuadas para dobles páginas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Associe les pages uniquement lorsque leur taille confirme qu'elles conviennent aux doubles pages."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbina le pagine solo quando le dimensioni confermano che sono adatte alle doppie pagine."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページサイズから見開きに適していると確認できる場合のみページを組み合わせます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 크기로 펼침 보기에 적합하다고 확인될 때만 페이지를 짝지어 표시합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Объединяет страницы только когда их размер подтверждает пригодность для разворота."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅在页面尺寸确认适合双页显示时才配对页面。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只有在頁面尺寸確認適合雙頁顯示時才會配對頁面。"
+          }
+        }
+      }
+    },
     "reader.pageLayout.dual" : {
       "localizations" : {
         "de" : {
@@ -54434,6 +54498,70 @@
         }
       }
     },
+    "reader.pageLayout.dual.detail" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erzwingt Doppelseiten und trennt nur Seiten, die eindeutig Querformat oder breit sind."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forces two-page spreads, separating only pages known to be landscape or wide."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fuerza dobles páginas y separa solo las páginas que se sabe que son horizontales o anchas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Force les doubles pages et sépare uniquement les pages reconnues comme paysage ou larges."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forza le doppie pagine, separando solo le pagine note come orizzontali o larghe."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2ページ見開きを強制し、横向きまたは幅広と判明しているページだけを分離します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "두 페이지 펼침을 강제하며, 가로형 또는 넓은 페이지로 확인된 경우에만 분리합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Принудительно включает развороты, отделяя только страницы, которые точно альбомные или широкие."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "强制双页显示，只会拆开已知为横向或宽页的页面。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強制雙頁顯示，只會拆開已知為橫向或寬頁的頁面。"
+          }
+        }
+      }
+    },
     "reader.pageLayout.single" : {
       "localizations" : {
         "de" : {
@@ -54494,6 +54622,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "單頁"
+          }
+        }
+      }
+    },
+    "reader.pageLayout.single.detail" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Immer eine Seite pro Ansicht anzeigen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Always show one page at a time."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar siempre una página a la vez."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toujours afficher une page à la fois."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra sempre una pagina alla volta."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常に1ページずつ表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "항상 한 번에 한 페이지씩 표시합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Всегда показывать по одной странице."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "始终一次显示一页。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一律一次顯示一頁。"
           }
         }
       }


### PR DESCRIPTION
## Problem

In the non-native/DIVINA reader, streamed PDF pages can arrive without width and height metadata. The forced Dual Page layout treated those missing dimensions the same as landscape pages, so every streamed PDF page stayed as a single-page item even when the user explicitly selected Dual Page.

Downloaded PDFs did not show the issue because local rendering records page dimensions before the DIVINA layout is built.

## Approach

Model page orientation as `portrait`, `landscape`, or `unknown` while generating reader view items. Forced Dual Page now treats unknown-size pages as pairable and only isolates pages that are explicitly known to be landscape. Auto layout keeps the conservative behavior and still requires known portrait dimensions before pairing.

The DIVINA Page Layout setting now shows option-specific descriptions so Auto explains its page-size requirement, while forced Dual Page explains that page size is only used to identify known wide pages that should remain separate.

## Related
- #845

## Validation

- [x] `make build`
- [x] `make localize`
- [x] `./misc/translate.py list`
- [x] `make format`
- [x] `make build-ios`
- [x] `git diff --check`
