### PR TITLE
fix(reader): macOS Reader menu commands being inert while a reader window is open

### DIFF
--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -695,9 +695,10 @@ struct DivinaReaderView: View {
       inFlightPreviousSegmentPreloads.removeAll()
       viewModel.clearPreloadedImages()
       readerPresentation.clearFlushHandler(for: sessionID)
-      #if os(macOS)
-        readerPresentation.clearReaderCommands()
-      #endif
+      // macOS reader commands are cleared on real window teardown (closeReader, via
+      // handleReaderWindowDisappear). Clearing them here too fires spuriously during the
+      // reader-window setup (fullscreen / remount), wiping the just-registered handlers
+      // while the reader is still active.
     }
     .onChange(of: scenePhase) { oldPhase, newPhase in
       handleScenePhaseChange(from: oldPhase, to: newPhase)

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -307,7 +307,8 @@
           readerPresentation.clearFlushHandler(for: sessionID)
           #if os(macOS)
             keyboardHelpTimer?.invalidate()
-            readerPresentation.clearReaderCommands()
+            // Commands are cleared on real window teardown (closeReader); clearing here
+            // misfires during macOS reader-window setup. See DivinaReaderView.
           #endif
         }
         .onChange(of: scenePhase) { oldPhase, newPhase in

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -197,7 +197,8 @@
         readerPresentation.clearFlushHandler(for: sessionID)
         #if os(macOS)
           hideKeyboardHelp()
-          readerPresentation.clearReaderCommands()
+          // Commands are cleared on real window teardown (closeReader); clearing here
+          // misfires during macOS reader-window setup. See DivinaReaderView.
         #endif
       }
       .onChange(of: scenePhase) { oldPhase, newPhase in


### PR DESCRIPTION
On macOS the Reader menu commands (Reader Settings, Reading Direction, Page Layout, Split Wide and so on) do nothing while a book is open. The menu populates, but clicking an item has no effect and the checkmarks never move.

Cause: each reader view (`DivinaReaderView`, `PdfReaderView`, `EpubReaderView`) registers its command handlers in `onAppear` and clears them in `onDisappear`. On macOS that `onDisappear` fires transiently during reader-window setup (fullscreen toggle and view remount), so the handlers get wiped right after they are registered, while the reader is still on screen. Every menu action after that hits nil handlers and no-ops.

Fix: remove the `clearReaderCommands()` call from the readers' `onDisappear`. The reader window already clears commands at real teardown through `closeReader` (called from `handleReaderWindowDisappear` when the window closes, and from present when switching books), so the inner-view clear was the source of the bug. With it gone, the handlers registered in `onAppear` survive the setup churn.

This affects all three readers, so the fix is applied to `DivinaReaderView`, `PdfReaderView` and `EpubReaderView`. iOS is unaffected since these commands are macOS only.

Tested on macOS: Reader Settings opens, and Reading Direction and Page Layout now apply with the checkmarks updating.