### PR TITLE
fix: keep reader flush handlers until teardown

### DIFF
--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -694,11 +694,8 @@ struct DivinaReaderView: View {
       inFlightNextSegmentPreloads.removeAll()
       inFlightPreviousSegmentPreloads.removeAll()
       viewModel.clearPreloadedImages()
-      readerPresentation.clearFlushHandler(for: sessionID)
-      // macOS reader commands are cleared on real window teardown (closeReader, via
-      // handleReaderWindowDisappear). Clearing them here too fires spuriously during the
-      // reader-window setup (fullscreen / remount), wiping the just-registered handlers
-      // while the reader is still active.
+      // Session-owned handlers are cleared on real teardown in ReaderPresentationManager.
+      // This view-level disappear can fire during macOS fullscreen/remount setup.
     }
     .onChange(of: scenePhase) { oldPhase, newPhase in
       handleScenePhaseChange(from: oldPhase, to: newPhase)

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -304,11 +304,8 @@
           logger.debug(
             "👋 EPUB reader disappeared for book \(handoffBookId), chapter=\(viewModel.currentChapterIndex), page=\(viewModel.currentPageIndex), hasLocation=\(viewModel.currentLocation != nil)"
           )
-          readerPresentation.clearFlushHandler(for: sessionID)
           #if os(macOS)
             keyboardHelpTimer?.invalidate()
-            // Commands are cleared on real window teardown (closeReader); clearing here
-            // misfires during macOS reader-window setup. See DivinaReaderView.
           #endif
         }
         .onChange(of: scenePhase) { oldPhase, newPhase in

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -194,11 +194,8 @@
           "👋 PDF reader disappeared for book \(book.id), page=\(viewModel.currentPageNumber)/\(viewModel.pageCount)"
         )
         showingControls = false
-        readerPresentation.clearFlushHandler(for: sessionID)
         #if os(macOS)
           hideKeyboardHelp()
-          // Commands are cleared on real window teardown (closeReader); clearing here
-          // misfires during macOS reader-window setup. See DivinaReaderView.
         #endif
       }
       .onChange(of: scenePhase) { oldPhase, newPhase in

--- a/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
+++ b/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
@@ -89,10 +89,6 @@ final class ReaderPresentationManager {
     flushHandlers[sessionID] = handler
   }
 
-  func clearFlushHandler(for sessionID: UUID) {
-    flushHandlers.removeValue(forKey: sessionID)
-  }
-
   #if os(iOS)
     /// Flush in-flight read progress when the app backgrounds, requesting iOS background
     /// time so the URLSession PATCH can finish before the process is suspended. Without


### PR DESCRIPTION
## Problem
PR #850 moved macOS reader command cleanup out of inner reader `onDisappear`, because that lifecycle event can fire during reader-window setup while the session remains active. The same transient `onDisappear` path still cleared reader progress flush handlers, which could prevent the real close path from flushing final progress.

## Approach
Keep progress flush handlers owned by `ReaderPresentationManager` session teardown. Reader views still release view-local resources on disappear, but session callbacks remain registered until `finishSession` runs during close or book replacement.

## Validation
- [x] `make format`
- [x] `make build-macos`
- [x] `git diff --check`
