### PR TITLE
fix: reset reader zoom on viewport changes

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 460;
+				CURRENT_PROJECT_VERSION = 461;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 460;
+				CURRENT_PROJECT_VERSION = 461;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 460;
+				CURRENT_PROJECT_VERSION = 461;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 460;
+				CURRENT_PROJECT_VERSION = 461;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/NativePagedPageContentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativePagedPageContentView_iOS.swift
@@ -28,6 +28,7 @@
     private var isPlaybackActive = false
     private var tracksGlobalZoomState = true
     private var isUpdatingZoomState = false
+    private var lastLayoutBoundsSize: CGSize = .zero
 
     override init(frame: CGRect) {
       super.init(frame: frame)
@@ -40,6 +41,7 @@
 
     override func layoutSubviews() {
       super.layoutSubviews()
+      resetViewportStateIfNeeded()
       updatePages()
     }
 
@@ -103,6 +105,7 @@
       currentScreenSize = .zero
       isPlaybackActive = false
       tracksGlobalZoomState = true
+      lastLayoutBoundsSize = .zero
       if let backgroundColor {
         self.backgroundColor = backgroundColor
         scrollView.backgroundColor = backgroundColor
@@ -196,13 +199,25 @@
     }
 
     private func resetZoomState() {
+      resetScrollViewportState()
+
+      guard tracksGlobalZoomState, let viewModel, viewModel.isZoomed else { return }
+      viewModel.isZoomed = false
+    }
+
+    private func resetViewportStateIfNeeded() {
+      let size = bounds.size
+      guard size.width > 0, size.height > 0 else { return }
+      guard size != lastLayoutBoundsSize else { return }
+      lastLayoutBoundsSize = size
+      resetZoomState()
+    }
+
+    private func resetScrollViewportState() {
       isUpdatingZoomState = true
       scrollView.setZoomScale(scrollView.minimumZoomScale, animated: false)
       scrollView.contentOffset = .zero
       isUpdatingZoomState = false
-
-      guard tracksGlobalZoomState, let viewModel, viewModel.isZoomed else { return }
-      viewModel.isZoomed = false
     }
 
     // Reset this slot's scroll view to minimum scale unconditionally, independent
@@ -210,11 +225,7 @@
     // a stale scale left on a slot that was zoomed while a page transition was in
     // flight. Uses isUpdatingZoomState so it does not re-fire scrollViewDidZoom.
     func forceResetZoom() {
-      guard scrollView.zoomScale != scrollView.minimumZoomScale else { return }
-      isUpdatingZoomState = true
-      scrollView.setZoomScale(scrollView.minimumZoomScale, animated: false)
-      scrollView.contentOffset = .zero
-      isUpdatingZoomState = false
+      resetScrollViewportState()
     }
 
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {

--- a/KMReader/Features/Reader/Views/TapZoneOverlay.swift
+++ b/KMReader/Features/Reader/Views/TapZoneOverlay.swift
@@ -82,14 +82,15 @@ struct TapZoneGridOverlayContent: View {
   }
 
   private func tSplitColor(normalizedX: CGFloat, normalizedY: CGFloat) -> Color {
-    color(for: TapZoneHelper.action(
-      normalizedX: normalizedX,
-      normalizedY: normalizedY,
-      tapZoneMode: tapZoneMode,
-      tapZoneInversionMode: tapZoneInversionMode,
-      readingDirection: readingDirection,
-      stripHeightFraction: Self.tSplitPreviewStripFraction
-    ))
+    color(
+      for: TapZoneHelper.action(
+        normalizedX: normalizedX,
+        normalizedY: normalizedY,
+        tapZoneMode: tapZoneMode,
+        tapZoneInversionMode: tapZoneInversionMode,
+        readingDirection: readingDirection,
+        stripHeightFraction: Self.tSplitPreviewStripFraction
+      ))
   }
 
   private func color(for action: TapZoneAction) -> Color {

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -49248,70 +49248,6 @@
         }
       }
     },
-    "Opt for single page, auto-detected spreads, or forced dual pages (landscape only)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie zwischen Einzelseite, automatisch erkannten Doppelseiten oder erzwungenen Doppelseiten (nur Querformat)"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opt for single page, auto-detected spreads, or forced dual pages (landscape only)"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elige pagina unica, dobles paginas detectadas automaticamente o doble pagina forzada (solo horizontal)"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisissez page unique, doubles pages détectées automatiquement ou double page forcée (paysage uniquement)"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scegli pagina singola, doppie pagine rilevate automaticamente o doppia pagina forzata (solo orizzontale)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "単ページ、自動見開き、強制見開き（横向きのみ）を選択"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "단일 페이지, 자동 감지 펼침 또는 강제 듀얼 페이지(가로 전용) 중 선택"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выберите одиночную страницу, автопределяемые развороты или принудительный двойной режим (только альбомный)"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择单页、自动跨页或强制双页（仅横屏）"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇單頁、自動跨頁或強制雙頁（僅橫向）"
-          }
-        }
-      }
-    },
     "Ordered" : {
       "localizations" : {
         "de" : {
@@ -55330,70 +55266,6 @@
         }
       }
     },
-    "reader.tapZoneMode.tSplit" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "T-Form"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "T-Split"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Forma de T"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Forme en T"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Forma a T"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "T字型"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "T자형"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Т-образный"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "T 形"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "T 形"
-          }
-        }
-      }
-    },
     "reader.tapZoneMode.none" : {
       "localizations" : {
         "de" : {
@@ -55454,6 +55326,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "禁用"
+          }
+        }
+      }
+    },
+    "reader.tapZoneMode.tSplit" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "T-Form"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "T-Split"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forma de T"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forme en T"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forma a T"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "T字型"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "T자형"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Т-образный"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "T 形"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "T 形"
           }
         }
       }


### PR DESCRIPTION
## Problem

Issue #837 reported that DIVINA pages could be cropped on iPhone after rotating into landscape. The native page view could keep a stale zoom scale or content offset from the previous viewport, so the newly laid-out landscape spread was clipped by the cover container.

## Approach

Reset the native page scroll view whenever its bounds size changes. The reset returns the scroll view to minimum zoom, clears content offset, and reconciles the shared zoom flag so page fitting is recalculated against the current viewport.

## Validation

- [x] Confirmed the reporter's landscape crop no longer reproduces locally
- [x] `make format`
- [x] `git diff --check`
- [x] `make build-ios`
