### PR TITLE
fix: keep pinned library items sorted locally

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 461;
+				CURRENT_PROJECT_VERSION = 462;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 461;
+				CURRENT_PROJECT_VERSION = 462;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 461;
+				CURRENT_PROJECT_VERSION = 462;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 461;
+				CURRENT_PROJECT_VERSION = 462;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Collection/Services/KomgaCollectionStore.swift
+++ b/KMReader/Features/Collection/Services/KomgaCollectionStore.swift
@@ -18,29 +18,12 @@ enum KomgaCollectionStore {
     sort: String?,
     search: String?
   ) -> [SeriesCollection] {
-    let instanceId = AppConfig.current.instanceId
-
-    var descriptor = FetchDescriptor<KomgaCollection>()
-
-    if let search = search, !search.isEmpty {
-      descriptor.predicate = #Predicate<KomgaCollection> { col in
-        col.instanceId == instanceId && col.name.localizedStandardContains(search)
-      }
-    } else {
-      descriptor.predicate = #Predicate<KomgaCollection> { col in
-        col.instanceId == instanceId
-      }
-    }
-
-    descriptor.sortBy = sortDescriptors(sort: sort)
-
-    do {
-      let results = try context.fetch(descriptor)
-      let ordered = pinnedFirst(results)
-      return paginate(ordered, offset: page * size, limit: size).map { $0.toCollection() }
-    } catch {
-      return []
-    }
+    let collections = fetchOrderedCollections(
+      context: context,
+      searchText: search ?? "",
+      sort: sort
+    )
+    return paginate(collections, offset: page * size, limit: size).map { $0.toCollection() }
   }
 
   static func fetchCollectionIds(
@@ -51,29 +34,12 @@ enum KomgaCollectionStore {
     offset: Int,
     limit: Int
   ) -> [String] {
-    let instanceId = AppConfig.current.instanceId
-
-    var descriptor = FetchDescriptor<KomgaCollection>()
-
-    if !searchText.isEmpty {
-      descriptor.predicate = #Predicate<KomgaCollection> { col in
-        col.instanceId == instanceId && col.name.localizedStandardContains(searchText)
-      }
-    } else {
-      descriptor.predicate = #Predicate<KomgaCollection> { col in
-        col.instanceId == instanceId
-      }
-    }
-
-    descriptor.sortBy = sortDescriptors(sort: sort)
-
-    do {
-      let results = try context.fetch(descriptor)
-      let ordered = pinnedFirst(results)
-      return paginate(ordered, offset: offset, limit: limit).map { $0.collectionId }
-    } catch {
-      return []
-    }
+    let collections = fetchOrderedCollections(
+      context: context,
+      searchText: searchText,
+      sort: sort
+    )
+    return paginate(collections, offset: offset, limit: limit).map { $0.collectionId }
   }
 
   static func fetchCollectionsByIds(
@@ -108,6 +74,41 @@ enum KomgaCollectionStore {
     return try? context.fetch(descriptor).first?.toCollection()
   }
 
+  private static func fetchOrderedCollections(
+    context: ModelContext,
+    searchText: String,
+    sort: String?
+  ) -> [KomgaCollection] {
+    let instanceId = AppConfig.current.instanceId
+
+    var descriptor = FetchDescriptor<KomgaCollection>()
+
+    if !searchText.isEmpty {
+      descriptor.predicate = #Predicate<KomgaCollection> { col in
+        col.instanceId == instanceId && col.name.localizedStandardContains(searchText)
+      }
+    } else {
+      descriptor.predicate = #Predicate<KomgaCollection> { col in
+        col.instanceId == instanceId
+      }
+    }
+
+    descriptor.sortBy = sortDescriptors(sort: sort)
+
+    do {
+      let results = try context.fetch(descriptor)
+      return pinnedFirst(results)
+    } catch {
+      return []
+    }
+  }
+
+  private static func pinnedFirst(_ collections: [KomgaCollection]) -> [KomgaCollection] {
+    let pinned = collections.filter(\.isPinned)
+    let unpinned = collections.filter { !$0.isPinned }
+    return pinned + unpinned
+  }
+
   private static func sortDescriptors(sort: String?) -> [SortDescriptor<KomgaCollection>] {
     let isAscending = sort?.contains("desc") != true
 
@@ -126,12 +127,6 @@ enum KomgaCollectionStore {
     return [
       SortDescriptor(\KomgaCollection.name, order: isAscending ? .forward : .reverse)
     ]
-  }
-
-  private static func pinnedFirst(_ collections: [KomgaCollection]) -> [KomgaCollection] {
-    let pinned = collections.filter(\.isPinned)
-    let unpinned = collections.filter { !$0.isPinned }
-    return pinned + unpinned
   }
 
   private static func paginate(

--- a/KMReader/Features/Collection/Views/CollectionsBrowseView.swift
+++ b/KMReader/Features/Collection/Views/CollectionsBrowseView.swift
@@ -17,8 +17,12 @@ struct CollectionsBrowseView: View {
     SimpleSortOptions()
   @AppStorage("collectionBrowseLayout") private var browseLayout: BrowseLayoutMode = .grid
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
-  @State private var viewModel = PaginatedIdViewModel()
+  @State private var isLoading = false
+  @State private var items: [IdentifiedString] = []
+  @State private var loadID = UUID()
   @State private var hasInitialized = false
+
+  private let syncPageSize = 200
 
   private var columns: [GridItem] {
     LayoutConfig.adaptiveColumns(for: gridDensity)
@@ -34,8 +38,8 @@ struct CollectionsBrowseView: View {
         .padding(.horizontal)
 
       BrowseStateView(
-        isLoading: viewModel.isLoading,
-        isEmpty: viewModel.pagination.isEmpty,
+        isLoading: isLoading,
+        isEmpty: items.isEmpty,
         emptyIcon: ContentIcon.collection,
         emptyTitle: LocalizedStringKey("No collections found"),
         emptyMessage: LocalizedStringKey("Try selecting a different library."),
@@ -48,36 +52,22 @@ struct CollectionsBrowseView: View {
         switch browseLayout {
         case .grid:
           LazyVGrid(columns: columns, spacing: spacing) {
-            ForEach(viewModel.pagination.items) { collection in
+            ForEach(items) { collection in
               CollectionQueryItemView(
                 collectionId: collection.id
               )
               .padding(.bottom)
-              .onAppear {
-                if viewModel.pagination.shouldLoadMore(after: collection) {
-                  Task {
-                    await loadCollections(refresh: false)
-                  }
-                }
-              }
             }
           }
           .padding(.horizontal)
         case .list:
           LazyVStack {
-            ForEach(viewModel.pagination.items) { collection in
+            ForEach(items) { collection in
               CollectionQueryItemView(
                 collectionId: collection.id,
                 layout: .list
               )
-              .onAppear {
-                if viewModel.pagination.shouldLoadMore(after: collection) {
-                  Task {
-                    await loadCollections(refresh: false)
-                  }
-                }
-              }
-              if !viewModel.pagination.isLast(collection) {
+              if items.last != collection {
                 Divider()
               }
             }
@@ -111,36 +101,63 @@ struct CollectionsBrowseView: View {
   }
 
   private func loadCollections(refresh: Bool) async {
-    await viewModel.load(
-      refresh: refresh,
-      offlineFetch: { offset, limit in
-        KomgaCollectionStore.fetchCollectionIds(
-          context: modelContext,
-          libraryIds: libraryIds,
-          searchText: searchText,
-          sort: sortOpts.sortString,
-          offset: offset,
-          limit: limit
-        )
-      },
-      onlineFetch: { page, size in
-        let result = try await SyncService.shared.syncCollections(
-          libraryIds: libraryIds,
-          page: page,
-          size: size,
-          sort: sortOpts.sortString,
-          search: searchText.isEmpty ? nil : searchText
-        )
-        let ids = KomgaCollectionStore.fetchCollectionIds(
-          context: modelContext,
-          libraryIds: libraryIds,
-          searchText: searchText,
-          sort: sortOpts.sortString,
-          offset: page * size,
-          limit: size
-        )
-        return (ids: ids, isLastPage: result.last || ids.count < size)
+    let currentLoadID = UUID()
+    loadID = currentLoadID
+    isLoading = true
+
+    do {
+      let ids = try await loadCollectionIds()
+      guard loadID == currentLoadID else { return }
+      withAnimation {
+        items = ids.map(IdentifiedString.init)
       }
+    } catch {
+      guard loadID == currentLoadID else { return }
+      if refresh {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
+
+    guard loadID == currentLoadID else { return }
+    isLoading = false
+  }
+
+  private func loadCollectionIds() async throws -> [String] {
+    let localIds = localCollectionIds()
+    guard !AppConfig.isOffline else { return localIds }
+
+    let serverIds = Set(try await syncCollectionIds())
+    return localIds.filter { serverIds.contains($0) }
+  }
+
+  private func localCollectionIds() -> [String] {
+    KomgaCollectionStore.fetchCollectionIds(
+      context: modelContext,
+      libraryIds: libraryIds,
+      searchText: searchText,
+      sort: sortOpts.sortString,
+      offset: 0,
+      limit: Int.max
     )
+  }
+
+  private func syncCollectionIds() async throws -> [String] {
+    var page = 0
+    var ids: [String] = []
+
+    while true {
+      let result = try await SyncService.shared.syncCollections(
+        libraryIds: libraryIds,
+        page: page,
+        size: syncPageSize,
+        sort: sortOpts.sortString,
+        search: searchText.isEmpty ? nil : searchText
+      )
+      ids.append(contentsOf: result.content.map(\.id))
+      guard !result.last else { break }
+      page += 1
+    }
+
+    return ids
   }
 }

--- a/KMReader/Features/ReadList/Services/KomgaReadListStore.swift
+++ b/KMReader/Features/ReadList/Services/KomgaReadListStore.swift
@@ -18,31 +18,12 @@ enum KomgaReadListStore {
     sort: String?,
     search: String?
   ) -> [ReadList] {
-    let instanceId = AppConfig.current.instanceId
-
-    var descriptor = FetchDescriptor<KomgaReadList>()
-
-    if let search = search, !search.isEmpty {
-      descriptor.predicate = #Predicate<KomgaReadList> { rl in
-        rl.instanceId == instanceId
-          && (rl.name.localizedStandardContains(search)
-            || rl.summary.localizedStandardContains(search))
-      }
-    } else {
-      descriptor.predicate = #Predicate<KomgaReadList> { rl in
-        rl.instanceId == instanceId
-      }
-    }
-
-    descriptor.sortBy = sortDescriptors(sort: sort)
-
-    do {
-      let results = try context.fetch(descriptor)
-      let ordered = pinnedFirst(results)
-      return paginate(ordered, offset: page * size, limit: size).map { $0.toReadList() }
-    } catch {
-      return []
-    }
+    let readLists = fetchOrderedReadLists(
+      context: context,
+      searchText: search ?? "",
+      sort: sort
+    )
+    return paginate(readLists, offset: page * size, limit: size).map { $0.toReadList() }
   }
 
   static func fetchReadListIds(
@@ -53,31 +34,12 @@ enum KomgaReadListStore {
     offset: Int,
     limit: Int
   ) -> [String] {
-    let instanceId = AppConfig.current.instanceId
-
-    var descriptor = FetchDescriptor<KomgaReadList>()
-
-    if !searchText.isEmpty {
-      descriptor.predicate = #Predicate<KomgaReadList> { rl in
-        rl.instanceId == instanceId
-          && (rl.name.localizedStandardContains(searchText)
-            || rl.summary.localizedStandardContains(searchText))
-      }
-    } else {
-      descriptor.predicate = #Predicate<KomgaReadList> { rl in
-        rl.instanceId == instanceId
-      }
-    }
-
-    descriptor.sortBy = sortDescriptors(sort: sort)
-
-    do {
-      let results = try context.fetch(descriptor)
-      let ordered = pinnedFirst(results)
-      return paginate(ordered, offset: offset, limit: limit).map { $0.readListId }
-    } catch {
-      return []
-    }
+    let readLists = fetchOrderedReadLists(
+      context: context,
+      searchText: searchText,
+      sort: sort
+    )
+    return paginate(readLists, offset: offset, limit: limit).map { $0.readListId }
   }
 
   static func fetchReadListsByIds(
@@ -111,6 +73,43 @@ enum KomgaReadListStore {
     return try? context.fetch(descriptor).first?.toReadList()
   }
 
+  private static func fetchOrderedReadLists(
+    context: ModelContext,
+    searchText: String,
+    sort: String?
+  ) -> [KomgaReadList] {
+    let instanceId = AppConfig.current.instanceId
+
+    var descriptor = FetchDescriptor<KomgaReadList>()
+
+    if !searchText.isEmpty {
+      descriptor.predicate = #Predicate<KomgaReadList> { rl in
+        rl.instanceId == instanceId
+          && (rl.name.localizedStandardContains(searchText)
+            || rl.summary.localizedStandardContains(searchText))
+      }
+    } else {
+      descriptor.predicate = #Predicate<KomgaReadList> { rl in
+        rl.instanceId == instanceId
+      }
+    }
+
+    descriptor.sortBy = sortDescriptors(sort: sort)
+
+    do {
+      let results = try context.fetch(descriptor)
+      return pinnedFirst(results)
+    } catch {
+      return []
+    }
+  }
+
+  private static func pinnedFirst(_ readLists: [KomgaReadList]) -> [KomgaReadList] {
+    let pinned = readLists.filter(\.isPinned)
+    let unpinned = readLists.filter { !$0.isPinned }
+    return pinned + unpinned
+  }
+
   private static func sortDescriptors(sort: String?) -> [SortDescriptor<KomgaReadList>] {
     let isAscending = sort?.contains("desc") != true
 
@@ -129,12 +128,6 @@ enum KomgaReadListStore {
     return [
       SortDescriptor(\KomgaReadList.name, order: isAscending ? .forward : .reverse)
     ]
-  }
-
-  private static func pinnedFirst(_ readLists: [KomgaReadList]) -> [KomgaReadList] {
-    let pinned = readLists.filter(\.isPinned)
-    let unpinned = readLists.filter { !$0.isPinned }
-    return pinned + unpinned
   }
 
   private static func paginate(

--- a/KMReader/Features/ReadList/Views/ReadListsBrowseView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListsBrowseView.swift
@@ -17,8 +17,12 @@ struct ReadListsBrowseView: View {
     SimpleSortOptions()
   @AppStorage("readListBrowseLayout") private var browseLayout: BrowseLayoutMode = .grid
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
-  @State private var viewModel = PaginatedIdViewModel()
+  @State private var isLoading = false
+  @State private var items: [IdentifiedString] = []
+  @State private var loadID = UUID()
   @State private var hasInitialized = false
+
+  private let syncPageSize = 200
 
   private var columns: [GridItem] {
     LayoutConfig.adaptiveColumns(for: gridDensity)
@@ -34,8 +38,8 @@ struct ReadListsBrowseView: View {
         .padding(.horizontal)
 
       BrowseStateView(
-        isLoading: viewModel.isLoading,
-        isEmpty: viewModel.pagination.isEmpty,
+        isLoading: isLoading,
+        isEmpty: items.isEmpty,
         emptyIcon: ContentIcon.readList,
         emptyTitle: LocalizedStringKey("No read lists found"),
         emptyMessage: LocalizedStringKey("Try selecting a different library."),
@@ -48,37 +52,23 @@ struct ReadListsBrowseView: View {
         switch browseLayout {
         case .grid:
           LazyVGrid(columns: columns, spacing: spacing) {
-            ForEach(viewModel.pagination.items) { readList in
+            ForEach(items) { readList in
               ReadListQueryItemView(
                 readListId: readList.id,
                 layout: .grid
               )
               .padding(.bottom)
-              .onAppear {
-                if viewModel.pagination.shouldLoadMore(after: readList) {
-                  Task {
-                    await loadReadLists(refresh: false)
-                  }
-                }
-              }
             }
           }
           .padding(.horizontal)
         case .list:
           LazyVStack {
-            ForEach(viewModel.pagination.items) { readList in
+            ForEach(items) { readList in
               ReadListQueryItemView(
                 readListId: readList.id,
                 layout: .list
               )
-              .onAppear {
-                if viewModel.pagination.shouldLoadMore(after: readList) {
-                  Task {
-                    await loadReadLists(refresh: false)
-                  }
-                }
-              }
-              if !viewModel.pagination.isLast(readList) {
+              if items.last != readList {
                 Divider()
               }
             }
@@ -112,36 +102,63 @@ struct ReadListsBrowseView: View {
   }
 
   private func loadReadLists(refresh: Bool) async {
-    await viewModel.load(
-      refresh: refresh,
-      offlineFetch: { offset, limit in
-        KomgaReadListStore.fetchReadListIds(
-          context: modelContext,
-          libraryIds: libraryIds,
-          searchText: searchText,
-          sort: sortOpts.sortString,
-          offset: offset,
-          limit: limit
-        )
-      },
-      onlineFetch: { page, size in
-        let result = try await SyncService.shared.syncReadLists(
-          libraryIds: libraryIds,
-          page: page,
-          size: size,
-          sort: sortOpts.sortString,
-          search: searchText.isEmpty ? nil : searchText
-        )
-        let ids = KomgaReadListStore.fetchReadListIds(
-          context: modelContext,
-          libraryIds: libraryIds,
-          searchText: searchText,
-          sort: sortOpts.sortString,
-          offset: page * size,
-          limit: size
-        )
-        return (ids: ids, isLastPage: result.last || ids.count < size)
+    let currentLoadID = UUID()
+    loadID = currentLoadID
+    isLoading = true
+
+    do {
+      let ids = try await loadReadListIds()
+      guard loadID == currentLoadID else { return }
+      withAnimation {
+        items = ids.map(IdentifiedString.init)
       }
+    } catch {
+      guard loadID == currentLoadID else { return }
+      if refresh {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
+
+    guard loadID == currentLoadID else { return }
+    isLoading = false
+  }
+
+  private func loadReadListIds() async throws -> [String] {
+    let localIds = localReadListIds()
+    guard !AppConfig.isOffline else { return localIds }
+
+    let serverIds = Set(try await syncReadListIds())
+    return localIds.filter { serverIds.contains($0) }
+  }
+
+  private func localReadListIds() -> [String] {
+    KomgaReadListStore.fetchReadListIds(
+      context: modelContext,
+      libraryIds: libraryIds,
+      searchText: searchText,
+      sort: sortOpts.sortString,
+      offset: 0,
+      limit: Int.max
     )
+  }
+
+  private func syncReadListIds() async throws -> [String] {
+    var page = 0
+    var ids: [String] = []
+
+    while true {
+      let result = try await SyncService.shared.syncReadLists(
+        libraryIds: libraryIds,
+        page: page,
+        size: syncPageSize,
+        sort: sortOpts.sortString,
+        search: searchText.isEmpty ? nil : searchText
+      )
+      ids.append(contentsOf: result.content.map(\.id))
+      guard !result.last else { break }
+      page += 1
+    }
+
+    return ids
   }
 }


### PR DESCRIPTION
## Problem
Library-scoped collection and read-list browsing could lose the server filter and pinned ordering because the online path mixed paginated server results with local SwiftData ordering.

Closes #853

## Approach
Load collection and read-list browse pages from the local store as full lists with pinned items first. In online mode, sync all server-scoped ids for the current library/search/sort, then filter the local list against that id set so server scope and local pin state both apply without extra per-item membership requests.

## Scope
- Update collection and read-list browse loading to use full local lists instead of scroll pagination
- Keep pinned-first ordering in the local stores
- Retain formatter output from `make format`
- Bump build version to 462

## Validation
- [x] `make format`
- [x] `make build-macos`
