### PR TITLE
fix: improve offline download reader state

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 462;
+				CURRENT_PROJECT_VERSION = 463;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 462;
+				CURRENT_PROJECT_VERSION = 463;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 462;
+				CURRENT_PROJECT_VERSION = 463;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 462;
+				CURRENT_PROJECT_VERSION = 463;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Network/APIClient.swift
+++ b/KMReader/Core/Network/APIClient.swift
@@ -7,14 +7,14 @@ import Foundation
 import OSLog
 
 struct DownloadProgressUserInfo {
-  static let urlKey = "url"
-  static let itemKey = "item"
-  static let receivedKey = "received"
-  static let expectedKey = "expected"
+  nonisolated static let urlKey = "url"
+  nonisolated static let itemKey = "item"
+  nonisolated static let receivedKey = "received"
+  nonisolated static let expectedKey = "expected"
 }
 
 extension Notification.Name {
-  static let fileDownloadProgress = Notification.Name("fileDownloadProgress")
+  nonisolated static let fileDownloadProgress = Notification.Name("fileDownloadProgress")
 }
 
 class APIClient {

--- a/KMReader/Features/Offline/Services/DownloadProgressTracker.swift
+++ b/KMReader/Features/Offline/Services/DownloadProgressTracker.swift
@@ -28,8 +28,8 @@ class DownloadProgressTracker {
   var queueUpdateToken: UUID = UUID()
 
   @ObservationIgnored private var lastProgressUpdate: [String: Date] = [:]
-  @ObservationIgnored private let progressUpdateInterval: TimeInterval = 1.0
-  @ObservationIgnored private let progressUpdateDelta = 0.001
+  @ObservationIgnored private let progressUpdateInterval: TimeInterval = 0.2
+  @ObservationIgnored private let progressUpdateDelta = 0.002
 
   /// Whether a download is currently active
   var isDownloading: Bool {
@@ -81,6 +81,11 @@ class DownloadProgressTracker {
 
     lastProgressUpdate[bookId] = now
     progress[bookId] = clampedValue
+  }
+
+  func updateProgress(bookId: String, receivedBytes: Int64, expectedBytes: Int64?) {
+    guard let expectedBytes, expectedBytes > 0 else { return }
+    updateProgress(bookId: bookId, value: Double(receivedBytes) / Double(expectedBytes))
   }
 
   func clearProgress(bookId: String) {

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -70,6 +70,30 @@ actor OfflineManager {
   private let pageImageCache = ImageCache()
 
   private init() {
+    _ = NotificationCenter.default.addObserver(
+      forName: .fileDownloadProgress,
+      object: nil,
+      queue: .main
+    ) { notification in
+      guard
+        let bookId = notification.userInfo?[DownloadProgressUserInfo.itemKey] as? String
+      else {
+        return
+      }
+
+      let receivedBytes =
+        notification.userInfo?[DownloadProgressUserInfo.receivedKey] as? Int64 ?? 0
+      let expectedBytes = notification.userInfo?[DownloadProgressUserInfo.expectedKey] as? Int64
+
+      Task { @MainActor in
+        DownloadProgressTracker.shared.updateProgress(
+          bookId: bookId,
+          receivedBytes: receivedBytes,
+          expectedBytes: expectedBytes
+        )
+      }
+    }
+
     #if os(iOS)
       // Schedule callback setup on main actor
       Task { @MainActor in

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -530,6 +530,10 @@ struct DivinaReaderView: View {
     }
   #endif
 
+  private var readerIsReadyForHints: Bool {
+    viewModel.hasPages && !viewModel.isLoading
+  }
+
   var body: some View {
     GeometryReader { geometry in
       let screenSize = geometry.size
@@ -674,7 +678,16 @@ struct DivinaReaderView: View {
       readerPresentation.updatePresentedBook(sessionID: sessionID, book: newBook)
     }
     .onChange(of: viewModel.pageCount) { oldCount, newCount in
-      if oldCount == 0 && newCount > 0 {
+      if oldCount == 0 && newCount > 0 && readerIsReadyForHints {
+        triggerTapZoneOverlay(timeout: 1)
+        triggerKeyboardHelp(timeout: 1.5)
+      }
+    }
+    .onChange(of: viewModel.isLoading) { _, isLoading in
+      if isLoading {
+        hideTapZoneOverlay()
+        hideKeyboardHelp()
+      } else if readerIsReadyForHints {
         triggerTapZoneOverlay(timeout: 1)
         triggerKeyboardHelp(timeout: 1.5)
       }
@@ -736,7 +749,13 @@ struct DivinaReaderView: View {
   ) -> some View {
     let contentKey = readerContentKey(useDualPage: useDualPage)
     Group {
-      if viewModel.hasPages {
+      if viewModel.isLoading {
+        ReaderLoadingView(
+          title: viewModel.loadingTitle,
+          detail: viewModel.loadingDetail,
+          progress: viewModel.loadingProgress
+        )
+      } else if viewModel.hasPages {
         Group {
           if readingDirection == .webtoon {
             #if os(iOS) || os(macOS)
@@ -838,12 +857,6 @@ struct DivinaReaderView: View {
             }
           }
         #endif
-      } else if viewModel.isLoading {
-        ReaderLoadingView(
-          title: viewModel.loadingTitle,
-          detail: viewModel.loadingDetail,
-          progress: viewModel.loadingProgress
-        )
       } else {
         NoPagesView(onDismiss: { closeReader() })
       }
@@ -1870,9 +1883,10 @@ struct DivinaReaderView: View {
   /// Show reader helper overlay (Tap zones on iOS, keyboard help on macOS)
   private func triggerTapZoneOverlay(timeout: TimeInterval) {
     // Respect user preference and ensure we have content
-    guard showTapZoneHints, viewModel.hasPages else { return }
+    guard showTapZoneHints, readerIsReadyForHints else { return }
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+      guard self.readerIsReadyForHints else { return }
       withAnimation {
         self.showTapZoneOverlay = true
       }
@@ -1910,10 +1924,11 @@ struct DivinaReaderView: View {
   /// Show keyboard help overlay
   private func triggerKeyboardHelp(timeout: TimeInterval) {
     // Respect user preference and ensure we have content
-    guard showKeyboardHelpOverlay, viewModel.hasPages else { return }
+    guard showKeyboardHelpOverlay, readerIsReadyForHints else { return }
     guard ReaderKeyboardAvailability.shouldAutoShowKeyboardHelp else { return }
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+      guard self.readerIsReadyForHints else { return }
       withAnimation {
         self.showKeyboardHelp = true
       }

--- a/KMReader/Features/Reader/Views/TapZoneOverlay.swift
+++ b/KMReader/Features/Reader/Views/TapZoneOverlay.swift
@@ -21,10 +21,6 @@ struct TapZoneOverlay: View {
     )
     .opacity(isVisible && showTapZoneHints && !tapZoneMode.isDisabled ? 1.0 : 0.0)
     .allowsHitTesting(false)
-    .onAppear {
-      guard showTapZoneHints && !tapZoneMode.isDisabled else { return }
-      isVisible = true
-    }
   }
 }
 


### PR DESCRIPTION
## Problem
Whole-file offline downloads could appear stale in the UI because foreground file download byte progress was not routed into the shared offline task progress tracker. While opening a DIVINA book that still needed offline file preparation, tap-zone hints could also stay visible during the download/loading phase because page metadata arrived before the actual reader content was ready.

## Approach
Route file download progress notifications into `DownloadProgressTracker` and make its visible update cadence more responsive. Keep DIVINA loading UI active while the reader is still preparing offline content, and only trigger tap-zone or keyboard hints once pages exist and the reader is no longer loading. The tap-zone overlay no longer self-enables on mount.

## Scope
- Improve whole-file offline download progress updates
- Gate DIVINA tap-zone and keyboard hints on reader readiness
- Bump build version to 463

## Validation
- [x] `make format`
- [x] `make build`
