### PR TITLE
fix: sync reader download live activity

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 464;
+				CURRENT_PROJECT_VERSION = 465;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 464;
+				CURRENT_PROJECT_VERSION = 465;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 464;
+				CURRENT_PROJECT_VERSION = 465;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 464;
+				CURRENT_PROJECT_VERSION = 465;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Offline/Services/BackgroundDownloadManager.swift
+++ b/KMReader/Features/Offline/Services/BackgroundDownloadManager.swift
@@ -33,6 +33,7 @@ import OSLog
     /// Callbacks for download completion
     var onDownloadComplete: ((String, Int?, URL) -> Void)?  // bookId, pageNumber?, fileURL
     var onDownloadFailed: ((String, Int?, Error) -> Void)?  // bookId, pageNumber?, error
+    var onDownloadProgress: ((String, Int64, Int64?) -> Void)?  // bookId, received, expected
     var onAllDownloadsComplete: ((String) -> Void)?  // bookId
 
     private lazy var backgroundSession: URLSession = {
@@ -373,6 +374,11 @@ import OSLog
         if taskInfo.isEpub, totalBytesExpectedToWrite > 0 {
           let progress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
           DownloadProgressTracker.shared.updateProgress(bookId: taskInfo.bookId, value: progress)
+          self.onDownloadProgress?(
+            taskInfo.bookId,
+            totalBytesWritten,
+            totalBytesExpectedToWrite
+          )
         }
       }
     }

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -64,6 +64,7 @@ actor OfflineManager {
   private var completedDownloadsSinceLastNotification = 0
   #if os(iOS)
     private var foregroundDownloadInfoByBookId: [String: (instanceId: String, info: DownloadInfo)] = [:]
+    private var liveActivityProgressSnapshots: [String: (progress: Double, updatedAt: Date)] = [:]
   #endif
 
   private let logger = AppLogger(.offline)
@@ -92,6 +93,15 @@ actor OfflineManager {
           expectedBytes: expectedBytes
         )
       }
+      #if os(iOS)
+        Task {
+          await self.updateDownloadLiveActivityProgress(
+            bookId: bookId,
+            receivedBytes: receivedBytes,
+            expectedBytes: expectedBytes
+          )
+        }
+      #endif
     }
 
     #if os(iOS)
@@ -120,6 +130,17 @@ actor OfflineManager {
           Task {
             await self.handleBackgroundDownloadFailed(
               bookId: bookId, pageNumber: pageNumber, error: error)
+          }
+        }
+
+        manager.onDownloadProgress = { [weak self] bookId, receivedBytes, expectedBytes in
+          guard let self = self else { return }
+          Task {
+            await self.updateDownloadLiveActivityProgress(
+              bookId: bookId,
+              receivedBytes: receivedBytes,
+              expectedBytes: expectedBytes
+            )
           }
         }
 
@@ -1196,6 +1217,7 @@ actor OfflineManager {
       backgroundDownloadTotalTasks.removeValue(forKey: bookId)
       backgroundDownloadCompletedTasks.removeValue(forKey: bookId)
       backgroundDownloadFinalizingBooks.remove(bookId)
+      liveActivityProgressSnapshots.removeValue(forKey: bookId)
     }
   #endif
 
@@ -1235,6 +1257,14 @@ actor OfflineManager {
         case .pages:
           try await downloadPages(bookId: info.bookId, to: bookDir)
         }
+
+        #if os(iOS)
+          await self.updateDownloadLiveActivityProcessing(
+            bookId: info.bookId,
+            instanceId: instanceId,
+            seriesTitle: info.seriesTitle
+          )
+        #endif
 
         // Mark complete in SwiftData
         await finalizeDownload(
@@ -1602,19 +1632,94 @@ actor OfflineManager {
   }
 
   #if os(iOS)
-    private func updateForegroundLiveActivityProgress(bookId: String, progress: Double) async {
-      guard let entry = foregroundDownloadInfoByBookId[bookId] else { return }
+    private func updateDownloadLiveActivityProgress(
+      bookId: String,
+      receivedBytes: Int64,
+      expectedBytes: Int64?
+    ) async {
+      guard let expectedBytes, expectedBytes > 0 else { return }
+      let progress = Double(receivedBytes) / Double(expectedBytes)
+      await updateDownloadLiveActivityProgress(bookId: bookId, progress: progress)
+    }
+
+    private func updateDownloadLiveActivityProgress(
+      bookId: String,
+      progress: Double,
+      bookInfoOverride: String? = nil
+    ) async {
+      let clampedProgress = min(max(progress, 0), 1)
+      guard shouldUpdateLiveActivityProgress(bookId: bookId, progress: clampedProgress) else {
+        return
+      }
+
+      let activityInfo: (instanceId: String, seriesTitle: String?, bookInfo: String)?
+      if let entry = foregroundDownloadInfoByBookId[bookId] {
+        activityInfo = (
+          instanceId: entry.instanceId,
+          seriesTitle: entry.info.seriesTitle,
+          bookInfo: bookInfoOverride ?? entry.info.bookInfo
+        )
+      } else if let entry = backgroundDownloadInfo[bookId] {
+        activityInfo = (
+          instanceId: entry.instanceId,
+          seriesTitle: entry.seriesTitle,
+          bookInfo: bookInfoOverride ?? entry.bookInfo
+        )
+      } else {
+        return
+      }
+
+      guard let activityInfo else { return }
       let pendingBooks =
-        (try? await DatabaseOperator.database().fetchPendingBooks(instanceId: entry.instanceId))
+        (try? await DatabaseOperator.database().fetchPendingBooks(instanceId: activityInfo.instanceId))
         ?? []
       let failedCount =
         (try? await DatabaseOperator.database().fetchFailedBooksCount(
-          instanceId: entry.instanceId
+          instanceId: activityInfo.instanceId
         )) ?? 0
       await LiveActivityManager.shared.updateActivity(
-        seriesTitle: entry.info.seriesTitle,
-        bookInfo: entry.info.bookInfo,
-        progress: progress,
+        seriesTitle: activityInfo.seriesTitle,
+        bookInfo: activityInfo.bookInfo,
+        progress: clampedProgress,
+        pendingCount: pendingBooks.count,
+        failedCount: failedCount
+      )
+    }
+
+    private func shouldUpdateLiveActivityProgress(bookId: String, progress: Double) -> Bool {
+      let now = Date()
+      let isTerminalValue = progress <= 0 || progress >= 1
+
+      guard let snapshot = liveActivityProgressSnapshots[bookId] else {
+        liveActivityProgressSnapshots[bookId] = (progress: progress, updatedAt: now)
+        return true
+      }
+
+      let hasMeaningfulDelta = abs(snapshot.progress - progress) >= 0.01
+      let isDue = now.timeIntervalSince(snapshot.updatedAt) >= 0.5
+      guard isTerminalValue || hasMeaningfulDelta || isDue else {
+        return false
+      }
+
+      liveActivityProgressSnapshots[bookId] = (progress: progress, updatedAt: now)
+      return true
+    }
+
+    private func updateDownloadLiveActivityProcessing(
+      bookId: String,
+      instanceId: String,
+      seriesTitle: String?
+    ) async {
+      liveActivityProgressSnapshots.removeValue(forKey: bookId)
+      let pendingBooks =
+        (try? await DatabaseOperator.database().fetchPendingBooks(instanceId: instanceId)) ?? []
+      let failedCount =
+        (try? await DatabaseOperator.database().fetchFailedBooksCount(instanceId: instanceId))
+        ?? 0
+      await LiveActivityManager.shared.updateActivity(
+        seriesTitle: seriesTitle,
+        bookInfo: String(localized: "Processing offline files..."),
+        progress: 1.0,
         pendingCount: pendingBooks.count,
         failedCount: failedCount
       )
@@ -1622,6 +1727,7 @@ actor OfflineManager {
 
     private func finishForegroundLiveActivity(bookId: String, instanceId: String) async {
       foregroundDownloadInfoByBookId.removeValue(forKey: bookId)
+      liveActivityProgressSnapshots.removeValue(forKey: bookId)
 
       let pendingBooks =
         (try? await DatabaseOperator.database().fetchPendingBooks(instanceId: instanceId)) ?? []
@@ -1910,20 +2016,10 @@ actor OfflineManager {
       logger.debug(
         "🔒 Claimed background finalize for book \(bookId), completed=\(completedTasks)/\(totalTasks)"
       )
-      let pendingBooks =
-        (try? await DatabaseOperator.database().fetchPendingBooks(
-          instanceId: info.instanceId
-        )) ?? []
-      let failedCount =
-        (try? await DatabaseOperator.database().fetchFailedBooksCount(
-          instanceId: info.instanceId
-        )) ?? 0
-      await LiveActivityManager.shared.updateActivity(
-        seriesTitle: info.seriesTitle,
-        bookInfo: String(localized: "Processing offline files..."),
-        progress: 0.0,
-        pendingCount: pendingBooks.count,
-        failedCount: failedCount
+      await updateDownloadLiveActivityProcessing(
+        bookId: bookId,
+        instanceId: info.instanceId,
+        seriesTitle: info.seriesTitle
       )
       await finalizeBackgroundBookDownload(bookId: bookId, info: info)
     }
@@ -2128,8 +2224,15 @@ actor OfflineManager {
     Self.excludeFromBackupIfNeeded(at: archiveFile)
 
     await MainActor.run {
-      DownloadProgressTracker.shared.updateProgress(bookId: bookId, value: 0.5)
+      DownloadProgressTracker.shared.updateProgress(bookId: bookId, value: 1.0)
     }
+    #if os(iOS)
+      await updateDownloadLiveActivityProgress(
+        bookId: bookId,
+        progress: 1.0,
+        bookInfoOverride: String(localized: "Processing offline files...")
+      )
+    #endif
 
     try Task.checkCancellation()
     try extractImageArchive(archiveFile: archiveFile, format: format, pages: pages, bookDir: bookDir)
@@ -2139,7 +2242,7 @@ actor OfflineManager {
       DownloadProgressTracker.shared.updateProgress(bookId: bookId, value: 1.0)
     }
     #if os(iOS)
-      await updateForegroundLiveActivityProgress(bookId: bookId, progress: 1.0)
+      await updateDownloadLiveActivityProgress(bookId: bookId, progress: 1.0)
     #endif
   }
 
@@ -2157,8 +2260,15 @@ actor OfflineManager {
     Self.excludeFromBackupIfNeeded(at: epubFile)
 
     await MainActor.run {
-      DownloadProgressTracker.shared.updateProgress(bookId: bookId, value: 0.5)
+      DownloadProgressTracker.shared.updateProgress(bookId: bookId, value: 1.0)
     }
+    #if os(iOS)
+      await updateDownloadLiveActivityProgress(
+        bookId: bookId,
+        progress: 1.0,
+        bookInfoOverride: String(localized: "Processing offline files...")
+      )
+    #endif
 
     try Task.checkCancellation()
     try extractEpubDivinaImages(epubFile: epubFile, pages: pages, bookDir: bookDir)
@@ -2168,7 +2278,7 @@ actor OfflineManager {
       DownloadProgressTracker.shared.updateProgress(bookId: bookId, value: 1.0)
     }
     #if os(iOS)
-      await updateForegroundLiveActivityProgress(bookId: bookId, progress: 1.0)
+      await updateDownloadLiveActivityProgress(bookId: bookId, progress: 1.0)
     #endif
   }
 
@@ -2240,7 +2350,7 @@ actor OfflineManager {
       DownloadProgressTracker.shared.updateProgress(bookId: bookId, value: 1.0)
     }
     #if os(iOS)
-      await updateForegroundLiveActivityProgress(bookId: bookId, progress: 1.0)
+      await updateDownloadLiveActivityProgress(bookId: bookId, progress: 1.0)
     #endif
   }
 
@@ -2258,8 +2368,15 @@ actor OfflineManager {
     Self.excludeFromBackupIfNeeded(at: epubFile)
 
     await MainActor.run {
-      DownloadProgressTracker.shared.updateProgress(bookId: bookId, value: 0.5)
+      DownloadProgressTracker.shared.updateProgress(bookId: bookId, value: 1.0)
     }
+    #if os(iOS)
+      await updateDownloadLiveActivityProgress(
+        bookId: bookId,
+        progress: 1.0,
+        bookInfoOverride: String(localized: "Processing offline files...")
+      )
+    #endif
 
     try Task.checkCancellation()
     try extractEpubToWebPub(epubFile: epubFile, bookId: bookId, manifest: manifest, bookDir: bookDir)
@@ -2271,7 +2388,7 @@ actor OfflineManager {
       DownloadProgressTracker.shared.updateProgress(bookId: bookId, value: 1.0)
     }
     #if os(iOS)
-      await updateForegroundLiveActivityProgress(bookId: bookId, progress: 1.0)
+      await updateDownloadLiveActivityProgress(bookId: bookId, progress: 1.0)
     #endif
   }
 

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -36,6 +36,7 @@
     case idle
     case fetchingMetadata
     case downloading
+    case processingOfflineFiles
     case preparingReader
     case paginating
   }
@@ -377,6 +378,9 @@
         case .pending:
           if let progress = DownloadProgressTracker.shared.progress[bookId] {
             downloadProgress = progress
+            if progress >= 1 {
+              loadingStage = .processingOfflineFiles
+            }
           }
         }
 
@@ -420,6 +424,9 @@
         case .pending:
           if let progress = DownloadProgressTracker.shared.progress[bookId] {
             downloadProgress = progress
+            if progress >= 1 {
+              loadingStage = .processingOfflineFiles
+            }
           }
         }
 

--- a/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
@@ -7,6 +7,7 @@
     case idle
     case fetchingMetadata
     case downloading
+    case processingOfflineFiles
     case preparingReader
   }
 
@@ -331,6 +332,9 @@
         case .pending:
           if let progress = DownloadProgressTracker.shared.progress[bookId] {
             downloadProgress = progress
+            if progress >= 1 {
+              loadingStage = .processingOfflineFiles
+            }
           }
         }
 

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -860,6 +860,7 @@ class ReaderViewModel {
       case .downloaded:
         if updatesLoadingState {
           loadingProgress = 1.0
+          loadingDetail = nil
         }
         return
       case .failed(let error):
@@ -873,6 +874,12 @@ class ReaderViewModel {
           let progress = DownloadProgressTracker.shared.progress[book.id]
         {
           loadingProgress = progress
+          if progress >= 1 {
+            loadingTitle = String(localized: "Processing offline files...")
+            loadingDetail = nil
+          } else {
+            loadingTitle = String(localized: "Downloading book...")
+          }
         }
       }
 

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -643,6 +643,8 @@
         return String(localized: "Fetching book info...")
       case .downloading:
         return String(localized: "Downloading book...")
+      case .processingOfflineFiles:
+        return String(localized: "Processing offline files...")
       case .preparingReader:
         return String(localized: "Preparing reader...")
       case .paginating:
@@ -664,6 +666,8 @@
             "\(String(format: "%.1f", received / 1024 / 1024)) / \(String(format: "%.1f", expected / 1024 / 1024)) MB"
         }
         return String(localized: "Downloading book content")
+      case .processingOfflineFiles:
+        return nil
       case .preparingReader:
         return String(localized: "Preparing reader view")
       case .paginating:

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -417,6 +417,8 @@
         return String(localized: "Fetching book info...")
       case .downloading:
         return String(localized: "Downloading book...")
+      case .processingOfflineFiles:
+        return String(localized: "Processing offline files...")
       case .preparingReader:
         return String(localized: "Preparing PDF...")
       case .idle:


### PR DESCRIPTION
## Problem
Reader-triggered single-file offline downloads could update the in-app progress tracker without keeping the download Live Activity in sync. After the file transfer finished, reader loading overlays also kept presenting the wait as a download instead of showing that offline files were being finalized.

## Approach
Forward foreground and background single-file byte progress through `OfflineManager` to the download Live Activity with light throttling. Treat the post-transfer finalize and extraction window as a distinct processing state so Live Activity and reader overlays report the same phase.

## Scope
- Sync foreground and background single-file download progress to the download Live Activity
- Show `Processing offline files...` after transfer completion while pending downloads are finalized
- Keep the build version bump as a separate commit

## Testing
- [x] `git diff --check HEAD~2..HEAD`
- [x] `make build-ios`
