### PR TITLE
fix: avoid SwiftData query deadlock

### DIFF
--- a/KMReader/ContentView.swift
+++ b/KMReader/ContentView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct ContentView: View {
@@ -193,7 +192,7 @@ struct ContentView: View {
             Task(priority: .utility) {
               await SSEService.shared.disconnect(notify: false)
               if let database = await DatabaseOperator.databaseIfConfigured() {
-                try? await database.commitImmediately()
+                try? await database.commit()
               }
             }
             WidgetDataService.refreshWidgetData()

--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -38,6 +38,17 @@ struct DownloadQueueSummary: Sendable {
   }
 }
 
+nonisolated struct HistoricalEventLocalReferences: Equatable, Sendable {
+  let bookNameById: [String: String]
+  let seriesNameById: [String: String]
+
+  static let empty = HistoricalEventLocalReferences(bookNameById: [:], seriesNameById: [:])
+
+  var hasMatches: Bool {
+    !bookNameById.isEmpty || !seriesNameById.isEmpty
+  }
+}
+
 @ModelActor
 actor DatabaseOperator {
   private actor SharedStore {
@@ -62,7 +73,6 @@ actor DatabaseOperator {
   private static let sharedStore = SharedStore()
 
   private let logger = AppLogger(.database)
-  private var pendingCommitTask: Task<Void, Never>?
   private let reconcileDeleteBatchSize = 1000
 
   static func configure(modelContainer: ModelContainer) async {
@@ -77,25 +87,13 @@ actor DatabaseOperator {
     await sharedStore.databaseIfConfigured()
   }
 
-  /// Commits changes with a 500ms debounce to avoid frequent UI updates
-  func commit() {
-    pendingCommitTask?.cancel()
-    pendingCommitTask = Task {
-      try? await Task.sleep(for: .milliseconds(500))
-      guard !Task.isCancelled else { return }
-      do {
-        try modelContext.save()
-      } catch {
-        logger.error("Failed to commit: \(error)")
-      }
+  func commit() throws {
+    do {
+      try modelContext.save()
+    } catch {
+      logger.error("Failed to commit: \(error)")
+      throw error
     }
-  }
-
-  /// Commits changes immediately without debounce
-  func commitImmediately() throws {
-    pendingCommitTask?.cancel()
-    pendingCommitTask = nil
-    try modelContext.save()
   }
 
   func hasChanges() -> Bool {
@@ -103,6 +101,197 @@ actor DatabaseOperator {
   }
 
   // MARK: - Book Operations
+
+  func fetchBookDisplayItem(bookId: String, instanceId: String) throws -> BookDisplayItem? {
+    guard !bookId.isEmpty, !instanceId.isEmpty else { return nil }
+
+    let compositeId = CompositeID.generate(instanceId: instanceId, id: bookId)
+    let descriptor = FetchDescriptor<KomgaBook>(
+      predicate: #Predicate { book in
+        book.id == compositeId
+      }
+    )
+    return try modelContext.fetch(descriptor).first.map(Self.makeBookDisplayItem)
+  }
+
+  func fetchFirstBookDisplayItem(seriesId: String, instanceId: String) throws -> BookDisplayItem? {
+    guard !seriesId.isEmpty, !instanceId.isEmpty else { return nil }
+
+    var descriptor = FetchDescriptor<KomgaBook>(
+      predicate: #Predicate { book in
+        book.instanceId == instanceId && book.seriesId == seriesId
+      },
+      sortBy: [SortDescriptor(\KomgaBook.metaNumberSort, order: .forward)]
+    )
+    descriptor.fetchLimit = 1
+    return try modelContext.fetch(descriptor).first.map(Self.makeBookDisplayItem)
+  }
+
+  func fetchBrowseBookIds(
+    instanceId: String,
+    libraryIds: [String]?,
+    searchText: String,
+    browseOpts: BookBrowseOptions,
+    offset: Int,
+    limit: Int,
+    offlineOnly: Bool = false
+  ) -> [String] {
+    guard !instanceId.isEmpty else { return [] }
+
+    return KomgaBookStore.fetchBookIds(
+      context: modelContext,
+      instanceId: instanceId,
+      libraryIds: libraryIds,
+      searchText: searchText,
+      browseOpts: browseOpts,
+      offset: offset,
+      limit: limit,
+      offlineOnly: offlineOnly
+    )
+  }
+
+  func fetchSeriesBookIds(
+    seriesId: String,
+    browseOpts: BookBrowseOptions,
+    page: Int,
+    size: Int
+  ) -> [String] {
+    KomgaBookStore.fetchSeriesBooks(
+      context: modelContext,
+      seriesId: seriesId,
+      page: page,
+      size: size,
+      browseOpts: browseOpts
+    ).map(\.id)
+  }
+
+  func fetchReadListBookIds(
+    readListId: String,
+    browseOpts: ReadListBookBrowseOptions,
+    page: Int,
+    size: Int
+  ) -> [String] {
+    KomgaBookStore.fetchReadListBooks(
+      context: modelContext,
+      readListId: readListId,
+      page: page,
+      size: size,
+      browseOpts: browseOpts
+    ).map(\.id)
+  }
+
+  func fetchDashboardOfflineBookIds(
+    section: DashboardSection,
+    libraryIds: [String],
+    offset: Int,
+    limit: Int
+  ) -> [String] {
+    switch section {
+    case .keepReading:
+      return KomgaBookStore.fetchKeepReadingBookIds(
+        context: modelContext,
+        libraryIds: libraryIds,
+        offset: offset,
+        limit: limit
+      )
+    case .onDeck:
+      return []
+    case .recentlyReadBooks:
+      return KomgaBookStore.fetchRecentlyReadBookIds(
+        context: modelContext,
+        libraryIds: libraryIds,
+        offset: offset,
+        limit: limit
+      )
+    case .recentlyReleasedBooks:
+      return KomgaBookStore.fetchRecentlyReleasedBookIds(
+        context: modelContext,
+        libraryIds: libraryIds,
+        offset: offset,
+        limit: limit
+      )
+    case .recentlyAddedBooks:
+      return KomgaBookStore.fetchRecentlyAddedBookIds(
+        context: modelContext,
+        libraryIds: libraryIds,
+        offset: offset,
+        limit: limit
+      )
+    default:
+      return []
+    }
+  }
+
+  func fetchOfflineContinueReadingBook(seriesId: String, instanceId: String) -> Book? {
+    guard !seriesId.isEmpty, !instanceId.isEmpty else { return nil }
+
+    if let inProgress = fetchLatestOfflineBook(
+      seriesId: seriesId,
+      instanceId: instanceId,
+      completed: false
+    ) {
+      return inProgress.toBook()
+    }
+
+    let orderedBooks = fetchOfflineSeriesBooks(seriesId: seriesId, instanceId: instanceId)
+    guard !orderedBooks.isEmpty else { return nil }
+
+    if let lastRead = fetchLatestOfflineBook(
+      seriesId: seriesId,
+      instanceId: instanceId,
+      completed: true
+    ) {
+      if let index = orderedBooks.firstIndex(where: { $0.bookId == lastRead.bookId }) {
+        let nextIndex = orderedBooks.index(after: index)
+        if nextIndex < orderedBooks.endIndex {
+          return orderedBooks[nextIndex].toBook()
+        }
+      }
+    }
+
+    if let firstUnread = orderedBooks.first(where: { $0.isUnread }) {
+      return firstUnread.toBook()
+    }
+
+    return orderedBooks.first?.toBook()
+  }
+
+  private func fetchLatestOfflineBook(
+    seriesId: String,
+    instanceId: String,
+    completed: Bool
+  ) -> KomgaBook? {
+    var descriptor = FetchDescriptor<KomgaBook>(
+      predicate: #Predicate { book in
+        book.seriesId == seriesId
+          && book.instanceId == instanceId
+          && book.progressReadDate != nil
+          && book.progressCompleted == completed
+      },
+      sortBy: [SortDescriptor(\KomgaBook.progressReadDate, order: .reverse)]
+    )
+    descriptor.fetchLimit = 1
+    return try? modelContext.fetch(descriptor).first
+  }
+
+  private func fetchOfflineSeriesBooks(seriesId: String, instanceId: String) -> [KomgaBook] {
+    let descriptor = FetchDescriptor<KomgaBook>(
+      predicate: #Predicate { book in
+        book.seriesId == seriesId && book.instanceId == instanceId
+      },
+      sortBy: [SortDescriptor(\KomgaBook.metaNumberSort, order: .forward)]
+    )
+    return (try? modelContext.fetch(descriptor)) ?? []
+  }
+
+  private static func makeBookDisplayItem(_ book: KomgaBook) -> BookDisplayItem {
+    BookDisplayItem(
+      instanceId: book.instanceId,
+      book: book.toBook(),
+      downloadStatus: book.downloadStatus,
+      readListIds: book.readListIds
+    )
+  }
 
   func upsertBook(dto: Book, instanceId: String) {
     let compositeId = CompositeID.generate(instanceId: instanceId, id: dto.id)
@@ -540,6 +729,93 @@ actor DatabaseOperator {
 
   // MARK: - Series Operations
 
+  func fetchSeriesDisplayItem(seriesId: String, instanceId: String) throws -> SeriesDisplayItem? {
+    guard !seriesId.isEmpty, !instanceId.isEmpty else { return nil }
+
+    let compositeId = CompositeID.generate(instanceId: instanceId, id: seriesId)
+    let descriptor = FetchDescriptor<KomgaSeries>(
+      predicate: #Predicate { series in
+        series.id == compositeId
+      }
+    )
+    return try modelContext.fetch(descriptor).first.map(Self.makeSeriesDisplayItem)
+  }
+
+  func fetchBrowseSeriesIds(
+    instanceId: String,
+    libraryIds: [String]?,
+    searchText: String,
+    browseOpts: SeriesBrowseOptions,
+    offset: Int,
+    limit: Int,
+    offlineOnly: Bool = false
+  ) -> [String] {
+    guard !instanceId.isEmpty else { return [] }
+
+    return KomgaSeriesStore.fetchSeriesIds(
+      context: modelContext,
+      instanceId: instanceId,
+      libraryIds: libraryIds,
+      searchText: searchText,
+      browseOpts: browseOpts,
+      offset: offset,
+      limit: limit,
+      offlineOnly: offlineOnly
+    )
+  }
+
+  func fetchCollectionSeriesIds(
+    collectionId: String,
+    browseOpts: CollectionSeriesBrowseOptions,
+    page: Int,
+    size: Int
+  ) -> [String] {
+    KomgaSeriesStore.fetchCollectionSeries(
+      context: modelContext,
+      collectionId: collectionId,
+      page: page,
+      size: size,
+      browseOpts: browseOpts
+    ).map(\.id)
+  }
+
+  func fetchDashboardOfflineSeriesIds(
+    section: DashboardSection,
+    libraryIds: [String],
+    offset: Int,
+    limit: Int
+  ) -> [String] {
+    switch section {
+    case .recentlyAddedSeries:
+      return KomgaSeriesStore.fetchNewlyAddedSeriesIds(
+        context: modelContext,
+        libraryIds: libraryIds,
+        offset: offset,
+        limit: limit
+      )
+    case .recentlyUpdatedSeries:
+      return KomgaSeriesStore.fetchRecentlyUpdatedSeriesIds(
+        context: modelContext,
+        libraryIds: libraryIds,
+        offset: offset,
+        limit: limit
+      )
+    default:
+      return []
+    }
+  }
+
+  private static func makeSeriesDisplayItem(_ series: KomgaSeries) -> SeriesDisplayItem {
+    SeriesDisplayItem(
+      instanceId: series.instanceId,
+      series: series.toSeries(),
+      downloadStatus: series.downloadStatus,
+      offlinePolicy: series.offlinePolicy,
+      offlinePolicyLimit: series.offlinePolicyLimit,
+      collectionIds: series.collectionIds
+    )
+  }
+
   func upsertSeries(dto: Series, instanceId: String) {
     let compositeId = CompositeID.generate(instanceId: instanceId, id: dto.id)
     let descriptor = FetchDescriptor<KomgaSeries>(predicate: #Predicate { $0.id == compositeId })
@@ -685,6 +961,135 @@ actor DatabaseOperator {
 
   // MARK: - Collection Operations
 
+  func fetchSidebarCollections(instanceId: String) throws -> [SidebarCollectionItem] {
+    guard !instanceId.isEmpty else { return [] }
+
+    let descriptor = FetchDescriptor<KomgaCollection>(
+      predicate: #Predicate { collection in
+        collection.instanceId == instanceId
+      },
+      sortBy: [SortDescriptor(\KomgaCollection.name, order: .forward)]
+    )
+    return try modelContext.fetch(descriptor).map { collection in
+      SidebarCollectionItem(
+        collectionId: collection.collectionId,
+        name: collection.name,
+        seriesCount: collection.seriesIds.count
+      )
+    }
+  }
+
+  func fetchSidebarCollections(instanceId: String, collectionIds: Set<String>) throws
+    -> [SidebarCollectionItem]
+  {
+    guard !instanceId.isEmpty, !collectionIds.isEmpty else { return [] }
+
+    let descriptor = FetchDescriptor<KomgaCollection>(
+      predicate: #Predicate { collection in
+        collection.instanceId == instanceId && collectionIds.contains(collection.collectionId)
+      },
+      sortBy: [SortDescriptor(\KomgaCollection.name, order: .forward)]
+    )
+    return try modelContext.fetch(descriptor).map { collection in
+      SidebarCollectionItem(
+        collectionId: collection.collectionId,
+        name: collection.name,
+        seriesCount: collection.seriesIds.count
+      )
+    }
+  }
+
+  func fetchPinnedCollectionDisplayItems(instanceId: String) throws -> [CollectionDisplayItem] {
+    guard !instanceId.isEmpty else { return [] }
+
+    let descriptor = FetchDescriptor<KomgaCollection>(
+      predicate: #Predicate { collection in
+        collection.instanceId == instanceId && collection.isPinned == true
+      },
+      sortBy: [SortDescriptor(\KomgaCollection.lastModifiedDate, order: .reverse)]
+    )
+    return try modelContext.fetch(descriptor).map { collection in
+      CollectionDisplayItem(
+        collectionId: collection.collectionId,
+        instanceId: collection.instanceId,
+        name: collection.name,
+        ordered: collection.ordered,
+        createdDate: collection.createdDate,
+        lastModifiedDate: collection.lastModifiedDate,
+        filtered: collection.filtered,
+        isPinned: collection.isPinned,
+        seriesIds: collection.seriesIds
+      )
+    }
+  }
+
+  func fetchCollectionDisplayItems(instanceId: String) throws -> [CollectionDisplayItem] {
+    guard !instanceId.isEmpty else { return [] }
+
+    let descriptor = FetchDescriptor<KomgaCollection>(
+      predicate: #Predicate { collection in
+        collection.instanceId == instanceId
+      },
+      sortBy: [SortDescriptor(\KomgaCollection.name, order: .forward)]
+    )
+    return try modelContext.fetch(descriptor).map { collection in
+      CollectionDisplayItem(
+        collectionId: collection.collectionId,
+        instanceId: collection.instanceId,
+        name: collection.name,
+        ordered: collection.ordered,
+        createdDate: collection.createdDate,
+        lastModifiedDate: collection.lastModifiedDate,
+        filtered: collection.filtered,
+        isPinned: collection.isPinned,
+        seriesIds: collection.seriesIds
+      )
+    }
+  }
+
+  func fetchCollectionIds(
+    libraryIds: [String]?,
+    searchText: String,
+    sort: String?,
+    offset: Int,
+    limit: Int
+  ) -> [String] {
+    KomgaCollectionStore.fetchCollectionIds(
+      context: modelContext,
+      libraryIds: libraryIds,
+      searchText: searchText,
+      sort: sort,
+      offset: offset,
+      limit: limit
+    )
+  }
+
+  func fetchCollectionDisplayItem(collectionId: String, instanceId: String) throws
+    -> CollectionDisplayItem?
+  {
+    guard !collectionId.isEmpty, !instanceId.isEmpty else { return nil }
+
+    let compositeId = CompositeID.generate(instanceId: instanceId, id: collectionId)
+    let descriptor = FetchDescriptor<KomgaCollection>(
+      predicate: #Predicate { collection in
+        collection.id == compositeId
+      }
+    )
+    return try modelContext.fetch(descriptor).first.map { collection in
+      CollectionDisplayItem(
+        collectionId: collection.collectionId,
+        instanceId: collection.instanceId,
+        name: collection.name,
+        ordered: collection.ordered,
+        createdDate: collection.createdDate,
+        lastModifiedDate: collection.lastModifiedDate,
+        filtered: collection.filtered,
+        isPinned: collection.isPinned,
+        seriesIds: collection.seriesIds
+      )
+    }
+  }
+
   func upsertCollection(dto: SeriesCollection, instanceId: String) {
     let compositeId = CompositeID.generate(instanceId: instanceId, id: dto.id)
     let descriptor = FetchDescriptor<KomgaCollection>(
@@ -780,6 +1185,141 @@ actor DatabaseOperator {
   }
 
   // MARK: - ReadList Operations
+
+  func fetchSidebarReadLists(instanceId: String) throws -> [SidebarReadListItem] {
+    guard !instanceId.isEmpty else { return [] }
+
+    let descriptor = FetchDescriptor<KomgaReadList>(
+      predicate: #Predicate { readList in
+        readList.instanceId == instanceId
+      },
+      sortBy: [SortDescriptor(\KomgaReadList.name, order: .forward)]
+    )
+    return try modelContext.fetch(descriptor).map { readList in
+      SidebarReadListItem(
+        readListId: readList.readListId,
+        name: readList.name,
+        bookCount: readList.bookIds.count
+      )
+    }
+  }
+
+  func fetchSidebarReadLists(instanceId: String, readListIds: Set<String>) throws
+    -> [SidebarReadListItem]
+  {
+    guard !instanceId.isEmpty, !readListIds.isEmpty else { return [] }
+
+    let descriptor = FetchDescriptor<KomgaReadList>(
+      predicate: #Predicate { readList in
+        readList.instanceId == instanceId && readListIds.contains(readList.readListId)
+      },
+      sortBy: [SortDescriptor(\KomgaReadList.name, order: .forward)]
+    )
+    return try modelContext.fetch(descriptor).map { readList in
+      SidebarReadListItem(
+        readListId: readList.readListId,
+        name: readList.name,
+        bookCount: readList.bookIds.count
+      )
+    }
+  }
+
+  func fetchPinnedReadListDisplayItems(instanceId: String) throws -> [ReadListDisplayItem] {
+    guard !instanceId.isEmpty else { return [] }
+
+    let descriptor = FetchDescriptor<KomgaReadList>(
+      predicate: #Predicate { readList in
+        readList.instanceId == instanceId && readList.isPinned == true
+      },
+      sortBy: [SortDescriptor(\KomgaReadList.lastModifiedDate, order: .reverse)]
+    )
+    return try modelContext.fetch(descriptor).map { readList in
+      ReadListDisplayItem(
+        readListId: readList.readListId,
+        instanceId: readList.instanceId,
+        name: readList.name,
+        summary: readList.summary,
+        ordered: readList.ordered,
+        createdDate: readList.createdDate,
+        lastModifiedDate: readList.lastModifiedDate,
+        filtered: readList.filtered,
+        isPinned: readList.isPinned,
+        bookIds: readList.bookIds,
+        downloadStatus: readList.downloadStatus
+      )
+    }
+  }
+
+  func fetchReadListDisplayItems(instanceId: String) throws -> [ReadListDisplayItem] {
+    guard !instanceId.isEmpty else { return [] }
+
+    let descriptor = FetchDescriptor<KomgaReadList>(
+      predicate: #Predicate { readList in
+        readList.instanceId == instanceId
+      },
+      sortBy: [SortDescriptor(\KomgaReadList.name, order: .forward)]
+    )
+    return try modelContext.fetch(descriptor).map { readList in
+      ReadListDisplayItem(
+        readListId: readList.readListId,
+        instanceId: readList.instanceId,
+        name: readList.name,
+        summary: readList.summary,
+        ordered: readList.ordered,
+        createdDate: readList.createdDate,
+        lastModifiedDate: readList.lastModifiedDate,
+        filtered: readList.filtered,
+        isPinned: readList.isPinned,
+        bookIds: readList.bookIds,
+        downloadStatus: readList.downloadStatus
+      )
+    }
+  }
+
+  func fetchReadListIds(
+    libraryIds: [String]?,
+    searchText: String,
+    sort: String?,
+    offset: Int,
+    limit: Int
+  ) -> [String] {
+    KomgaReadListStore.fetchReadListIds(
+      context: modelContext,
+      libraryIds: libraryIds,
+      searchText: searchText,
+      sort: sort,
+      offset: offset,
+      limit: limit
+    )
+  }
+
+  func fetchReadListDisplayItem(readListId: String, instanceId: String) throws
+    -> ReadListDisplayItem?
+  {
+    guard !readListId.isEmpty, !instanceId.isEmpty else { return nil }
+
+    let compositeId = CompositeID.generate(instanceId: instanceId, id: readListId)
+    let descriptor = FetchDescriptor<KomgaReadList>(
+      predicate: #Predicate { readList in
+        readList.id == compositeId
+      }
+    )
+    return try modelContext.fetch(descriptor).first.map { readList in
+      ReadListDisplayItem(
+        readListId: readList.readListId,
+        instanceId: readList.instanceId,
+        name: readList.name,
+        summary: readList.summary,
+        ordered: readList.ordered,
+        createdDate: readList.createdDate,
+        lastModifiedDate: readList.lastModifiedDate,
+        filtered: readList.filtered,
+        isPinned: readList.isPinned,
+        bookIds: readList.bookIds,
+        downloadStatus: readList.downloadStatus
+      )
+    }
+  }
 
   func upsertReadList(dto: ReadList, instanceId: String) {
     let compositeId = CompositeID.generate(instanceId: instanceId, id: dto.id)
@@ -1177,7 +1717,70 @@ actor DatabaseOperator {
     }
   }
 
+  func fetchHistoricalEventLocalReferences(
+    instanceId: String,
+    bookIds: Set<String>,
+    seriesIds: Set<String>
+  ) throws -> HistoricalEventLocalReferences {
+    guard !instanceId.isEmpty, !bookIds.isEmpty || !seriesIds.isEmpty else {
+      return .empty
+    }
+
+    var bookNameById: [String: String] = [:]
+    if !bookIds.isEmpty {
+      let descriptor = FetchDescriptor<KomgaBook>(
+        predicate: #Predicate { book in
+          book.instanceId == instanceId && bookIds.contains(book.bookId)
+        }
+      )
+      for book in try modelContext.fetch(descriptor) {
+        bookNameById[book.bookId] = book.metaTitle
+      }
+    }
+
+    var seriesNameById: [String: String] = [:]
+    if !seriesIds.isEmpty {
+      let descriptor = FetchDescriptor<KomgaSeries>(
+        predicate: #Predicate { series in
+          series.instanceId == instanceId && seriesIds.contains(series.seriesId)
+        }
+      )
+      for series in try modelContext.fetch(descriptor) {
+        seriesNameById[series.seriesId] = series.metaTitle
+      }
+    }
+
+    return HistoricalEventLocalReferences(
+      bookNameById: bookNameById,
+      seriesNameById: seriesNameById
+    )
+  }
+
   // MARK: - Book Download Status Operations
+
+  func fetchOfflineTaskItems(instanceId: String) throws -> [OfflineTaskItem] {
+    guard !instanceId.isEmpty else { return [] }
+
+    let descriptor = FetchDescriptor<KomgaBook>(
+      predicate: #Predicate { book in
+        book.instanceId == instanceId
+          && (book.downloadStatusRaw == "pending" || book.downloadStatusRaw == "downloading"
+            || book.downloadStatusRaw == "failed")
+      },
+      sortBy: [SortDescriptor(\KomgaBook.downloadAt, order: .forward)]
+    )
+    return try modelContext.fetch(descriptor).map { book in
+      OfflineTaskItem(
+        id: book.id,
+        bookId: book.bookId,
+        seriesTitle: book.seriesTitle,
+        metaNumber: book.metaNumber,
+        metaTitle: book.metaTitle,
+        downloadStatusRaw: book.downloadStatusRaw,
+        downloadStatus: book.downloadStatus
+      )
+    }
+  }
 
   func updateBookDownloadStatus(
     bookId: String,
@@ -1482,7 +2085,7 @@ actor DatabaseOperator {
         }
         self.syncSeriesDownloadStatus(
           seriesId: seriesId, instanceId: instanceId)
-        self.commit()
+        try? self.commit()
       }
     }
   }
@@ -1580,7 +2183,7 @@ actor DatabaseOperator {
       }
       self.syncSeriesDownloadStatus(
         seriesId: seriesId, instanceId: instanceId)
-      self.commit()
+      try? self.commit()
     }
   }
 
@@ -1614,7 +2217,7 @@ actor DatabaseOperator {
       }
       self.syncSeriesDownloadStatus(
         seriesId: seriesId, instanceId: instanceId)
-      self.commit()
+      try? self.commit()
     }
   }
 
@@ -1868,7 +2471,7 @@ actor DatabaseOperator {
       }
       self.syncReadListDownloadStatus(
         readListId: readListId, instanceId: instanceId)
-      self.commit()
+      try? self.commit()
     }
   }
 
@@ -1905,11 +2508,82 @@ actor DatabaseOperator {
       }
       self.syncReadListDownloadStatus(
         readListId: readListId, instanceId: instanceId)
-      self.commit()
+      try? self.commit()
     }
   }
 
   // MARK: - Library Operations
+
+  func fetchSidebarLibraries(instanceId: String) throws -> [SidebarLibraryItem] {
+    guard !instanceId.isEmpty else { return [] }
+
+    let allLibrariesId = KomgaLibrary.allLibrariesId
+    let descriptor = FetchDescriptor<KomgaLibrary>(
+      predicate: #Predicate { library in
+        library.instanceId == instanceId && library.libraryId != allLibrariesId
+      },
+      sortBy: [SortDescriptor(\KomgaLibrary.name, order: .forward)]
+    )
+    return try modelContext.fetch(descriptor).map { library in
+      SidebarLibraryItem(
+        libraryId: library.libraryId,
+        name: library.name,
+        fileSize: library.fileSize,
+        booksCount: library.booksCount,
+        seriesCount: library.seriesCount,
+        sidecarsCount: library.sidecarsCount,
+        collectionsCount: library.collectionsCount,
+        readlistsCount: library.readlistsCount
+      )
+    }
+  }
+
+  func fetchAllLibrariesItem(instanceId: String) throws -> SidebarLibraryItem? {
+    guard !instanceId.isEmpty else { return nil }
+
+    let allLibrariesId = KomgaLibrary.allLibrariesId
+    let descriptor = FetchDescriptor<KomgaLibrary>(
+      predicate: #Predicate { library in
+        library.instanceId == instanceId && library.libraryId == allLibrariesId
+      }
+    )
+    guard let library = try modelContext.fetch(descriptor).first else { return nil }
+    return SidebarLibraryItem(
+      libraryId: library.libraryId,
+      name: library.name,
+      fileSize: library.fileSize,
+      booksCount: library.booksCount,
+      seriesCount: library.seriesCount,
+      sidecarsCount: library.sidecarsCount,
+      collectionsCount: library.collectionsCount,
+      readlistsCount: library.readlistsCount
+    )
+  }
+
+  func updateLibraryMetrics(
+    instanceId: String,
+    metricsByLibrary: [String: LibraryMetricValues]
+  ) throws {
+    guard !instanceId.isEmpty, !metricsByLibrary.isEmpty else { return }
+
+    let libraryIds = Set(metricsByLibrary.keys)
+    let descriptor = FetchDescriptor<KomgaLibrary>(
+      predicate: #Predicate { library in
+        library.instanceId == instanceId && libraryIds.contains(library.libraryId)
+      }
+    )
+    let libraries = try modelContext.fetch(descriptor)
+
+    for library in libraries {
+      guard let metrics = metricsByLibrary[library.libraryId] else { continue }
+      if library.fileSize != metrics.fileSize { library.fileSize = metrics.fileSize }
+      if library.booksCount != metrics.booksCount { library.booksCount = metrics.booksCount }
+      if library.seriesCount != metrics.seriesCount { library.seriesCount = metrics.seriesCount }
+      if library.sidecarsCount != metrics.sidecarsCount {
+        library.sidecarsCount = metrics.sidecarsCount
+      }
+    }
+  }
 
   func replaceLibraries(_ libraries: [LibraryInfo], for instanceId: String) throws {
     let descriptor = FetchDescriptor<KomgaLibrary>(
@@ -2047,6 +2721,171 @@ actor DatabaseOperator {
     }
   }
 
+  // MARK: - Saved Filter Operations
+
+  func fetchSavedFilterDisplayItems(filterType: SavedFilterType) throws -> [SavedFilterDisplayItem]
+  {
+    let filterTypeRaw = filterType.rawValue
+    let descriptor = FetchDescriptor<SavedFilter>(
+      predicate: #Predicate { filter in
+        filter.filterTypeRaw == filterTypeRaw
+      },
+      sortBy: [SortDescriptor(\SavedFilter.updatedAt, order: .reverse)]
+    )
+    return try modelContext.fetch(descriptor).map { filter in
+      SavedFilterDisplayItem(
+        id: filter.id,
+        name: filter.name,
+        filterType: filter.filterType,
+        filterDataJSON: filter.filterDataJSON,
+        updatedAt: filter.updatedAt
+      )
+    }
+  }
+
+  func createSavedFilter(
+    name: String,
+    filterType: SavedFilterType,
+    filterDataJSON: String
+  ) throws {
+    modelContext.insert(
+      SavedFilter(
+        name: name,
+        filterType: filterType,
+        filterDataJSON: filterDataJSON
+      )
+    )
+  }
+
+  func renameSavedFilter(id: UUID, name: String) throws {
+    let descriptor = FetchDescriptor<SavedFilter>(
+      predicate: #Predicate { filter in
+        filter.id == id
+      }
+    )
+    guard let filter = try modelContext.fetch(descriptor).first else { return }
+    filter.name = name
+    filter.updatedAt = Date()
+  }
+
+  func deleteSavedFilter(id: UUID) throws {
+    let descriptor = FetchDescriptor<SavedFilter>(
+      predicate: #Predicate { filter in
+        filter.id == id
+      }
+    )
+    guard let filter = try modelContext.fetch(descriptor).first else { return }
+    modelContext.delete(filter)
+  }
+
+  // MARK: - EPUB Theme Preset Operations
+
+  func fetchEpubThemePresetDisplayItems() throws -> [EpubThemePresetDisplayItem] {
+    let descriptor = FetchDescriptor<EpubThemePreset>(
+      sortBy: [SortDescriptor(\EpubThemePreset.updatedAt, order: .reverse)]
+    )
+    return try modelContext.fetch(descriptor).map { preset in
+      EpubThemePresetDisplayItem(
+        id: preset.id,
+        name: preset.name,
+        preferencesJSON: preset.preferencesJSON,
+        updatedAt: preset.updatedAt
+      )
+    }
+  }
+
+  func createEpubThemePreset(name: String, preferencesJSON: String) throws {
+    modelContext.insert(
+      EpubThemePreset(
+        name: name,
+        preferencesJSON: preferencesJSON
+      )
+    )
+  }
+
+  func renameEpubThemePreset(id: UUID, name: String) throws {
+    let descriptor = FetchDescriptor<EpubThemePreset>(
+      predicate: #Predicate { preset in
+        preset.id == id
+      }
+    )
+    guard let preset = try modelContext.fetch(descriptor).first else { return }
+    preset.name = name
+    preset.updatedAt = Date()
+  }
+
+  func deleteEpubThemePreset(id: UUID) throws {
+    let descriptor = FetchDescriptor<EpubThemePreset>(
+      predicate: #Predicate { preset in
+        preset.id == id
+      }
+    )
+    guard let preset = try modelContext.fetch(descriptor).first else { return }
+    modelContext.delete(preset)
+  }
+
+  // MARK: - Custom Font Operations
+
+  func fetchCustomFontDisplayItems() throws -> [CustomFontDisplayItem] {
+    let descriptor = FetchDescriptor<CustomFont>(
+      sortBy: [SortDescriptor(\CustomFont.name, order: .forward)]
+    )
+    return try modelContext.fetch(descriptor).map(Self.makeCustomFontDisplayItem)
+  }
+
+  func fetchCustomFontPath(name: String) throws -> String? {
+    let descriptor = FetchDescriptor<CustomFont>(
+      predicate: #Predicate { font in
+        font.name == name
+      }
+    )
+    return try modelContext.fetch(descriptor).first?.path
+  }
+
+  func customFontExists(name: String) throws -> Bool {
+    let descriptor = FetchDescriptor<CustomFont>(
+      predicate: #Predicate { font in
+        font.name == name
+      }
+    )
+    return try modelContext.fetchCount(descriptor) > 0
+  }
+
+  func createCustomFont(
+    name: String,
+    path: String? = nil,
+    fileName: String? = nil,
+    fileSize: Int64? = nil
+  ) throws {
+    modelContext.insert(
+      CustomFont(
+        name: name,
+        path: path,
+        fileName: fileName,
+        fileSize: fileSize
+      )
+    )
+  }
+
+  func deleteCustomFont(name: String) throws {
+    let descriptor = FetchDescriptor<CustomFont>(
+      predicate: #Predicate { font in
+        font.name == name
+      }
+    )
+    guard let font = try modelContext.fetch(descriptor).first else { return }
+    modelContext.delete(font)
+  }
+
+  private static func makeCustomFontDisplayItem(_ font: CustomFont) -> CustomFontDisplayItem {
+    CustomFontDisplayItem(
+      name: font.name,
+      path: font.path,
+      fileName: font.fileName,
+      fileSize: font.fileSize
+    )
+  }
+
   // MARK: - Instance Operations
 
   func upsertInstance(
@@ -2119,6 +2958,64 @@ actor DatabaseOperator {
     }
   }
 
+  func fetchServerDisplayItems() throws -> [ServerDisplayItem] {
+    let descriptor = FetchDescriptor<KomgaInstance>(
+      sortBy: [
+        SortDescriptor(\KomgaInstance.lastUsedAt, order: .reverse),
+        SortDescriptor(\KomgaInstance.name, order: .forward),
+      ]
+    )
+    return try modelContext.fetch(descriptor).map(Self.makeServerDisplayItem)
+  }
+
+  func updateServerDisplayItem(
+    id: UUID,
+    name: String,
+    serverURL: String,
+    username: String,
+    authToken: String,
+    authMethod: AuthenticationMethod
+  ) throws -> ServerDisplayItem? {
+    let descriptor = FetchDescriptor<KomgaInstance>(
+      predicate: #Predicate { instance in
+        instance.id == id
+      }
+    )
+    guard let instance = try modelContext.fetch(descriptor).first else { return nil }
+
+    instance.name = name
+    instance.serverURL = serverURL
+    instance.username = username
+    instance.authToken = authToken
+    instance.authMethod = authMethod
+    instance.lastUsedAt = Date()
+
+    return Self.makeServerDisplayItem(instance)
+  }
+
+  func deleteServerDisplayItem(id: UUID) throws {
+    let descriptor = FetchDescriptor<KomgaInstance>(
+      predicate: #Predicate { instance in
+        instance.id == id
+      }
+    )
+    guard let instance = try modelContext.fetch(descriptor).first else { return }
+    modelContext.delete(instance)
+  }
+
+  private static func makeServerDisplayItem(_ instance: KomgaInstance) -> ServerDisplayItem {
+    ServerDisplayItem(
+      id: instance.id,
+      name: instance.name,
+      serverURL: instance.serverURL,
+      username: instance.username,
+      authToken: instance.authToken,
+      isAdmin: instance.isAdmin,
+      authMethod: instance.resolvedAuthMethod,
+      lastUsedAt: instance.lastUsedAt
+    )
+  }
+
   func updateSeriesLastSyncedAt(instanceId: String, date: Date) throws {
     guard let uuid = UUID(uuidString: instanceId) else { return }
     let descriptor = FetchDescriptor<KomgaInstance>(
@@ -2164,6 +3061,21 @@ actor DatabaseOperator {
       return (Date(timeIntervalSince1970: 0), Date(timeIntervalSince1970: 0))
     }
     return (instance.seriesLastSyncedAt, instance.booksLastSyncedAt)
+  }
+
+  func fetchOfflineInstanceSyncInfo(instanceId: String) throws -> OfflineInstanceSyncInfo? {
+    guard let uuid = UUID(uuidString: instanceId) else { return nil }
+    let descriptor = FetchDescriptor<KomgaInstance>(
+      predicate: #Predicate { instance in
+        instance.id == uuid
+      }
+    )
+    guard let instance = try modelContext.fetch(descriptor).first else { return nil }
+    return OfflineInstanceSyncInfo(
+      instanceId: instanceId,
+      seriesLastSyncedAt: instance.seriesLastSyncedAt,
+      booksLastSyncedAt: instance.booksLastSyncedAt
+    )
   }
 
   func fetchLibraries(instanceId: String) -> [LibraryInfo] {
@@ -2262,7 +3174,7 @@ actor DatabaseOperator {
     syncReadListsContainingBooks(bookIds: affectedBookIds, instanceId: instanceId)
 
     if queuedCount > 0 {
-      commit()
+      try? commit()
     }
     return queuedCount
   }
@@ -2291,6 +3203,94 @@ actor DatabaseOperator {
     fetchBooksCount(instanceId: instanceId, status: "downloaded")
   }
 
+  func fetchOfflineDownloadedBooksSnapshot(instanceId: String) throws -> OfflineDownloadedBooksSnapshot
+  {
+    guard !instanceId.isEmpty else { return .empty }
+
+    let bookDescriptor = FetchDescriptor<KomgaBook>(
+      predicate: #Predicate { book in
+        book.instanceId == instanceId && book.downloadStatusRaw == "downloaded"
+      },
+      sortBy: [SortDescriptor(\KomgaBook.libraryId, order: .forward)]
+    )
+    let downloadedBooks = try modelContext.fetch(bookDescriptor)
+    guard !downloadedBooks.isEmpty else { return .empty }
+
+    let libraryDescriptor = FetchDescriptor<KomgaLibrary>(
+      predicate: #Predicate { library in
+        library.instanceId == instanceId
+      }
+    )
+    let libraryMap = Dictionary(
+      uniqueKeysWithValues: try modelContext.fetch(libraryDescriptor).map { library in
+        (library.libraryId, library.name)
+      }
+    )
+
+    let seriesIds = Set(downloadedBooks.filter { !$0.oneshot }.map(\.seriesId))
+    let seriesMap: [String: String]
+    if seriesIds.isEmpty {
+      seriesMap = [:]
+    } else {
+      let compositeSeriesIds = seriesIds.map {
+        CompositeID.generate(instanceId: instanceId, id: $0)
+      }
+      let seriesDescriptor = FetchDescriptor<KomgaSeries>(
+        predicate: #Predicate { series in
+          compositeSeriesIds.contains(series.id)
+        }
+      )
+      seriesMap = Dictionary(
+        uniqueKeysWithValues: try modelContext.fetch(seriesDescriptor).map { series in
+          (series.seriesId, series.name)
+        }
+      )
+    }
+
+    let libraryBooksMap = Dictionary(grouping: downloadedBooks) { $0.libraryId }
+    var libraryGroups: [OfflineDownloadedLibraryGroup] = []
+
+    for (libraryId, libraryBooks) in libraryBooksMap {
+      let oneshotBooks = libraryBooks.filter(\.oneshot)
+        .map(Self.makeOfflineDownloadedBookItem)
+        .sorted {
+          $0.oneshotTitle.localizedCaseInsensitiveCompare($1.oneshotTitle) == .orderedAscending
+        }
+
+      let seriesBooksMap = Dictionary(grouping: libraryBooks.filter { !$0.oneshot }) { $0.seriesId }
+      var seriesGroups: [OfflineDownloadedSeriesGroup] = []
+      for (seriesId, seriesBooks) in seriesBooksMap {
+        let bookItems = seriesBooks
+          .map(Self.makeOfflineDownloadedBookItem)
+          .sorted { $0.metaNumberSort < $1.metaNumberSort }
+        seriesGroups.append(
+          OfflineDownloadedSeriesGroup(
+            id: seriesId,
+            name: seriesMap[seriesId] ?? bookItems.first?.seriesTitle,
+            books: bookItems
+          )
+        )
+      }
+      seriesGroups.sort {
+        ($0.name ?? "").localizedCaseInsensitiveCompare($1.name ?? "") == .orderedAscending
+      }
+
+      libraryGroups.append(
+        OfflineDownloadedLibraryGroup(
+          id: libraryId,
+          name: libraryMap[libraryId],
+          seriesGroups: seriesGroups,
+          oneshotBooks: oneshotBooks
+        )
+      )
+    }
+
+    libraryGroups.sort {
+      ($0.name ?? "").localizedCaseInsensitiveCompare($1.name ?? "") == .orderedAscending
+    }
+    return OfflineDownloadedBooksSnapshot(libraryGroups: libraryGroups)
+  }
+
   func fetchDownloadedBooks(instanceId: String) -> [Book] {
     let descriptor = FetchDescriptor<KomgaBook>(
       predicate: #Predicate { $0.instanceId == instanceId && $0.downloadStatusRaw == "downloaded" }
@@ -2302,6 +3302,24 @@ actor DatabaseOperator {
     } catch {
       return []
     }
+  }
+
+  private static func makeOfflineDownloadedBookItem(_ book: KomgaBook) -> OfflineDownloadedBookItem
+  {
+    OfflineDownloadedBookItem(
+      id: book.id,
+      instanceId: book.instanceId,
+      bookId: book.bookId,
+      seriesId: book.seriesId,
+      libraryId: book.libraryId,
+      bookName: book.name,
+      seriesTitle: book.seriesTitle,
+      metaNumber: book.metaNumber,
+      metaTitle: book.metaTitle,
+      metaNumberSort: book.metaNumberSort,
+      downloadedSize: book.downloadedSize,
+      isReadCompleted: book.readProgress?.completed == true
+    )
   }
 
   func fetchOfflineEpubBookIdsMissingProgression(instanceId: String) async -> [String] {

--- a/KMReader/Features/Auth/Models/AuthenticationMethod.swift
+++ b/KMReader/Features/Auth/Models/AuthenticationMethod.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum AuthenticationMethod: String, Codable {
+nonisolated enum AuthenticationMethod: String, Codable, Sendable {
   case basicAuth
   case apiKey
 }

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-import SwiftData
 import SwiftUI
 
 @MainActor
@@ -140,9 +139,9 @@ class AuthViewModel {
     }
   }
 
-  func switchTo(instance: KomgaInstance) async -> Bool {
+  func switchTo(instance: ServerDisplayItem) async -> Bool {
     isSwitching = true
-    switchingInstanceId = instance.id.uuidString
+    switchingInstanceId = instance.instanceId
     defer {
       isSwitching = false
       switchingInstanceId = nil
@@ -156,7 +155,7 @@ class AuthViewModel {
       let validatedUser = try await AuthService.establishSession(
         serverURL: instance.serverURL,
         authToken: instance.authToken,
-        authMethod: instance.resolvedAuthMethod,
+        authMethod: instance.authMethod,
         timeout: AppConfig.authTimeout
       )
 
@@ -165,10 +164,10 @@ class AuthViewModel {
         serverURL: instance.serverURL,
         username: instance.username,
         authToken: instance.authToken,
-        authMethod: instance.resolvedAuthMethod,
+        authMethod: instance.authMethod,
         user: validatedUser,
         displayName: instance.displayName,
-        instanceId: instance.id.uuidString,
+        instanceId: instance.instanceId,
         shouldPersistInstance: false,
         successMessage: String(localized: "Switched to \(instance.name)")
       )
@@ -185,10 +184,10 @@ class AuthViewModel {
           serverURL: instance.serverURL,
           serverDisplayName: instance.displayName,
           authToken: instance.authToken,
-          authMethod: instance.resolvedAuthMethod,
+          authMethod: instance.authMethod,
           username: instance.username,
           isAdmin: false,
-          instanceId: instance.id.uuidString
+          instanceId: instance.instanceId
         )
 
         AppConfig.isLoggedIn = true

--- a/KMReader/Features/Book/Models/BookDisplayItem.swift
+++ b/KMReader/Features/Book/Models/BookDisplayItem.swift
@@ -1,0 +1,100 @@
+//
+// BookDisplayItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct BookDisplayItem: Equatable, Identifiable, Sendable {
+  let id: String
+  let instanceId: String
+  let book: Book
+  let downloadStatus: DownloadStatus
+  let readListIds: [String]
+
+  init(
+    instanceId: String,
+    book: Book,
+    downloadStatus: DownloadStatus,
+    readListIds: [String] = []
+  ) {
+    id = book.id
+    self.instanceId = instanceId
+    self.book = book
+    self.downloadStatus = downloadStatus
+    self.readListIds = readListIds
+  }
+
+  var bookId: String {
+    book.id
+  }
+
+  var seriesId: String {
+    book.seriesId
+  }
+
+  var seriesTitle: String {
+    book.seriesTitle
+  }
+
+  var created: Date {
+    book.created
+  }
+
+  var size: String {
+    book.size
+  }
+
+  var media: Media {
+    book.media
+  }
+
+  var mediaPagesCount: Int {
+    book.media.pagesCount
+  }
+
+  var metaTitle: String {
+    book.metadata.title
+  }
+
+  var metaNumber: String {
+    book.metadata.number
+  }
+
+  var metaReleaseDate: String? {
+    book.metadata.releaseDate
+  }
+
+  var progressPage: Int? {
+    book.readProgress?.page
+  }
+
+  var progressCompleted: Bool? {
+    book.readProgress?.completed
+  }
+
+  var completedLastReadText: String? {
+    guard isCompleted, let readDate = book.readProgress?.readDate else { return nil }
+    return readDate.formatted(.relative(presentation: .named, unitsStyle: .abbreviated))
+  }
+
+  var oneshot: Bool {
+    book.oneshot
+  }
+
+  var isUnavailable: Bool {
+    book.deleted
+  }
+
+  var isUnread: Bool {
+    book.isUnread
+  }
+
+  var isCompleted: Bool {
+    book.isCompleted
+  }
+
+  var isInProgress: Bool {
+    book.isInProgress
+  }
+}

--- a/KMReader/Features/Book/Services/KomgaBookStore.swift
+++ b/KMReader/Features/Book/Services/KomgaBookStore.swift
@@ -240,8 +240,9 @@ enum KomgaBookStore {
     }
   }
 
-  static func fetchBookIds(
+  nonisolated static func fetchBookIds(
     context: ModelContext,
+    instanceId: String = AppConfig.current.instanceId,
     libraryIds: [String]?,
     searchText: String,
     browseOpts: BookBrowseOptions,
@@ -249,7 +250,6 @@ enum KomgaBookStore {
     limit: Int,
     offlineOnly: Bool = false
   ) -> [String] {
-    let instanceId = AppConfig.current.instanceId
     let ids = libraryIds ?? []
     var descriptor = FetchDescriptor<KomgaBook>()
 
@@ -363,7 +363,7 @@ enum KomgaBookStore {
     }
   }
 
-  static func fetchKeepReadingBookIds(
+  nonisolated static func fetchKeepReadingBookIds(
     context: ModelContext,
     libraryIds: [String],
     offset: Int,
@@ -397,7 +397,7 @@ enum KomgaBookStore {
     }
   }
 
-  static func fetchRecentlyReleasedBookIds(
+  nonisolated static func fetchRecentlyReleasedBookIds(
     context: ModelContext,
     libraryIds: [String],
     offset: Int,
@@ -429,7 +429,7 @@ enum KomgaBookStore {
     }
   }
 
-  static func fetchRecentlyReadBookIds(
+  nonisolated static func fetchRecentlyReadBookIds(
     context: ModelContext,
     libraryIds: [String],
     offset: Int,
@@ -465,7 +465,7 @@ enum KomgaBookStore {
     }
   }
 
-  static func fetchRecentlyAddedBookIds(
+  nonisolated static func fetchRecentlyAddedBookIds(
     context: ModelContext,
     libraryIds: [String],
     offset: Int,

--- a/KMReader/Features/Book/ViewModels/BookViewModel.swift
+++ b/KMReader/Features/Book/ViewModels/BookViewModel.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-import SwiftData
 import SwiftUI
 
 @MainActor
@@ -16,7 +15,6 @@ class BookViewModel {
   private(set) var pagination = PaginationState<IdentifiedString>(pageSize: 50)
 
   func loadSeriesBooks(
-    context: ModelContext,
     seriesId: String,
     browseOpts: BookBrowseOptions,
     refresh: Bool = true
@@ -39,15 +37,18 @@ class BookViewModel {
     }
 
     if AppConfig.isOffline {
-      let books = KomgaBookStore.fetchSeriesBooks(
-        context: context,
+      guard let database = try? await DatabaseOperator.database() else {
+        guard loadID == pagination.loadID else { return }
+        applyPage(ids: [], moreAvailable: false)
+        return
+      }
+      let ids = await database.fetchSeriesBookIds(
         seriesId: seriesId,
+        browseOpts: browseOpts,
         page: pagination.currentPage,
-        size: pagination.pageSize,
-        browseOpts: browseOpts
+        size: pagination.pageSize
       )
       guard loadID == pagination.loadID else { return }
-      let ids = books.map { $0.id }
       applyPage(ids: ids, moreAvailable: ids.count == pagination.pageSize)
     } else {
       do {
@@ -74,26 +75,6 @@ class BookViewModel {
       _ = pagination.applyPage(wrappedIds)
     }
     pagination.advance(moreAvailable: moreAvailable)
-  }
-
-  func loadBook(context: ModelContext, id: String) async {
-    isLoading = true
-
-    if let cached = KomgaBookStore.fetchBook(context: context, id: id) {
-      currentBook = cached
-    }
-
-    do {
-      currentBook = try await SyncService.syncBook(bookId: id)
-    } catch {
-      if currentBook == nil {
-        ErrorManager.shared.alert(error: error)
-      }
-    }
-
-    withAnimation {
-      isLoading = false
-    }
   }
 
   func updatePageReadProgress(bookId: String, page: Int, completed: Bool = false) async {
@@ -135,7 +116,6 @@ class BookViewModel {
   }
 
   func loadBrowseBooks(
-    context: ModelContext,
     browseOpts: BookBrowseOptions,
     searchText: String = "",
     libraryIds: [String]? = nil,
@@ -161,8 +141,13 @@ class BookViewModel {
     }
 
     if AppConfig.isOffline || useLocalOnly {
-      let ids = KomgaBookStore.fetchBookIds(
-        context: context,
+      guard let database = try? await DatabaseOperator.database() else {
+        guard loadID == pagination.loadID else { return }
+        applyPage(ids: [], moreAvailable: false)
+        return
+      }
+      let ids = await database.fetchBrowseBookIds(
+        instanceId: AppConfig.current.instanceId,
         libraryIds: libraryIds,
         searchText: searchText,
         browseOpts: browseOpts,
@@ -205,7 +190,6 @@ class BookViewModel {
   }
 
   func loadReadListBooks(
-    context: ModelContext,
     readListId: String,
     browseOpts: ReadListBookBrowseOptions,
     libraryIds: [String]? = nil,
@@ -231,15 +215,18 @@ class BookViewModel {
     }
 
     if AppConfig.isOffline {
-      let books = KomgaBookStore.fetchReadListBooks(
-        context: context,
+      guard let database = try? await DatabaseOperator.database() else {
+        guard loadID == pagination.loadID else { return }
+        applyPage(ids: [], moreAvailable: false)
+        return
+      }
+      let ids = await database.fetchReadListBookIds(
         readListId: readListId,
+        browseOpts: browseOpts,
         page: pagination.currentPage,
-        size: pagination.pageSize,
-        browseOpts: browseOpts
+        size: pagination.pageSize
       )
       guard loadID == pagination.loadID else { return }
-      let ids = books.map { $0.id }
       applyPage(ids: ids, moreAvailable: ids.count == pagination.pageSize)
     } else {
       do {

--- a/KMReader/Features/Book/Views/BookCardView.swift
+++ b/KMReader/Features/Book/Views/BookCardView.swift
@@ -3,12 +3,12 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct BookCardView: View {
-  @Bindable var komgaBook: KomgaBook
+  let item: BookDisplayItem
   var onReadBook: ((Bool) -> Void)? = nil
+  var onMutationCompleted: (() -> Void)? = nil
   var showSeriesTitle: Bool = false
   var showSeriesNavigation: Bool = true
 
@@ -23,24 +23,24 @@ struct BookCardView: View {
   @State private var showEditSheet = false
 
   private var progress: Double {
-    guard let progressPage = komgaBook.progressPage else { return 0 }
-    guard komgaBook.mediaPagesCount > 0 else { return 0 }
-    return Double(progressPage) / Double(komgaBook.mediaPagesCount)
+    guard let progressPage = item.progressPage else { return 0 }
+    guard item.mediaPagesCount > 0 else { return 0 }
+    return Double(progressPage) / Double(item.mediaPagesCount)
   }
 
   var shouldShowSeriesTitle: Bool {
-    return showSeriesTitle && showBookCardSeriesTitle && !komgaBook.seriesTitle.isEmpty
+    return showSeriesTitle && showBookCardSeriesTitle && !item.seriesTitle.isEmpty
   }
 
   var bookTitleLine: String {
-    if komgaBook.oneshot {
-      return komgaBook.metaTitle
+    if item.oneshot {
+      return item.metaTitle
     }
-    return String("\(komgaBook.metaNumber) - \(komgaBook.metaTitle)")
+    return String("\(item.metaNumber) - \(item.metaTitle)")
   }
 
   var bookTitleLineLimit: Int {
-    (shouldShowSeriesTitle || komgaBook.oneshot) ? 1 : 2
+    (shouldShowSeriesTitle || item.oneshot) ? 1 : 2
   }
 
   var contentSpacing: CGFloat {
@@ -54,17 +54,17 @@ struct BookCardView: View {
   }
 
   private var coverBlurRadius: CGFloat {
-    thumbnailBlurUnreadCovers && komgaBook.isUnread ? CoverBlurStyle.unreadRadius : 0
+    thumbnailBlurUnreadCovers && item.isUnread ? CoverBlurStyle.unreadRadius : 0
   }
 
   private var completedMetaText: String {
-    komgaBook.completedLastReadText ?? "\(komgaBook.mediaPagesCount) pages"
+    item.completedLastReadText ?? "\(item.mediaPagesCount) pages"
   }
 
   var body: some View {
     VStack(alignment: .leading, spacing: contentSpacing) {
       ThumbnailImage(
-        id: komgaBook.bookId,
+        id: item.bookId,
         type: .book,
         shadowStyle: .platform,
         contentBlurRadius: coverBlurRadius,
@@ -79,15 +79,15 @@ struct BookCardView: View {
             }
           }
 
-          if komgaBook.isUnread && thumbnailShowUnreadIndicator {
+          if item.isUnread && thumbnailShowUnreadIndicator {
             UnreadIndicator()
               .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
           }
         }
       } menu: {
         BookContextMenu(
-          book: komgaBook.toBook(),
-          downloadStatus: komgaBook.downloadStatus,
+          book: item.book,
+          downloadStatus: item.downloadStatus,
           onReadBook: onReadBook,
           onShowReadListPicker: {
             showReadListPicker = true
@@ -98,24 +98,25 @@ struct BookCardView: View {
           onEditRequested: {
             showEditSheet = true
           },
+          onMutationCompleted: onMutationCompleted,
           showSeriesNavigation: showSeriesNavigation
         )
       }
 
       if thumbnailShowProgressBar && !cardTextOverlayMode {
         ReadingProgressBar(progress: progress, type: .card)
-          .opacity(komgaBook.isInProgress ? 1 : 0)
+          .opacity(item.isInProgress ? 1 : 0)
       }
 
       if !cardTextOverlayMode && !coverOnlyCards {
         VStack(alignment: .leading) {
-          if komgaBook.oneshot {
+          if item.oneshot {
             Text("Oneshot")
               .font(.caption)
               .foregroundColor(.blue)
               .lineLimit(1)
           } else if shouldShowSeriesTitle {
-            Text(komgaBook.seriesTitle)
+            Text(item.seriesTitle)
               .font(.caption)
               .foregroundColor(.secondary)
               .lineLimit(1)
@@ -125,8 +126,8 @@ struct BookCardView: View {
             .lineLimit(bookTitleLineLimit)
 
           HStack(spacing: 4) {
-            let mediaStatus = komgaBook.media?.statusValue ?? .unknown
-            if komgaBook.isUnavailable {
+            let mediaStatus = item.media.statusValue
+            if item.isUnavailable {
               Text("Unavailable")
                 .foregroundColor(.red)
             } else if mediaStatus != .ready {
@@ -142,13 +143,13 @@ struct BookCardView: View {
                   .foregroundColor(.secondary)
                   .font(.caption2)
               }
-              Text(progress == 1 ? completedMetaText : "\(komgaBook.mediaPagesCount) pages")
+              Text(progress == 1 ? completedMetaText : "\(item.mediaPagesCount) pages")
                 .lineLimit(1)
             }
-            if komgaBook.downloadStatus != .notDownloaded {
+            if item.downloadStatus != .notDownloaded {
               Spacer()
-              Image(systemName: komgaBook.downloadStatus.displayIcon)
-                .foregroundColor(komgaBook.downloadStatus.displayColor)
+              Image(systemName: item.downloadStatus.displayIcon)
+                .foregroundColor(item.downloadStatus.displayColor)
                 .font(.caption2)
             }
           }
@@ -168,14 +169,14 @@ struct BookCardView: View {
     }
     .sheet(isPresented: $showReadListPicker) {
       ReadListPickerSheet(
-        bookId: komgaBook.bookId,
+        bookId: item.bookId,
         onSelect: { readListId in
           addToReadList(readListId: readListId)
         }
       )
     }
     .sheet(isPresented: $showEditSheet) {
-      BookEditSheet(book: komgaBook.toBook())
+      BookEditSheet(book: item.book)
     }
 
   }
@@ -183,18 +184,18 @@ struct BookCardView: View {
   @ViewBuilder
   private var overlayTextContent: some View {
     let style = CardOverlayTextStyle.standard
-    let showDownloadIcon = komgaBook.downloadStatus != .notDownloaded
-    let showProgressBar = komgaBook.isInProgress && thumbnailShowProgressBar
+    let showDownloadIcon = item.downloadStatus != .notDownloaded
+    let showProgressBar = item.isInProgress && thumbnailShowProgressBar
 
     CardOverlayTextStack(
       title: bookTitleLine,
-      subtitle: (shouldShowSeriesTitle && !komgaBook.oneshot) ? komgaBook.seriesTitle : nil,
+      subtitle: (shouldShowSeriesTitle && !item.oneshot) ? item.seriesTitle : nil,
       titleLineLimit: bookTitleLineLimit,
       style: style
     ) {
       HStack(spacing: 4) {
-        let mediaStatus = komgaBook.media?.statusValue ?? .unknown
-        if komgaBook.isUnavailable {
+        let mediaStatus = item.media.statusValue
+        if item.isUnavailable {
           Text("Unavailable")
             .foregroundColor(.red)
         } else if mediaStatus != .ready {
@@ -210,13 +211,13 @@ struct BookCardView: View {
               .foregroundColor(style.secondaryColor)
               .font(.caption2)
           }
-          Text(progress == 1 ? completedMetaText : "\(komgaBook.mediaPagesCount) pages")
+          Text(progress == 1 ? completedMetaText : "\(item.mediaPagesCount) pages")
             .lineLimit(1)
         }
         if showDownloadIcon && !showProgressBar {
           Spacer()
-          Image(systemName: komgaBook.downloadStatus.displayIcon)
-            .foregroundColor(komgaBook.downloadStatus.displayColor)
+          Image(systemName: item.downloadStatus.displayIcon)
+            .foregroundColor(item.downloadStatus.displayColor)
             .font(.caption2)
         }
       }
@@ -227,8 +228,8 @@ struct BookCardView: View {
             .padding(.top, 2)
             .layoutPriority(1)
           if showDownloadIcon {
-            Image(systemName: komgaBook.downloadStatus.displayIcon)
-              .foregroundColor(komgaBook.downloadStatus.displayColor)
+            Image(systemName: item.downloadStatus.displayIcon)
+              .foregroundColor(item.downloadStatus.displayColor)
               .font(.caption2)
           }
         }
@@ -241,10 +242,11 @@ struct BookCardView: View {
       do {
         try await ReadListService.addBooksToReadList(
           readListId: readListId,
-          bookIds: [komgaBook.bookId]
+          bookIds: [item.bookId]
         )
         ErrorManager.shared.notify(
           message: String(localized: "notification.book.booksAddedToReadList"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -254,9 +256,10 @@ struct BookCardView: View {
   private func deleteBook() {
     Task {
       do {
-        try await BookService.deleteBook(bookId: komgaBook.bookId)
-        await CacheManager.clearCache(forBookId: komgaBook.bookId)
+        try await BookService.deleteBook(bookId: item.bookId)
+        await CacheManager.clearCache(forBookId: item.bookId)
         ErrorManager.shared.notify(message: String(localized: "notification.book.deleted"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }

--- a/KMReader/Features/Book/Views/BookContextMenu.swift
+++ b/KMReader/Features/Book/Views/BookContextMenu.swift
@@ -13,6 +13,7 @@ struct BookContextMenu: View {
   var onShowReadListPicker: (() -> Void)? = nil
   var onDeleteRequested: (() -> Void)? = nil
   var onEditRequested: (() -> Void)? = nil
+  var onMutationCompleted: (() -> Void)? = nil
   var showSeriesNavigation: Bool = true
 
   @AppStorage("currentAccount") private var current: Current = .init()
@@ -106,6 +107,7 @@ struct BookContextMenu: View {
           ErrorManager.shared.notify(
             message: downloadNotificationMessage(for: previousStatus)
           )
+          onMutationCompleted?()
         }
       } label: {
         Label(downloadStatus.menuLabel, systemImage: downloadStatus.menuIcon)
@@ -151,6 +153,7 @@ struct BookContextMenu: View {
         try await BookService.markAsRead(bookId: bookId)
         _ = try await SyncService.syncBookAndSeries(bookId: bookId, seriesId: book.seriesId)
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedRead"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -163,6 +166,7 @@ struct BookContextMenu: View {
         try await BookService.markAsUnread(bookId: bookId)
         _ = try await SyncService.syncBook(bookId: bookId)
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedUnread"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -187,6 +191,7 @@ struct BookContextMenu: View {
         try await BookService.refreshMetadata(bookId: bookId)
         ErrorManager.shared.notify(
           message: String(localized: "notification.book.metadataRefreshed"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }

--- a/KMReader/Features/Book/Views/BookDetailView.swift
+++ b/KMReader/Features/Book/Views/BookDetailView.swift
@@ -192,6 +192,8 @@ struct BookDetailView: View {
 
   @MainActor
   private func loadBook() async {
+    await loadLocalBook()
+
     do {
       _ = try await SyncService.syncBook(bookId: bookId)
       await SyncService.syncBookReadLists(bookId: bookId)

--- a/KMReader/Features/Book/Views/BookDetailView.swift
+++ b/KMReader/Features/Book/Views/BookDetailView.swift
@@ -4,7 +4,6 @@
 //
 
 import Flow
-import SwiftData
 import SwiftUI
 
 struct BookDetailView: View {
@@ -13,8 +12,7 @@ struct BookDetailView: View {
   @Environment(\.dismiss) private var dismiss
   @AppStorage("currentAccount") private var current: Current = .init()
 
-  @Query private var komgaBooks: [KomgaBook]
-
+  @State private var item: BookDisplayItem?
   @State private var hasError = false
   @State private var showDeleteConfirmation = false
   @State private var showReadListPicker = false
@@ -22,22 +20,14 @@ struct BookDetailView: View {
 
   init(bookId: String) {
     self.bookId = bookId
-    let compositeId = CompositeID.generate(id: bookId)
-    _komgaBooks = Query(filter: #Predicate<KomgaBook> { $0.id == compositeId })
   }
 
-  /// The KomgaBook from SwiftData (reactive).
-  private var komgaBook: KomgaBook? {
-    komgaBooks.first
-  }
-
-  /// Convert to API Book type for compatibility with existing components.
   private var book: Book? {
-    komgaBook?.toBook()
+    item?.book
   }
 
   private var downloadStatus: DownloadStatus {
-    komgaBook?.downloadStatus ?? .notDownloaded
+    item?.downloadStatus ?? .notDownloaded
   }
 
   private var navigationTitle: String {
@@ -63,8 +53,8 @@ struct BookDetailView: View {
             inSheet: false
           )
 
-          if let komgaBook = komgaBook {
-            BookReadListsSection(readListIds: komgaBook.readListIds)
+          if let item {
+            BookReadListsSection(readListIds: item.readListIds)
           }
         } else if hasError {
           VStack(spacing: 16) {
@@ -203,19 +193,30 @@ struct BookDetailView: View {
   @MainActor
   private func loadBook() async {
     do {
-      // Sync from network to SwiftData (book property will update reactively)
       _ = try await SyncService.syncBook(bookId: bookId)
       await SyncService.syncBookReadLists(bookId: bookId)
     } catch {
       if case APIError.notFound = error {
         dismiss()
       } else {
-        if komgaBook == nil {
+        if item == nil {
           hasError = true
           ErrorManager.shared.alert(error: error)
         }
       }
     }
+    await loadLocalBook()
+  }
+
+  private func loadLocalBook() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      item = nil
+      return
+    }
+    item = try? await database.fetchBookDisplayItem(
+      bookId: bookId,
+      instanceId: current.instanceId
+    )
   }
 
   private func addToReadList(readListId: String) {

--- a/KMReader/Features/Book/Views/BookItemView.swift
+++ b/KMReader/Features/Book/Views/BookItemView.swift
@@ -6,9 +6,10 @@
 import SwiftUI
 
 struct BookItemView: View {
-  @Bindable var book: KomgaBook
+  let item: BookDisplayItem
   let layout: BrowseLayoutMode
   let onReadBook: (Bool) -> Void
+  var onMutationCompleted: (() -> Void)? = nil
   var showSeriesTitle: Bool = true
   var showSeriesNavigation: Bool = true
 
@@ -16,15 +17,17 @@ struct BookItemView: View {
     switch layout {
     case .grid:
       BookCardView(
-        komgaBook: book,
+        item: item,
         onReadBook: onReadBook,
+        onMutationCompleted: onMutationCompleted,
         showSeriesTitle: showSeriesTitle,
         showSeriesNavigation: showSeriesNavigation
       )
     case .list:
       BookRowView(
-        komgaBook: book,
+        item: item,
         onReadBook: onReadBook,
+        onMutationCompleted: onMutationCompleted,
         showSeriesTitle: showSeriesTitle,
         showSeriesNavigation: showSeriesNavigation
       )

--- a/KMReader/Features/Book/Views/BookQueryItemView.swift
+++ b/KMReader/Features/Book/Views/BookQueryItemView.swift
@@ -3,10 +3,9 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
-/// Wrapper view that accepts only bookId and uses @Query to fetch the book reactively.
+/// Wrapper view that accepts only bookId and fetches a book display projection.
 struct BookQueryItemView: View {
   let bookId: String
   let layout: BrowseLayoutMode
@@ -14,8 +13,9 @@ struct BookQueryItemView: View {
   var showSeriesNavigation: Bool = true
   var readListContext: ReaderReadListContext? = nil
 
+  @AppStorage("currentAccount") private var current: Current = .init()
   @Environment(\.readerActions) private var readerActions
-  @Query private var komgaBooks: [KomgaBook]
+  @State private var item: BookDisplayItem?
 
   init(
     bookId: String,
@@ -30,46 +30,64 @@ struct BookQueryItemView: View {
     self.showSeriesNavigation = showSeriesNavigation
     self.readListContext = readListContext
 
-    let compositeId = CompositeID.generate(id: bookId)
-    _komgaBooks = Query(filter: #Predicate<KomgaBook> { $0.id == compositeId })
-  }
-
-  private var komgaBook: KomgaBook? {
-    komgaBooks.first
   }
 
   var body: some View {
-    if let book = komgaBook {
-      switch layout {
-      case .grid:
-        BookCardView(
-          komgaBook: book,
-          onReadBook: { incognito in
-            readerActions.open(
-              book: book.toBook(),
-              incognito: incognito,
-              readListContext: readListContext
-            )
-          },
-          showSeriesTitle: showSeriesTitle,
-          showSeriesNavigation: showSeriesNavigation
-        )
-      case .list:
-        BookRowView(
-          komgaBook: book,
-          onReadBook: { incognito in
-            readerActions.open(
-              book: book.toBook(),
-              incognito: incognito,
-              readListContext: readListContext
-            )
-          },
-          showSeriesTitle: showSeriesTitle,
-          showSeriesNavigation: showSeriesNavigation
-        )
+    Group {
+      if let item {
+        switch layout {
+        case .grid:
+          BookCardView(
+            item: item,
+            onReadBook: { incognito in
+              readerActions.open(
+                book: item.book,
+                incognito: incognito,
+                readListContext: readListContext
+              )
+            },
+            onMutationCompleted: reloadItem,
+            showSeriesTitle: showSeriesTitle,
+            showSeriesNavigation: showSeriesNavigation
+          )
+        case .list:
+          BookRowView(
+            item: item,
+            onReadBook: { incognito in
+              readerActions.open(
+                book: item.book,
+                incognito: incognito,
+                readListContext: readListContext
+              )
+            },
+            onMutationCompleted: reloadItem,
+            showSeriesTitle: showSeriesTitle,
+            showSeriesNavigation: showSeriesNavigation
+          )
+        }
+      } else {
+        CardPlaceholder(layout: layout, kind: .book)
       }
-    } else {
-      CardPlaceholder(layout: layout, kind: .book)
     }
+    .task(id: "\(current.instanceId)|\(bookId)") {
+      await loadItem()
+    }
+  }
+
+  private func reloadItem() {
+    Task {
+      await loadItem()
+    }
+  }
+
+  private func loadItem() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      item = nil
+      return
+    }
+    item = try? await database.fetchBookDisplayItem(
+      bookId: bookId,
+      instanceId: current.instanceId
+    )
   }
 }

--- a/KMReader/Features/Book/Views/BookQueryItemView.swift
+++ b/KMReader/Features/Book/Views/BookQueryItemView.swift
@@ -72,6 +72,11 @@ struct BookQueryItemView: View {
     .task(id: "\(current.instanceId)|\(bookId)") {
       await loadItem()
     }
+    .onReceive(NotificationCenter.default.publisher(for: .bookProjectionDidChange)) {
+      notification in
+      guard notification.userInfo?["bookId"] as? String == bookId else { return }
+      reloadItem()
+    }
   }
 
   private func reloadItem() {

--- a/KMReader/Features/Book/Views/BookReadListsSection.swift
+++ b/KMReader/Features/Book/Views/BookReadListsSection.swift
@@ -3,53 +3,76 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct BookReadListsSection: View {
-  @Query private var komgaReadLists: [KomgaReadList]
+  @AppStorage("currentAccount") private var current: Current = .init()
 
-  init(readListIds: [String]) {
-    let instanceId = AppConfig.current.instanceId
-    _komgaReadLists = Query(
-      filter: #Predicate<KomgaReadList> {
-        $0.instanceId == instanceId && readListIds.contains($0.readListId)
-      })
-  }
+  let readListIds: [String]
 
-  private var readLists: [ReadList] {
-    komgaReadLists.map { $0.toReadList() }
+  @State private var readLists: [SidebarReadListItem] = []
+
+  private var readListIdsKey: String {
+    readListIds.sorted().joined(separator: ",")
   }
 
   var body: some View {
-    if !readLists.isEmpty {
-      VStack(alignment: .leading, spacing: 6) {
-        HStack(spacing: 4) {
-          Image(systemName: ContentIcon.readList)
-            .font(.caption)
-          Text("Read Lists")
-            .font(.headline)
-        }
-        .foregroundColor(.secondary)
+    Group {
+      if !readLists.isEmpty {
+        VStack(alignment: .leading, spacing: 6) {
+          HStack(spacing: 4) {
+            Image(systemName: ContentIcon.readList)
+              .font(.caption)
+            Text("Read Lists")
+              .font(.headline)
+          }
+          .foregroundColor(.secondary)
 
-        VStack(alignment: .leading, spacing: 8) {
-          ForEach(readLists) { readList in
-            NavigationLink(value: NavDestination.readListDetail(readListId: readList.id)) {
-              HStack {
-                Label(readList.name, systemImage: ContentIcon.readList)
-                  .foregroundColor(.primary)
-                Spacer()
-                Image(systemName: "chevron.right")
-                  .font(.caption)
-                  .foregroundColor(.secondary)
-              }
-              .padding()
-              .background(Color.secondary.opacity(0.1))
-              .cornerRadius(16)
-            }.adaptiveButtonStyle(.plain)
+          VStack(alignment: .leading, spacing: 8) {
+            ForEach(readLists) { readList in
+              NavigationLink(value: NavDestination.readListDetail(readListId: readList.readListId)) {
+                HStack {
+                  Label(readList.name, systemImage: ContentIcon.readList)
+                    .foregroundColor(.primary)
+                  Spacer()
+                  Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                }
+                .padding()
+                .background(Color.secondary.opacity(0.1))
+                .cornerRadius(16)
+              }.adaptiveButtonStyle(.plain)
+            }
           }
         }
       }
+    }
+    .task(id: "\(current.instanceId)|\(readListIdsKey)") {
+      await loadReadLists()
+    }
+  }
+
+  private func loadReadLists() async {
+    let instanceId = current.instanceId
+    guard !instanceId.isEmpty, !readListIds.isEmpty else {
+      if !readLists.isEmpty {
+        readLists = []
+      }
+      return
+    }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedReadLists = try await database.fetchSidebarReadLists(
+        instanceId: instanceId,
+        readListIds: Set(readListIds)
+      )
+      if readLists != loadedReadLists {
+        readLists = loadedReadLists
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
     }
   }
 }

--- a/KMReader/Features/Book/Views/BookRowView.swift
+++ b/KMReader/Features/Book/Views/BookRowView.swift
@@ -3,12 +3,12 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct BookRowView: View {
-  @Bindable var komgaBook: KomgaBook
+  let item: BookDisplayItem
   var onReadBook: ((Bool) -> Void)?
+  var onMutationCompleted: (() -> Void)? = nil
   var showSeriesTitle: Bool = false
   var showSeriesNavigation: Bool = true
 
@@ -19,28 +19,28 @@ struct BookRowView: View {
   @State private var showEditSheet = false
 
   private var progress: Double {
-    guard let progressPage = komgaBook.progressPage else { return 0 }
-    guard komgaBook.mediaPagesCount > 0 else { return 0 }
-    return Double(progressPage) / Double(komgaBook.mediaPagesCount)
+    guard let progressPage = item.progressPage else { return 0 }
+    guard item.mediaPagesCount > 0 else { return 0 }
+    return Double(progressPage) / Double(item.mediaPagesCount)
   }
 
   var shouldShowSeriesTitle: Bool {
-    return showSeriesTitle && !komgaBook.seriesTitle.isEmpty
+    return showSeriesTitle && !item.seriesTitle.isEmpty
   }
 
   var bookTitleLine: String {
-    if komgaBook.oneshot {
-      return komgaBook.metaTitle
+    if item.oneshot {
+      return item.metaTitle
     }
-    return String("\(komgaBook.metaNumber) - \(komgaBook.metaTitle)")
+    return String("\(item.metaNumber) - \(item.metaTitle)")
   }
 
   var bookTitleLineLimit: Int {
-    (shouldShowSeriesTitle || komgaBook.oneshot) ? 1 : 2
+    (shouldShowSeriesTitle || item.oneshot) ? 1 : 2
   }
 
   private var coverBlurRadius: CGFloat {
-    thumbnailBlurUnreadCovers && komgaBook.isUnread ? CoverBlurStyle.unreadRadius : 0
+    thumbnailBlurUnreadCovers && item.isUnread ? CoverBlurStyle.unreadRadius : 0
   }
 
   var body: some View {
@@ -49,7 +49,7 @@ struct BookRowView: View {
         onReadBook?(false)
       } label: {
         ThumbnailImage(
-          id: komgaBook.bookId,
+          id: item.bookId,
           type: .book,
           contentBlurRadius: coverBlurRadius,
           width: 60
@@ -61,18 +61,18 @@ struct BookRowView: View {
           onReadBook?(false)
         } label: {
           VStack(alignment: .leading, spacing: 4) {
-            if komgaBook.oneshot {
+            if item.oneshot {
               Text("Oneshot")
                 .font(.footnote)
                 .foregroundColor(.blue)
             } else if shouldShowSeriesTitle {
-              Text(komgaBook.seriesTitle)
+              Text(item.seriesTitle)
                 .font(.footnote)
                 .foregroundColor(.secondary)
                 .lineLimit(1)
             }
-            Text("#\(komgaBook.metaNumber) - \(komgaBook.metaTitle)")
-              .foregroundColor(komgaBook.isCompleted ? .secondary : .primary)
+            Text("#\(item.metaNumber) - \(item.metaTitle)")
+              .foregroundColor(item.isCompleted ? .secondary : .primary)
               .lineLimit(bookTitleLineLimit)
           }
         }.adaptiveButtonStyle(.plain)
@@ -80,21 +80,21 @@ struct BookRowView: View {
         HStack {
           VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 4) {
-              if let releaseDate = komgaBook.metaReleaseDate, !releaseDate.isEmpty {
+              if let releaseDate = item.metaReleaseDate, !releaseDate.isEmpty {
                 Label(releaseDate, systemImage: "calendar")
               } else {
                 Label(
-                  komgaBook.created.formatted(date: .abbreviated, time: .omitted),
+                  item.created.formatted(date: .abbreviated, time: .omitted),
                   systemImage: "clock")
               }
-              if let progressPage = komgaBook.progressPage,
-                let progressCompleted = komgaBook.progressCompleted
+              if let progressPage = item.progressPage,
+                let progressCompleted = item.progressCompleted
               {
                 Text("•")
                 if progressCompleted {
                   Image(systemName: "checkmark.circle.fill")
                     .foregroundColor(.green)
-                  if let completedLastReadText = komgaBook.completedLastReadText {
+                  if let completedLastReadText = item.completedLastReadText {
                     Text(completedLastReadText)
                   }
                 } else {
@@ -111,18 +111,18 @@ struct BookRowView: View {
             .foregroundColor(.secondary)
 
             HStack(spacing: 4) {
-              let mediaStatus = komgaBook.media?.statusValue ?? .unknown
-              if komgaBook.isUnavailable {
+              let mediaStatus = item.media.statusValue
+              if item.isUnavailable {
                 Text("Unavailable")
                   .foregroundColor(.red)
               } else if mediaStatus != .ready {
                 Text(mediaStatus.label)
                   .foregroundColor(mediaStatus.color)
               } else {
-                Label("\(komgaBook.mediaPagesCount) pages", systemImage: "book.pages")
+                Label("\(item.mediaPagesCount) pages", systemImage: "book.pages")
                   .foregroundColor(.secondary)
                 Text("•").foregroundColor(.secondary)
-                Label(komgaBook.size, systemImage: "doc")
+                Label(item.size, systemImage: "doc")
                   .foregroundColor(.secondary)
               }
             }.font(.footnote)
@@ -130,14 +130,14 @@ struct BookRowView: View {
 
           Spacer()
 
-          if komgaBook.downloadStatus != .notDownloaded {
-            Image(systemName: komgaBook.downloadStatus.displayIcon)
-              .foregroundColor(komgaBook.downloadStatus.displayColor)
+          if item.downloadStatus != .notDownloaded {
+            Image(systemName: item.downloadStatus.displayIcon)
+              .foregroundColor(item.downloadStatus.displayColor)
           }
           EllipsisMenuButton {
             BookContextMenu(
-              book: komgaBook.toBook(),
-              downloadStatus: komgaBook.downloadStatus,
+              book: item.book,
+              downloadStatus: item.downloadStatus,
               onReadBook: onReadBook,
               onShowReadListPicker: {
                 showReadListPicker = true
@@ -148,9 +148,10 @@ struct BookRowView: View {
               onEditRequested: {
                 showEditSheet = true
               },
+              onMutationCompleted: onMutationCompleted,
               showSeriesNavigation: showSeriesNavigation
             )
-            .id(komgaBook.bookId)
+            .id(item.bookId)
           }
         }
       }
@@ -165,14 +166,14 @@ struct BookRowView: View {
     }
     .sheet(isPresented: $showReadListPicker) {
       ReadListPickerSheet(
-        bookId: komgaBook.bookId,
+        bookId: item.bookId,
         onSelect: { readListId in
           addToReadList(readListId: readListId)
         }
       )
     }
     .sheet(isPresented: $showEditSheet) {
-      BookEditSheet(book: komgaBook.toBook())
+      BookEditSheet(book: item.book)
     }
 
   }
@@ -182,10 +183,11 @@ struct BookRowView: View {
       do {
         try await ReadListService.addBooksToReadList(
           readListId: readListId,
-          bookIds: [komgaBook.bookId]
+          bookIds: [item.bookId]
         )
         ErrorManager.shared.notify(
           message: String(localized: "notification.book.booksAddedToReadList"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -195,9 +197,10 @@ struct BookRowView: View {
   private func deleteBook() {
     Task {
       do {
-        try await BookService.deleteBook(bookId: komgaBook.bookId)
-        await CacheManager.clearCache(forBookId: komgaBook.bookId)
+        try await BookService.deleteBook(bookId: item.bookId)
+        await CacheManager.clearCache(forBookId: item.bookId)
         ErrorManager.shared.notify(message: String(localized: "notification.book.deleted"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }

--- a/KMReader/Features/Book/Views/BookSelectionItemView.swift
+++ b/KMReader/Features/Book/Views/BookSelectionItemView.swift
@@ -3,10 +3,9 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
-/// View for book selection mode that accepts only bookId and uses @Query to fetch the book.
+/// View for book selection mode that accepts only bookId and fetches a book display projection.
 struct BookSelectionItemView: View {
   let bookId: String
   let layout: BrowseLayoutMode
@@ -14,7 +13,8 @@ struct BookSelectionItemView: View {
   let refreshBooks: () -> Void
   var showSeriesTitle: Bool = true
 
-  @Query private var komgaBooks: [KomgaBook]
+  @AppStorage("currentAccount") private var current: Current = .init()
+  @State private var item: BookDisplayItem?
 
   init(
     bookId: String,
@@ -29,13 +29,6 @@ struct BookSelectionItemView: View {
     self.refreshBooks = refreshBooks
     self.showSeriesTitle = showSeriesTitle
 
-    let instanceId = AppConfig.current.instanceId
-    let compositeId = CompositeID.generate(instanceId: instanceId, id: bookId)
-    _komgaBooks = Query(filter: #Predicate<KomgaBook> { $0.id == compositeId })
-  }
-
-  private var komgaBook: KomgaBook? {
-    komgaBooks.first
   }
 
   private var isSelected: Bool {
@@ -43,43 +36,59 @@ struct BookSelectionItemView: View {
   }
 
   var body: some View {
-    if let book = komgaBook {
-      Group {
-        switch layout {
-        case .grid:
-          BookCardView(
-            komgaBook: book,
-            onReadBook: { _ in },
-            showSeriesTitle: showSeriesTitle
-          )
-        case .list:
-          BookRowView(
-            komgaBook: book,
-            onReadBook: { _ in },
-            showSeriesTitle: showSeriesTitle
-          )
-        }
-      }
-      .allowsHitTesting(false)
-      .scaleEffect(isSelected ? 0.96 : 1.0)
-      .overlay {
-        if isSelected {
-          RoundedRectangle(cornerRadius: 12)
-            .stroke(Color.accentColor, lineWidth: 2)
-        }
-      }
-      .contentShape(Rectangle())
-      .highPriorityGesture(
-        TapGesture().onEnded {
-          withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-            if isSelected {
-              selectedBookIds.remove(bookId)
-            } else {
-              selectedBookIds.insert(bookId)
-            }
+    Group {
+      if let item {
+        Group {
+          switch layout {
+          case .grid:
+            BookCardView(
+              item: item,
+              onReadBook: { _ in },
+              showSeriesTitle: showSeriesTitle
+            )
+          case .list:
+            BookRowView(
+              item: item,
+              onReadBook: { _ in },
+              showSeriesTitle: showSeriesTitle
+            )
           }
         }
-      )
+        .allowsHitTesting(false)
+        .scaleEffect(isSelected ? 0.96 : 1.0)
+        .overlay {
+          if isSelected {
+            RoundedRectangle(cornerRadius: 12)
+              .stroke(Color.accentColor, lineWidth: 2)
+          }
+        }
+        .contentShape(Rectangle())
+        .highPriorityGesture(
+          TapGesture().onEnded {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+              if isSelected {
+                selectedBookIds.remove(bookId)
+              } else {
+                selectedBookIds.insert(bookId)
+              }
+            }
+          }
+        )
+      }
     }
+    .task(id: "\(current.instanceId)|\(bookId)") {
+      await loadItem()
+    }
+  }
+
+  private func loadItem() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      item = nil
+      return
+    }
+    item = try? await database.fetchBookDisplayItem(
+      bookId: bookId,
+      instanceId: current.instanceId
+    )
   }
 }

--- a/KMReader/Features/Book/Views/BooksBrowseView.swift
+++ b/KMReader/Features/Book/Views/BooksBrowseView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct BooksBrowseView: View {
@@ -13,8 +12,6 @@ struct BooksBrowseView: View {
   let metadataFilter: MetadataFilterConfig?
   @Binding var showFilterSheet: Bool
   @Binding var showSavedFilters: Bool
-
-  @Environment(\.modelContext) private var modelContext
 
   @AppStorage("bookBrowseOptions") private var storedBrowseOpts: BookBrowseOptions = BookBrowseOptions()
   @State private var browseOpts: BookBrowseOptions = BookBrowseOptions()
@@ -93,7 +90,6 @@ struct BooksBrowseView: View {
     let effectiveBrowseOpts =
       (searchIgnoreFilters && !searchText.isEmpty) ? BookBrowseOptions() : browseOpts
     await viewModel.loadBrowseBooks(
-      context: modelContext,
       browseOpts: effectiveBrowseOpts,
       searchText: searchText,
       libraryIds: libraryIds,

--- a/KMReader/Features/Book/Views/BooksQueryView.swift
+++ b/KMReader/Features/Book/Views/BooksQueryView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct BooksQueryView: View {
@@ -16,7 +15,6 @@ struct BooksQueryView: View {
   let offlineOnly: Bool
 
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
-  @Environment(\.modelContext) private var modelContext
 
   private var columns: [GridItem] {
     LayoutConfig.adaptiveColumns(for: gridDensity)
@@ -97,7 +95,6 @@ struct BooksQueryView: View {
   private func loadBooks(refresh: Bool) {
     Task {
       await viewModel.loadBrowseBooks(
-        context: modelContext,
         browseOpts: browseOpts,
         searchText: searchText,
         libraryIds: libraryIds,

--- a/KMReader/Features/Book/Views/ListViews/BooksListViewForReadList.swift
+++ b/KMReader/Features/Book/Views/ListViews/BooksListViewForReadList.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 // Books list view for read list
@@ -21,17 +20,11 @@ struct BooksListViewForReadList: View {
   @State private var selectedBookIds: Set<String> = []
   @State private var isSelectionMode = false
   @State private var isDeleting = false
-  @Environment(\.modelContext) private var modelContext
-
-  @Query private var readLists: [KomgaReadList]
-
-  private var readList: KomgaReadList? {
-    readLists.first
-  }
+  @State private var readListItem: ReadListDisplayItem?
 
   private var readListContext: ReaderReadListContext? {
-    guard let readList else { return nil }
-    return ReaderReadListContext(id: readList.readListId, name: readList.name)
+    guard let readListItem else { return nil }
+    return ReaderReadListContext(id: readListItem.readListId, name: readListItem.name)
   }
 
   init(
@@ -42,9 +35,6 @@ struct BooksListViewForReadList: View {
     self.readListId = readListId
     self._showFilterSheet = showFilterSheet
     self._showSavedFilters = showSavedFilters
-
-    let compositeId = CompositeID.generate(id: readListId)
-    _readLists = Query(filter: #Predicate<KomgaReadList> { $0.id == compositeId })
   }
 
   private var supportsSelectionMode: Bool {
@@ -101,10 +91,10 @@ struct BooksListViewForReadList: View {
       if supportsSelectionMode && isSelectionMode {
         SelectionToolbar(
           selectedCount: selectedBookIds.count,
-          totalCount: readList?.bookIds.count ?? 0,
+          totalCount: readListItem?.bookCount ?? 0,
           isDeleting: isDeleting,
           onSelectAll: {
-            if let bookIds = readList?.bookIds {
+            if let bookIds = readListItem?.bookIds {
               if selectedBookIds.count == bookIds.count {
                 selectedBookIds.removeAll()
               } else {
@@ -125,7 +115,7 @@ struct BooksListViewForReadList: View {
         .padding(.horizontal)
       }
 
-      if readList?.bookIds != nil {
+      if readListItem != nil {
         ReadListBooksQueryView(
           readListId: readListId,
           readListContext: readListContext,
@@ -158,11 +148,22 @@ struct BooksListViewForReadList: View {
   }
 
   private func refreshBooks() async {
+    await loadReadList()
     await bookViewModel.loadReadListBooks(
-      context: modelContext,
       readListId: readListId,
       browseOpts: browseOpts,
       refresh: true
+    )
+  }
+
+  private func loadReadList() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      readListItem = nil
+      return
+    }
+    readListItem = try? await database.fetchReadListDisplayItem(
+      readListId: readListId,
+      instanceId: current.instanceId
     )
   }
 
@@ -180,6 +181,7 @@ struct BooksListViewForReadList: View {
       )
       // Sync the readlist to update its bookIds in local SwiftData
       _ = try? await SyncService.syncReadList(id: readListId)
+      await loadReadList()
 
       ErrorManager.shared.notify(message: String(localized: "notification.readList.booksRemoved"))
 

--- a/KMReader/Features/Book/Views/ListViews/BooksListViewForSeries.swift
+++ b/KMReader/Features/Book/Views/ListViews/BooksListViewForSeries.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 // Books list view for series detail
@@ -16,7 +15,6 @@ struct BooksListViewForSeries: View {
   @AppStorage("seriesDetailLayout") private var layoutMode: BrowseLayoutMode = .list
   @AppStorage("seriesBookBrowseOptions") private var browseOpts: BookBrowseOptions =
     BookBrowseOptions()
-  @Environment(\.modelContext) private var modelContext
 
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
@@ -66,7 +64,6 @@ struct BooksListViewForSeries: View {
 
   private func refreshBooks(refresh: Bool) async {
     await bookViewModel.loadSeriesBooks(
-      context: modelContext,
       seriesId: seriesId,
       browseOpts: browseOpts,
       refresh: refresh

--- a/KMReader/Features/Book/Views/ListViews/ReadListBooksQueryView.swift
+++ b/KMReader/Features/Book/Views/ListViews/ReadListBooksQueryView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct ReadListBooksQueryView: View {
@@ -18,7 +17,6 @@ struct ReadListBooksQueryView: View {
   let refreshBooks: () -> Void
 
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
-  @Environment(\.modelContext) private var modelContext
 
   private var columns: [GridItem] {
     LayoutConfig.adaptiveColumns(for: gridDensity)
@@ -127,7 +125,6 @@ struct ReadListBooksQueryView: View {
 
   private func loadMore(refresh: Bool) async {
     await bookViewModel.loadReadListBooks(
-      context: modelContext,
       readListId: readListId,
       browseOpts: browseOpts,
       refresh: refresh

--- a/KMReader/Features/Book/Views/ListViews/SeriesBooksQueryView.swift
+++ b/KMReader/Features/Book/Views/ListViews/SeriesBooksQueryView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct SeriesBooksQueryView: View {
@@ -13,7 +12,6 @@ struct SeriesBooksQueryView: View {
   let browseLayout: BrowseLayoutMode
 
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
-  @Environment(\.modelContext) private var modelContext
 
   private var columns: [GridItem] {
     LayoutConfig.adaptiveColumns(for: gridDensity)
@@ -89,7 +87,6 @@ struct SeriesBooksQueryView: View {
   private func loadBooks(refresh: Bool) {
     Task {
       await bookViewModel.loadSeriesBooks(
-        context: modelContext,
         seriesId: seriesId,
         browseOpts: browseOpts,
         refresh: refresh

--- a/KMReader/Features/Browse/Models/SavedFilter.swift
+++ b/KMReader/Features/Browse/Models/SavedFilter.swift
@@ -6,7 +6,7 @@
 import Foundation
 import SwiftData
 
-enum SavedFilterType: String, CaseIterable, Identifiable {
+nonisolated enum SavedFilterType: String, CaseIterable, Identifiable, Sendable {
   case series
   case books
   case collectionSeries

--- a/KMReader/Features/Browse/Models/SavedFilterDisplayItem.swift
+++ b/KMReader/Features/Browse/Models/SavedFilterDisplayItem.swift
@@ -1,0 +1,14 @@
+//
+// SavedFilterDisplayItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct SavedFilterDisplayItem: Equatable, Identifiable, Sendable {
+  let id: UUID
+  let name: String
+  let filterType: SavedFilterType
+  let filterDataJSON: String
+  let updatedAt: Date
+}

--- a/KMReader/Features/Browse/Views/SaveFilterSheet.swift
+++ b/KMReader/Features/Browse/Views/SaveFilterSheet.swift
@@ -3,12 +3,10 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct SaveFilterSheet: View {
   @Environment(\.dismiss) private var dismiss
-  @Environment(\.modelContext) private var modelContext
 
   let filterType: SavedFilterType
   let seriesOptions: SeriesBrowseOptions?
@@ -70,29 +68,39 @@ struct SaveFilterSheet: View {
 
     isSaving = true
 
-    guard
-      let savedFilter = SavedFilter.create(
-        name: trimmedName,
-        filterType: filterType,
-        seriesOptions: seriesOptions,
-        bookOptions: bookOptions,
-        collectionOptions: collectionOptions,
-        readListOptions: readListOptions
-      )
-    else {
+    guard let filterDataJSON else {
       ErrorManager.shared.alert(message: "Failed to create filter")
       isSaving = false
       return
     }
 
-    modelContext.insert(savedFilter)
+    Task {
+      do {
+        let database = try await DatabaseOperator.database()
+        try await database.createSavedFilter(
+          name: trimmedName,
+          filterType: filterType,
+          filterDataJSON: filterDataJSON
+        )
+        try await database.commit()
+        dismiss()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+        isSaving = false
+      }
+    }
+  }
 
-    do {
-      try modelContext.save()
-      dismiss()
-    } catch {
-      ErrorManager.shared.alert(error: error)
-      isSaving = false
+  private var filterDataJSON: String? {
+    switch filterType {
+    case .series:
+      return seriesOptions?.rawValue
+    case .books, .seriesBooks:
+      return bookOptions?.rawValue
+    case .collectionSeries:
+      return collectionOptions?.rawValue
+    case .readListBooks:
+      return readListOptions?.rawValue
     }
   }
 }

--- a/KMReader/Features/Browse/Views/SavedFiltersView.swift
+++ b/KMReader/Features/Browse/Views/SavedFiltersView.swift
@@ -3,16 +3,14 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct SavedFiltersView: View {
   @Environment(\.dismiss) private var dismiss
-  @Environment(\.modelContext) private var modelContext
-  @Query(sort: \SavedFilter.updatedAt, order: .reverse) private var savedFilters: [SavedFilter]
 
   let filterType: SavedFilterType
-  @State private var filterToRename: SavedFilter?
+  @State private var savedFilters: [SavedFilterDisplayItem] = []
+  @State private var filterToRename: SavedFilterDisplayItem?
   @State private var newName: String = ""
 
   var body: some View {
@@ -21,9 +19,7 @@ struct SavedFiltersView: View {
       size: .medium,
       applyFormStyle: true
     ) {
-      let displayFilters = savedFilters.filter { $0.filterType == filterType }
-
-      if displayFilters.isEmpty {
+      if savedFilters.isEmpty {
         ContentUnavailableView {
           Label("No Saved Filters", systemImage: "bookmark.slash")
         } description: {
@@ -34,7 +30,7 @@ struct SavedFiltersView: View {
       } else {
         List {
           Section(filterType.displayName) {
-            ForEach(displayFilters) { filter in
+            ForEach(savedFilters) { filter in
               filterRow(filter)
             }
           }
@@ -59,10 +55,13 @@ struct SavedFiltersView: View {
         }
       }
     }
+    .task(id: filterType) {
+      await loadFilters()
+    }
   }
 
   @ViewBuilder
-  private func filterRow(_ filter: SavedFilter) -> some View {
+  private func filterRow(_ filter: SavedFilterDisplayItem) -> some View {
     HStack {
       VStack(alignment: .leading, spacing: 4) {
         Text(filter.name)
@@ -125,45 +124,71 @@ struct SavedFiltersView: View {
     }
   }
 
-  private func applyFilterDirectly(_ filter: SavedFilter) {
+  private func applyFilterDirectly(_ filter: SavedFilterDisplayItem) {
     switch filter.filterType {
     case .series:
-      if let options = filter.getSeriesBrowseOptions() {
+      if let options = SeriesBrowseOptions(rawValue: filter.filterDataJSON) {
         AppConfig.seriesBrowseOptions = options.rawValue
       }
     case .books:
-      if let options = filter.getBookBrowseOptions() {
+      if let options = BookBrowseOptions(rawValue: filter.filterDataJSON) {
         AppConfig.bookBrowseOptions = options.rawValue
       }
     case .collectionSeries:
-      if let options = filter.getCollectionSeriesBrowseOptions() {
+      if let options = CollectionSeriesBrowseOptions(rawValue: filter.filterDataJSON) {
         AppConfig.collectionSeriesBrowseOptions = options.rawValue
       }
     case .readListBooks:
-      if let options = filter.getReadListBookBrowseOptions() {
+      if let options = ReadListBookBrowseOptions(rawValue: filter.filterDataJSON) {
         AppConfig.readListBookBrowseOptions = options.rawValue
       }
     case .seriesBooks:
-      if let options = filter.getBookBrowseOptions() {
+      if let options = BookBrowseOptions(rawValue: filter.filterDataJSON) {
         AppConfig.seriesBookBrowseOptions = options.rawValue
       }
     }
   }
 
-  private func deleteFilter(_ filter: SavedFilter) {
-    modelContext.delete(filter)
-    try? modelContext.save()
+  private func deleteFilter(_ filter: SavedFilterDisplayItem) {
+    Task {
+      do {
+        let database = try await DatabaseOperator.database()
+        try await database.deleteSavedFilter(id: filter.id)
+        try await database.commit()
+        await loadFilters()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
   }
 
-  private func renameFilter(_ filter: SavedFilter, to newName: String) {
+  private func renameFilter(_ filter: SavedFilterDisplayItem, to newName: String) {
     let trimmed = newName.trimmingCharacters(in: .whitespaces)
     guard !trimmed.isEmpty else { return }
 
-    filter.name = trimmed
-    filter.updatedAt = Date()
-    try? modelContext.save()
+    Task {
+      do {
+        let database = try await DatabaseOperator.database()
+        try await database.renameSavedFilter(id: filter.id, name: trimmed)
+        try await database.commit()
+        await loadFilters()
+        filterToRename = nil
+        self.newName = ""
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
+  }
 
-    filterToRename = nil
-    self.newName = ""
+  private func loadFilters() async {
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedFilters = try await database.fetchSavedFilterDisplayItems(filterType: filterType)
+      if savedFilters != loadedFilters {
+        savedFilters = loadedFilters
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
   }
 }

--- a/KMReader/Features/Browse/Views/Sheets/CollectionPickerSheet.swift
+++ b/KMReader/Features/Browse/Views/Sheets/CollectionPickerSheet.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 private struct CollectionItem: Identifiable {
@@ -21,8 +20,7 @@ struct CollectionPickerSheet: View {
   @State private var searchText: String = ""
   @State private var showCreateSheet = false
   @State private var isCreating = false
-
-  @Query private var komgaCollections: [KomgaCollection]
+  @State private var collections: [CollectionDisplayItem] = []
 
   let seriesId: String
   let onSelect: (String) -> Void
@@ -33,19 +31,13 @@ struct CollectionPickerSheet: View {
   ) {
     self.seriesId = seriesId
     self.onSelect = onSelect
-
-    let instanceId = AppConfig.current.instanceId
-    _komgaCollections = Query(
-      filter: #Predicate<KomgaCollection> { $0.instanceId == instanceId },
-      sort: [SortDescriptor(\KomgaCollection.name, order: .forward)]
-    )
   }
 
-  private var filteredCollections: [KomgaCollection] {
+  private var filteredCollections: [CollectionDisplayItem] {
     if searchText.isEmpty {
-      return Array(komgaCollections)
+      return collections
     }
-    return komgaCollections.filter {
+    return collections.filter {
       $0.name.localizedCaseInsensitiveContains(searchText)
     }
   }
@@ -63,7 +55,7 @@ struct CollectionPickerSheet: View {
   var body: some View {
     SheetView(title: String(localized: "Select Collection"), size: .large, applyFormStyle: true) {
       Form {
-        if isLoading && komgaCollections.isEmpty {
+        if isLoading && collections.isEmpty {
           LoadingIcon()
             .frame(maxWidth: .infinity)
         } else if filteredCollections.isEmpty && searchText.isEmpty {
@@ -112,7 +104,7 @@ struct CollectionPickerSheet: View {
     }
     .searchable(text: $searchText)
     .task {
-      await syncCollections()
+      await refreshCollections()
     }
     .sheet(isPresented: $showCreateSheet) {
       CreateCollectionSheet(
@@ -125,11 +117,32 @@ struct CollectionPickerSheet: View {
     }
   }
 
-  private func syncCollections() async {
+  private func refreshCollections() async {
+    await loadCollections()
     guard !AppConfig.isOffline else { return }
     isLoading = true
     await SyncService.syncCollections(instanceId: current.instanceId)
     isLoading = false
+    await loadCollections()
+  }
+
+  private func loadCollections() async {
+    guard !current.instanceId.isEmpty else {
+      if !collections.isEmpty { collections = [] }
+      return
+    }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedCollections = try await database.fetchCollectionDisplayItems(
+        instanceId: current.instanceId
+      )
+      if collections != loadedCollections {
+        collections = loadedCollections
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
   }
 
   private func confirmSelection() {

--- a/KMReader/Features/Browse/Views/Sheets/LibraryPickerSheet.swift
+++ b/KMReader/Features/Browse/Views/Sheets/LibraryPickerSheet.swift
@@ -3,35 +3,12 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct LibraryPickerSheet: View {
   @Environment(\.dismiss) private var dismiss
-  @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("libraryPickerSingleSelection") private var isSingleSelectionMode = false
-  @Query(sort: [SortDescriptor(\KomgaLibrary.name, order: .forward)]) private var allLibraries: [KomgaLibrary]
-  @State private var isRefreshing = false
-
-  private let metricsLoader = LibraryMetricsLoader.shared
-
-  private var libraries: [KomgaLibrary] {
-    guard !current.instanceId.isEmpty else {
-      return []
-    }
-    return allLibraries.filter {
-      $0.instanceId == current.instanceId && $0.libraryId != KomgaLibrary.allLibrariesId
-    }
-  }
-
-  private var allLibrariesEntry: KomgaLibrary? {
-    guard !current.instanceId.isEmpty else {
-      return nil
-    }
-    return allLibraries.first {
-      $0.instanceId == current.instanceId && $0.libraryId == KomgaLibrary.allLibrariesId
-    }
-  }
+  @State private var refreshTrigger = 0
 
   var body: some View {
     SheetView(title: String(localized: "Libraries"), size: .large, applyFormStyle: true) {
@@ -43,7 +20,8 @@ struct LibraryPickerSheet: View {
         onLibrarySelected: { _ in
           guard isSingleSelectionMode else { return }
           dismiss()
-        }
+        },
+        refreshTrigger: refreshTrigger
       )
     } controls: {
       HStack(spacing: 12) {
@@ -59,41 +37,11 @@ struct LibraryPickerSheet: View {
         }
 
         Button {
-          Task { @MainActor in await refreshLibrariesAndMetrics() }
+          refreshTrigger += 1
         } label: {
           Label("Refresh", systemImage: "arrow.clockwise")
         }
-        .disabled(isRefreshing)
       }
     }
-  }
-
-  @MainActor
-  private func refreshLibrariesAndMetrics() async {
-    guard !isRefreshing else { return }
-    isRefreshing = true
-
-    await LibraryManager.shared.refreshLibraries()
-
-    if current.isAdmin, !current.instanceId.isEmpty {
-      let libraryIds = libraries.map { $0.libraryId }
-      let hasAllEntry = allLibrariesEntry != nil
-
-      let metricsByLibrary = await metricsLoader.refreshMetrics(
-        instanceId: current.instanceId,
-        libraryIds: libraryIds,
-        ensureAllLibrariesEntry: hasAllEntry
-      )
-
-      for library in libraries {
-        guard let metrics = metricsByLibrary[library.libraryId] else { continue }
-        library.fileSize = metrics.fileSize
-        library.booksCount = metrics.booksCount
-        library.seriesCount = metrics.seriesCount
-        library.sidecarsCount = metrics.sidecarsCount
-      }
-    }
-
-    isRefreshing = false
   }
 }

--- a/KMReader/Features/Browse/Views/Sheets/ReadListPickerSheet.swift
+++ b/KMReader/Features/Browse/Views/Sheets/ReadListPickerSheet.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 private struct ReadListItem: Identifiable {
@@ -21,8 +20,7 @@ struct ReadListPickerSheet: View {
   @State private var searchText: String = ""
   @State private var showCreateSheet = false
   @State private var isCreating = false
-
-  @Query private var komgaReadLists: [KomgaReadList]
+  @State private var readLists: [ReadListDisplayItem] = []
 
   let bookId: String
   let onSelect: (String) -> Void
@@ -33,25 +31,15 @@ struct ReadListPickerSheet: View {
   ) {
     self.bookId = bookId
     self.onSelect = onSelect
-
-    let instanceId = AppConfig.current.instanceId
-    _komgaReadLists = Query(
-      filter: #Predicate<KomgaReadList> { $0.instanceId == instanceId },
-      sort: [SortDescriptor(\KomgaReadList.name, order: .forward)]
-    )
   }
 
-  private var filteredReadLists: [KomgaReadList] {
+  private var filteredReadLists: [ReadListDisplayItem] {
     if searchText.isEmpty {
-      return Array(komgaReadLists)
+      return readLists
     }
-    return komgaReadLists.filter {
+    return readLists.filter {
       $0.name.localizedCaseInsensitiveContains(searchText)
     }
-  }
-
-  private func isAlreadyInReadList(_ readList: KomgaReadList) -> Bool {
-    return readList.bookIds.contains(bookId)
   }
 
   private var readListItems: [ReadListItem] {
@@ -67,7 +55,7 @@ struct ReadListPickerSheet: View {
   var body: some View {
     SheetView(title: String(localized: "Select Read List"), size: .large, applyFormStyle: true) {
       Form {
-        if isLoading && komgaReadLists.isEmpty {
+        if isLoading && readLists.isEmpty {
           LoadingIcon()
             .frame(maxWidth: .infinity)
         } else if filteredReadLists.isEmpty && searchText.isEmpty {
@@ -116,7 +104,7 @@ struct ReadListPickerSheet: View {
     }
     .searchable(text: $searchText)
     .task {
-      await syncReadLists()
+      await refreshReadLists()
     }
     .sheet(isPresented: $showCreateSheet) {
       CreateReadListSheet(
@@ -129,11 +117,32 @@ struct ReadListPickerSheet: View {
     }
   }
 
-  private func syncReadLists() async {
+  private func refreshReadLists() async {
+    await loadReadLists()
     guard !AppConfig.isOffline else { return }
     isLoading = true
     await SyncService.syncReadLists(instanceId: current.instanceId)
     isLoading = false
+    await loadReadLists()
+  }
+
+  private func loadReadLists() async {
+    guard !current.instanceId.isEmpty else {
+      if !readLists.isEmpty { readLists = [] }
+      return
+    }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedReadLists = try await database.fetchReadListDisplayItems(
+        instanceId: current.instanceId
+      )
+      if readLists != loadedReadLists {
+        readLists = loadedReadLists
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
   }
 
   private func confirmSelection() {

--- a/KMReader/Features/Collection/Models/CollectionDisplayItem.swift
+++ b/KMReader/Features/Collection/Models/CollectionDisplayItem.swift
@@ -1,0 +1,58 @@
+//
+// CollectionDisplayItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct CollectionDisplayItem: Equatable, Identifiable, Sendable {
+  let id: String
+  let collectionId: String
+  let instanceId: String
+  let name: String
+  let ordered: Bool
+  let createdDate: Date
+  let lastModifiedDate: Date
+  let filtered: Bool
+  let isPinned: Bool
+  let seriesIds: [String]
+
+  init(
+    collectionId: String,
+    instanceId: String,
+    name: String,
+    ordered: Bool,
+    createdDate: Date,
+    lastModifiedDate: Date,
+    filtered: Bool,
+    isPinned: Bool,
+    seriesIds: [String]
+  ) {
+    id = collectionId
+    self.collectionId = collectionId
+    self.instanceId = instanceId
+    self.name = name
+    self.ordered = ordered
+    self.createdDate = createdDate
+    self.lastModifiedDate = lastModifiedDate
+    self.filtered = filtered
+    self.isPinned = isPinned
+    self.seriesIds = seriesIds
+  }
+
+  var seriesCount: Int {
+    seriesIds.count
+  }
+
+  var collection: SeriesCollection {
+    SeriesCollection(
+      id: collectionId,
+      name: name,
+      ordered: ordered,
+      seriesIds: seriesIds,
+      createdDate: createdDate,
+      lastModifiedDate: lastModifiedDate,
+      filtered: filtered
+    )
+  }
+}

--- a/KMReader/Features/Collection/Services/KomgaCollectionStore.swift
+++ b/KMReader/Features/Collection/Services/KomgaCollectionStore.swift
@@ -26,7 +26,7 @@ enum KomgaCollectionStore {
     return paginate(collections, offset: page * size, limit: size).map { $0.toCollection() }
   }
 
-  static func fetchCollectionIds(
+  nonisolated static func fetchCollectionIds(
     context: ModelContext,
     libraryIds: [String]?,
     searchText: String,
@@ -74,7 +74,7 @@ enum KomgaCollectionStore {
     return try? context.fetch(descriptor).first?.toCollection()
   }
 
-  private static func fetchOrderedCollections(
+  nonisolated private static func fetchOrderedCollections(
     context: ModelContext,
     searchText: String,
     sort: String?
@@ -103,13 +103,13 @@ enum KomgaCollectionStore {
     }
   }
 
-  private static func pinnedFirst(_ collections: [KomgaCollection]) -> [KomgaCollection] {
+  nonisolated private static func pinnedFirst(_ collections: [KomgaCollection]) -> [KomgaCollection] {
     let pinned = collections.filter(\.isPinned)
     let unpinned = collections.filter { !$0.isPinned }
     return pinned + unpinned
   }
 
-  private static func sortDescriptors(sort: String?) -> [SortDescriptor<KomgaCollection>] {
+  nonisolated private static func sortDescriptors(sort: String?) -> [SortDescriptor<KomgaCollection>] {
     let isAscending = sort?.contains("desc") != true
 
     if sort?.contains("createdDate") == true {
@@ -129,7 +129,7 @@ enum KomgaCollectionStore {
     ]
   }
 
-  private static func paginate(
+  nonisolated private static func paginate(
     _ collections: [KomgaCollection],
     offset: Int,
     limit: Int

--- a/KMReader/Features/Collection/Views/CollectionCardView.swift
+++ b/KMReader/Features/Collection/Views/CollectionCardView.swift
@@ -6,7 +6,8 @@
 import SwiftUI
 
 struct CollectionCardView: View {
-  @Bindable var komgaCollection: KomgaCollection
+  let item: CollectionDisplayItem
+  var onMutationCompleted: (() -> Void)? = nil
 
   @AppStorage("coverOnlyCards") private var coverOnlyCards: Bool = false
   @AppStorage("cardTextOverlayMode") private var cardTextOverlayMode: Bool = false
@@ -20,11 +21,11 @@ struct CollectionCardView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: contentSpacing) {
       ThumbnailImage(
-        id: komgaCollection.collectionId,
+        id: item.collectionId,
         type: .collection,
         shadowStyle: .platform,
         alignment: .bottom,
-        navigationLink: NavDestination.collectionDetail(collectionId: komgaCollection.collectionId),
+        navigationLink: NavDestination.collectionDetail(collectionId: item.collectionId),
         preserveAspectRatioOverride: cardTextOverlayMode ? false : nil
       ) {
         if cardTextOverlayMode {
@@ -34,9 +35,9 @@ struct CollectionCardView: View {
         }
       } menu: {
         CollectionContextMenu(
-          collectionId: komgaCollection.collectionId,
-          menuTitle: komgaCollection.name,
-          isPinned: komgaCollection.isPinned,
+          collectionId: item.collectionId,
+          menuTitle: item.name,
+          isPinned: item.isPinned,
           onDeleteRequested: {
             showDeleteConfirmation = true
           },
@@ -52,15 +53,15 @@ struct CollectionCardView: View {
       if !cardTextOverlayMode && !coverOnlyCards {
         VStack(alignment: .leading) {
           HStack(spacing: 4) {
-            if komgaCollection.isPinned {
+            if item.isPinned {
               Image(systemName: "pin.fill")
             }
-            Text(komgaCollection.name)
+            Text(item.name)
               .lineLimit(1)
           }
 
           HStack(spacing: 4) {
-            Text("\(komgaCollection.seriesIds.count) series")
+            Text("\(item.seriesCount) series")
             Spacer()
           }.foregroundColor(.secondary)
         }.font(.footnote)
@@ -77,18 +78,18 @@ struct CollectionCardView: View {
       Text("Are you sure you want to delete this collection? This action cannot be undone.")
     }
     .sheet(isPresented: $showEditSheet) {
-      CollectionEditSheet(collection: komgaCollection.toCollection())
+      CollectionEditSheet(collection: item.collection)
     }
   }
 
   @ViewBuilder
   private var overlayTextContent: some View {
     CardOverlayTextStack(
-      title: komgaCollection.name,
-      titleLeadingSystemImage: komgaCollection.isPinned ? "pin.fill" : nil
+      title: item.name,
+      titleLeadingSystemImage: item.isPinned ? "pin.fill" : nil
     ) {
       HStack(spacing: 4) {
-        Text("\(komgaCollection.seriesIds.count) series")
+        Text("\(item.seriesCount) series")
       }
     }
   }
@@ -97,8 +98,9 @@ struct CollectionCardView: View {
     Task {
       do {
         try await CollectionService.deleteCollection(
-          collectionId: komgaCollection.collectionId)
+          collectionId: item.collectionId)
         ErrorManager.shared.notify(message: String(localized: "notification.collection.deleted"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -106,14 +108,15 @@ struct CollectionCardView: View {
   }
 
   private func togglePinned() {
-    let nextPinned = !komgaCollection.isPinned
+    let nextPinned = !item.isPinned
     Task {
       try? await DatabaseOperator.database().setCollectionPinned(
-        collectionId: komgaCollection.collectionId,
-        instanceId: komgaCollection.instanceId,
+        collectionId: item.collectionId,
+        instanceId: item.instanceId,
         isPinned: nextPinned
       )
       try? await DatabaseOperator.database().commit()
+      onMutationCompleted?()
     }
   }
 }

--- a/KMReader/Features/Collection/Views/CollectionCompactCardView.swift
+++ b/KMReader/Features/Collection/Views/CollectionCompactCardView.swift
@@ -5,33 +5,36 @@
 
 import SwiftUI
 
+@MainActor
 struct CollectionCompactCardView: View {
-  @Bindable var komgaCollection: KomgaCollection
+  let item: CollectionDisplayItem
   var coverWidth: CGFloat = 80
+  var onChanged: () -> Void = {}
+
   @State private var showEditSheet = false
   @State private var showDeleteConfirmation = false
 
   var body: some View {
     NavigationLink(
-      value: NavDestination.collectionDetail(collectionId: komgaCollection.collectionId)
+      value: NavDestination.collectionDetail(collectionId: item.collectionId)
     ) {
       HStack(alignment: .top, spacing: 10) {
-        ThumbnailImage(id: komgaCollection.collectionId, type: .collection, width: coverWidth)
+        ThumbnailImage(id: item.collectionId, type: .collection, width: coverWidth)
           .frame(width: coverWidth)
           .allowsHitTesting(false)
 
         VStack(alignment: .leading, spacing: 4) {
-          Text(komgaCollection.name)
+          Text(item.name)
             .font(.headline)
             .fontWeight(.medium)
             .lineLimit(2)
             .multilineTextAlignment(.leading)
 
-          Text("\(komgaCollection.seriesIds.count) series")
+          Text("\(item.seriesCount) series")
             .font(.footnote)
             .foregroundColor(.secondary)
 
-          Text(komgaCollection.lastModifiedDate.formattedMediumDate)
+          Text(item.lastModifiedDate.formattedMediumDate)
             .font(.caption)
             .foregroundColor(.secondary)
         }
@@ -52,9 +55,9 @@ struct CollectionCompactCardView: View {
     .adaptiveButtonStyle(.plain)
     .contextMenu {
       CollectionContextMenu(
-        collectionId: komgaCollection.collectionId,
-        menuTitle: komgaCollection.name,
-        isPinned: komgaCollection.isPinned,
+        collectionId: item.collectionId,
+        menuTitle: item.name,
+        isPinned: item.isPinned,
         onDeleteRequested: {
           showDeleteConfirmation = true
         },
@@ -74,8 +77,8 @@ struct CollectionCompactCardView: View {
     } message: {
       Text("Are you sure you want to delete this collection? This action cannot be undone.")
     }
-    .sheet(isPresented: $showEditSheet) {
-      CollectionEditSheet(collection: komgaCollection.toCollection())
+    .sheet(isPresented: $showEditSheet, onDismiss: onChanged) {
+      CollectionEditSheet(collection: item.collection)
     }
   }
 
@@ -83,8 +86,9 @@ struct CollectionCompactCardView: View {
     Task {
       do {
         try await CollectionService.deleteCollection(
-          collectionId: komgaCollection.collectionId)
+          collectionId: item.collectionId)
         ErrorManager.shared.notify(message: String(localized: "notification.collection.deleted"))
+        onChanged()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -92,14 +96,20 @@ struct CollectionCompactCardView: View {
   }
 
   private func togglePinned() {
-    let nextPinned = !komgaCollection.isPinned
+    let nextPinned = !item.isPinned
     Task {
-      try? await DatabaseOperator.database().setCollectionPinned(
-        collectionId: komgaCollection.collectionId,
-        instanceId: komgaCollection.instanceId,
-        isPinned: nextPinned
-      )
-      try? await DatabaseOperator.database().commit()
+      do {
+        let database = try await DatabaseOperator.database()
+        await database.setCollectionPinned(
+          collectionId: item.collectionId,
+          instanceId: item.instanceId,
+          isPinned: nextPinned
+        )
+        try? await database.commit()
+        onChanged()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
     }
   }
 }

--- a/KMReader/Features/Collection/Views/CollectionDetailView.swift
+++ b/KMReader/Features/Collection/Views/CollectionDetailView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct CollectionDetailView: View {
@@ -14,9 +13,7 @@ struct CollectionDetailView: View {
 
   @Environment(\.dismiss) private var dismiss
 
-  // SwiftData query for reactive updates
-  @Query private var komgaCollections: [KomgaCollection]
-
+  @State private var item: CollectionDisplayItem?
   @State private var showDeleteConfirmation = false
   @State private var showEditSheet = false
   @State private var showFilterSheet = false
@@ -24,18 +21,10 @@ struct CollectionDetailView: View {
 
   init(collectionId: String) {
     self.collectionId = collectionId
-    let compositeId = CompositeID.generate(id: collectionId)
-    _komgaCollections = Query(filter: #Predicate<KomgaCollection> { $0.id == compositeId })
   }
 
-  /// The KomgaCollection from SwiftData (reactive).
-  private var komgaCollection: KomgaCollection? {
-    komgaCollections.first
-  }
-
-  /// Convert to API SeriesCollection type for compatibility with existing components.
   private var collection: SeriesCollection? {
-    komgaCollection?.toCollection()
+    item?.collection
   }
 
   private var navigationTitle: String {
@@ -43,7 +32,7 @@ struct CollectionDetailView: View {
   }
 
   private var isPinned: Bool {
-    komgaCollection?.isPinned ?? false
+    item?.isPinned ?? false
   }
 
   var body: some View {
@@ -61,7 +50,7 @@ struct CollectionDetailView: View {
           ).padding(.horizontal)
 
           // Series list
-          if komgaCollection != nil {
+          if item != nil {
             CollectionSeriesListView(
               collectionId: collectionId,
               showFilterSheet: $showFilterSheet,
@@ -120,15 +109,26 @@ struct CollectionDetailView: View {
 extension CollectionDetailView {
   private func loadCollectionDetails() async {
     do {
-      // Sync from network to SwiftData (collection property will update reactively)
       _ = try await SyncService.syncCollection(id: collectionId)
     } catch {
       if case APIError.notFound = error {
         dismiss()
-      } else if komgaCollection == nil {
+      } else if item == nil {
         ErrorManager.shared.alert(error: error)
       }
     }
+    await loadLocalCollection()
+  }
+
+  private func loadLocalCollection() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      item = nil
+      return
+    }
+    item = try? await database.fetchCollectionDisplayItem(
+      collectionId: collectionId,
+      instanceId: current.instanceId
+    )
   }
 
   @MainActor
@@ -143,15 +143,16 @@ extension CollectionDetailView {
   }
 
   private func togglePinned() {
-    guard let komgaCollection else { return }
-    let nextPinned = !komgaCollection.isPinned
+    guard let item else { return }
+    let nextPinned = !item.isPinned
     Task {
       try? await DatabaseOperator.database().setCollectionPinned(
-        collectionId: komgaCollection.collectionId,
-        instanceId: komgaCollection.instanceId,
+        collectionId: item.collectionId,
+        instanceId: item.instanceId,
         isPinned: nextPinned
       )
       try? await DatabaseOperator.database().commit()
+      await loadLocalCollection()
     }
   }
 

--- a/KMReader/Features/Collection/Views/CollectionDetailView.swift
+++ b/KMReader/Features/Collection/Views/CollectionDetailView.swift
@@ -108,6 +108,7 @@ struct CollectionDetailView: View {
 // Helper functions for CollectionDetailView
 extension CollectionDetailView {
   private func loadCollectionDetails() async {
+    await loadLocalCollection()
     do {
       _ = try await SyncService.syncCollection(id: collectionId)
     } catch {

--- a/KMReader/Features/Collection/Views/CollectionItemQueryView.swift
+++ b/KMReader/Features/Collection/Views/CollectionItemQueryView.swift
@@ -3,23 +3,25 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct CollectionItemQueryView: View {
-  @Bindable var collection: KomgaCollection
+  let item: CollectionDisplayItem
   var layout: BrowseLayoutMode = .grid
+  var onMutationCompleted: (() -> Void)? = nil
 
   var body: some View {
-    NavigationLink(value: NavDestination.collectionDetail(collectionId: collection.collectionId)) {
+    NavigationLink(value: NavDestination.collectionDetail(collectionId: item.collectionId)) {
       switch layout {
       case .grid:
         CollectionCardView(
-          komgaCollection: collection
+          item: item,
+          onMutationCompleted: onMutationCompleted
         )
       case .list:
         CollectionRowView(
-          komgaCollection: collection
+          item: item,
+          onMutationCompleted: onMutationCompleted
         )
       }
     }

--- a/KMReader/Features/Collection/Views/CollectionQueryItemView.swift
+++ b/KMReader/Features/Collection/Views/CollectionQueryItemView.swift
@@ -3,15 +3,15 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
-/// Wrapper view that accepts only collectionId and uses @Query to fetch the collection reactively.
+/// Wrapper view that accepts only collectionId and fetches a collection display projection.
 struct CollectionQueryItemView: View {
   let collectionId: String
   var layout: BrowseLayoutMode = .grid
 
-  @Query private var komgaCollections: [KomgaCollection]
+  @AppStorage("currentAccount") private var current: Current = .init()
+  @State private var item: CollectionDisplayItem?
 
   init(
     collectionId: String,
@@ -20,28 +20,46 @@ struct CollectionQueryItemView: View {
     self.collectionId = collectionId
     self.layout = layout
 
-    let compositeId = CompositeID.generate(id: collectionId)
-    _komgaCollections = Query(filter: #Predicate<KomgaCollection> { $0.id == compositeId })
-  }
-
-  private var komgaCollection: KomgaCollection? {
-    komgaCollections.first
   }
 
   var body: some View {
-    if let collection = komgaCollection {
-      switch layout {
-      case .grid:
-        CollectionCardView(
-          komgaCollection: collection
-        )
-      case .list:
-        CollectionRowView(
-          komgaCollection: collection
-        )
+    Group {
+      if let item {
+        switch layout {
+        case .grid:
+          CollectionCardView(
+            item: item,
+            onMutationCompleted: reloadItem
+          )
+        case .list:
+          CollectionRowView(
+            item: item,
+            onMutationCompleted: reloadItem
+          )
+        }
+      } else {
+        CardPlaceholder(layout: layout, kind: .collection)
       }
-    } else {
-      CardPlaceholder(layout: layout, kind: .collection)
     }
+    .task(id: "\(current.instanceId)|\(collectionId)") {
+      await loadItem()
+    }
+  }
+
+  private func reloadItem() {
+    Task {
+      await loadItem()
+    }
+  }
+
+  private func loadItem() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      item = nil
+      return
+    }
+    item = try? await database.fetchCollectionDisplayItem(
+      collectionId: collectionId,
+      instanceId: current.instanceId
+    )
   }
 }

--- a/KMReader/Features/Collection/Views/CollectionRowView.swift
+++ b/KMReader/Features/Collection/Views/CollectionRowView.swift
@@ -6,7 +6,8 @@
 import SwiftUI
 
 struct CollectionRowView: View {
-  @Bindable var komgaCollection: KomgaCollection
+  let item: CollectionDisplayItem
+  var onMutationCompleted: (() -> Void)? = nil
 
   @State private var showEditSheet = false
   @State private var showDeleteConfirmation = false
@@ -14,21 +15,21 @@ struct CollectionRowView: View {
   var body: some View {
     HStack(spacing: 12) {
       NavigationLink(
-        value: NavDestination.collectionDetail(collectionId: komgaCollection.collectionId)
+        value: NavDestination.collectionDetail(collectionId: item.collectionId)
       ) {
-        ThumbnailImage(id: komgaCollection.collectionId, type: .collection, width: 60)
+        ThumbnailImage(id: item.collectionId, type: .collection, width: 60)
       }
       .adaptiveButtonStyle(.plain)
 
       VStack(alignment: .leading, spacing: 6) {
         NavigationLink(
-          value: NavDestination.collectionDetail(collectionId: komgaCollection.collectionId)
+          value: NavDestination.collectionDetail(collectionId: item.collectionId)
         ) {
           HStack(spacing: 6) {
-            Text(komgaCollection.name)
+            Text(item.name)
               .font(.callout)
               .lineLimit(2)
-            if komgaCollection.isPinned {
+            if item.isPinned {
               Image(systemName: "pin.fill")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
@@ -38,12 +39,12 @@ struct CollectionRowView: View {
 
         HStack {
           VStack(alignment: .leading, spacing: 4) {
-            Label("\(komgaCollection.seriesIds.count) series", systemImage: ContentIcon.series)
+            Label("\(item.seriesCount) series", systemImage: ContentIcon.series)
               .font(.footnote)
               .foregroundColor(.secondary)
 
             Label(
-              komgaCollection.lastModifiedDate.formatted(date: .abbreviated, time: .omitted),
+              item.lastModifiedDate.formatted(date: .abbreviated, time: .omitted),
               systemImage: "clock"
             )
             .font(.caption)
@@ -54,9 +55,9 @@ struct CollectionRowView: View {
 
           EllipsisMenuButton {
             CollectionContextMenu(
-              collectionId: komgaCollection.collectionId,
-              menuTitle: komgaCollection.name,
-              isPinned: komgaCollection.isPinned,
+              collectionId: item.collectionId,
+              menuTitle: item.name,
+              isPinned: item.isPinned,
               onDeleteRequested: {
                 showDeleteConfirmation = true
               },
@@ -67,7 +68,7 @@ struct CollectionRowView: View {
                 togglePinned()
               }
             )
-            .id(komgaCollection.collectionId)
+            .id(item.collectionId)
           }
         }
       }
@@ -81,7 +82,7 @@ struct CollectionRowView: View {
       Text("Are you sure you want to delete this collection? This action cannot be undone.")
     }
     .sheet(isPresented: $showEditSheet) {
-      CollectionEditSheet(collection: komgaCollection.toCollection())
+      CollectionEditSheet(collection: item.collection)
     }
   }
 
@@ -89,8 +90,9 @@ struct CollectionRowView: View {
     Task {
       do {
         try await CollectionService.deleteCollection(
-          collectionId: komgaCollection.collectionId)
+          collectionId: item.collectionId)
         ErrorManager.shared.notify(message: String(localized: "notification.collection.deleted"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -98,14 +100,15 @@ struct CollectionRowView: View {
   }
 
   private func togglePinned() {
-    let nextPinned = !komgaCollection.isPinned
+    let nextPinned = !item.isPinned
     Task {
       try? await DatabaseOperator.database().setCollectionPinned(
-        collectionId: komgaCollection.collectionId,
-        instanceId: komgaCollection.instanceId,
+        collectionId: item.collectionId,
+        instanceId: item.instanceId,
         isPinned: nextPinned
       )
       try? await DatabaseOperator.database().commit()
+      onMutationCompleted?()
     }
   }
 }

--- a/KMReader/Features/Collection/Views/CollectionsBrowseView.swift
+++ b/KMReader/Features/Collection/Views/CollectionsBrowseView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct CollectionsBrowseView: View {
@@ -12,7 +11,6 @@ struct CollectionsBrowseView: View {
   let refreshTrigger: UUID
   @Binding var showFilterSheet: Bool
 
-  @Environment(\.modelContext) private var modelContext
   @AppStorage("collectionSortOptions") private var sortOpts: SimpleSortOptions =
     SimpleSortOptions()
   @AppStorage("collectionBrowseLayout") private var browseLayout: BrowseLayoutMode = .grid
@@ -123,16 +121,16 @@ struct CollectionsBrowseView: View {
   }
 
   private func loadCollectionIds() async throws -> [String] {
-    let localIds = localCollectionIds()
+    let localIds = await localCollectionIds()
     guard !AppConfig.isOffline else { return localIds }
 
     let serverIds = Set(try await syncCollectionIds())
     return localIds.filter { serverIds.contains($0) }
   }
 
-  private func localCollectionIds() -> [String] {
-    KomgaCollectionStore.fetchCollectionIds(
-      context: modelContext,
+  private func localCollectionIds() async -> [String] {
+    guard let database = try? await DatabaseOperator.database() else { return [] }
+    return await database.fetchCollectionIds(
       libraryIds: libraryIds,
       searchText: searchText,
       sort: sortOpts.sortString,

--- a/KMReader/Features/Collection/Views/Sections/CollectionSeriesListView.swift
+++ b/KMReader/Features/Collection/Views/Sections/CollectionSeriesListView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 // Series list view for collection
@@ -21,13 +20,7 @@ struct CollectionSeriesListView: View {
   @State private var selectedSeriesIds: Set<String> = []
   @State private var isSelectionMode = false
   @State private var isDeleting = false
-  @Environment(\.modelContext) private var modelContext
-
-  @Query private var collections: [KomgaCollection]
-
-  private var collection: KomgaCollection? {
-    collections.first
-  }
+  @State private var collectionItem: CollectionDisplayItem?
 
   init(
     collectionId: String,
@@ -37,9 +30,6 @@ struct CollectionSeriesListView: View {
     self.collectionId = collectionId
     self._showFilterSheet = showFilterSheet
     self._showSavedFilters = showSavedFilters
-
-    let compositeId = CompositeID.generate(id: collectionId)
-    _collections = Query(filter: #Predicate<KomgaCollection> { $0.id == compositeId })
   }
 
   private var supportsSelectionMode: Bool {
@@ -85,10 +75,10 @@ struct CollectionSeriesListView: View {
       if supportsSelectionMode && isSelectionMode {
         SelectionToolbar(
           selectedCount: selectedSeriesIds.count,
-          totalCount: collection?.seriesIds.count ?? 0,
+          totalCount: collectionItem?.seriesCount ?? 0,
           isDeleting: isDeleting,
           onSelectAll: {
-            if let seriesIds = collection?.seriesIds {
+            if let seriesIds = collectionItem?.seriesIds {
               if selectedSeriesIds.count == seriesIds.count {
                 selectedSeriesIds.removeAll()
               } else {
@@ -109,7 +99,7 @@ struct CollectionSeriesListView: View {
         .padding(.horizontal)
       }
 
-      if collection?.seriesIds != nil {
+      if collectionItem != nil {
         CollectionSeriesQueryView(
           collectionId: collectionId,
           seriesViewModel: seriesViewModel,
@@ -136,11 +126,22 @@ struct CollectionSeriesListView: View {
   }
 
   private func refreshSeries() async {
+    await loadCollection()
     await seriesViewModel.loadCollectionSeries(
-      context: modelContext,
       collectionId: collectionId,
       browseOpts: browseOpts,
       refresh: true
+    )
+  }
+
+  private func loadCollection() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      collectionItem = nil
+      return
+    }
+    collectionItem = try? await database.fetchCollectionDisplayItem(
+      collectionId: collectionId,
+      instanceId: current.instanceId
     )
   }
 
@@ -158,6 +159,7 @@ struct CollectionSeriesListView: View {
       )
       // Sync the collection to update its seriesIds in local SwiftData
       _ = try? await SyncService.syncCollection(id: collectionId)
+      await loadCollection()
 
       ErrorManager.shared.notify(
         message: String(localized: "notification.series.removedFromCollection"))

--- a/KMReader/Features/Collection/Views/Sections/CollectionSeriesQueryView.swift
+++ b/KMReader/Features/Collection/Views/Sections/CollectionSeriesQueryView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct CollectionSeriesQueryView: View {
@@ -16,7 +15,6 @@ struct CollectionSeriesQueryView: View {
   let isAdmin: Bool
 
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
-  @Environment(\.modelContext) private var modelContext
 
   private var columns: [GridItem] {
     LayoutConfig.adaptiveColumns(for: gridDensity)
@@ -95,7 +93,6 @@ struct CollectionSeriesQueryView: View {
 
   private func loadMore(refresh: Bool) async {
     await seriesViewModel.loadCollectionSeries(
-      context: modelContext,
       collectionId: collectionId,
       browseOpts: browseOpts,
       refresh: refresh

--- a/KMReader/Features/Dashboard/Models/DashboardSection.swift
+++ b/KMReader/Features/Dashboard/Models/DashboardSection.swift
@@ -4,17 +4,16 @@
 //
 
 import Foundation
-import SwiftData
 import SwiftUI
 
-enum DashboardSectionContentKind {
+enum DashboardSectionContentKind: Sendable {
   case books
   case series
   case collections
   case readLists
 }
 
-enum DashboardSection: String, CaseIterable, Identifiable, Codable {
+enum DashboardSection: String, CaseIterable, Identifiable, Codable, Sendable {
   case keepReading = "keepReading"
   case onDeck = "onDeck"
   case pinnedCollections = "pinnedCollections"
@@ -188,72 +187,24 @@ enum DashboardSection: String, CaseIterable, Identifiable, Codable {
     }
   }
 
-  func fetchOfflineBookIds(
-    context: ModelContext,
-    libraryIds: [String],
-    offset: Int,
-    limit: Int
-  ) -> [String] {
-    switch self {
-    case .keepReading:
-      return KomgaBookStore.fetchKeepReadingBookIds(
-        context: context,
-        libraryIds: libraryIds,
-        offset: offset,
-        limit: limit
-      )
-    case .onDeck:
-      return []
-    case .recentlyReadBooks:
-      return KomgaBookStore.fetchRecentlyReadBookIds(
-        context: context,
-        libraryIds: libraryIds,
-        offset: offset,
-        limit: limit
-      )
-    case .recentlyReleasedBooks:
-      return KomgaBookStore.fetchRecentlyReleasedBookIds(
-        context: context,
-        libraryIds: libraryIds,
-        offset: offset,
-        limit: limit
-      )
-    case .recentlyAddedBooks:
-      return KomgaBookStore.fetchRecentlyAddedBookIds(
-        context: context,
-        libraryIds: libraryIds,
-        offset: offset,
-        limit: limit
-      )
-    default:
-      return []
-    }
+  func fetchOfflineBookIds(libraryIds: [String], offset: Int, limit: Int) async -> [String] {
+    guard let database = try? await DatabaseOperator.database() else { return [] }
+    return await database.fetchDashboardOfflineBookIds(
+      section: self,
+      libraryIds: libraryIds,
+      offset: offset,
+      limit: limit
+    )
   }
 
-  func fetchOfflineSeriesIds(
-    context: ModelContext,
-    libraryIds: [String],
-    offset: Int,
-    limit: Int
-  ) -> [String] {
-    switch self {
-    case .recentlyAddedSeries:
-      return KomgaSeriesStore.fetchNewlyAddedSeriesIds(
-        context: context,
-        libraryIds: libraryIds,
-        offset: offset,
-        limit: limit
-      )
-    case .recentlyUpdatedSeries:
-      return KomgaSeriesStore.fetchRecentlyUpdatedSeriesIds(
-        context: context,
-        libraryIds: libraryIds,
-        offset: offset,
-        limit: limit
-      )
-    default:
-      return []
-    }
+  func fetchOfflineSeriesIds(libraryIds: [String], offset: Int, limit: Int) async -> [String] {
+    guard let database = try? await DatabaseOperator.database() else { return [] }
+    return await database.fetchDashboardOfflineSeriesIds(
+      section: self,
+      libraryIds: libraryIds,
+      offset: offset,
+      limit: limit
+    )
   }
 }
 

--- a/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 @MainActor
@@ -17,13 +16,11 @@ struct DashboardPinnedSectionView: View {
   private var showDashboardSectionGradientBackground: Bool =
     AppConfig.showDashboardSectionGradientBackground
 
-  @Query private var pinnedCollections: [KomgaCollection]
-  @Query private var pinnedReadLists: [KomgaReadList]
-
   @Environment(\.colorScheme) private var colorScheme
 
   @State private var isLoading = false
-  @State private var hasLoadedInitial = false
+  @State private var pinnedCollections: [CollectionDisplayItem] = []
+  @State private var pinnedReadLists: [ReadListDisplayItem] = []
   @State private var isHoveringScrollArea = false
   @State private var hoverShowDelayTask: Task<Void, Never>?
   @State private var hoverHideDelayTask: Task<Void, Never>?
@@ -31,20 +28,6 @@ struct DashboardPinnedSectionView: View {
   init(section: DashboardSection, refreshTrigger: DashboardRefreshTrigger) {
     self.section = section
     self.refreshTrigger = refreshTrigger
-
-    let instanceId = AppConfig.current.instanceId
-    _pinnedCollections = Query(
-      filter: #Predicate<KomgaCollection> { item in
-        item.instanceId == instanceId && item.isPinned == true
-      },
-      sort: [SortDescriptor(\KomgaCollection.lastModifiedDate, order: .reverse)]
-    )
-    _pinnedReadLists = Query(
-      filter: #Predicate<KomgaReadList> { item in
-        item.instanceId == instanceId && item.isPinned == true
-      },
-      sort: [SortDescriptor(\KomgaReadList.lastModifiedDate, order: .reverse)]
-    )
   }
 
   private var isSupportedSection: Bool {
@@ -158,8 +141,9 @@ struct DashboardPinnedSectionView: View {
                 case .collections:
                   ForEach(pinnedCollections) { collection in
                     CollectionCompactCardView(
-                      komgaCollection: collection,
-                      coverWidth: compactCoverWidth
+                      item: collection,
+                      coverWidth: compactCoverWidth,
+                      onChanged: schedulePinnedItemsReload
                     )
                     .id(collection.collectionId)
                     .frame(width: compactCardWidth)
@@ -167,8 +151,9 @@ struct DashboardPinnedSectionView: View {
                 case .readLists:
                   ForEach(pinnedReadLists) { readList in
                     ReadListCompactCardView(
-                      komgaReadList: readList,
-                      coverWidth: compactCoverWidth
+                      item: readList,
+                      coverWidth: compactCoverWidth,
+                      onChanged: schedulePinnedItemsReload
                     )
                     .id(readList.readListId)
                     .frame(width: compactCardWidth)
@@ -234,17 +219,22 @@ struct DashboardPinnedSectionView: View {
           await refresh()
         }
       }
-      .task {
-        guard !hasLoadedInitial else { return }
-        hasLoadedInitial = true
+      .task(id: currentInstanceId) {
         await refresh()
       }
     }
   }
 
   private func refresh() async {
-    guard !isLoading, !AppConfig.isOffline else { return }
+    guard !isLoading else { return }
     isLoading = true
+    defer {
+      isLoading = false
+    }
+
+    await loadPinnedItems()
+
+    guard !AppConfig.isOffline else { return }
     switch section.contentKind {
     case .collections:
       await SyncService.syncCollections(instanceId: currentInstanceId)
@@ -253,6 +243,46 @@ struct DashboardPinnedSectionView: View {
     default:
       break
     }
-    isLoading = false
+    await loadPinnedItems()
+  }
+
+  private func schedulePinnedItemsReload() {
+    Task {
+      await loadPinnedItems()
+    }
+  }
+
+  private func loadPinnedItems() async {
+    guard !currentInstanceId.isEmpty else {
+      if !pinnedCollections.isEmpty { pinnedCollections = [] }
+      if !pinnedReadLists.isEmpty { pinnedReadLists = [] }
+      return
+    }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      switch section.contentKind {
+      case .collections:
+        let loadedCollections = try await database.fetchPinnedCollectionDisplayItems(
+          instanceId: currentInstanceId
+        )
+        if pinnedCollections != loadedCollections {
+          pinnedCollections = loadedCollections
+        }
+        if !pinnedReadLists.isEmpty { pinnedReadLists = [] }
+      case .readLists:
+        let loadedReadLists = try await database.fetchPinnedReadListDisplayItems(
+          instanceId: currentInstanceId
+        )
+        if pinnedReadLists != loadedReadLists {
+          pinnedReadLists = loadedReadLists
+        }
+        if !pinnedCollections.isEmpty { pinnedCollections = [] }
+      default:
+        break
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
   }
 }

--- a/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
@@ -10,7 +10,7 @@ struct DashboardPinnedSectionView: View {
   let section: DashboardSection
   let refreshTrigger: DashboardRefreshTrigger
 
-  @AppStorage("currentInstanceId") private var currentInstanceId: String = ""
+  @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
   @AppStorage("showDashboardSectionGradientBackground")
   private var showDashboardSectionGradientBackground: Bool =
@@ -223,6 +223,10 @@ struct DashboardPinnedSectionView: View {
         await refresh()
       }
     }
+  }
+
+  private var currentInstanceId: String {
+    current.instanceId
   }
 
   private func refresh() async {

--- a/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 @MainActor
@@ -19,8 +18,6 @@ struct DashboardSectionDetailView: View {
   @State private var isLoading = false
   @State private var isQueueingAllOffline = false
   @State private var hasLoadedInitial = false
-
-  @Environment(\.modelContext) private var modelContext
 
   private var columns: [GridItem] {
     LayoutConfig.adaptiveColumns(for: gridDensity)
@@ -210,15 +207,13 @@ struct DashboardSectionDetailView: View {
       let ids: [String]
       switch section.contentKind {
       case .books:
-        ids = section.fetchOfflineBookIds(
-          context: modelContext,
+        ids = await section.fetchOfflineBookIds(
           libraryIds: libraryIds,
           offset: pagination.currentPage * pagination.pageSize,
           limit: pagination.pageSize
         )
       case .series:
-        ids = section.fetchOfflineSeriesIds(
-          context: modelContext,
+        ids = await section.fetchOfflineSeriesIds(
           libraryIds: libraryIds,
           offset: pagination.currentPage * pagination.pageSize,
           limit: pagination.pageSize

--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 enum DashboardRefreshSource {
@@ -27,7 +26,6 @@ struct DashboardSectionView: View {
   @AppStorage("showDashboardSectionGradientBackground")
   private var showDashboardSectionGradientBackground: Bool =
     AppConfig.showDashboardSectionGradientBackground
-  @Environment(\.modelContext) private var modelContext
   @Environment(\.colorScheme) private var colorScheme
 
   @State private var pagination = PaginationState<IdentifiedString>(pageSize: 20)
@@ -222,15 +220,13 @@ struct DashboardSectionView: View {
       let ids: [String]
       switch section.contentKind {
       case .books:
-        ids = section.fetchOfflineBookIds(
-          context: modelContext,
+        ids = await section.fetchOfflineBookIds(
           libraryIds: libraryIds,
           offset: pagination.currentPage * pagination.pageSize,
           limit: pagination.pageSize
         )
       case .series:
-        ids = section.fetchOfflineSeriesIds(
-          context: modelContext,
+        ids = await section.fetchOfflineSeriesIds(
           libraryIds: libraryIds,
           offset: pagination.currentPage * pagination.pageSize,
           limit: pagination.pageSize

--- a/KMReader/Features/History/Views/ServerReadingStatsView.swift
+++ b/KMReader/Features/History/Views/ServerReadingStatsView.swift
@@ -4,37 +4,24 @@
 //
 
 import Charts
-import SwiftData
 import SwiftUI
 
 struct ServerReadingStatsView: View {
   @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("isOffline") private var isOffline: Bool = false
-  @Query private var instances: [KomgaInstance]
-  @Query(sort: [SortDescriptor(\KomgaLibrary.name, order: .forward)]) private var allLibraries: [KomgaLibrary]
 
   @State private var selectedLibraryId: String = ""
   @State private var viewModel = ReadingStatsViewModel()
   @State private var selectedTimePointIndex: Int?
-
-  private var libraries: [KomgaLibrary] {
-    guard !current.instanceId.isEmpty else { return [] }
-    return allLibraries.filter {
-      $0.instanceId == current.instanceId && $0.libraryId != KomgaLibrary.allLibrariesId
-    }
-  }
-
-  private var currentInstance: KomgaInstance? {
-    guard let uuid = UUID(uuidString: current.instanceId) else { return nil }
-    return instances.first { $0.id == uuid }
-  }
+  @State private var libraries: [SidebarLibraryItem] = []
+  @State private var syncInfo: OfflineInstanceSyncInfo?
 
   private var shouldShowInitialSyncHint: Bool {
-    guard let currentInstance else { return false }
+    guard let syncInfo else { return false }
     let neverSyncedAt = Date(timeIntervalSince1970: 0)
     let hasNeverSynced =
-      currentInstance.seriesLastSyncedAt == neverSyncedAt
-      && currentInstance.booksLastSyncedAt == neverSyncedAt
+      syncInfo.seriesLastSyncedAt == neverSyncedAt
+      && syncInfo.booksLastSyncedAt == neverSyncedAt
     let hasAnyLocalBook = (viewModel.payload?.summary.totalBooks ?? 0) > 0
     return hasNeverSynced && !hasAnyLocalBook
   }
@@ -79,6 +66,7 @@ struct ServerReadingStatsView: View {
     .inlineNavigationBarTitle(ServerSection.readingStats.title)
     .task(id: current.instanceId) {
       selectedLibraryId = ""
+      await loadLocalContext()
       await reload(forceRefresh: false)
     }
     .onChange(of: selectedLibraryId) { _, _ in
@@ -92,6 +80,7 @@ struct ServerReadingStatsView: View {
     .onChange(of: isOffline) { oldValue, newValue in
       if oldValue && !newValue {
         Task {
+          await loadLocalContext()
           await reload(forceRefresh: false)
         }
       }
@@ -611,5 +600,32 @@ struct ServerReadingStatsView: View {
       libraryId: selectedLibraryId,
       forceRefresh: forceRefresh
     )
+  }
+
+  private func loadLocalContext() async {
+    let instanceId = current.instanceId
+    guard !instanceId.isEmpty else {
+      if !libraries.isEmpty {
+        libraries = []
+      }
+      if syncInfo != nil {
+        syncInfo = nil
+      }
+      return
+    }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedLibraries = try await database.fetchSidebarLibraries(instanceId: instanceId)
+      let loadedSyncInfo = try await database.fetchOfflineInstanceSyncInfo(instanceId: instanceId)
+      if libraries != loadedLibraries {
+        libraries = loadedLibraries
+      }
+      if syncInfo != loadedSyncInfo {
+        syncInfo = loadedSyncInfo
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
   }
 }

--- a/KMReader/Features/Library/Services/LibraryMetricsLoader.swift
+++ b/KMReader/Features/Library/Services/LibraryMetricsLoader.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-import SwiftData
 
 struct LibraryMetricsLoader {
   static let shared = LibraryMetricsLoader()
@@ -116,7 +115,8 @@ struct LibraryMetricsLoader {
     ensureEntry: Bool
   ) async {
     if !ensureEntry {
-      try? await DatabaseOperator.database().upsertAllLibrariesEntry(
+      let database = try? await DatabaseOperator.database()
+      try? await database?.upsertAllLibrariesEntry(
         instanceId: instanceId,
         fileSize: nil,
         booksCount: nil,
@@ -125,6 +125,7 @@ struct LibraryMetricsLoader {
         collectionsCount: nil,
         readlistsCount: nil
       )
+      try? await database?.commit()
     }
 
     var metrics = AllLibrariesMetricsData()
@@ -199,7 +200,8 @@ struct LibraryMetricsLoader {
       }
     }
 
-    try? await DatabaseOperator.database().upsertAllLibrariesEntry(
+    let database = try? await DatabaseOperator.database()
+    try? await database?.upsertAllLibrariesEntry(
       instanceId: instanceId,
       fileSize: metrics.fileSize,
       booksCount: metrics.booksCount,
@@ -208,10 +210,11 @@ struct LibraryMetricsLoader {
       collectionsCount: metrics.collectionsCount,
       readlistsCount: metrics.readlistsCount
     )
+    try? await database?.commit()
   }
 }
 
-struct LibraryMetricValues {
+nonisolated struct LibraryMetricValues: Equatable, Sendable {
   var fileSize: Double?
   var seriesCount: Double?
   var booksCount: Double?

--- a/KMReader/Features/Offline/Models/OfflineDownloadedBooksSnapshot.swift
+++ b/KMReader/Features/Offline/Models/OfflineDownloadedBooksSnapshot.swift
@@ -1,0 +1,75 @@
+//
+// OfflineDownloadedBooksSnapshot.swift
+//
+//
+
+import Foundation
+
+nonisolated struct OfflineDownloadedBookItem: Equatable, Identifiable, Sendable {
+  let id: String
+  let instanceId: String
+  let bookId: String
+  let seriesId: String
+  let libraryId: String
+  let bookName: String
+  let seriesTitle: String
+  let metaNumber: String
+  let metaTitle: String
+  let metaNumberSort: Double
+  let downloadedSize: Int64
+  let isReadCompleted: Bool
+
+  var listTitle: String {
+    "#\(metaNumber) - \(metaTitle)"
+  }
+
+  var oneshotTitle: String {
+    metaTitle.isEmpty ? bookName : metaTitle
+  }
+}
+
+nonisolated struct OfflineDownloadedSeriesGroup: Equatable, Identifiable, Sendable {
+  let id: String
+  let name: String?
+  let books: [OfflineDownloadedBookItem]
+
+  var downloadedSize: Int64 {
+    books.reduce(0) { $0 + $1.downloadedSize }
+  }
+}
+
+nonisolated struct OfflineDownloadedLibraryGroup: Equatable, Identifiable, Sendable {
+  let id: String
+  let name: String?
+  let seriesGroups: [OfflineDownloadedSeriesGroup]
+  let oneshotBooks: [OfflineDownloadedBookItem]
+
+  var downloadedSize: Int64 {
+    let seriesSize = seriesGroups.reduce(0) { $0 + $1.downloadedSize }
+    let oneshotSize = oneshotBooks.reduce(0) { $0 + $1.downloadedSize }
+    return seriesSize + oneshotSize
+  }
+}
+
+nonisolated struct OfflineDownloadedBooksSnapshot: Equatable, Sendable {
+  let libraryGroups: [OfflineDownloadedLibraryGroup]
+
+  static let empty = OfflineDownloadedBooksSnapshot(libraryGroups: [])
+
+  var isEmpty: Bool {
+    libraryGroups.allSatisfy { $0.seriesGroups.isEmpty && $0.oneshotBooks.isEmpty }
+  }
+
+  var totalDownloadedSize: Int64 {
+    libraryGroups.reduce(0) { $0 + $1.downloadedSize }
+  }
+
+  var hasReadBooks: Bool {
+    libraryGroups.contains { libraryGroup in
+      libraryGroup.oneshotBooks.contains { $0.isReadCompleted }
+        || libraryGroup.seriesGroups.contains { seriesGroup in
+          seriesGroup.books.contains { $0.isReadCompleted }
+        }
+    }
+  }
+}

--- a/KMReader/Features/Offline/Models/OfflineInstanceSyncInfo.swift
+++ b/KMReader/Features/Offline/Models/OfflineInstanceSyncInfo.swift
@@ -1,0 +1,16 @@
+//
+// OfflineInstanceSyncInfo.swift
+//
+//
+
+import Foundation
+
+nonisolated struct OfflineInstanceSyncInfo: Equatable, Sendable {
+  let instanceId: String
+  let seriesLastSyncedAt: Date
+  let booksLastSyncedAt: Date
+
+  var latestSync: Date {
+    max(seriesLastSyncedAt, booksLastSyncedAt)
+  }
+}

--- a/KMReader/Features/Offline/Models/OfflineTaskItem.swift
+++ b/KMReader/Features/Offline/Models/OfflineTaskItem.swift
@@ -1,0 +1,28 @@
+//
+// OfflineTaskItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct OfflineTaskItem: Equatable, Identifiable, Sendable {
+  let id: String
+  let bookId: String
+  let seriesTitle: String
+  let metaNumber: String
+  let metaTitle: String
+  let downloadStatusRaw: String
+  let downloadStatus: DownloadStatus
+
+  var isDownloading: Bool {
+    downloadStatusRaw == "downloading"
+  }
+
+  var isPending: Bool {
+    downloadStatusRaw == "pending"
+  }
+
+  var isFailed: Bool {
+    downloadStatusRaw == "failed"
+  }
+}

--- a/KMReader/Features/Offline/Views/OfflineBooksBrowseView.swift
+++ b/KMReader/Features/Offline/Views/OfflineBooksBrowseView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct OfflineBooksBrowseView: View {
@@ -12,8 +11,6 @@ struct OfflineBooksBrowseView: View {
   let refreshTrigger: UUID
   @Binding var showFilterSheet: Bool
   @Binding var showSavedFilters: Bool
-
-  @Environment(\.modelContext) private var modelContext
 
   @AppStorage("offlineBookBrowseOptions") private var storedBrowseOpts: BookBrowseOptions =
     Self.defaultBrowseOptions
@@ -93,7 +90,6 @@ struct OfflineBooksBrowseView: View {
       (searchIgnoreFilters && !searchText.isEmpty) ? BookBrowseOptions() : browseOpts
 
     await viewModel.loadBrowseBooks(
-      context: modelContext,
       browseOpts: effectiveBrowseOpts,
       searchText: searchText,
       libraryIds: libraryIds,

--- a/KMReader/Features/Offline/Views/OfflineBooksView.swift
+++ b/KMReader/Features/Offline/Views/OfflineBooksView.swift
@@ -3,30 +3,16 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct OfflineBooksView: View {
-  @Environment(\.modelContext) private var modelContext
-  @Query var downloadedBooks: [KomgaBook]
-  @Query var libraries: [KomgaLibrary]
+  @AppStorage("currentAccount") private var current: Current = .init()
 
   @State private var showRemoveAllAlert = false
   @State private var showRemoveReadAlert = false
   @State private var isScanning = false
-
-  struct SeriesGroup: Identifiable {
-    let id: String
-    let series: KomgaSeries?
-    let books: [KomgaBook]
-  }
-
-  struct LibraryGroup: Identifiable {
-    let id: String
-    let library: KomgaLibrary?
-    let seriesGroups: [SeriesGroup]
-    let oneshotBooks: [KomgaBook]
-  }
+  @State private var snapshot: OfflineDownloadedBooksSnapshot = .empty
+  @State private var progressTracker = DownloadProgressTracker.shared
 
   private let formatter: ByteCountFormatter = {
     let f = ByteCountFormatter()
@@ -35,86 +21,9 @@ struct OfflineBooksView: View {
     return f
   }()
 
-  init() {
-    let instanceId = AppConfig.current.instanceId
-    _downloadedBooks = Query(
-      filter: #Predicate<KomgaBook> {
-        $0.instanceId == instanceId && $0.downloadStatusRaw == "downloaded"
-      },
-      sort: [SortDescriptor(\KomgaBook.libraryId)]
-    )
-    _libraries = Query(
-      filter: #Predicate<KomgaLibrary> {
-        $0.instanceId == instanceId
-      }
-    )
-  }
-
-  private var groupedBooks: [LibraryGroup] {
-    let libraryGroups = Dictionary(grouping: downloadedBooks) { $0.libraryId }
-    var result: [LibraryGroup] = []
-
-    for (libraryId, lBooks) in libraryGroups {
-      let library = libraries.first { $0.libraryId == libraryId }
-
-      let oneshots = lBooks.filter { $0.oneshot }
-      let seriesBooks = lBooks.filter { !$0.oneshot }
-
-      let seriesGroupsMap = Dictionary(grouping: seriesBooks) { $0.seriesId }
-
-      // Batch fetch all series at once
-      let instanceId = AppConfig.current.instanceId
-      let seriesIds = Set(seriesGroupsMap.keys)
-      let compositeIds = seriesIds.map { CompositeID.generate(instanceId: instanceId, id: $0) }
-      let seriesDescriptor = FetchDescriptor<KomgaSeries>(
-        predicate: #Predicate { compositeIds.contains($0.id) })
-      let allSeries = (try? modelContext.fetch(seriesDescriptor)) ?? []
-      let seriesMap = Dictionary(
-        allSeries.map { ($0.seriesId, $0) },
-        uniquingKeysWith: { first, _ in first }
-      )
-
-      var sGroups: [SeriesGroup] = []
-      for (seriesId, sBooks) in seriesGroupsMap {
-        sGroups.append(
-          SeriesGroup(
-            id: seriesId, series: seriesMap[seriesId],
-            books: sBooks.sorted { ($0.metadata?.numberSort ?? 0) < ($1.metadata?.numberSort ?? 0) }))
-      }
-
-      sGroups.sort {
-        ($0.series?.name ?? $0.books.first?.seriesTitle ?? "")
-          < ($1.series?.name ?? $1.books.first?.seriesTitle ?? "")
-      }
-      result.append(
-        LibraryGroup(
-          id: libraryId,
-          library: library,
-          seriesGroups: sGroups,
-          oneshotBooks: oneshots.sorted {
-            let lhsTitle = $0.metadata?.title ?? ""
-            let rhsTitle = $1.metadata?.title ?? ""
-            return (lhsTitle.isEmpty ? $0.name : lhsTitle)
-              < (rhsTitle.isEmpty ? $1.name : rhsTitle)
-          }
-        ))
-    }
-
-    result.sort { ($0.library?.name ?? "") < ($1.library?.name ?? "") }
-    return result
-  }
-
-  private var totalDownloadedSize: Int64 {
-    downloadedBooks.reduce(0) { $0 + $1.downloadedSize }
-  }
-
-  private var hasReadBooks: Bool {
-    downloadedBooks.contains { $0.readProgress?.completed == true }
-  }
-
   var body: some View {
     Form {
-      if downloadedBooks.isEmpty {
+      if snapshot.isEmpty {
         ContentUnavailableView {
           Label(String(localized: "settings.offline.no_books"), systemImage: ContentIcon.book)
         } description: {
@@ -127,7 +36,7 @@ struct OfflineBooksView: View {
             Text(String(localized: "settings.offline_books.total_size"))
               .fontWeight(.semibold)
             Spacer()
-            Text(formatter.string(fromByteCount: totalDownloadedSize))
+            Text(formatter.string(fromByteCount: snapshot.totalDownloadedSize))
               .foregroundColor(.accentColor)
           }
 
@@ -148,6 +57,7 @@ struct OfflineBooksView: View {
                   message: String(localized: "settings.offline_books.cleanup_orphaned.no_orphaned")
                 )
               }
+              await loadSnapshot()
             }
           } label: {
             HStack {
@@ -177,16 +87,16 @@ struct OfflineBooksView: View {
                 String(localized: "settings.offline_books.remove_read"),
                 systemImage: "checkmark.circle")
             }
-            .disabled(!hasReadBooks)
+            .disabled(!snapshot.hasReadBooks)
           }.adaptiveButtonStyle(.bordered)
         }
 
-        ForEach(groupedBooks) { lGroup in
+        ForEach(snapshot.libraryGroups) { lGroup in
           Section(
             header: HStack {
-              Text(lGroup.library?.name ?? String(localized: "Unknown"))
+              Text(lGroup.name ?? String(localized: "Unknown"))
               Spacer()
-              Text(formatter.string(fromByteCount: totalSize(for: lGroup)))
+              Text(formatter.string(fromByteCount: lGroup.downloadedSize))
                 .font(.caption)
                 .foregroundColor(.secondary)
             }
@@ -195,20 +105,20 @@ struct OfflineBooksView: View {
               #if os(tvOS)
                 Section(
                   header: HStack {
-                    Text(sGroup.series?.name ?? String(localized: "Unknown"))
+                    Text(sGroup.name ?? String(localized: "Unknown"))
                     Spacer()
-                    Text(formatter.string(fromByteCount: seriesSize(for: sGroup.books)))
+                    Text(formatter.string(fromByteCount: sGroup.downloadedSize))
                       .font(.caption)
                       .foregroundColor(.secondary)
                   }
                 ) {
                   ForEach(sGroup.books) { book in
                     HStack {
-                      Text("#\(book.metaNumber) - \(book.metaTitle)")
+                      Text(book.listTitle)
                         .font(.footnote)
 
                       Spacer()
-                      if book.readProgress?.completed == true {
+                      if book.isReadCompleted {
                         Image(systemName: "checkmark.circle.fill")
                           .font(.caption)
                           .foregroundColor(.secondary)
@@ -223,11 +133,11 @@ struct OfflineBooksView: View {
                 DisclosureGroup {
                   ForEach(sGroup.books) { book in
                     HStack {
-                      Text("#\(book.metaNumber) - \(book.metaTitle)")
+                      Text(book.listTitle)
                         .font(.footnote)
 
                       Spacer()
-                      if book.readProgress?.completed == true {
+                      if book.isReadCompleted {
                         Image(systemName: "checkmark.circle.fill")
                           .font(.caption)
                           .foregroundColor(.secondary)
@@ -246,9 +156,9 @@ struct OfflineBooksView: View {
                   }
                 } label: {
                   HStack {
-                    Text(sGroup.series?.name ?? String(localized: "Unknown"))
+                    Text(sGroup.name ?? String(localized: "Unknown"))
                     Spacer()
-                    Text(formatter.string(fromByteCount: seriesSize(for: sGroup.books)))
+                    Text(formatter.string(fromByteCount: sGroup.downloadedSize))
                       .font(.caption)
                       .foregroundColor(.secondary)
                   }
@@ -269,18 +179,18 @@ struct OfflineBooksView: View {
                   header: HStack {
                     Text(String(localized: "settings.offline_books.oneshots"))
                     Spacer()
-                    Text(formatter.string(fromByteCount: seriesSize(for: lGroup.oneshotBooks)))
+                    Text(formatter.string(fromByteCount: downloadedSize(for: lGroup.oneshotBooks)))
                       .font(.caption)
                       .foregroundColor(.secondary)
                   }
                 ) {
                   ForEach(lGroup.oneshotBooks) { book in
                     HStack {
-                      Text(book.metaTitle)
+                      Text(book.oneshotTitle)
                         .font(.footnote)
 
                       Spacer()
-                      if book.readProgress?.completed == true {
+                      if book.isReadCompleted {
                         Image(systemName: "checkmark.circle.fill")
                           .font(.caption)
                           .foregroundColor(.secondary)
@@ -295,11 +205,11 @@ struct OfflineBooksView: View {
                 DisclosureGroup {
                   ForEach(lGroup.oneshotBooks) { book in
                     HStack {
-                      Text(book.metaTitle)
+                      Text(book.oneshotTitle)
                         .font(.footnote)
 
                       Spacer()
-                      if book.readProgress?.completed == true {
+                      if book.isReadCompleted {
                         Image(systemName: "checkmark.circle.fill")
                           .font(.caption)
                           .foregroundColor(.secondary)
@@ -321,7 +231,7 @@ struct OfflineBooksView: View {
                   HStack {
                     Text(String(localized: "settings.offline_books.oneshots"))
                     Spacer()
-                    Text(formatter.string(fromByteCount: seriesSize(for: lGroup.oneshotBooks)))
+                    Text(formatter.string(fromByteCount: downloadedSize(for: lGroup.oneshotBooks)))
                       .font(.caption)
                       .foregroundColor(.secondary)
                   }
@@ -363,26 +273,29 @@ struct OfflineBooksView: View {
     } message: {
       Text(String(localized: "settings.offline_books.remove_read.message"))
     }
-  }
-
-  private func seriesSize(for books: [KomgaBook]) -> Int64 {
-    books.reduce(0) { $0 + $1.downloadedSize }
-  }
-
-  private func totalSize(for lGroup: LibraryGroup) -> Int64 {
-    let sSize = lGroup.seriesGroups.reduce(0) { $0 + seriesSize(for: $1.books) }
-    let oSize = lGroup.oneshotBooks.reduce(0) { $0 + $1.downloadedSize }
-    return sSize + oSize
-  }
-
-  private func deleteBook(_ book: KomgaBook) {
-    Task {
-      await OfflineManager.shared.deleteBookManually(
-        seriesId: book.seriesId, instanceId: book.instanceId, bookId: book.bookId)
+    .task(id: current.instanceId) {
+      await loadSnapshot()
+    }
+    .onChange(of: progressTracker.queueUpdateToken) { _, _ in
+      Task {
+        await loadSnapshot()
+      }
     }
   }
 
-  private func deleteSeries(_ books: [KomgaBook]) {
+  private func downloadedSize(for books: [OfflineDownloadedBookItem]) -> Int64 {
+    books.reduce(0) { $0 + $1.downloadedSize }
+  }
+
+  private func deleteBook(_ book: OfflineDownloadedBookItem) {
+    Task {
+      await OfflineManager.shared.deleteBookManually(
+        seriesId: book.seriesId, instanceId: book.instanceId, bookId: book.bookId)
+      await loadSnapshot()
+    }
+  }
+
+  private func deleteSeries(_ books: [OfflineDownloadedBookItem]) {
     guard let firstBook = books.first else { return }
     Task {
       await OfflineManager.shared.deleteBooksManually(
@@ -390,6 +303,7 @@ struct OfflineBooksView: View {
         instanceId: firstBook.instanceId,
         bookIds: books.map { $0.bookId }
       )
+      await loadSnapshot()
     }
   }
 
@@ -399,6 +313,7 @@ struct OfflineBooksView: View {
       ErrorManager.shared.notify(
         message: String(localized: "notification.offline.booksRemovedAll")
       )
+      await loadSnapshot()
     }
   }
 
@@ -408,6 +323,29 @@ struct OfflineBooksView: View {
       ErrorManager.shared.notify(
         message: String(localized: "notification.offline.booksRemovedRead")
       )
+      await loadSnapshot()
+    }
+  }
+
+  private func loadSnapshot() async {
+    let instanceId = current.instanceId
+    guard !instanceId.isEmpty else {
+      if snapshot != .empty {
+        snapshot = .empty
+      }
+      return
+    }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedSnapshot = try await database.fetchOfflineDownloadedBooksSnapshot(
+        instanceId: instanceId
+      )
+      if snapshot != loadedSnapshot {
+        snapshot = loadedSnapshot
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
     }
   }
 }

--- a/KMReader/Features/Offline/Views/OfflineSeriesBrowseView.swift
+++ b/KMReader/Features/Offline/Views/OfflineSeriesBrowseView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct OfflineSeriesBrowseView: View {
@@ -17,8 +16,6 @@ struct OfflineSeriesBrowseView: View {
     Self.defaultBrowseOptions
   @AppStorage("seriesBrowseLayout") private var browseLayout: BrowseLayoutMode = .grid
   @AppStorage("searchIgnoreFilters") private var searchIgnoreFilters: Bool = false
-
-  @Environment(\.modelContext) private var modelContext
 
   @State private var browseOpts: SeriesBrowseOptions = Self.defaultBrowseOptions
   @State private var viewModel = SeriesViewModel()
@@ -92,7 +89,6 @@ struct OfflineSeriesBrowseView: View {
     let effectiveBrowseOpts =
       (searchIgnoreFilters && !searchText.isEmpty) ? SeriesBrowseOptions() : browseOpts
     await viewModel.loadSeries(
-      context: modelContext,
       browseOpts: effectiveBrowseOpts,
       searchText: searchText,
       libraryIds: libraryIds,

--- a/KMReader/Features/Offline/Views/OfflineTasksView.swift
+++ b/KMReader/Features/Offline/Views/OfflineTasksView.swift
@@ -3,11 +3,9 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct OfflineTasksView: View {
-  @Environment(\.modelContext) private var modelContext
   @AppStorage("currentAccount") private var current: Current = .init()
   private var instanceId: String { current.instanceId }
   @AppStorage("offlinePaused") private var isPaused: Bool = false
@@ -16,45 +14,33 @@ struct OfflineTasksView: View {
   @State private var showingBulkAlert = false
   @State private var showingAutoDeleteAlert = false
   @State private var pendingBulkAction: BulkAction?
+  @State private var tasks: [OfflineTaskItem] = []
+  @State private var progressTracker = DownloadProgressTracker.shared
 
   enum BulkAction {
     case retryAll, cancelAll
   }
 
-  @Query private var books: [KomgaBook]
-
-  init() {
-    let instanceId = AppConfig.current.instanceId
-    _books = Query(
-      filter: #Predicate<KomgaBook> { book in
-        book.instanceId == instanceId
-          && (book.downloadStatusRaw == "pending" || book.downloadStatusRaw == "downloading"
-            || book.downloadStatusRaw == "failed")
-      },
-      sort: [SortDescriptor(\KomgaBook.downloadAt, order: .forward)]
-    )
+  private var downloadingTasks: [OfflineTaskItem] {
+    tasks.filter(\.isDownloading)
   }
 
-  private var downloadingBooks: [KomgaBook] {
-    books.filter { $0.downloadStatusRaw == "downloading" }
+  private var pendingTasks: [OfflineTaskItem] {
+    tasks.filter(\.isPending)
   }
 
-  private var pendingBooks: [KomgaBook] {
-    books.filter { $0.downloadStatusRaw == "pending" }
-  }
-
-  private var failedBooks: [KomgaBook] {
-    books.filter { $0.downloadStatusRaw == "failed" }
+  private var failedTasks: [OfflineTaskItem] {
+    tasks.filter(\.isFailed)
   }
 
   private var currentStatus: SyncStatus {
     if isPaused {
       return .paused
     }
-    if !downloadingBooks.isEmpty {
+    if !downloadingTasks.isEmpty {
       return .downloading
     }
-    if !pendingBooks.isEmpty {
+    if !pendingTasks.isEmpty {
       return .syncing
     }
     return .idle
@@ -117,26 +103,47 @@ struct OfflineTasksView: View {
         }
       }
 
-      if !downloadingBooks.isEmpty {
+      if !downloadingTasks.isEmpty {
         Section("Downloading") {
-          ForEach(downloadingBooks) { book in
-            OfflineTaskRow(book: book)
+          ForEach(downloadingTasks) { task in
+            OfflineTaskRow(
+              task: task,
+              onChanged: {
+                Task {
+                  await loadTasks()
+                }
+              }
+            )
           }
         }
       }
 
-      if !pendingBooks.isEmpty {
+      if !pendingTasks.isEmpty {
         Section("Pending") {
-          ForEach(pendingBooks) { book in
-            OfflineTaskRow(book: book)
+          ForEach(pendingTasks) { task in
+            OfflineTaskRow(
+              task: task,
+              onChanged: {
+                Task {
+                  await loadTasks()
+                }
+              }
+            )
           }
         }
       }
 
-      if !failedBooks.isEmpty {
+      if !failedTasks.isEmpty {
         Section {
-          ForEach(failedBooks) { book in
-            OfflineTaskRow(book: book)
+          ForEach(failedTasks) { task in
+            OfflineTaskRow(
+              task: task,
+              onChanged: {
+                Task {
+                  await loadTasks()
+                }
+              }
+            )
           }
         } header: {
           HStack {
@@ -171,7 +178,7 @@ struct OfflineTasksView: View {
         }
       }
 
-      if books.isEmpty {
+      if tasks.isEmpty {
         ContentUnavailableView {
           Label("No Download Tasks", systemImage: "square.and.arrow.down")
         } description: {
@@ -184,7 +191,7 @@ struct OfflineTasksView: View {
     .inlineNavigationBarTitle(OfflineSection.tasks.title)
     .animation(.default, value: isPaused)
     .animation(.default, value: currentStatus)
-    .animation(.default, value: books)
+    .animation(.default, value: tasks)
     .alert(
       "Confirm Action", isPresented: $showingBulkAlert,
       presenting: pendingBulkAction
@@ -197,11 +204,13 @@ struct OfflineTasksView: View {
             ErrorManager.shared.notify(
               message: String(localized: "notification.offline.retryAllFailed")
             )
+            await loadTasks()
           case .cancelAll:
             await OfflineManager.shared.cancelFailedDownloads(instanceId: instanceId)
             ErrorManager.shared.notify(
               message: String(localized: "notification.offline.cancelAllFailed")
             )
+            await loadTasks()
           }
         }
       } label: {
@@ -226,8 +235,14 @@ struct OfflineTasksView: View {
         OfflineManager.shared.triggerSync(instanceId: instanceId, restart: true)
       }
     }
-    .task {
+    .task(id: instanceId) {
+      await loadTasks()
       OfflineManager.shared.triggerSync(instanceId: instanceId)
+    }
+    .onChange(of: progressTracker.queueUpdateToken) { _, _ in
+      Task {
+        await loadTasks()
+      }
     }
     .alert(
       String(localized: "settings.offline.auto_delete_read"),
@@ -245,28 +260,49 @@ struct OfflineTasksView: View {
       Text(String(localized: "settings.offline.auto_delete_read.message"))
     }
   }
+
+  private func loadTasks() async {
+    guard !instanceId.isEmpty else {
+      if !tasks.isEmpty {
+        tasks = []
+      }
+      return
+    }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedTasks = try await database.fetchOfflineTaskItems(instanceId: instanceId)
+      if tasks != loadedTasks {
+        tasks = loadedTasks
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
+  }
 }
 
 struct OfflineTaskRow: View {
   @AppStorage("currentAccount") private var current: Current = .init()
   private var instanceId: String { current.instanceId }
-  @Bindable var book: KomgaBook
+  let task: OfflineTaskItem
+  let onChanged: () -> Void
+
+  @State private var progressTracker = DownloadProgressTracker.shared
 
   private var progress: Double? {
-    DownloadProgressTracker.shared.progress[book.bookId]
+    progressTracker.progress[task.bookId]
   }
 
   var body: some View {
     HStack(alignment: .center, spacing: 12) {
       VStack(alignment: .leading, spacing: 4) {
-        Text(book.seriesTitle)
+        Text(task.seriesTitle)
           .font(.caption)
           .lineLimit(1)
-        Text("#\(book.metaNumber) - \(book.metaTitle)")
+        Text("#\(task.metaNumber) - \(task.metaTitle)")
           .lineLimit(1)
 
-        switch book.downloadStatus {
-        case .pending:
+        if task.isPending || task.isDownloading {
           if let progress = progress {
             if progress >= 1 {
               Text(String(localized: "Processing offline files..."))
@@ -285,17 +321,19 @@ struct OfflineTaskRow: View {
               }
             }
           } else {
-            Text("Pending in queue...")
+            Text(
+              task.isDownloading
+                ? String(localized: "Downloading")
+                : String(localized: "Pending in queue...")
+            )
               .font(.caption)
               .foregroundColor(.secondary)
           }
-        case .failed(let error):
+        } else if case .failed(let error) = task.downloadStatus {
           Text(error)
             .font(.caption)
             .foregroundColor(.red)
             .lineLimit(2)
-        default:
-          EmptyView()
         }
       }
 
@@ -303,11 +341,12 @@ struct OfflineTaskRow: View {
 
       #if os(iOS) || os(macOS)
         HStack(spacing: 16) {
-          if case .failed = book.downloadStatus {
+          if task.isFailed {
             Button {
               Task {
                 await OfflineManager.shared.retryDownload(
-                  instanceId: instanceId, bookId: book.bookId)
+                  instanceId: instanceId, bookId: task.bookId)
+                onChanged()
               }
             } label: {
               Image(systemName: "arrow.clockwise.circle")
@@ -318,11 +357,12 @@ struct OfflineTaskRow: View {
 
           Button(role: .destructive) {
             Task {
-              await OfflineManager.shared.cancelDownload(bookId: book.bookId)
+              await OfflineManager.shared.cancelDownload(bookId: task.bookId)
               OfflineManager.shared.triggerSync(instanceId: instanceId)
+              onChanged()
             }
           } label: {
-            Image(systemName: book.downloadStatusRaw == "failed" ? "trash" : "xmark.circle")
+            Image(systemName: task.isFailed ? "trash" : "xmark.circle")
               .foregroundColor(.red)
           }
           .adaptiveButtonStyle(.plain)

--- a/KMReader/Features/Offline/Views/OfflineView.swift
+++ b/KMReader/Features/Offline/Views/OfflineView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct OfflineView: View {
@@ -17,8 +16,6 @@ struct OfflineView: View {
   @AppStorage("offlineBrowseContent") private var offlineBrowseContent: BrowseContentType = .series
   @AppStorage("isOffline") private var isOffline: Bool = false
 
-  @Query private var instances: [KomgaInstance]
-
   @State private var refreshTrigger = UUID()
   @State private var searchQuery: String = ""
   @State private var activeSearchText: String = ""
@@ -27,27 +24,22 @@ struct OfflineView: View {
   @State private var showSavedFilters = false
   @State private var showSyncConfirmation = false
   @State private var latestReadHistoryTime: Date?
+  @State private var syncInfo: OfflineInstanceSyncInfo?
 
   private var syncViewModel: SyncViewModel {
     SyncViewModel.shared
   }
 
-  private var currentInstance: KomgaInstance? {
-    guard let uuid = UUID(uuidString: current.instanceId) else { return nil }
-    return instances.first { $0.id == uuid }
-  }
-
   private var lastSyncTimeText: String {
-    guard let instance = currentInstance else {
+    guard let syncInfo else {
       return String(localized: "settings.sync_data.never")
     }
-    let latestSync = max(instance.seriesLastSyncedAt, instance.booksLastSyncedAt)
-    if latestSync == Date(timeIntervalSince1970: 0) {
+    if syncInfo.latestSync == Date(timeIntervalSince1970: 0) {
       return String(localized: "settings.sync_data.never")
     }
     let formatter = RelativeDateTimeFormatter()
     formatter.unitsStyle = .short
-    return formatter.localizedString(for: latestSync, relativeTo: Date())
+    return formatter.localizedString(for: syncInfo.latestSync, relativeTo: Date())
   }
 
   private var title: String {
@@ -206,11 +198,13 @@ struct OfflineView: View {
       Button(String(localized: "offline.sync.confirm.action")) {
         Task {
           await syncViewModel.syncData()
+          await loadSyncInfo()
         }
       }
       Button(String(localized: "offline.sync.confirm.forceAction"), role: .destructive) {
         Task {
           await syncViewModel.syncData(forceFullSync: true)
+          await loadSyncInfo()
         }
       }
       Button(String(localized: "Cancel"), role: .cancel) {}
@@ -234,10 +228,14 @@ struct OfflineView: View {
     .task(id: current.instanceId) {
       guard !authViewModel.isSwitching else { return }
       latestReadHistoryTime = AppConfig.recentlyReadRecordTime(instanceId: current.instanceId)
+      await loadSyncInfo()
     }
     .onChange(of: resolvedLibraryIdsKey) { _, _ in
       guard !authViewModel.isSwitching else { return }
       refreshBrowse()
+      Task {
+        await loadSyncInfo()
+      }
     }
   }
 
@@ -360,6 +358,25 @@ struct OfflineView: View {
 
   private func refreshBrowse() {
     refreshTrigger = UUID()
+  }
+
+  private func loadSyncInfo() async {
+    guard !current.instanceId.isEmpty else {
+      if syncInfo != nil { syncInfo = nil }
+      return
+    }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedSyncInfo = try await database.fetchOfflineInstanceSyncInfo(
+        instanceId: current.instanceId
+      )
+      if syncInfo != loadedSyncInfo {
+        syncInfo = loadedSyncInfo
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
   }
 
   private func triggerReadingProgressSync(force: Bool = false) {

--- a/KMReader/Features/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailView.swift
@@ -4,7 +4,6 @@
 //
 
 import Flow
-import SwiftData
 import SwiftUI
 
 struct OneshotDetailView: View {
@@ -13,9 +12,8 @@ struct OneshotDetailView: View {
   @Environment(\.dismiss) private var dismiss
   @AppStorage("currentAccount") private var current: Current = .init()
 
-  @Query private var komgaSeriesList: [KomgaSeries]
-  @Query private var komgaBookList: [KomgaBook]
-
+  @State private var seriesItem: SeriesDisplayItem?
+  @State private var bookItem: BookDisplayItem?
   @State private var isLoading = true
   @State private var hasError = false
   @State private var showDeleteConfirmation = false
@@ -25,33 +23,18 @@ struct OneshotDetailView: View {
 
   init(seriesId: String) {
     self.seriesId = seriesId
-    let instanceId = AppConfig.current.instanceId
-    let seriesCompositeId = CompositeID.generate(instanceId: instanceId, id: seriesId)
-    _komgaSeriesList = Query(filter: #Predicate<KomgaSeries> { $0.id == seriesCompositeId })
-    _komgaBookList = Query(
-      filter: #Predicate<KomgaBook> { $0.instanceId == instanceId && $0.seriesId == seriesId })
-  }
-
-  /// The KomgaSeries from SwiftData (reactive).
-  private var komgaSeries: KomgaSeries? {
-    komgaSeriesList.first
-  }
-
-  /// The KomgaBook from SwiftData (reactive).
-  private var komgaBook: KomgaBook? {
-    komgaBookList.first
   }
 
   private var series: Series? {
-    komgaSeries?.toSeries()
+    seriesItem?.series
   }
 
   private var book: Book? {
-    komgaBook?.toBook()
+    bookItem?.book
   }
 
   private var downloadStatus: DownloadStatus {
-    komgaBook?.downloadStatus ?? .notDownloaded
+    bookItem?.downloadStatus ?? .notDownloaded
   }
 
   private var navigationTitle: String {
@@ -78,12 +61,12 @@ struct OneshotDetailView: View {
             inSheet: false
           )
 
-          if let komgaSeries = komgaSeries {
-            SeriesCollectionsSection(collectionIds: komgaSeries.collectionIds)
+          if let seriesItem {
+            SeriesCollectionsSection(collectionIds: seriesItem.collectionIds)
           }
 
-          if let komgaBook = komgaBook {
-            BookReadListsSection(readListIds: komgaBook.readListIds)
+          if let bookItem {
+            BookReadListsSection(readListIds: bookItem.readListIds)
           }
         } else if hasError {
           VStack(spacing: 16) {
@@ -172,12 +155,30 @@ struct OneshotDetailView: View {
     } catch {
       if case APIError.notFound = error {
         dismiss()
-      } else if komgaSeries == nil || komgaBook == nil {
+      } else if seriesItem == nil || bookItem == nil {
         hasError = true
         ErrorManager.shared.alert(error: error)
       }
       isLoading = false
     }
+    await loadLocalOneshot()
+  }
+
+  private func loadLocalOneshot() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      seriesItem = nil
+      bookItem = nil
+      return
+    }
+
+    seriesItem = try? await database.fetchSeriesDisplayItem(
+      seriesId: seriesId,
+      instanceId: current.instanceId
+    )
+    bookItem = try? await database.fetchFirstBookDisplayItem(
+      seriesId: seriesId,
+      instanceId: current.instanceId
+    )
   }
 
   private func clearCache() {

--- a/KMReader/Features/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailView.swift
@@ -140,6 +140,7 @@ struct OneshotDetailView: View {
 
   private func refreshOneshotData() async {
     isLoading = true
+    await loadLocalOneshot()
     do {
       _ = try await SyncService.syncSeriesDetail(seriesId: seriesId)
       let fetchedBooks = try await SyncService.syncBooks(

--- a/KMReader/Features/ReadList/Models/ReadListDisplayItem.swift
+++ b/KMReader/Features/ReadList/Models/ReadListDisplayItem.swift
@@ -1,0 +1,65 @@
+//
+// ReadListDisplayItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct ReadListDisplayItem: Equatable, Identifiable, Sendable {
+  let id: String
+  let readListId: String
+  let instanceId: String
+  let name: String
+  let summary: String
+  let ordered: Bool
+  let createdDate: Date
+  let lastModifiedDate: Date
+  let filtered: Bool
+  let isPinned: Bool
+  let bookIds: [String]
+  let downloadStatus: SeriesDownloadStatus
+
+  init(
+    readListId: String,
+    instanceId: String,
+    name: String,
+    summary: String,
+    ordered: Bool,
+    createdDate: Date,
+    lastModifiedDate: Date,
+    filtered: Bool,
+    isPinned: Bool,
+    bookIds: [String],
+    downloadStatus: SeriesDownloadStatus
+  ) {
+    id = readListId
+    self.readListId = readListId
+    self.instanceId = instanceId
+    self.name = name
+    self.summary = summary
+    self.ordered = ordered
+    self.createdDate = createdDate
+    self.lastModifiedDate = lastModifiedDate
+    self.filtered = filtered
+    self.isPinned = isPinned
+    self.bookIds = bookIds
+    self.downloadStatus = downloadStatus
+  }
+
+  var bookCount: Int {
+    bookIds.count
+  }
+
+  var readList: ReadList {
+    ReadList(
+      id: readListId,
+      name: name,
+      summary: summary,
+      ordered: ordered,
+      bookIds: bookIds,
+      createdDate: createdDate,
+      lastModifiedDate: lastModifiedDate,
+      filtered: filtered
+    )
+  }
+}

--- a/KMReader/Features/ReadList/Services/KomgaReadListStore.swift
+++ b/KMReader/Features/ReadList/Services/KomgaReadListStore.swift
@@ -26,7 +26,7 @@ enum KomgaReadListStore {
     return paginate(readLists, offset: page * size, limit: size).map { $0.toReadList() }
   }
 
-  static func fetchReadListIds(
+  nonisolated static func fetchReadListIds(
     context: ModelContext,
     libraryIds: [String]?,
     searchText: String,
@@ -73,7 +73,7 @@ enum KomgaReadListStore {
     return try? context.fetch(descriptor).first?.toReadList()
   }
 
-  private static func fetchOrderedReadLists(
+  nonisolated private static func fetchOrderedReadLists(
     context: ModelContext,
     searchText: String,
     sort: String?
@@ -104,13 +104,13 @@ enum KomgaReadListStore {
     }
   }
 
-  private static func pinnedFirst(_ readLists: [KomgaReadList]) -> [KomgaReadList] {
+  nonisolated private static func pinnedFirst(_ readLists: [KomgaReadList]) -> [KomgaReadList] {
     let pinned = readLists.filter(\.isPinned)
     let unpinned = readLists.filter { !$0.isPinned }
     return pinned + unpinned
   }
 
-  private static func sortDescriptors(sort: String?) -> [SortDescriptor<KomgaReadList>] {
+  nonisolated private static func sortDescriptors(sort: String?) -> [SortDescriptor<KomgaReadList>] {
     let isAscending = sort?.contains("desc") != true
 
     if sort?.contains("createdDate") == true {
@@ -130,7 +130,7 @@ enum KomgaReadListStore {
     ]
   }
 
-  private static func paginate(
+  nonisolated private static func paginate(
     _ readLists: [KomgaReadList],
     offset: Int,
     limit: Int

--- a/KMReader/Features/ReadList/Views/ReadListCardView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListCardView.swift
@@ -6,7 +6,8 @@
 import SwiftUI
 
 struct ReadListCardView: View {
-  @Bindable var komgaReadList: KomgaReadList
+  let item: ReadListDisplayItem
+  var onMutationCompleted: (() -> Void)? = nil
 
   @AppStorage("coverOnlyCards") private var coverOnlyCards: Bool = false
   @AppStorage("cardTextOverlayMode") private var cardTextOverlayMode: Bool = false
@@ -20,11 +21,11 @@ struct ReadListCardView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: contentSpacing) {
       ThumbnailImage(
-        id: komgaReadList.readListId,
+        id: item.readListId,
         type: .readlist,
         shadowStyle: .platform,
         alignment: .bottom,
-        navigationLink: NavDestination.readListDetail(readListId: komgaReadList.readListId),
+        navigationLink: NavDestination.readListDetail(readListId: item.readListId),
         preserveAspectRatioOverride: cardTextOverlayMode ? false : nil
       ) {
         if cardTextOverlayMode {
@@ -34,10 +35,10 @@ struct ReadListCardView: View {
         }
       } menu: {
         ReadListContextMenu(
-          readListId: komgaReadList.readListId,
-          menuTitle: komgaReadList.name,
-          downloadStatus: komgaReadList.downloadStatus,
-          isPinned: komgaReadList.isPinned,
+          readListId: item.readListId,
+          menuTitle: item.name,
+          downloadStatus: item.downloadStatus,
+          isPinned: item.isPinned,
           onDeleteRequested: {
             showDeleteConfirmation = true
           },
@@ -46,22 +47,23 @@ struct ReadListCardView: View {
           },
           onPinToggleRequested: {
             togglePinned()
-          }
+          },
+          onMutationCompleted: onMutationCompleted
         )
       }
 
       if !cardTextOverlayMode && !coverOnlyCards {
         VStack(alignment: .leading) {
           HStack(spacing: 4) {
-            if komgaReadList.isPinned {
+            if item.isPinned {
               Image(systemName: "pin.fill")
             }
-            Text(komgaReadList.name)
+            Text(item.name)
               .lineLimit(1)
           }
 
           HStack(spacing: 4) {
-            Text("\(komgaReadList.bookIds.count) books")
+            Text("\(item.bookCount) books")
             Spacer()
           }.foregroundColor(.secondary)
         }.font(.footnote)
@@ -78,18 +80,18 @@ struct ReadListCardView: View {
       Text("Are you sure you want to delete this read list? This action cannot be undone.")
     }
     .sheet(isPresented: $showEditSheet) {
-      ReadListEditSheet(readList: komgaReadList.toReadList())
+      ReadListEditSheet(readList: item.readList)
     }
   }
 
   @ViewBuilder
   private var overlayTextContent: some View {
     CardOverlayTextStack(
-      title: komgaReadList.name,
-      titleLeadingSystemImage: komgaReadList.isPinned ? "pin.fill" : nil
+      title: item.name,
+      titleLeadingSystemImage: item.isPinned ? "pin.fill" : nil
     ) {
       HStack(spacing: 4) {
-        Text("\(komgaReadList.bookIds.count) books")
+        Text("\(item.bookCount) books")
       }
     }
   }
@@ -97,8 +99,9 @@ struct ReadListCardView: View {
   private func deleteReadList() {
     Task {
       do {
-        try await ReadListService.deleteReadList(readListId: komgaReadList.readListId)
+        try await ReadListService.deleteReadList(readListId: item.readListId)
         ErrorManager.shared.notify(message: String(localized: "notification.readList.deleted"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -106,14 +109,15 @@ struct ReadListCardView: View {
   }
 
   private func togglePinned() {
-    let nextPinned = !komgaReadList.isPinned
+    let nextPinned = !item.isPinned
     Task {
       try? await DatabaseOperator.database().setReadListPinned(
-        readListId: komgaReadList.readListId,
-        instanceId: komgaReadList.instanceId,
+        readListId: item.readListId,
+        instanceId: item.instanceId,
         isPinned: nextPinned
       )
       try? await DatabaseOperator.database().commit()
+      onMutationCompleted?()
     }
   }
 }

--- a/KMReader/Features/ReadList/Views/ReadListCompactCardView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListCompactCardView.swift
@@ -5,31 +5,34 @@
 
 import SwiftUI
 
+@MainActor
 struct ReadListCompactCardView: View {
-  @Bindable var komgaReadList: KomgaReadList
+  let item: ReadListDisplayItem
   var coverWidth: CGFloat = 80
+  var onChanged: () -> Void = {}
+
   @State private var showEditSheet = false
   @State private var showDeleteConfirmation = false
 
   var body: some View {
-    NavigationLink(value: NavDestination.readListDetail(readListId: komgaReadList.readListId)) {
+    NavigationLink(value: NavDestination.readListDetail(readListId: item.readListId)) {
       HStack(alignment: .top, spacing: 10) {
-        ThumbnailImage(id: komgaReadList.readListId, type: .readlist, width: coverWidth)
+        ThumbnailImage(id: item.readListId, type: .readlist, width: coverWidth)
           .frame(width: coverWidth)
           .allowsHitTesting(false)
 
         VStack(alignment: .leading, spacing: 4) {
-          Text(komgaReadList.name)
+          Text(item.name)
             .font(.headline)
             .fontWeight(.medium)
             .lineLimit(2)
             .multilineTextAlignment(.leading)
 
-          Text("\(komgaReadList.bookIds.count) books")
+          Text("\(item.bookCount) books")
             .font(.footnote)
             .foregroundColor(.secondary)
 
-          Text(komgaReadList.lastModifiedDate.formattedMediumDate)
+          Text(item.lastModifiedDate.formattedMediumDate)
             .font(.caption)
             .foregroundColor(.secondary)
         }
@@ -50,10 +53,10 @@ struct ReadListCompactCardView: View {
     .adaptiveButtonStyle(.plain)
     .contextMenu {
       ReadListContextMenu(
-        readListId: komgaReadList.readListId,
-        menuTitle: komgaReadList.name,
-        downloadStatus: komgaReadList.downloadStatus,
-        isPinned: komgaReadList.isPinned,
+        readListId: item.readListId,
+        menuTitle: item.name,
+        downloadStatus: item.downloadStatus,
+        isPinned: item.isPinned,
         onDeleteRequested: {
           showDeleteConfirmation = true
         },
@@ -73,16 +76,17 @@ struct ReadListCompactCardView: View {
     } message: {
       Text("Are you sure you want to delete this read list? This action cannot be undone.")
     }
-    .sheet(isPresented: $showEditSheet) {
-      ReadListEditSheet(readList: komgaReadList.toReadList())
+    .sheet(isPresented: $showEditSheet, onDismiss: onChanged) {
+      ReadListEditSheet(readList: item.readList)
     }
   }
 
   private func deleteReadList() {
     Task {
       do {
-        try await ReadListService.deleteReadList(readListId: komgaReadList.readListId)
+        try await ReadListService.deleteReadList(readListId: item.readListId)
         ErrorManager.shared.notify(message: String(localized: "notification.readList.deleted"))
+        onChanged()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -90,14 +94,20 @@ struct ReadListCompactCardView: View {
   }
 
   private func togglePinned() {
-    let nextPinned = !komgaReadList.isPinned
+    let nextPinned = !item.isPinned
     Task {
-      try? await DatabaseOperator.database().setReadListPinned(
-        readListId: komgaReadList.readListId,
-        instanceId: komgaReadList.instanceId,
-        isPinned: nextPinned
-      )
-      try? await DatabaseOperator.database().commit()
+      do {
+        let database = try await DatabaseOperator.database()
+        await database.setReadListPinned(
+          readListId: item.readListId,
+          instanceId: item.instanceId,
+          isPinned: nextPinned
+        )
+        try? await database.commit()
+        onChanged()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
     }
   }
 }

--- a/KMReader/Features/ReadList/Views/ReadListContextMenu.swift
+++ b/KMReader/Features/ReadList/Views/ReadListContextMenu.swift
@@ -14,6 +14,7 @@ struct ReadListContextMenu: View {
   var onDeleteRequested: (() -> Void)? = nil
   var onEditRequested: (() -> Void)? = nil
   var onPinToggleRequested: (() -> Void)? = nil
+  var onMutationCompleted: (() -> Void)? = nil
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("isOffline") private var isOffline: Bool = false
@@ -145,6 +146,7 @@ struct ReadListContextMenu: View {
       ErrorManager.shared.notify(
         message: String(localized: "notification.readList.offlineDownloadQueued")
       )
+      onMutationCompleted?()
     }
   }
 
@@ -160,6 +162,7 @@ struct ReadListContextMenu: View {
       ErrorManager.shared.notify(
         message: String(localized: "notification.readList.offlineDownloadQueued")
       )
+      onMutationCompleted?()
     }
   }
 
@@ -173,6 +176,7 @@ struct ReadListContextMenu: View {
       ErrorManager.shared.notify(
         message: String(localized: "notification.readList.offlineRemoved")
       )
+      onMutationCompleted?()
     }
   }
 
@@ -185,6 +189,7 @@ struct ReadListContextMenu: View {
       ErrorManager.shared.notify(
         message: String(localized: "notification.readList.offlineRemoved")
       )
+      onMutationCompleted?()
     }
   }
 

--- a/KMReader/Features/ReadList/Views/ReadListDetailView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListDetailView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct ReadListDetailView: View {
@@ -14,9 +13,7 @@ struct ReadListDetailView: View {
 
   @Environment(\.dismiss) private var dismiss
 
-  // SwiftData query for reactive updates
-  @Query private var komgaReadLists: [KomgaReadList]
-
+  @State private var item: ReadListDisplayItem?
   @State private var showDeleteConfirmation = false
   @State private var showEditSheet = false
   @State private var showFilterSheet = false
@@ -24,18 +21,10 @@ struct ReadListDetailView: View {
 
   init(readListId: String) {
     self.readListId = readListId
-    let compositeId = CompositeID.generate(id: readListId)
-    _komgaReadLists = Query(filter: #Predicate<KomgaReadList> { $0.id == compositeId })
   }
 
-  /// The KomgaReadList from SwiftData (reactive).
-  private var komgaReadList: KomgaReadList? {
-    komgaReadLists.first
-  }
-
-  /// Convert to API ReadList type for compatibility with existing components.
   private var readList: ReadList? {
-    komgaReadList?.toReadList()
+    item?.readList
   }
 
   private var navigationTitle: String {
@@ -43,7 +32,7 @@ struct ReadListDetailView: View {
   }
 
   private var isPinned: Bool {
-    komgaReadList?.isPinned ?? false
+    item?.isPinned ?? false
   }
 
   var body: some View {
@@ -61,15 +50,23 @@ struct ReadListDetailView: View {
             #endif
 
             Divider()
-            if let komgaReadList = komgaReadList {
-              ReadListDownloadActionsSection(komgaReadList: komgaReadList)
+            if let item {
+              ReadListDownloadActionsSection(
+                readListId: item.readListId,
+                status: item.downloadStatus,
+                onMutationCompleted: {
+                  Task {
+                    await loadReadListDetails()
+                  }
+                }
+              )
             }
             Divider()
           }
           .padding(.horizontal)
 
           // Books list
-          if komgaReadList != nil {
+          if item != nil {
             BooksListViewForReadList(
               readListId: readListId,
               showFilterSheet: $showFilterSheet,
@@ -128,15 +125,26 @@ struct ReadListDetailView: View {
 extension ReadListDetailView {
   private func loadReadListDetails() async {
     do {
-      // Sync from network to SwiftData (readList property will update reactively)
       _ = try await SyncService.syncReadList(id: readListId)
     } catch {
       if case APIError.notFound = error {
         dismiss()
-      } else if komgaReadList == nil {
+      } else if item == nil {
         ErrorManager.shared.alert(error: error)
       }
     }
+    await loadLocalReadList()
+  }
+
+  private func loadLocalReadList() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      item = nil
+      return
+    }
+    item = try? await database.fetchReadListDisplayItem(
+      readListId: readListId,
+      instanceId: current.instanceId
+    )
   }
 
   @MainActor
@@ -151,15 +159,16 @@ extension ReadListDetailView {
   }
 
   private func togglePinned() {
-    guard let komgaReadList else { return }
-    let nextPinned = !komgaReadList.isPinned
+    guard let item else { return }
+    let nextPinned = !item.isPinned
     Task {
       try? await DatabaseOperator.database().setReadListPinned(
-        readListId: komgaReadList.readListId,
-        instanceId: komgaReadList.instanceId,
+        readListId: item.readListId,
+        instanceId: item.instanceId,
         isPinned: nextPinned
       )
       try? await DatabaseOperator.database().commit()
+      await loadLocalReadList()
     }
   }
 

--- a/KMReader/Features/ReadList/Views/ReadListDetailView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListDetailView.swift
@@ -124,6 +124,7 @@ struct ReadListDetailView: View {
 // Helper functions for ReadListDetailView
 extension ReadListDetailView {
   private func loadReadListDetails() async {
+    await loadLocalReadList()
     do {
       _ = try await SyncService.syncReadList(id: readListId)
     } catch {

--- a/KMReader/Features/ReadList/Views/ReadListDownloadActionsSection.swift
+++ b/KMReader/Features/ReadList/Views/ReadListDownloadActionsSection.swift
@@ -3,21 +3,14 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct ReadListDownloadActionsSection: View {
-  @Bindable var komgaReadList: KomgaReadList
+  let readListId: String
+  let status: SeriesDownloadStatus
+  var onMutationCompleted: (() -> Void)? = nil
 
   @AppStorage("currentAccount") private var current: Current = .init()
-
-  private var readList: ReadList {
-    komgaReadList.toReadList()
-  }
-
-  private var status: SeriesDownloadStatus {
-    komgaReadList.downloadStatus
-  }
 
   @State private var pendingAction: SeriesDownloadAction?
   @State private var pendingUnreadLimit: Int?
@@ -141,22 +134,23 @@ struct ReadListDownloadActionsSection: View {
   private func downloadAll() {
     Task {
       // Sync books first
-      try? await SyncService.syncAllReadListBooks(readListId: readList.id)
+      try? await SyncService.syncAllReadListBooks(readListId: readListId)
       try? await DatabaseOperator.database().downloadReadListOffline(
-        readListId: readList.id, instanceId: current.instanceId
+        readListId: readListId, instanceId: current.instanceId
       )
       try? await DatabaseOperator.database().commit()
       ErrorManager.shared.notify(
         message: String(localized: "notification.readList.offlineDownloadQueued")
       )
+      onMutationCompleted?()
     }
   }
 
   private func downloadUnread(limit: Int) {
     Task {
-      try? await SyncService.syncAllReadListBooks(readListId: readList.id)
+      try? await SyncService.syncAllReadListBooks(readListId: readListId)
       try? await DatabaseOperator.database().downloadReadListUnreadOffline(
-        readListId: readList.id,
+        readListId: readListId,
         instanceId: current.instanceId,
         limit: limit
       )
@@ -164,19 +158,21 @@ struct ReadListDownloadActionsSection: View {
       ErrorManager.shared.notify(
         message: String(localized: "notification.readList.offlineDownloadQueued")
       )
+      onMutationCompleted?()
     }
   }
 
   private func removeRead() {
     Task {
       try? await DatabaseOperator.database().removeReadListReadOffline(
-        readListId: readList.id,
+        readListId: readListId,
         instanceId: current.instanceId
       )
       try? await DatabaseOperator.database().commit()
       ErrorManager.shared.notify(
         message: String(localized: "notification.readList.offlineRemoved")
       )
+      onMutationCompleted?()
     }
   }
 
@@ -194,12 +190,13 @@ struct ReadListDownloadActionsSection: View {
   private func removeAll() {
     Task {
       try? await DatabaseOperator.database().removeReadListOffline(
-        readListId: readList.id, instanceId: current.instanceId
+        readListId: readListId, instanceId: current.instanceId
       )
       try? await DatabaseOperator.database().commit()
       ErrorManager.shared.notify(
         message: String(localized: "notification.readList.offlineRemoved")
       )
+      onMutationCompleted?()
     }
   }
 }

--- a/KMReader/Features/ReadList/Views/ReadListItemQueryView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListItemQueryView.swift
@@ -3,23 +3,25 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct ReadListItemQueryView: View {
-  @Bindable var readList: KomgaReadList
+  let item: ReadListDisplayItem
   var layout: BrowseLayoutMode = .grid
+  var onMutationCompleted: (() -> Void)? = nil
 
   var body: some View {
-    NavigationLink(value: NavDestination.readListDetail(readListId: readList.readListId)) {
+    NavigationLink(value: NavDestination.readListDetail(readListId: item.readListId)) {
       switch layout {
       case .grid:
         ReadListCardView(
-          komgaReadList: readList
+          item: item,
+          onMutationCompleted: onMutationCompleted
         )
       case .list:
         ReadListRowView(
-          komgaReadList: readList
+          item: item,
+          onMutationCompleted: onMutationCompleted
         )
       }
     }

--- a/KMReader/Features/ReadList/Views/ReadListQueryItemView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListQueryItemView.swift
@@ -3,15 +3,15 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
-/// Wrapper view that accepts only readListId and uses @Query to fetch the read list reactively.
+/// Wrapper view that accepts only readListId and fetches a read-list display projection.
 struct ReadListQueryItemView: View {
   let readListId: String
   var layout: BrowseLayoutMode = .grid
 
-  @Query private var komgaReadLists: [KomgaReadList]
+  @AppStorage("currentAccount") private var current: Current = .init()
+  @State private var item: ReadListDisplayItem?
 
   init(
     readListId: String,
@@ -20,28 +20,46 @@ struct ReadListQueryItemView: View {
     self.readListId = readListId
     self.layout = layout
 
-    let compositeId = CompositeID.generate(id: readListId)
-    _komgaReadLists = Query(filter: #Predicate<KomgaReadList> { $0.id == compositeId })
-  }
-
-  private var komgaReadList: KomgaReadList? {
-    komgaReadLists.first
   }
 
   var body: some View {
-    if let readList = komgaReadList {
-      switch layout {
-      case .grid:
-        ReadListCardView(
-          komgaReadList: readList
-        )
-      case .list:
-        ReadListRowView(
-          komgaReadList: readList
-        )
+    Group {
+      if let item {
+        switch layout {
+        case .grid:
+          ReadListCardView(
+            item: item,
+            onMutationCompleted: reloadItem
+          )
+        case .list:
+          ReadListRowView(
+            item: item,
+            onMutationCompleted: reloadItem
+          )
+        }
+      } else {
+        CardPlaceholder(layout: layout, kind: .readList)
       }
-    } else {
-      CardPlaceholder(layout: layout, kind: .readList)
     }
+    .task(id: "\(current.instanceId)|\(readListId)") {
+      await loadItem()
+    }
+  }
+
+  private func reloadItem() {
+    Task {
+      await loadItem()
+    }
+  }
+
+  private func loadItem() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      item = nil
+      return
+    }
+    item = try? await database.fetchReadListDisplayItem(
+      readListId: readListId,
+      instanceId: current.instanceId
+    )
   }
 }

--- a/KMReader/Features/ReadList/Views/ReadListRowView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListRowView.swift
@@ -6,25 +6,26 @@
 import SwiftUI
 
 struct ReadListRowView: View {
-  @Bindable var komgaReadList: KomgaReadList
+  let item: ReadListDisplayItem
+  var onMutationCompleted: (() -> Void)? = nil
 
   @State private var showEditSheet = false
   @State private var showDeleteConfirmation = false
 
   var body: some View {
     HStack(spacing: 12) {
-      NavigationLink(value: NavDestination.readListDetail(readListId: komgaReadList.readListId)) {
-        ThumbnailImage(id: komgaReadList.readListId, type: .readlist, width: 60)
+      NavigationLink(value: NavDestination.readListDetail(readListId: item.readListId)) {
+        ThumbnailImage(id: item.readListId, type: .readlist, width: 60)
       }
       .adaptiveButtonStyle(.plain)
 
       VStack(alignment: .leading, spacing: 6) {
-        NavigationLink(value: NavDestination.readListDetail(readListId: komgaReadList.readListId)) {
+        NavigationLink(value: NavDestination.readListDetail(readListId: item.readListId)) {
           HStack(spacing: 6) {
-            Text(komgaReadList.name)
+            Text(item.name)
               .font(.callout)
               .lineLimit(2)
-            if komgaReadList.isPinned {
+            if item.isPinned {
               Image(systemName: "pin.fill")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
@@ -34,19 +35,19 @@ struct ReadListRowView: View {
 
         HStack {
           VStack(alignment: .leading, spacing: 4) {
-            Label("\(komgaReadList.bookIds.count) books", systemImage: ContentIcon.book)
+            Label("\(item.bookCount) books", systemImage: ContentIcon.book)
               .font(.footnote)
               .foregroundColor(.secondary)
 
             Label(
-              komgaReadList.lastModifiedDate.formatted(date: .abbreviated, time: .omitted),
+              item.lastModifiedDate.formatted(date: .abbreviated, time: .omitted),
               systemImage: "clock"
             )
             .font(.caption)
             .foregroundColor(.secondary)
 
-            if !komgaReadList.summary.isEmpty {
-              Text(komgaReadList.summary)
+            if !item.summary.isEmpty {
+              Text(item.summary)
                 .font(.caption)
                 .foregroundColor(.secondary)
                 .lineLimit(1)
@@ -57,10 +58,10 @@ struct ReadListRowView: View {
 
           EllipsisMenuButton {
             ReadListContextMenu(
-              readListId: komgaReadList.readListId,
-              menuTitle: komgaReadList.name,
-              downloadStatus: komgaReadList.downloadStatus,
-              isPinned: komgaReadList.isPinned,
+              readListId: item.readListId,
+              menuTitle: item.name,
+              downloadStatus: item.downloadStatus,
+              isPinned: item.isPinned,
               onDeleteRequested: {
                 showDeleteConfirmation = true
               },
@@ -69,9 +70,10 @@ struct ReadListRowView: View {
               },
               onPinToggleRequested: {
                 togglePinned()
-              }
+              },
+              onMutationCompleted: onMutationCompleted
             )
-            .id(komgaReadList.readListId)
+            .id(item.readListId)
           }
         }
       }
@@ -85,15 +87,16 @@ struct ReadListRowView: View {
       Text("Are you sure you want to delete this read list? This action cannot be undone.")
     }
     .sheet(isPresented: $showEditSheet) {
-      ReadListEditSheet(readList: komgaReadList.toReadList())
+      ReadListEditSheet(readList: item.readList)
     }
   }
 
   private func deleteReadList() {
     Task {
       do {
-        try await ReadListService.deleteReadList(readListId: komgaReadList.readListId)
+        try await ReadListService.deleteReadList(readListId: item.readListId)
         ErrorManager.shared.notify(message: String(localized: "notification.readList.deleted"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -101,14 +104,15 @@ struct ReadListRowView: View {
   }
 
   private func togglePinned() {
-    let nextPinned = !komgaReadList.isPinned
+    let nextPinned = !item.isPinned
     Task {
       try? await DatabaseOperator.database().setReadListPinned(
-        readListId: komgaReadList.readListId,
-        instanceId: komgaReadList.instanceId,
+        readListId: item.readListId,
+        instanceId: item.instanceId,
         isPinned: nextPinned
       )
       try? await DatabaseOperator.database().commit()
+      onMutationCompleted?()
     }
   }
 }

--- a/KMReader/Features/ReadList/Views/ReadListsBrowseView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListsBrowseView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct ReadListsBrowseView: View {
@@ -12,7 +11,6 @@ struct ReadListsBrowseView: View {
   let refreshTrigger: UUID
   @Binding var showFilterSheet: Bool
 
-  @Environment(\.modelContext) private var modelContext
   @AppStorage("readListSortOptions") private var sortOpts: SimpleSortOptions =
     SimpleSortOptions()
   @AppStorage("readListBrowseLayout") private var browseLayout: BrowseLayoutMode = .grid
@@ -124,16 +122,16 @@ struct ReadListsBrowseView: View {
   }
 
   private func loadReadListIds() async throws -> [String] {
-    let localIds = localReadListIds()
+    let localIds = await localReadListIds()
     guard !AppConfig.isOffline else { return localIds }
 
     let serverIds = Set(try await syncReadListIds())
     return localIds.filter { serverIds.contains($0) }
   }
 
-  private func localReadListIds() -> [String] {
-    KomgaReadListStore.fetchReadListIds(
-      context: modelContext,
+  private func localReadListIds() async -> [String] {
+    guard let database = try? await DatabaseOperator.database() else { return [] }
+    return await database.fetchReadListIds(
       libraryIds: libraryIds,
       searchText: searchText,
       sort: sortOpts.sortString,

--- a/KMReader/Features/Reader/Models/CustomFontDisplayItem.swift
+++ b/KMReader/Features/Reader/Models/CustomFontDisplayItem.swift
@@ -1,0 +1,22 @@
+//
+// CustomFontDisplayItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct CustomFontDisplayItem: Equatable, Identifiable, Sendable {
+  let id: String
+  let name: String
+  let path: String?
+  let fileName: String?
+  let fileSize: Int64?
+
+  init(name: String, path: String?, fileName: String?, fileSize: Int64?) {
+    id = name
+    self.name = name
+    self.path = path
+    self.fileName = fileName
+    self.fileSize = fileSize
+  }
+}

--- a/KMReader/Features/Reader/Models/EpubThemePresetDisplayItem.swift
+++ b/KMReader/Features/Reader/Models/EpubThemePresetDisplayItem.swift
@@ -1,0 +1,17 @@
+//
+// EpubThemePresetDisplayItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct EpubThemePresetDisplayItem: Equatable, Identifiable, Sendable {
+  let id: UUID
+  let name: String
+  let preferencesJSON: String
+  let updatedAt: Date
+
+  var preferences: EpubThemePreferences? {
+    EpubThemePreferences(rawValue: preferencesJSON)
+  }
+}

--- a/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
+++ b/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
@@ -7,6 +7,7 @@ import Foundation
 
 extension Notification.Name {
   static let bookProjectionDidChange = Notification.Name("BookProjectionDidChange")
+  static let seriesProjectionDidChange = Notification.Name("SeriesProjectionDidChange")
 }
 
 actor ReaderProgressDispatchService {
@@ -608,6 +609,7 @@ actor ReaderProgressDispatchService {
     )
     try await database.commit()
     await Self.postBookProjectionDidChange(bookId: update.bookId)
+    await Self.postSeriesProjectionDidChange(bookId: update.bookId)
     logger.debug(
       "💾 [Progress/Page] Queued offline sync item: book=\(update.bookId), version=\(update.version), page=\(update.page), completed=\(update.completed)"
     )
@@ -698,6 +700,7 @@ actor ReaderProgressDispatchService {
         try? await database.commit()
       }
       await Self.postBookProjectionDidChange(bookId: update.bookId)
+      await Self.postSeriesProjectionDidChange(bookId: update.bookId)
     } catch let apiError as APIError {
       if case .badRequest(let message, _, _, _) = apiError,
         message.lowercased().contains("epub extension not found")
@@ -774,6 +777,23 @@ actor ReaderProgressDispatchService {
         name: .bookProjectionDidChange,
         object: nil,
         userInfo: ["bookId": bookId]
+      )
+    }
+  }
+
+  private nonisolated static func postSeriesProjectionDidChange(bookId: String) async {
+    guard let database = try? await DatabaseOperator.database(),
+      let item = try? await database.fetchBookDisplayItem(
+        bookId: bookId,
+        instanceId: AppConfig.current.instanceId
+      )
+    else { return }
+
+    await MainActor.run {
+      NotificationCenter.default.post(
+        name: .seriesProjectionDidChange,
+        object: nil,
+        userInfo: ["seriesId": item.book.seriesId]
       )
     }
   }

--- a/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
+++ b/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
@@ -5,6 +5,10 @@
 
 import Foundation
 
+extension Notification.Name {
+  static let bookProjectionDidChange = Notification.Name("BookProjectionDidChange")
+}
+
 actor ReaderProgressDispatchService {
   static let shared = ReaderProgressDispatchService()
 
@@ -603,6 +607,7 @@ actor ReaderProgressDispatchService {
       completed: update.completed
     )
     try await database.commit()
+    await Self.postBookProjectionDidChange(bookId: update.bookId)
     logger.debug(
       "💾 [Progress/Page] Queued offline sync item: book=\(update.bookId), version=\(update.version), page=\(update.page), completed=\(update.completed)"
     )
@@ -692,6 +697,7 @@ actor ReaderProgressDispatchService {
       } else {
         try? await database.commit()
       }
+      await Self.postBookProjectionDidChange(bookId: update.bookId)
     } catch let apiError as APIError {
       if case .badRequest(let message, _, _, _) = apiError,
         message.lowercased().contains("epub extension not found")
@@ -760,6 +766,16 @@ actor ReaderProgressDispatchService {
 
     let nsError = error as NSError
     return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut
+  }
+
+  private nonisolated static func postBookProjectionDidChange(bookId: String) async {
+    await MainActor.run {
+      NotificationCenter.default.post(
+        name: .bookProjectionDidChange,
+        object: nil,
+        userInfo: ["bookId": bookId]
+      )
+    }
   }
 
 }

--- a/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
+++ b/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
@@ -602,7 +602,7 @@ actor ReaderProgressDispatchService {
       page: update.page,
       completed: update.completed
     )
-    try await database.commitImmediately()
+    try await database.commit()
     logger.debug(
       "💾 [Progress/Page] Queued offline sync item: book=\(update.bookId), version=\(update.version), page=\(update.page), completed=\(update.completed)"
     )
@@ -688,9 +688,9 @@ actor ReaderProgressDispatchService {
         progression: update.progression
       )
       if AppConfig.isOffline {
-        try await database.commitImmediately()
+        try await database.commit()
       } else {
-        await database.commit()
+        try? await database.commit()
       }
     } catch let apiError as APIError {
       if case .badRequest(let message, _, _, _) = apiError,

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -1086,7 +1086,7 @@
           bookId: bookId,
           progression: progression
         )
-        await database.commit()
+        try? await database.commit()
         logger.debug(
           "Synced remote EPUB progression to local storage: href=\(progression.locator.href), progression=\(progression.locator.locations?.progression ?? 0)"
         )
@@ -1095,7 +1095,7 @@
           bookId: bookId,
           progression: nil
         )
-        await database.commit()
+        try? await database.commit()
         logger.debug("Synced remote EPUB progression to local storage: missing progression")
       case .retryableFailure(let error):
         logger.warning(
@@ -1106,7 +1106,7 @@
           bookId: bookId,
           progression: nil
         )
-        await database.commit()
+        try? await database.commit()
         logger.warning(
           "Ignoring non-retryable remote EPUB progression payload for book \(bookId): \(error.localizedDescription)"
         )

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -629,7 +629,7 @@ class ReaderViewModel {
     Task {
       if let database = await DatabaseOperator.databaseIfConfigured() {
         await database.updatePageRotations(bookId: bookId, rotations: rotations)
-        await database.commit()
+        try? await database.commit()
       }
     }
   }
@@ -957,7 +957,7 @@ class ReaderViewModel {
     if let database = await DatabaseOperator.databaseIfConfigured() {
       await database.updateBookPages(bookId: bookId, pages: result.pages)
       await database.updateBookTOC(bookId: bookId, toc: result.tableOfContents)
-      await database.commit()
+      try? await database.commit()
     }
     if result.renderedImageCount > 0 {
       await OfflineManager.shared.refreshDownloadedBookSize(
@@ -1166,7 +1166,7 @@ class ReaderViewModel {
           bookId: isolatePosition.bookId,
           pages: sortedLocalPages
         )
-        await database.commit()
+        try? await database.commit()
       }
     }
   }

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -1354,7 +1354,7 @@ struct DivinaReaderView: View {
 
       if let resolvedBook, let database {
         await database.upsertBook(dto: resolvedBook, instanceId: instanceId)
-        await database.commit()
+        try? await database.commit()
       }
       return resolvedBook
     } catch {

--- a/KMReader/Features/Reader/Views/Sheets/CustomFontsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/CustomFontsSheet.swift
@@ -5,7 +5,6 @@
 
 #if os(iOS)
   import CoreText
-  import SwiftData
   import SwiftUI
   import UIKit
   import UniformTypeIdentifiers
@@ -16,9 +15,7 @@
     @State private var fontInputErrorMessage: String = ""
     @State private var showFontPicker: Bool = false
     @State private var showDocumentPicker: Bool = false
-
-    @Query(sort: \CustomFont.name, order: .forward) private var customFonts: [CustomFont]
-    @Environment(\.modelContext) private var modelContext
+    @State private var customFonts: [CustomFontDisplayItem] = []
 
     var body: some View {
       SheetView(title: String(localized: "Custom Fonts"), size: .large, applyFormStyle: true) {
@@ -155,6 +152,9 @@
           handleFontFileImport(url)
         }
       }
+      .task {
+        await loadCustomFonts()
+      }
     }
 
     private func handleFontPickerSelection(_ font: UIFont) {
@@ -169,24 +169,9 @@
         return
       }
 
-      // Add font to custom fonts list (even if it's in system fonts,
-      // because it might be a profile-installed font that we want to ensure is available)
-      let customFont = CustomFont(name: familyName)
-      modelContext.insert(customFont)
-      do {
-        try modelContext.save()
-      } catch {
-        showFontInputError = true
-        fontInputErrorMessage = "Failed to save font: \(error.localizedDescription)"
-        return
+      Task {
+        await saveCustomFont(name: familyName)
       }
-
-      // Refresh font provider
-      FontProvider.refresh()
-
-      // Clear any error
-      showFontInputError = false
-      fontInputErrorMessage = ""
     }
 
     private func handleFontFileImport(_ url: URL) {
@@ -272,26 +257,15 @@
         return
       }
 
-      // Add font to custom fonts list with relative path, fileName, and fileSize
-      let customFont = CustomFont(
-        name: actualFontName, path: relativePath, fileName: fileName, fileSize: fileSize)
-      modelContext.insert(customFont)
-      do {
-        try modelContext.save()
-      } catch {
-        showFontInputError = true
-        fontInputErrorMessage = "Failed to save font: \(error.localizedDescription)"
-        // Clean up
-        FontFileManager.deleteFont(at: relativePath)
-        return
+      Task {
+        await saveCustomFont(
+          name: actualFontName,
+          path: relativePath,
+          fileName: fileName,
+          fileSize: fileSize,
+          cleanupPathOnFailure: relativePath
+        )
       }
-
-      // Refresh font provider
-      FontProvider.refresh()
-
-      // Clear any error
-      showFontInputError = false
-      fontInputErrorMessage = ""
     }
 
     private func addCustomFont() {
@@ -323,43 +297,27 @@
         return
       }
 
-      // Add font to custom fonts list
-      let customFont = CustomFont(name: fontName)
-      modelContext.insert(customFont)
-      do {
-        try modelContext.save()
-      } catch {
-        showFontInputError = true
-        fontInputErrorMessage = "Failed to save font: \(error.localizedDescription)"
-        return
+      Task {
+        await saveCustomFont(name: fontName, clearInputOnSuccess: true)
       }
-
-      // Clear input and error
-      customFontInput = ""
-      showFontInputError = false
-      fontInputErrorMessage = ""
-
-      // Refresh font provider
-      FontProvider.refresh()
     }
 
-    private func removeCustomFont(_ font: CustomFont) {
-      // If this is an imported font, clean up the file
-      if let relativePath = font.path {
-        FontFileManager.deleteFont(at: relativePath)
+    private func removeCustomFont(_ font: CustomFontDisplayItem) {
+      Task {
+        do {
+          let database = try await DatabaseOperator.database()
+          try await database.deleteCustomFont(name: font.name)
+          try await database.commit()
+          if let relativePath = font.path {
+            FontFileManager.deleteFont(at: relativePath)
+          }
+          await loadCustomFonts()
+          FontProvider.refresh()
+        } catch {
+          showFontInputError = true
+          fontInputErrorMessage = "Failed to delete font: \(error.localizedDescription)"
+        }
       }
-
-      modelContext.delete(font)
-      do {
-        try modelContext.save()
-      } catch {
-        showFontInputError = true
-        fontInputErrorMessage = "Failed to delete font: \(error.localizedDescription)"
-        return
-      }
-
-      // Refresh font provider
-      FontProvider.refresh()
     }
 
     private func isFontAvailable(_ fontName: String) -> Bool {
@@ -386,6 +344,53 @@
       formatter.allowedUnits = [.useKB, .useMB]
       formatter.countStyle = .file
       return formatter.string(fromByteCount: bytes)
+    }
+
+    private func saveCustomFont(
+      name: String,
+      path: String? = nil,
+      fileName: String? = nil,
+      fileSize: Int64? = nil,
+      clearInputOnSuccess: Bool = false,
+      cleanupPathOnFailure: String? = nil
+    ) async {
+      do {
+        let database = try await DatabaseOperator.database()
+        try await database.createCustomFont(
+          name: name,
+          path: path,
+          fileName: fileName,
+          fileSize: fileSize
+        )
+        try await database.commit()
+
+        if clearInputOnSuccess {
+          customFontInput = ""
+        }
+        showFontInputError = false
+        fontInputErrorMessage = ""
+        await loadCustomFonts()
+        FontProvider.refresh()
+      } catch {
+        if let cleanupPathOnFailure {
+          FontFileManager.deleteFont(at: cleanupPathOnFailure)
+        }
+        showFontInputError = true
+        fontInputErrorMessage = "Failed to save font: \(error.localizedDescription)"
+      }
+    }
+
+    private func loadCustomFonts() async {
+      do {
+        let database = try await DatabaseOperator.database()
+        let loadedFonts = try await database.fetchCustomFontDisplayItems()
+        if customFonts != loadedFonts {
+          customFonts = loadedFonts
+        }
+      } catch {
+        showFontInputError = true
+        fontInputErrorMessage = "Failed to load fonts: \(error.localizedDescription)"
+      }
     }
   }
 

--- a/KMReader/Features/Reader/Views/Sheets/EpubSettingsPreviewView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubSettingsPreviewView.swift
@@ -1,6 +1,5 @@
 #if os(iOS) || os(macOS)
   import Foundation
-  import SwiftData
   import SwiftUI
   import WebKit
 
@@ -8,14 +7,10 @@
     let preferences: EpubThemePreferences
 
     @Environment(\.colorScheme) private var colorScheme
-    @Query(sort: \CustomFont.name, order: .forward) private var customFonts: [CustomFont]
+    @State private var customFontPath: String?
 
-    private var customFontPath: String? {
-      guard case .system(let fontName) = preferences.fontFamily else { return nil }
-      guard let relativePath = customFonts.first(where: { $0.name == fontName })?.path else {
-        return nil
-      }
-      return FontFileManager.resolvePath(relativePath)
+    private var customFontName: String? {
+      preferences.fontFamily.fontName
     }
 
     var body: some View {
@@ -24,6 +19,31 @@
         colorScheme: colorScheme,
         customFontPath: customFontPath
       )
+      .task(id: customFontName ?? "") {
+        await loadCustomFontPath()
+      }
+    }
+
+    private func loadCustomFontPath() async {
+      guard let customFontName else {
+        if customFontPath != nil {
+          customFontPath = nil
+        }
+        return
+      }
+
+      do {
+        let database = try await DatabaseOperator.database()
+        let relativePath = try await database.fetchCustomFontPath(name: customFontName)
+        let resolvedPath = relativePath.flatMap(FontFileManager.resolvePath)
+        if customFontPath != resolvedPath {
+          customFontPath = resolvedPath
+        }
+      } catch {
+        if customFontPath != nil {
+          customFontPath = nil
+        }
+      }
     }
   }
 

--- a/KMReader/Features/Reader/Views/Sheets/EpubThemePreferencesView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubThemePreferencesView_macOS.swift
@@ -1,6 +1,5 @@
 #if os(macOS)
   import AppKit
-  import SwiftData
   import SwiftUI
 
   struct EpubThemePreferencesView: View {
@@ -19,7 +18,6 @@
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
-    @Environment(\.modelContext) private var modelContext
 
     init(
       inSheet: Bool = false,
@@ -415,11 +413,20 @@
       let trimmed = newPresetName.trimmingCharacters(in: .whitespaces)
       guard !trimmed.isEmpty else { return }
 
-      let preset = EpubThemePreset.create(name: trimmed, preferences: draft)
-      modelContext.insert(preset)
-      try? modelContext.save()
-      ErrorManager.shared.notify(message: String(localized: "Preset saved: \(trimmed)"))
-      newPresetName = ""
+      Task {
+        do {
+          let database = try await DatabaseOperator.database()
+          try await database.createEpubThemePreset(
+            name: trimmed,
+            preferencesJSON: draft.rawValue
+          )
+          try await database.commit()
+          ErrorManager.shared.notify(message: String(localized: "Preset saved: \(trimmed)"))
+          newPresetName = ""
+        } catch {
+          ErrorManager.shared.alert(error: error)
+        }
+      }
     }
 
     private func savePreferences() {

--- a/KMReader/Features/Reader/Views/Sheets/EpubThemePresetsView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubThemePresetsView.swift
@@ -3,17 +3,15 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct EpubThemePresetsView: View {
   let onApply: ((EpubThemePreferences) -> Void)?
 
   @Environment(\.dismiss) private var dismiss
-  @Environment(\.modelContext) private var modelContext
-  @Query(sort: \EpubThemePreset.updatedAt, order: .reverse) private var presets: [EpubThemePreset]
 
-  @State private var presetToRename: EpubThemePreset?
+  @State private var presets: [EpubThemePresetDisplayItem] = []
+  @State private var presetToRename: EpubThemePresetDisplayItem?
   @State private var newName: String = ""
 
   init(onApply: ((EpubThemePreferences) -> Void)? = nil) {
@@ -44,6 +42,9 @@ struct EpubThemePresetsView: View {
         }
       }
     }
+    .task {
+      await loadPresets()
+    }
     .alert(
       "Rename Preset",
       isPresented: .init(
@@ -65,7 +66,7 @@ struct EpubThemePresetsView: View {
   }
 
   @ViewBuilder
-  private func presetRow(_ preset: EpubThemePreset) -> some View {
+  private func presetRow(_ preset: EpubThemePresetDisplayItem) -> some View {
     HStack {
       VStack(alignment: .leading, spacing: 4) {
         Text(preset.name)
@@ -128,8 +129,8 @@ struct EpubThemePresetsView: View {
     }
   }
 
-  private func applyPreset(_ preset: EpubThemePreset) {
-    if let preferences = preset.getPreferences() {
+  private func applyPreset(_ preset: EpubThemePresetDisplayItem) {
+    if let preferences = preset.preferences {
       if let onApply {
         onApply(preferences)
       } else {
@@ -139,20 +140,46 @@ struct EpubThemePresetsView: View {
     }
   }
 
-  private func deletePreset(_ preset: EpubThemePreset) {
-    modelContext.delete(preset)
-    try? modelContext.save()
+  private func deletePreset(_ preset: EpubThemePresetDisplayItem) {
+    Task {
+      do {
+        let database = try await DatabaseOperator.database()
+        try await database.deleteEpubThemePreset(id: preset.id)
+        try await database.commit()
+        await loadPresets()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
   }
 
-  private func renamePreset(_ preset: EpubThemePreset, to newName: String) {
+  private func renamePreset(_ preset: EpubThemePresetDisplayItem, to newName: String) {
     let trimmed = newName.trimmingCharacters(in: .whitespaces)
     guard !trimmed.isEmpty else { return }
 
-    preset.name = trimmed
-    preset.updatedAt = Date()
-    try? modelContext.save()
+    Task {
+      do {
+        let database = try await DatabaseOperator.database()
+        try await database.renameEpubThemePreset(id: preset.id, name: trimmed)
+        try await database.commit()
+        await loadPresets()
+        presetToRename = nil
+        self.newName = ""
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
+  }
 
-    presetToRename = nil
-    self.newName = ""
+  private func loadPresets() async {
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedPresets = try await database.fetchEpubThemePresetDisplayItems()
+      if presets != loadedPresets {
+        presets = loadedPresets
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
   }
 }

--- a/KMReader/Features/Series/Models/SeriesDisplayItem.swift
+++ b/KMReader/Features/Series/Models/SeriesDisplayItem.swift
@@ -1,0 +1,69 @@
+//
+// SeriesDisplayItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct SeriesDisplayItem: Equatable, Identifiable, Sendable {
+  let id: String
+  let instanceId: String
+  let series: Series
+  let downloadStatus: SeriesDownloadStatus
+  let offlinePolicy: SeriesOfflinePolicy
+  let offlinePolicyLimit: Int
+  let collectionIds: [String]
+
+  init(
+    instanceId: String,
+    series: Series,
+    downloadStatus: SeriesDownloadStatus,
+    offlinePolicy: SeriesOfflinePolicy,
+    offlinePolicyLimit: Int,
+    collectionIds: [String] = []
+  ) {
+    id = series.id
+    self.instanceId = instanceId
+    self.series = series
+    self.downloadStatus = downloadStatus
+    self.offlinePolicy = offlinePolicy
+    self.offlinePolicyLimit = offlinePolicyLimit
+    self.collectionIds = collectionIds
+  }
+
+  var seriesId: String {
+    series.id
+  }
+
+  var metaTitle: String {
+    series.metadata.title
+  }
+
+  var booksCount: Int {
+    series.booksCount
+  }
+
+  var booksReadCount: Int {
+    series.booksReadCount
+  }
+
+  var booksUnreadCount: Int {
+    series.booksUnreadCount
+  }
+
+  var booksInProgressCount: Int {
+    series.booksInProgressCount
+  }
+
+  var oneshot: Bool {
+    series.oneshot
+  }
+
+  var isUnavailable: Bool {
+    series.deleted
+  }
+
+  var isUnread: Bool {
+    series.isUnread
+  }
+}

--- a/KMReader/Features/Series/Services/KomgaSeriesStore.swift
+++ b/KMReader/Features/Series/Services/KomgaSeriesStore.swift
@@ -76,8 +76,9 @@ enum KomgaSeriesStore {
     }
   }
 
-  static func fetchSeriesIds(
+  nonisolated static func fetchSeriesIds(
     context: ModelContext,
+    instanceId: String = AppConfig.current.instanceId,
     libraryIds: [String]?,
     searchText: String,
     browseOpts: SeriesBrowseOptions,
@@ -85,7 +86,6 @@ enum KomgaSeriesStore {
     limit: Int,
     offlineOnly: Bool = false
   ) -> [String] {
-    let instanceId = AppConfig.current.instanceId
     let ids = libraryIds ?? []
     var descriptor = FetchDescriptor<KomgaSeries>()
 
@@ -209,7 +209,7 @@ enum KomgaSeriesStore {
     }
   }
 
-  static func fetchSeriesByIds(
+  nonisolated static func fetchSeriesByIds(
     context: ModelContext,
     ids: [String],
     instanceId: String
@@ -234,7 +234,7 @@ enum KomgaSeriesStore {
     }
   }
 
-  static func fetchNewlyAddedSeriesIds(
+  nonisolated static func fetchNewlyAddedSeriesIds(
     context: ModelContext,
     libraryIds: [String],
     offset: Int,
@@ -266,7 +266,7 @@ enum KomgaSeriesStore {
     }
   }
 
-  static func fetchRecentlyUpdatedSeriesIds(
+  nonisolated static func fetchRecentlyUpdatedSeriesIds(
     context: ModelContext,
     libraryIds: [String],
     offset: Int,
@@ -308,7 +308,7 @@ enum KomgaSeriesStore {
     return try? context.fetch(descriptor).first?.toSeries()
   }
 
-  static func fetchCollectionSeries(
+  nonisolated static func fetchCollectionSeries(
     context: ModelContext,
     collectionId: String,
     page: Int,

--- a/KMReader/Features/Series/Services/SeriesContinueReadingResolver.swift
+++ b/KMReader/Features/Series/Services/SeriesContinueReadingResolver.swift
@@ -4,78 +4,22 @@
 //
 
 import Foundation
-import SwiftData
 
 @MainActor
 enum SeriesContinueReadingResolver {
   static func resolve(
     seriesId: String,
-    isOffline: Bool,
-    context: ModelContext
+    instanceId: String,
+    isOffline: Bool
   ) async -> Book? {
     if isOffline {
-      return resolveOffline(seriesId: seriesId, context: context)
+      return await resolveOffline(seriesId: seriesId, instanceId: instanceId)
     }
     return await SeriesContinueReadingOnlineResolver.resolve(seriesId: seriesId)
   }
 
-  private static func resolveOffline(seriesId: String, context: ModelContext) -> Book? {
-    if let inProgress = fetchLatestOfflineBook(seriesId: seriesId, status: .inProgress, context: context) {
-      return inProgress
-    }
-
-    let orderedBooks = fetchOfflineSeriesBooks(context: context, seriesId: seriesId)
-    guard !orderedBooks.isEmpty else { return nil }
-
-    if let lastRead = fetchLatestOfflineBook(seriesId: seriesId, status: .read, context: context) {
-      if let index = orderedBooks.firstIndex(where: { $0.bookId == lastRead.id }) {
-        let nextIndex = orderedBooks.index(after: index)
-        if nextIndex < orderedBooks.endIndex {
-          return orderedBooks[nextIndex].toBook()
-        }
-      }
-    }
-
-    if let firstUnread = orderedBooks.first(where: isUnread) {
-      return firstUnread.toBook()
-    }
-
-    return orderedBooks.first?.toBook()
-  }
-
-  private static func fetchLatestOfflineBook(
-    seriesId: String,
-    status: ReadStatus,
-    context: ModelContext
-  ) -> Book? {
-    var opts = BookBrowseOptions()
-    opts.includeReadStatuses = [status]
-    opts.sortField = .dateRead
-    opts.sortDirection = .descending
-
-    return KomgaBookStore.fetchSeriesBooks(
-      context: context,
-      seriesId: seriesId,
-      page: 0,
-      size: 1,
-      browseOpts: opts
-    ).first
-  }
-
-  private static func fetchOfflineSeriesBooks(
-    context: ModelContext,
-    seriesId: String
-  ) -> [KomgaBook] {
-    let instanceId = AppConfig.current.instanceId
-    let descriptor = FetchDescriptor<KomgaBook>(
-      predicate: #Predicate { $0.seriesId == seriesId && $0.instanceId == instanceId },
-      sortBy: [SortDescriptor(\KomgaBook.metaNumberSort, order: .forward)]
-    )
-
-    return (try? context.fetch(descriptor)) ?? []
-  }
-
-  private static func isUnread(_ book: KomgaBook) -> Bool {
-    book.isUnread
+  private static func resolveOffline(seriesId: String, instanceId: String) async -> Book? {
+    guard let database = try? await DatabaseOperator.database() else { return nil }
+    return await database.fetchOfflineContinueReadingBook(seriesId: seriesId, instanceId: instanceId)
   }
 }

--- a/KMReader/Features/Series/ViewModels/SeriesViewModel.swift
+++ b/KMReader/Features/Series/ViewModels/SeriesViewModel.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-import SwiftData
 import SwiftUI
 
 @MainActor
@@ -15,7 +14,6 @@ class SeriesViewModel {
   private(set) var pagination = PaginationState<IdentifiedString>(pageSize: 50)
 
   func loadSeries(
-    context: ModelContext,
     browseOpts: SeriesBrowseOptions,
     searchText: String = "",
     libraryIds: [String]? = nil,
@@ -41,8 +39,13 @@ class SeriesViewModel {
     }
 
     if AppConfig.isOffline || useLocalOnly {
-      let ids = KomgaSeriesStore.fetchSeriesIds(
-        context: context,
+      guard let database = try? await DatabaseOperator.database() else {
+        guard loadID == pagination.loadID else { return }
+        applyPage(ids: [], moreAvailable: false)
+        return
+      }
+      let ids = await database.fetchBrowseSeriesIds(
+        instanceId: AppConfig.current.instanceId,
         libraryIds: libraryIds,
         searchText: searchText,
         browseOpts: browseOpts,
@@ -87,7 +90,6 @@ class SeriesViewModel {
   }
 
   func loadCollectionSeries(
-    context: ModelContext,
     collectionId: String,
     browseOpts: CollectionSeriesBrowseOptions,
     libraryIds: [String]? = nil,
@@ -113,15 +115,18 @@ class SeriesViewModel {
     }
 
     if AppConfig.isOffline {
-      let series = KomgaSeriesStore.fetchCollectionSeries(
-        context: context,
+      guard let database = try? await DatabaseOperator.database() else {
+        guard loadID == pagination.loadID else { return }
+        applyPage(ids: [], moreAvailable: false)
+        return
+      }
+      let ids = await database.fetchCollectionSeriesIds(
         collectionId: collectionId,
+        browseOpts: browseOpts,
         page: pagination.currentPage,
-        size: pagination.pageSize,
-        browseOpts: browseOpts
+        size: pagination.pageSize
       )
       guard loadID == pagination.loadID else { return }
-      let ids = series.map { $0.id }
       applyPage(ids: ids, moreAvailable: ids.count == pagination.pageSize)
     } else {
       do {

--- a/KMReader/Features/Series/Views/SeriesBrowseView.swift
+++ b/KMReader/Features/Series/Views/SeriesBrowseView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct SeriesBrowseView: View {
@@ -17,8 +16,6 @@ struct SeriesBrowseView: View {
   @AppStorage("seriesBrowseOptions") private var storedBrowseOpts: SeriesBrowseOptions = SeriesBrowseOptions()
   @AppStorage("seriesBrowseLayout") private var browseLayout: BrowseLayoutMode = .grid
   @AppStorage("searchIgnoreFilters") private var searchIgnoreFilters: Bool = false
-
-  @Environment(\.modelContext) private var modelContext
 
   @State private var browseOpts: SeriesBrowseOptions = SeriesBrowseOptions()
   @State private var viewModel = SeriesViewModel()
@@ -93,7 +90,6 @@ struct SeriesBrowseView: View {
     let effectiveBrowseOpts =
       (searchIgnoreFilters && !searchText.isEmpty) ? SeriesBrowseOptions() : browseOpts
     await viewModel.loadSeries(
-      context: modelContext,
       browseOpts: effectiveBrowseOpts,
       searchText: searchText,
       libraryIds: libraryIds,

--- a/KMReader/Features/Series/Views/SeriesCardView.swift
+++ b/KMReader/Features/Series/Views/SeriesCardView.swift
@@ -3,11 +3,11 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct SeriesCardView: View {
-  @Bindable var komgaSeries: KomgaSeries
+  let item: SeriesDisplayItem
+  var onMutationCompleted: (() -> Void)? = nil
 
   @AppStorage("coverOnlyCards") private var coverOnlyCards: Bool = false
   @AppStorage("cardTextOverlayMode") private var cardTextOverlayMode: Bool = false
@@ -19,16 +19,16 @@ struct SeriesCardView: View {
   @State private var showEditSheet = false
 
   var navDestination: NavDestination {
-    if komgaSeries.oneshot {
-      return NavDestination.oneshotDetail(seriesId: komgaSeries.seriesId)
+    if item.oneshot {
+      return NavDestination.oneshotDetail(seriesId: item.seriesId)
     } else {
-      return NavDestination.seriesDetail(seriesId: komgaSeries.seriesId)
+      return NavDestination.seriesDetail(seriesId: item.seriesId)
     }
   }
 
   var progress: Double {
-    guard komgaSeries.booksCount > 0 else { return 0 }
-    return Double(komgaSeries.booksReadCount) / Double(komgaSeries.booksCount)
+    guard item.booksCount > 0 else { return 0 }
+    return Double(item.booksReadCount) / Double(item.booksCount)
   }
 
   private var contentSpacing: CGFloat {
@@ -36,13 +36,13 @@ struct SeriesCardView: View {
   }
 
   private var coverBlurRadius: CGFloat {
-    thumbnailBlurUnreadCovers && komgaSeries.isUnread ? CoverBlurStyle.unreadRadius : 0
+    thumbnailBlurUnreadCovers && item.isUnread ? CoverBlurStyle.unreadRadius : 0
   }
 
   var body: some View {
     VStack(alignment: .leading, spacing: contentSpacing) {
       ThumbnailImage(
-        id: komgaSeries.seriesId,
+        id: item.seriesId,
         type: .series,
         shadowStyle: .platform,
         contentBlurRadius: coverBlurRadius,
@@ -56,23 +56,23 @@ struct SeriesCardView: View {
               overlayTextContent
             }
           }
-          if thumbnailShowUnreadIndicator && komgaSeries.booksUnreadCount > 0 {
+          if thumbnailShowUnreadIndicator && item.booksUnreadCount > 0 {
             VStack(alignment: .trailing) {
-              UnreadCountBadge(count: komgaSeries.booksUnreadCount)
+              UnreadCountBadge(count: item.booksUnreadCount)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
             }
           }
         }
       } menu: {
         SeriesContextMenu(
-          seriesId: komgaSeries.seriesId,
-          menuTitle: komgaSeries.metaTitle,
-          downloadStatus: komgaSeries.downloadStatus,
-          offlinePolicy: komgaSeries.offlinePolicy,
-          offlinePolicyLimit: komgaSeries.offlinePolicyLimit,
-          booksUnreadCount: komgaSeries.booksUnreadCount,
-          booksReadCount: komgaSeries.booksReadCount,
-          booksInProgressCount: komgaSeries.booksInProgressCount,
+          seriesId: item.seriesId,
+          menuTitle: item.metaTitle,
+          downloadStatus: item.downloadStatus,
+          offlinePolicy: item.offlinePolicy,
+          offlinePolicyLimit: item.offlinePolicyLimit,
+          booksUnreadCount: item.booksUnreadCount,
+          booksReadCount: item.booksReadCount,
+          booksInProgressCount: item.booksInProgressCount,
           onShowCollectionPicker: {
             showCollectionPicker = true
           },
@@ -81,20 +81,21 @@ struct SeriesCardView: View {
           },
           onEditRequested: {
             showEditSheet = true
-          }
+          },
+          onMutationCompleted: onMutationCompleted
         )
       }
 
       if !cardTextOverlayMode && !coverOnlyCards {
         VStack(alignment: .leading) {
-          Text(komgaSeries.metaTitle)
+          Text(item.metaTitle)
             .lineLimit(1)
 
           HStack(spacing: 4) {
-            if komgaSeries.isUnavailable {
+            if item.isUnavailable {
               Text("Unavailable")
                 .foregroundColor(.red)
-            } else if komgaSeries.oneshot {
+            } else if item.oneshot {
               Text("Oneshot")
                 .foregroundColor(.blue)
             } else {
@@ -107,13 +108,13 @@ struct SeriesCardView: View {
                   .foregroundColor(.secondary)
                   .font(.caption2)
               }
-              Text("\(komgaSeries.booksCount) books")
+              Text("\(item.booksCount) books")
                 .lineLimit(1)
             }
-            if komgaSeries.downloadStatus != .notDownloaded {
+            if item.downloadStatus != .notDownloaded {
               Spacer()
-              Image(systemName: komgaSeries.downloadStatus.icon)
-                .foregroundColor(komgaSeries.downloadStatus.color)
+              Image(systemName: item.downloadStatus.icon)
+                .foregroundColor(item.downloadStatus.color)
                 .font(.caption2)
             }
           }
@@ -134,14 +135,14 @@ struct SeriesCardView: View {
     }
     .sheet(isPresented: $showCollectionPicker) {
       CollectionPickerSheet(
-        seriesId: komgaSeries.seriesId,
+        seriesId: item.seriesId,
         onSelect: { collectionId in
           addToCollection(collectionId: collectionId)
         }
       )
     }
     .sheet(isPresented: $showEditSheet) {
-      SeriesEditSheet(series: komgaSeries.toSeries())
+      SeriesEditSheet(series: item.series)
     }
   }
 
@@ -149,12 +150,12 @@ struct SeriesCardView: View {
   private var overlayTextContent: some View {
     let style = CardOverlayTextStyle.standard
 
-    CardOverlayTextStack(title: komgaSeries.metaTitle, style: style) {
+    CardOverlayTextStack(title: item.metaTitle, style: style) {
       HStack(spacing: 4) {
-        if komgaSeries.isUnavailable {
+        if item.isUnavailable {
           Text("Unavailable")
             .foregroundColor(.red)
-        } else if komgaSeries.oneshot {
+        } else if item.oneshot {
           Text("Oneshot")
             .foregroundColor(.blue)
         } else {
@@ -167,13 +168,13 @@ struct SeriesCardView: View {
               .foregroundColor(style.secondaryColor)
               .font(.caption2)
           }
-          Text("\(komgaSeries.booksCount) books")
+          Text("\(item.booksCount) books")
             .lineLimit(1)
         }
-        if komgaSeries.downloadStatus != .notDownloaded {
+        if item.downloadStatus != .notDownloaded {
           Spacer()
-          Image(systemName: komgaSeries.downloadStatus.icon)
-            .foregroundColor(komgaSeries.downloadStatus.color)
+          Image(systemName: item.downloadStatus.icon)
+            .foregroundColor(item.downloadStatus.color)
             .font(.caption2)
         }
       }
@@ -185,10 +186,11 @@ struct SeriesCardView: View {
       do {
         try await CollectionService.addSeriesToCollection(
           collectionId: collectionId,
-          seriesIds: [komgaSeries.seriesId]
+          seriesIds: [item.seriesId]
         )
         ErrorManager.shared.notify(
           message: String(localized: "notification.series.addedToCollection"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -198,8 +200,9 @@ struct SeriesCardView: View {
   private func deleteSeries() {
     Task {
       do {
-        try await SeriesService.deleteSeries(seriesId: komgaSeries.seriesId)
+        try await SeriesService.deleteSeries(seriesId: item.seriesId)
         ErrorManager.shared.notify(message: String(localized: "notification.series.deleted"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }

--- a/KMReader/Features/Series/Views/SeriesCollectionsSection.swift
+++ b/KMReader/Features/Series/Views/SeriesCollectionsSection.swift
@@ -3,53 +3,76 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct SeriesCollectionsSection: View {
-  @Query private var komgaCollections: [KomgaCollection]
+  @AppStorage("currentAccount") private var current: Current = .init()
 
-  init(collectionIds: [String]) {
-    let instanceId = AppConfig.current.instanceId
-    _komgaCollections = Query(
-      filter: #Predicate<KomgaCollection> {
-        $0.instanceId == instanceId && collectionIds.contains($0.collectionId)
-      })
-  }
+  let collectionIds: [String]
 
-  private var collections: [SeriesCollection] {
-    komgaCollections.map { $0.toCollection() }
+  @State private var collections: [SidebarCollectionItem] = []
+
+  private var collectionIdsKey: String {
+    collectionIds.sorted().joined(separator: ",")
   }
 
   var body: some View {
-    if !collections.isEmpty {
-      VStack(alignment: .leading, spacing: 8) {
-        HStack(spacing: 4) {
-          Text("Collections")
-            .font(.headline)
-        }
-        .foregroundColor(.secondary)
-
+    Group {
+      if !collections.isEmpty {
         VStack(alignment: .leading, spacing: 8) {
-          ForEach(collections) { collection in
-            NavigationLink(
-              value: NavDestination.collectionDetail(collectionId: collection.id)
-            ) {
-              HStack {
-                Label(collection.name, systemImage: ContentIcon.collection)
-                  .foregroundColor(.primary)
-                Spacer()
-                Image(systemName: "chevron.right")
-                  .font(.caption)
-                  .foregroundColor(.secondary)
-              }
-              .padding()
-              .background(Color.secondary.opacity(0.1))
-              .cornerRadius(16)
-            }.adaptiveButtonStyle(.plain)
+          HStack(spacing: 4) {
+            Text("Collections")
+              .font(.headline)
+          }
+          .foregroundColor(.secondary)
+
+          VStack(alignment: .leading, spacing: 8) {
+            ForEach(collections) { collection in
+              NavigationLink(
+                value: NavDestination.collectionDetail(collectionId: collection.collectionId)
+              ) {
+                HStack {
+                  Label(collection.name, systemImage: ContentIcon.collection)
+                    .foregroundColor(.primary)
+                  Spacer()
+                  Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                }
+                .padding()
+                .background(Color.secondary.opacity(0.1))
+                .cornerRadius(16)
+              }.adaptiveButtonStyle(.plain)
+            }
           }
         }
       }
+    }
+    .task(id: "\(current.instanceId)|\(collectionIdsKey)") {
+      await loadCollections()
+    }
+  }
+
+  private func loadCollections() async {
+    let instanceId = current.instanceId
+    guard !instanceId.isEmpty, !collectionIds.isEmpty else {
+      if !collections.isEmpty {
+        collections = []
+      }
+      return
+    }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedCollections = try await database.fetchSidebarCollections(
+        instanceId: instanceId,
+        collectionIds: Set(collectionIds)
+      )
+      if collections != loadedCollections {
+        collections = loadedCollections
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
     }
   }
 }

--- a/KMReader/Features/Series/Views/SeriesContextMenu.swift
+++ b/KMReader/Features/Series/Views/SeriesContextMenu.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct SeriesContextMenu: View {
@@ -19,11 +18,11 @@ struct SeriesContextMenu: View {
   var onShowCollectionPicker: (() -> Void)? = nil
   var onDeleteRequested: (() -> Void)? = nil
   var onEditRequested: (() -> Void)? = nil
+  var onMutationCompleted: (() -> Void)? = nil
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("isOffline") private var isOffline: Bool = false
 
-  @Environment(\.modelContext) private var modelContext
   @Environment(\.readerActions) private var readerActions
 
   private var status: SeriesDownloadStatus {
@@ -205,8 +204,8 @@ struct SeriesContextMenu: View {
     Task {
       let book = await SeriesContinueReadingResolver.resolve(
         seriesId: seriesId,
-        isOffline: isOffline,
-        context: modelContext
+        instanceId: current.instanceId,
+        isOffline: isOffline
       )
       if let book {
         readerActions.open(book: book, incognito: false)
@@ -232,6 +231,7 @@ struct SeriesContextMenu: View {
         try await SeriesService.refreshMetadata(seriesId: seriesId)
         ErrorManager.shared.notify(
           message: String(localized: "notification.series.metadataRefreshed"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -243,6 +243,7 @@ struct SeriesContextMenu: View {
       do {
         try await SeriesService.markAsRead(seriesId: seriesId)
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedRead"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -254,6 +255,7 @@ struct SeriesContextMenu: View {
       do {
         try await SeriesService.markAsUnread(seriesId: seriesId)
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedUnread"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -285,6 +287,7 @@ struct SeriesContextMenu: View {
         seriesId: seriesId, instanceId: current.instanceId, policy: policy
       )
       try? await DatabaseOperator.database().commit()
+      onMutationCompleted?()
     }
   }
 
@@ -298,6 +301,7 @@ struct SeriesContextMenu: View {
         limit: limit
       )
       try? await DatabaseOperator.database().commit()
+      onMutationCompleted?()
     }
   }
 
@@ -378,6 +382,7 @@ struct SeriesContextMenu: View {
       ErrorManager.shared.notify(
         message: String(localized: "notification.series.offlineDownloadQueued")
       )
+      onMutationCompleted?()
     }
   }
 
@@ -393,6 +398,7 @@ struct SeriesContextMenu: View {
       ErrorManager.shared.notify(
         message: String(localized: "notification.series.offlineDownloadQueued")
       )
+      onMutationCompleted?()
     }
   }
 
@@ -405,6 +411,7 @@ struct SeriesContextMenu: View {
       ErrorManager.shared.notify(
         message: String(localized: "notification.series.offlineRemoved")
       )
+      onMutationCompleted?()
     }
   }
 
@@ -417,6 +424,7 @@ struct SeriesContextMenu: View {
       ErrorManager.shared.notify(
         message: String(localized: "notification.series.offlineRemoved")
       )
+      onMutationCompleted?()
     }
   }
 

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -4,7 +4,6 @@
 //
 
 import Flow
-import SwiftData
 import SwiftUI
 
 struct SeriesDetailView: View {
@@ -15,11 +14,9 @@ struct SeriesDetailView: View {
   @AppStorage("seriesDetailLayout") private var seriesDetailLayout: BrowseLayoutMode = .list
 
   @Environment(\.dismiss) private var dismiss
-  @Environment(\.modelContext) private var modelContext
   @Environment(\.readerActions) private var readerActions
 
-  @Query private var komgaSeriesList: [KomgaSeries]
-
+  @State private var item: SeriesDisplayItem?
   @State private var bookViewModel = BookViewModel()
   @State private var showDeleteConfirmation = false
   @State private var showCollectionPicker = false
@@ -29,18 +26,10 @@ struct SeriesDetailView: View {
 
   init(seriesId: String) {
     self.seriesId = seriesId
-    let compositeId = CompositeID.generate(id: seriesId)
-    _komgaSeriesList = Query(filter: #Predicate<KomgaSeries> { $0.id == compositeId })
   }
 
-  /// The KomgaSeries from SwiftData (reactive).
-  private var komgaSeries: KomgaSeries? {
-    komgaSeriesList.first
-  }
-
-  /// Convert to API Series type for compatibility with existing components.
   private var series: Series? {
-    komgaSeries?.toSeries()
+    item?.series
   }
 
   private var canMarkSeriesAsRead: Bool {
@@ -101,19 +90,29 @@ struct SeriesDetailView: View {
               .padding(.vertical, 8)
             }
 
-            if let komgaSeries = komgaSeries {
-              SeriesCollectionsSection(collectionIds: komgaSeries.collectionIds)
+            if let item {
+              SeriesCollectionsSection(collectionIds: item.collectionIds)
             }
 
             Divider()
-            if let komgaSeries = komgaSeries {
-              SeriesDownloadActionsSection(komgaSeries: komgaSeries)
+            if let item {
+              SeriesDownloadActionsSection(
+                seriesId: item.seriesId,
+                status: item.downloadStatus,
+                policy: item.offlinePolicy,
+                offlinePolicyLimit: item.offlinePolicyLimit,
+                onMutationCompleted: {
+                  Task {
+                    await refreshSeriesData()
+                  }
+                }
+              )
             }
             Divider()
           }
           .padding(.horizontal)
 
-          if komgaSeries != nil {
+          if item != nil {
             BooksListViewForSeries(
               seriesId: seriesId,
               bookViewModel: bookViewModel,
@@ -178,16 +177,27 @@ struct SeriesDetailView: View {
 extension SeriesDetailView {
   private func refreshSeriesData() async {
     do {
-      // Sync from network to SwiftData (series property will update reactively)
       _ = try await SyncService.syncSeriesDetail(seriesId: seriesId)
       await SyncService.syncSeriesCollections(seriesId: seriesId)
     } catch {
       if case APIError.notFound = error {
         dismiss()
-      } else if komgaSeries == nil {
+      } else if item == nil {
         ErrorManager.shared.alert(error: error)
       }
     }
+    await loadLocalSeries()
+  }
+
+  private func loadLocalSeries() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      item = nil
+      return
+    }
+    item = try? await database.fetchSeriesDisplayItem(
+      seriesId: seriesId,
+      instanceId: current.instanceId
+    )
   }
 
   private func analyzeSeries() {
@@ -256,8 +266,8 @@ extension SeriesDetailView {
     Task {
       let book = await SeriesContinueReadingResolver.resolve(
         seriesId: seriesId,
-        isOffline: isOffline,
-        context: modelContext
+        instanceId: current.instanceId,
+        isOffline: isOffline
       )
       if let book {
         readerActions.open(book: book, incognito: false)

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -176,6 +176,7 @@ struct SeriesDetailView: View {
 
 extension SeriesDetailView {
   private func refreshSeriesData() async {
+    await loadLocalSeries()
     do {
       _ = try await SyncService.syncSeriesDetail(seriesId: seriesId)
       await SyncService.syncSeriesCollections(seriesId: seriesId)

--- a/KMReader/Features/Series/Views/SeriesDownloadActionsSection.swift
+++ b/KMReader/Features/Series/Views/SeriesDownloadActionsSection.swift
@@ -3,32 +3,23 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct SeriesDownloadActionsSection: View {
-  @Bindable var komgaSeries: KomgaSeries
+  let seriesId: String
+  let status: SeriesDownloadStatus
+  let policy: SeriesOfflinePolicy
+  let offlinePolicyLimit: Int
+  var onMutationCompleted: (() -> Void)? = nil
 
   @AppStorage("currentAccount") private var current: Current = .init()
-
-  private var series: Series {
-    komgaSeries.toSeries()
-  }
-
-  private var status: SeriesDownloadStatus {
-    komgaSeries.downloadStatus
-  }
-
-  private var policy: SeriesOfflinePolicy {
-    komgaSeries.offlinePolicy
-  }
 
   private var limitPresets: [Int] {
     [1, 3, 5, 10, 25, 50, 0]
   }
 
   private var policyLabel: Text {
-    Text("Offline Policy") + Text(" : ") + Text(policy.title(limit: komgaSeries.offlinePolicyLimit))
+    Text("Offline Policy") + Text(" : ") + Text(policy.title(limit: offlinePolicyLimit))
   }
 
   private var actions: [SeriesDownloadAction] {
@@ -182,31 +173,33 @@ struct SeriesDownloadActionsSection: View {
     Task {
       // Sync books first if policy is not manual
       if newPolicy != .manual {
-        try? await SyncService.syncAllSeriesBooks(seriesId: series.id)
+        try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
       }
       try? await DatabaseOperator.database().updateSeriesOfflinePolicy(
-        seriesId: series.id, instanceId: current.instanceId, policy: newPolicy
+        seriesId: seriesId, instanceId: current.instanceId, policy: newPolicy
       )
       try? await DatabaseOperator.database().commit()
+      onMutationCompleted?()
     }
   }
 
   private func updatePolicyAndLimit(_ newPolicy: SeriesOfflinePolicy, limit: Int) {
     Task {
-      try? await SyncService.syncAllSeriesBooks(seriesId: series.id)
+      try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
       try? await DatabaseOperator.database().updateSeriesOfflinePolicy(
-        seriesId: series.id,
+        seriesId: seriesId,
         instanceId: current.instanceId,
         policy: newPolicy,
         limit: limit
       )
       try? await DatabaseOperator.database().commit()
+      onMutationCompleted?()
     }
   }
 
   @ViewBuilder
   private func offlinePolicyLabel(_ value: SeriesOfflinePolicy) -> some View {
-    let title = value.title(limit: komgaSeries.offlinePolicyLimit)
+    let title = value.title(limit: offlinePolicyLimit)
     if value == policy {
       Label(title, systemImage: "checkmark")
     } else {
@@ -217,7 +210,7 @@ struct SeriesDownloadActionsSection: View {
   @ViewBuilder
   private func limitOptionLabel(policy: SeriesOfflinePolicy, limit: Int) -> some View {
     let title = SeriesOfflinePolicy.limitTitle(limit)
-    if komgaSeries.offlinePolicy == policy && komgaSeries.offlinePolicyLimit == limit {
+    if self.policy == policy && offlinePolicyLimit == limit {
       Label(title, systemImage: "checkmark")
     } else {
       Text(title)
@@ -229,7 +222,7 @@ struct SeriesDownloadActionsSection: View {
     case .download:
       downloadAll()
     case .downloadUnread:
-      let limit = pendingUnreadLimit ?? komgaSeries.offlinePolicyLimit
+      let limit = pendingUnreadLimit ?? offlinePolicyLimit
       pendingUnreadLimit = nil
       downloadUnread(limit: limit)
     case .removeRead:
@@ -242,22 +235,23 @@ struct SeriesDownloadActionsSection: View {
   private func downloadAll() {
     Task {
       // Sync books first
-      try? await SyncService.syncAllSeriesBooks(seriesId: series.id)
+      try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
       try? await DatabaseOperator.database().downloadSeriesOffline(
-        seriesId: series.id, instanceId: current.instanceId
+        seriesId: seriesId, instanceId: current.instanceId
       )
       try? await DatabaseOperator.database().commit()
       ErrorManager.shared.notify(
         message: String(localized: "notification.series.offlineDownloadQueued")
       )
+      onMutationCompleted?()
     }
   }
 
   private func downloadUnread(limit: Int) {
     Task {
-      try? await SyncService.syncAllSeriesBooks(seriesId: series.id)
+      try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
       try? await DatabaseOperator.database().downloadSeriesUnreadOffline(
-        seriesId: series.id,
+        seriesId: seriesId,
         instanceId: current.instanceId,
         limit: limit
       )
@@ -265,19 +259,21 @@ struct SeriesDownloadActionsSection: View {
       ErrorManager.shared.notify(
         message: String(localized: "notification.series.offlineDownloadQueued")
       )
+      onMutationCompleted?()
     }
   }
 
   private func removeRead() {
     Task {
       try? await DatabaseOperator.database().removeSeriesReadOffline(
-        seriesId: series.id,
+        seriesId: seriesId,
         instanceId: current.instanceId
       )
       try? await DatabaseOperator.database().commit()
       ErrorManager.shared.notify(
         message: String(localized: "notification.series.offlineRemoved")
       )
+      onMutationCompleted?()
     }
   }
 
@@ -295,12 +291,13 @@ struct SeriesDownloadActionsSection: View {
   private func removeAll() {
     Task {
       try? await DatabaseOperator.database().removeSeriesOffline(
-        seriesId: series.id, instanceId: current.instanceId
+        seriesId: seriesId, instanceId: current.instanceId
       )
       try? await DatabaseOperator.database().commit()
       ErrorManager.shared.notify(
         message: String(localized: "notification.series.offlineRemoved")
       )
+      onMutationCompleted?()
     }
   }
 }

--- a/KMReader/Features/Series/Views/SeriesItemView.swift
+++ b/KMReader/Features/Series/Views/SeriesItemView.swift
@@ -6,18 +6,21 @@
 import SwiftUI
 
 struct SeriesItemView: View {
-  @Bindable var series: KomgaSeries
+  let item: SeriesDisplayItem
   let layout: BrowseLayoutMode
+  var onMutationCompleted: (() -> Void)? = nil
 
   var body: some View {
     switch layout {
     case .grid:
       SeriesCardView(
-        komgaSeries: series
+        item: item,
+        onMutationCompleted: onMutationCompleted
       )
     case .list:
       SeriesRowView(
-        komgaSeries: series
+        item: item,
+        onMutationCompleted: onMutationCompleted
       )
     }
   }

--- a/KMReader/Features/Series/Views/SeriesQueryItemView.swift
+++ b/KMReader/Features/Series/Views/SeriesQueryItemView.swift
@@ -3,16 +3,15 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
-/// Wrapper view that accepts only seriesId and uses @Query to fetch the series reactively.
+/// Wrapper view that accepts only seriesId and fetches a series display projection.
 struct SeriesQueryItemView: View {
   let seriesId: String
   let layout: BrowseLayoutMode
 
   @AppStorage("currentAccount") private var current: Current = .init()
-  @Query private var komgaSeriesList: [KomgaSeries]
+  @State private var item: SeriesDisplayItem?
 
   init(
     seriesId: String,
@@ -21,28 +20,46 @@ struct SeriesQueryItemView: View {
     self.seriesId = seriesId
     self.layout = layout
 
-    let compositeId = CompositeID.generate(id: seriesId)
-    _komgaSeriesList = Query(filter: #Predicate<KomgaSeries> { $0.id == compositeId })
-  }
-
-  private var komgaSeries: KomgaSeries? {
-    komgaSeriesList.first
   }
 
   var body: some View {
-    if let series = komgaSeries {
-      switch layout {
-      case .grid:
-        SeriesCardView(
-          komgaSeries: series
-        )
-      case .list:
-        SeriesRowView(
-          komgaSeries: series
-        )
+    Group {
+      if let item {
+        switch layout {
+        case .grid:
+          SeriesCardView(
+            item: item,
+            onMutationCompleted: reloadItem
+          )
+        case .list:
+          SeriesRowView(
+            item: item,
+            onMutationCompleted: reloadItem
+          )
+        }
+      } else {
+        CardPlaceholder(layout: layout, kind: .series)
       }
-    } else {
-      CardPlaceholder(layout: layout, kind: .series)
     }
+    .task(id: "\(current.instanceId)|\(seriesId)") {
+      await loadItem()
+    }
+  }
+
+  private func reloadItem() {
+    Task {
+      await loadItem()
+    }
+  }
+
+  private func loadItem() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      item = nil
+      return
+    }
+    item = try? await database.fetchSeriesDisplayItem(
+      seriesId: seriesId,
+      instanceId: current.instanceId
+    )
   }
 }

--- a/KMReader/Features/Series/Views/SeriesQueryItemView.swift
+++ b/KMReader/Features/Series/Views/SeriesQueryItemView.swift
@@ -44,6 +44,11 @@ struct SeriesQueryItemView: View {
     .task(id: "\(current.instanceId)|\(seriesId)") {
       await loadItem()
     }
+    .onReceive(NotificationCenter.default.publisher(for: .seriesProjectionDidChange)) {
+      notification in
+      guard notification.userInfo?["seriesId"] as? String == seriesId else { return }
+      reloadItem()
+    }
   }
 
   private func reloadItem() {

--- a/KMReader/Features/Series/Views/SeriesQueryView.swift
+++ b/KMReader/Features/Series/Views/SeriesQueryView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct SeriesQueryView: View {
@@ -16,7 +15,6 @@ struct SeriesQueryView: View {
   let offlineOnly: Bool
 
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
-  @Environment(\.modelContext) private var modelContext
 
   private var columns: [GridItem] {
     LayoutConfig.adaptiveColumns(for: gridDensity)
@@ -97,7 +95,6 @@ struct SeriesQueryView: View {
   private func loadSeries(refresh: Bool) {
     Task {
       await viewModel.loadSeries(
-        context: modelContext,
         browseOpts: browseOpts,
         searchText: searchText,
         libraryIds: libraryIds,

--- a/KMReader/Features/Series/Views/SeriesRowView.swift
+++ b/KMReader/Features/Series/Views/SeriesRowView.swift
@@ -3,11 +3,11 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct SeriesRowView: View {
-  @Bindable var komgaSeries: KomgaSeries
+  let item: SeriesDisplayItem
+  var onMutationCompleted: (() -> Void)? = nil
 
   @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
 
@@ -16,29 +16,29 @@ struct SeriesRowView: View {
   @State private var showEditSheet = false
 
   var series: Series {
-    komgaSeries.toSeries()
+    item.series
   }
 
   var downloadStatus: SeriesDownloadStatus {
-    komgaSeries.downloadStatus
+    item.downloadStatus
   }
 
   var navDestination: NavDestination {
-    if komgaSeries.oneshot {
-      return NavDestination.oneshotDetail(seriesId: komgaSeries.seriesId)
+    if item.oneshot {
+      return NavDestination.oneshotDetail(seriesId: item.seriesId)
     } else {
-      return NavDestination.seriesDetail(seriesId: komgaSeries.seriesId)
+      return NavDestination.seriesDetail(seriesId: item.seriesId)
     }
   }
 
   var progress: Double {
-    guard komgaSeries.booksCount > 0 else { return 0 }
-    guard komgaSeries.booksReadCount > 0 else { return 0 }
-    return Double(komgaSeries.booksReadCount) / Double(komgaSeries.booksCount)
+    guard item.booksCount > 0 else { return 0 }
+    guard item.booksReadCount > 0 else { return 0 }
+    return Double(item.booksReadCount) / Double(item.booksCount)
   }
 
   private var coverBlurRadius: CGFloat {
-    thumbnailBlurUnreadCovers && komgaSeries.isUnread ? CoverBlurStyle.unreadRadius : 0
+    thumbnailBlurUnreadCovers && item.isUnread ? CoverBlurStyle.unreadRadius : 0
   }
 
   var body: some View {
@@ -113,14 +113,14 @@ struct SeriesRowView: View {
           }
           EllipsisMenuButton {
             SeriesContextMenu(
-              seriesId: komgaSeries.seriesId,
-              menuTitle: komgaSeries.metaTitle,
-              downloadStatus: komgaSeries.downloadStatus,
-              offlinePolicy: komgaSeries.offlinePolicy,
-              offlinePolicyLimit: komgaSeries.offlinePolicyLimit,
-              booksUnreadCount: komgaSeries.booksUnreadCount,
-              booksReadCount: komgaSeries.booksReadCount,
-              booksInProgressCount: komgaSeries.booksInProgressCount,
+              seriesId: item.seriesId,
+              menuTitle: item.metaTitle,
+              downloadStatus: item.downloadStatus,
+              offlinePolicy: item.offlinePolicy,
+              offlinePolicyLimit: item.offlinePolicyLimit,
+              booksUnreadCount: item.booksUnreadCount,
+              booksReadCount: item.booksReadCount,
+              booksInProgressCount: item.booksInProgressCount,
               onShowCollectionPicker: {
                 showCollectionPicker = true
               },
@@ -129,9 +129,10 @@ struct SeriesRowView: View {
               },
               onEditRequested: {
                 showEditSheet = true
-              }
+              },
+              onMutationCompleted: onMutationCompleted
             )
-            .id(komgaSeries.seriesId)
+            .id(item.seriesId)
           }
         }
       }
@@ -166,6 +167,7 @@ struct SeriesRowView: View {
         )
         ErrorManager.shared.notify(
           message: String(localized: "notification.series.addedToCollection"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }
@@ -177,6 +179,7 @@ struct SeriesRowView: View {
       do {
         try await SeriesService.deleteSeries(seriesId: series.id)
         ErrorManager.shared.notify(message: String(localized: "notification.series.deleted"))
+        onMutationCompleted?()
       } catch {
         ErrorManager.shared.alert(error: error)
       }

--- a/KMReader/Features/Series/Views/SeriesSelectionItemView.swift
+++ b/KMReader/Features/Series/Views/SeriesSelectionItemView.swift
@@ -3,16 +3,16 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
-/// View for series selection mode that accepts only seriesId and uses @Query to fetch the series.
+/// View for series selection mode that accepts only seriesId and fetches a series display projection.
 struct SeriesSelectionItemView: View {
   let seriesId: String
   let layout: BrowseLayoutMode
   @Binding var selectedSeriesIds: Set<String>
 
-  @Query private var komgaSeriesList: [KomgaSeries]
+  @AppStorage("currentAccount") private var current: Current = .init()
+  @State private var item: SeriesDisplayItem?
 
   init(
     seriesId: String,
@@ -23,13 +23,6 @@ struct SeriesSelectionItemView: View {
     self.layout = layout
     self._selectedSeriesIds = selectedSeriesIds
 
-    let instanceId = AppConfig.current.instanceId
-    let compositeId = CompositeID.generate(instanceId: instanceId, id: seriesId)
-    _komgaSeriesList = Query(filter: #Predicate<KomgaSeries> { $0.id == compositeId })
-  }
-
-  private var komgaSeries: KomgaSeries? {
-    komgaSeriesList.first
   }
 
   private var isSelected: Bool {
@@ -37,39 +30,55 @@ struct SeriesSelectionItemView: View {
   }
 
   var body: some View {
-    if let series = komgaSeries {
-      Group {
-        switch layout {
-        case .grid:
-          SeriesCardView(
-            komgaSeries: series
-          )
-        case .list:
-          SeriesRowView(
-            komgaSeries: series
-          )
-        }
-      }
-      .allowsHitTesting(false)
-      .scaleEffect(isSelected ? 0.96 : 1.0)
-      .overlay {
-        if isSelected {
-          RoundedRectangle(cornerRadius: 12)
-            .stroke(Color.accentColor, lineWidth: 2)
-        }
-      }
-      .contentShape(Rectangle())
-      .highPriorityGesture(
-        TapGesture().onEnded {
-          withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-            if isSelected {
-              selectedSeriesIds.remove(seriesId)
-            } else {
-              selectedSeriesIds.insert(seriesId)
-            }
+    Group {
+      if let item {
+        Group {
+          switch layout {
+          case .grid:
+            SeriesCardView(
+              item: item
+            )
+          case .list:
+            SeriesRowView(
+              item: item
+            )
           }
         }
-      )
+        .allowsHitTesting(false)
+        .scaleEffect(isSelected ? 0.96 : 1.0)
+        .overlay {
+          if isSelected {
+            RoundedRectangle(cornerRadius: 12)
+              .stroke(Color.accentColor, lineWidth: 2)
+          }
+        }
+        .contentShape(Rectangle())
+        .highPriorityGesture(
+          TapGesture().onEnded {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+              if isSelected {
+                selectedSeriesIds.remove(seriesId)
+              } else {
+                selectedSeriesIds.insert(seriesId)
+              }
+            }
+          }
+        )
+      }
     }
+    .task(id: "\(current.instanceId)|\(seriesId)") {
+      await loadItem()
+    }
+  }
+
+  private func loadItem() async {
+    guard let database = try? await DatabaseOperator.database() else {
+      item = nil
+      return
+    }
+    item = try? await database.fetchSeriesDisplayItem(
+      seriesId: seriesId,
+      instanceId: current.instanceId
+    )
   }
 }

--- a/KMReader/Features/Server/ServerDisplayItem.swift
+++ b/KMReader/Features/Server/ServerDisplayItem.swift
@@ -1,0 +1,25 @@
+//
+// ServerDisplayItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct ServerDisplayItem: Equatable, Identifiable, Sendable {
+  let id: UUID
+  let name: String
+  let serverURL: String
+  let username: String
+  let authToken: String
+  let isAdmin: Bool
+  let authMethod: AuthenticationMethod
+  let lastUsedAt: Date
+
+  var instanceId: String {
+    id.uuidString
+  }
+
+  var displayName: String {
+    name.isEmpty ? serverURL : name
+  }
+}

--- a/KMReader/Features/Server/ServerEditView.swift
+++ b/KMReader/Features/Server/ServerEditView.swift
@@ -3,14 +3,14 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct ServerEditView: View {
   let authViewModel: AuthViewModel
+  let instance: ServerDisplayItem
+  let onSaved: () -> Void
+
   @Environment(\.dismiss) private var dismiss
-  @Environment(\.modelContext) private var modelContext
-  @Bindable var instance: KomgaInstance
   @AppStorage("currentAccount") private var current: Current = .init()
 
   @State private var name: String
@@ -20,6 +20,7 @@ struct ServerEditView: View {
   @State private var apiKey: String = ""
   @State private var authMethod: AuthenticationMethod
   @State private var isValidating = false
+  @State private var isSaving = false
   @State private var validationMessage: String?
   @State private var isValidated = false
 
@@ -40,14 +41,15 @@ struct ServerEditView: View {
     }
   }
 
-  init(instance: KomgaInstance, authViewModel: AuthViewModel) {
+  init(instance: ServerDisplayItem, authViewModel: AuthViewModel, onSaved: @escaping () -> Void) {
+    self.instance = instance
     self.authViewModel = authViewModel
-    _instance = Bindable(instance)
+    self.onSaved = onSaved
     _name = State(initialValue: instance.name)
     _serverURL = State(initialValue: instance.serverURL)
     _username = State(initialValue: instance.username)
-    _authMethod = State(initialValue: instance.resolvedAuthMethod)
-    if instance.resolvedAuthMethod == .apiKey {
+    _authMethod = State(initialValue: instance.authMethod)
+    if instance.authMethod == .apiKey {
       _apiKey = State(initialValue: instance.authToken)
     }
   }
@@ -63,7 +65,7 @@ struct ServerEditView: View {
           TextField("Server URL", text: $serverURL)
             .textContentType(.URL)
             #if os(iOS) || os(tvOS)
-              .autocapitalization(.none)
+              .textInputAutocapitalization(.never)
               .keyboardType(.URL)
             #endif
             .autocorrectionDisabled()
@@ -118,7 +120,7 @@ struct ServerEditView: View {
             TextField(String(localized: "Username"), text: $username)
               .textContentType(.username)
               #if os(iOS) || os(tvOS)
-                .autocapitalization(.none)
+                .textInputAutocapitalization(.never)
               #endif
               .autocorrectionDisabled()
               .onChange(of: username) { _, _ in
@@ -134,7 +136,7 @@ struct ServerEditView: View {
             SecureField(String(localized: "API Key"), text: $apiKey)
               .textContentType(.password)
               #if os(iOS) || os(tvOS)
-                .autocapitalization(.none)
+                .textInputAutocapitalization(.never)
               #endif
               .autocorrectionDisabled()
               .onChange(of: apiKey) { _, _ in
@@ -166,7 +168,11 @@ struct ServerEditView: View {
       Button {
         saveChanges()
       } label: {
-        Label(String(localized: "Save"), systemImage: "checkmark")
+        if isSaving {
+          LoadingIcon()
+        } else {
+          Label(String(localized: "Save"), systemImage: "checkmark")
+        }
       }
       .disabled(!canSave)
     }
@@ -188,7 +194,7 @@ struct ServerEditView: View {
 
   private var hasChanges: Bool {
     if trimmedName != instance.name || trimmedServerURL != instance.serverURL
-      || authMethod != instance.resolvedAuthMethod
+      || authMethod != instance.authMethod
     {
       return true
     }
@@ -200,6 +206,7 @@ struct ServerEditView: View {
   }
 
   private var canSave: Bool {
+    guard !isSaving else { return false }
     guard !trimmedServerURL.isEmpty else { return false }
 
     if authMethod == .basicAuth {
@@ -218,11 +225,11 @@ struct ServerEditView: View {
     if authMethod == .basicAuth {
       isCredsChanged =
         trimmedServerURL != instance.serverURL || trimmedUsername != instance.username
-        || !password.isEmpty || authMethod != instance.resolvedAuthMethod
+        || !password.isEmpty || authMethod != instance.authMethod
     } else {
       isCredsChanged =
         trimmedServerURL != instance.serverURL || apiKey != instance.authToken
-        || authMethod != instance.resolvedAuthMethod
+        || authMethod != instance.authMethod
     }
 
     if isCredsChanged {
@@ -242,7 +249,7 @@ struct ServerEditView: View {
       // If password is empty, can only validate if only serverURL changed (username unchanged)
       // If username changed, password must be provided
       return trimmedServerURL != instance.serverURL && trimmedUsername == instance.username
-        && instance.resolvedAuthMethod == .basicAuth
+        && instance.authMethod == .basicAuth
     } else {
       return !apiKey.isEmpty
     }
@@ -253,41 +260,60 @@ struct ServerEditView: View {
       return
     }
 
-    instance.name =
+    let resolvedName =
       trimmedName.isEmpty
       ? defaultInstanceName(serverURL: trimmedServerURL)
       : trimmedName
-    instance.serverURL = trimmedServerURL
-    instance.authMethod = authMethod
 
+    let resolvedAuthToken: String
     if authMethod == .basicAuth {
-      instance.username = trimmedUsername
       if !password.isEmpty {
         guard let token = makeAuthToken(username: trimmedUsername, password: password) else {
           ErrorManager.shared.notify(
             message: String(localized: "notification.settings.encodeCredentialsFailed"))
           return
         }
-        instance.authToken = token
+        resolvedAuthToken = token
+      } else {
+        resolvedAuthToken = instance.authToken
       }
     } else {
-      // For API Key, we use the key as the token directly
-      instance.authToken = apiKey
-      // API Key auth returns a User object, so we can use that email/username
+      resolvedAuthToken = apiKey
     }
 
-    instance.lastUsedAt = Date()
+    isSaving = true
 
-    do {
-      try modelContext.save()
-      if current.instanceId == instance.id.uuidString {
-        Task {
-          _ = await authViewModel.switchTo(instance: instance)
+    Task {
+      do {
+        let database = try await DatabaseOperator.database()
+        guard
+          let updatedInstance = try await database.updateServerDisplayItem(
+            id: instance.id,
+            name: resolvedName,
+            serverURL: trimmedServerURL,
+            username: trimmedUsername,
+            authToken: resolvedAuthToken,
+            authMethod: authMethod
+          )
+        else {
+          isSaving = false
+          return
         }
+        try await database.commit()
+        isSaving = false
+
+        if current.instanceId == updatedInstance.instanceId {
+          Task {
+            _ = await authViewModel.switchTo(instance: updatedInstance)
+          }
+        }
+
+        onSaved()
+        dismiss()
+      } catch {
+        isSaving = false
+        ErrorManager.shared.alert(error: error)
       }
-      dismiss()
-    } catch {
-      ErrorManager.shared.alert(error: error)
     }
   }
 

--- a/KMReader/Features/Server/ServerHistoryView.swift
+++ b/KMReader/Features/Server/ServerHistoryView.swift
@@ -3,12 +3,10 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct ServerHistoryView: View {
   @AppStorage("currentAccount") private var current: Current = .init()
-  @Environment(\.modelContext) private var modelContext
 
   @State private var pagination = PaginationState<HistoricalEvent>(pageSize: 20)
   @State private var isLoading = false
@@ -246,7 +244,6 @@ struct ServerHistoryView: View {
     isLoadingMore = false
   }
 
-  @MainActor
   private func updateLocalReferences(for events: [HistoricalEvent]) async {
     let instanceId = AppConfig.current.instanceId
     let bookIds = Set(
@@ -262,80 +259,27 @@ struct ServerHistoryView: View {
         .filter { !$0.isEmpty }
     )
 
-    var hasLocalMatches = false
-
-    if !bookIds.isEmpty {
-      let idsToFetch = Array(bookIds.subtracting(bookNameById.keys))
-      if !idsToFetch.isEmpty {
-        let descriptor = FetchDescriptor<KomgaBook>(
-          predicate: #Predicate { book in
-            book.instanceId == instanceId && idsToFetch.contains(book.bookId)
-          }
-        )
-        if let results = try? modelContext.fetch(descriptor), !results.isEmpty {
-          hasLocalMatches = true
-          for book in results {
-            bookNameById[book.bookId] = book.metaTitle
-          }
-        }
-      } else if !bookNameById.isEmpty {
-        hasLocalMatches = true
-      }
+    let missingBookIds = bookIds.subtracting(bookNameById.keys)
+    let missingSeriesIds = seriesIds.subtracting(seriesNameById.keys)
+    guard !missingBookIds.isEmpty || !missingSeriesIds.isEmpty else {
+      return
     }
 
-    if !seriesIds.isEmpty {
-      let idsToFetch = Array(seriesIds.subtracting(seriesNameById.keys))
-      if !idsToFetch.isEmpty {
-        let descriptor = FetchDescriptor<KomgaSeries>(
-          predicate: #Predicate { series in
-            series.instanceId == instanceId && idsToFetch.contains(series.seriesId)
-          }
-        )
-        if let results = try? modelContext.fetch(descriptor), !results.isEmpty {
-          hasLocalMatches = true
-          for series in results {
-            seriesNameById[series.seriesId] = series.metaTitle
-          }
-        }
-      } else if !seriesNameById.isEmpty {
-        hasLocalMatches = true
-      }
-    }
-
-    if hasLocalMatches == false && (!bookIds.isEmpty || !seriesIds.isEmpty) {
-      hasLocalMatches =
-        containsLocalMatches(bookIds: Array(bookIds), seriesIds: Array(seriesIds))
-    }
-
-  }
-
-  @MainActor
-  private func containsLocalMatches(bookIds: [String], seriesIds: [String]) -> Bool {
-    let instanceId = AppConfig.current.instanceId
-
-    if !bookIds.isEmpty {
-      let descriptor = FetchDescriptor<KomgaBook>(
-        predicate: #Predicate { book in
-          book.instanceId == instanceId && bookIds.contains(book.bookId)
-        }
+    do {
+      let references = try await DatabaseOperator.database().fetchHistoricalEventLocalReferences(
+        instanceId: instanceId,
+        bookIds: missingBookIds,
+        seriesIds: missingSeriesIds
       )
-      if let results = try? modelContext.fetch(descriptor), !results.isEmpty {
-        return true
+      for (bookId, name) in references.bookNameById {
+        bookNameById[bookId] = name
       }
-    }
-
-    if !seriesIds.isEmpty {
-      let descriptor = FetchDescriptor<KomgaSeries>(
-        predicate: #Predicate { series in
-          series.instanceId == instanceId && seriesIds.contains(series.seriesId)
-        }
-      )
-      if let results = try? modelContext.fetch(descriptor), !results.isEmpty {
-        return true
+      for (seriesId, name) in references.seriesNameById {
+        seriesNameById[seriesId] = name
       }
+    } catch {
+      ErrorManager.shared.alert(error: error)
     }
-
-    return false
   }
 
   private func clearLocalReferencedEntities() async {
@@ -372,7 +316,7 @@ struct ServerHistoryView: View {
     }
 
     do {
-      try await database.commitImmediately()
+      try await database.commit()
     } catch {
       ErrorManager.shared.alert(error: error)
       isClearingLocal = false

--- a/KMReader/Features/Server/ServerLibrariesView.swift
+++ b/KMReader/Features/Server/ServerLibrariesView.swift
@@ -12,6 +12,7 @@ struct ServerLibrariesView: View {
   @State private var deleteConfirmationText: String = ""
   @State private var showAddSheet = false
   @State private var libraryToEdit: Library?
+  @State private var libraryListRefreshTrigger = 0
 
   private var isDeleteAlertPresented: Binding<Bool> {
     Binding(
@@ -43,7 +44,8 @@ struct ServerLibrariesView: View {
       onDeleteLibrary: { library in
         libraryPendingDelete = library
         deleteConfirmationText = ""
-      }
+      },
+      refreshTrigger: libraryListRefreshTrigger
     )
     .inlineNavigationBarTitle(ServerSection.libraries.title)
     .toolbar {
@@ -57,10 +59,10 @@ struct ServerLibrariesView: View {
         }
       }
     }
-    .sheet(isPresented: $showAddSheet) {
+    .sheet(isPresented: $showAddSheet, onDismiss: refreshLibraryList) {
       LibraryAddSheet()
     }
-    .sheet(isPresented: isEditSheetPresented) {
+    .sheet(isPresented: isEditSheetPresented, onDismiss: refreshLibraryList) {
       if let library = libraryToEdit {
         LibraryEditSheet(library: library)
       }
@@ -103,6 +105,7 @@ struct ServerLibrariesView: View {
       do {
         try await LibraryService.deleteLibrary(id: library.libraryId)
         await LibraryManager.shared.refreshLibraries()
+        refreshLibraryList()
         ErrorManager.shared.notify(
           message: String(localized: "notification.library.deleted"))
       } catch {
@@ -111,6 +114,10 @@ struct ServerLibrariesView: View {
       libraryPendingDelete = nil
       deleteConfirmationText = ""
     }
+  }
+
+  private func refreshLibraryList() {
+    libraryListRefreshTrigger += 1
   }
 }
 

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct ServerListView: View {
@@ -21,16 +20,12 @@ struct ServerListView: View {
   }
 
   @Environment(\.dismiss) private var dismiss
-  @Environment(\.modelContext) private var modelContext
-  @Query(sort: [
-    SortDescriptor(\KomgaInstance.lastUsedAt, order: .reverse),
-    SortDescriptor(\KomgaInstance.name, order: .forward),
-  ]) private var instances: [KomgaInstance]
   @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("isLoggedInV2") private var isLoggedIn: Bool = false
 
-  @State private var instancePendingDeletion: KomgaInstance?
-  @State private var editingInstance: KomgaInstance?
+  @State private var instances: [ServerDisplayItem] = []
+  @State private var instancePendingDeletion: ServerDisplayItem?
+  @State private var editingInstance: ServerDisplayItem?
   @State private var showLogin = false
   @State private var showLogoutAlert = false
 
@@ -123,7 +118,15 @@ struct ServerListView: View {
     #endif
     .inlineNavigationBarTitle(navigationTitle)
     .sheet(item: $editingInstance) { instance in
-      ServerEditView(instance: instance, authViewModel: authViewModel)
+      ServerEditView(
+        instance: instance,
+        authViewModel: authViewModel,
+        onSaved: {
+          Task {
+            await loadInstances()
+          }
+        }
+      )
     }
     .alert(
       String(localized: "Delete Server"),
@@ -163,7 +166,20 @@ struct ServerListView: View {
         LoginView(authViewModel: authViewModel)
       }
     }
+    .task {
+      await loadInstances()
+    }
+    .onChange(of: showLogin) { _, isPresented in
+      if !isPresented {
+        Task {
+          await loadInstances()
+        }
+      }
+    }
     .onChange(of: isLoggedIn) { _, loggedIn in
+      Task {
+        await loadInstances()
+      }
       if loggedIn && mode == .onboarding {
         dismiss()
       }
@@ -216,39 +232,52 @@ struct ServerListView: View {
     }
   }
 
-  private func isActive(_ instance: KomgaInstance) -> Bool {
-    activeInstanceId == instance.id.uuidString
+  private func isActive(_ instance: ServerDisplayItem) -> Bool {
+    activeInstanceId == instance.instanceId
   }
 
-  private func isSwitching(_ instance: KomgaInstance) -> Bool {
-    authViewModel.isSwitching && authViewModel.switchingInstanceId == instance.id.uuidString
+  private func isSwitching(_ instance: ServerDisplayItem) -> Bool {
+    authViewModel.isSwitching && authViewModel.switchingInstanceId == instance.instanceId
   }
 
-  private func switchTo(_ instance: KomgaInstance) {
+  private func switchTo(_ instance: ServerDisplayItem) {
     guard !isActive(instance) else { return }
     Task {
       let success = await authViewModel.switchTo(instance: instance)
       if success {
-        instance.lastUsedAt = Date()
-        saveChanges()
+        do {
+          let database = try await DatabaseOperator.database()
+          await database.updateInstanceLastUsed(instanceId: instance.instanceId)
+          try await database.commit()
+          await loadInstances()
+        } catch {
+          ErrorManager.shared.alert(error: error)
+        }
       }
     }
   }
 
-  private func delete(_ instance: KomgaInstance) {
-    if isActive(instance) {
-      authViewModel.logout()
-    }
-    // Clear libraries (sync)
-    let instanceId = instance.id.uuidString
-    LibraryManager.shared.removeLibraries(for: instanceId)
-    modelContext.delete(instance)
-    saveChanges()
-    ErrorManager.shared.notify(message: String(localized: "notification.server.deleted"))
-    instancePendingDeletion = nil
-
-    // Clear SwiftData entities and offline data (async)
+  private func delete(_ instance: ServerDisplayItem) {
     Task {
+      if isActive(instance) {
+        authViewModel.logout()
+      }
+
+      let instanceId = instance.instanceId
+      LibraryManager.shared.removeLibraries(for: instanceId)
+
+      do {
+        let database = try await DatabaseOperator.database()
+        try await database.deleteServerDisplayItem(id: instance.id)
+        try await database.commit()
+        await loadInstances()
+        ErrorManager.shared.notify(message: String(localized: "notification.server.deleted"))
+        instancePendingDeletion = nil
+      } catch {
+        ErrorManager.shared.alert(error: error)
+        return
+      }
+
       await SyncService.clearInstanceData(instanceId: instanceId)
       await OfflineManager.shared.cancelAllDownloads()
       OfflineManager.removeOfflineData(for: instanceId)
@@ -256,9 +285,13 @@ struct ServerListView: View {
     }
   }
 
-  private func saveChanges() {
+  private func loadInstances() async {
     do {
-      try modelContext.save()
+      let database = try await DatabaseOperator.database()
+      let loadedInstances = try await database.fetchServerDisplayItems()
+      if instances != loadedInstances {
+        instances = loadedInstances
+      }
     } catch {
       ErrorManager.shared.alert(error: error)
     }

--- a/KMReader/Features/Server/ServerRowView.swift
+++ b/KMReader/Features/Server/ServerRowView.swift
@@ -3,13 +3,12 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct ServerRowView: View {
-  @Bindable var instance: KomgaInstance
+  let instance: ServerDisplayItem
+
   @Environment(\.colorScheme) private var colorScheme
-  @AppStorage("currentAccount") private var current: Current = .init()
 
   let isGlobalSwitching: Bool
   let isSwitching: Bool
@@ -52,7 +51,7 @@ struct ServerRowView: View {
           )
           infoDetailRow(
             icon: "key.fill",
-            text: instance.resolvedAuthMethod == .apiKey
+            text: instance.authMethod == .apiKey
               ? String(localized: "API Key") : String(localized: "Username & Password"),
             textColor: .secondary
           )

--- a/KMReader/Features/Settings/EpubThemePreferencesView.swift
+++ b/KMReader/Features/Settings/EpubThemePreferencesView.swift
@@ -5,7 +5,6 @@
 
 #if os(iOS)
   import Foundation
-  import SwiftData
   import SwiftUI
 
   struct EpubThemePreferencesView: View {
@@ -22,12 +21,10 @@
     @State private var showSavePresetAlert: Bool = false
     @State private var newPresetName: String = ""
     @State private var fontListRefreshId: UUID = UUID()
+    @State private var customFonts: [CustomFontDisplayItem] = []
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) var colorScheme
-    @Environment(\.modelContext) private var modelContext
-
-    @Query(sort: \CustomFont.name, order: .forward) private var customFonts: [CustomFont]
 
     init(
       inSheet: Bool = false,
@@ -392,20 +389,26 @@
         }
       }
       .inlineNavigationBarTitle(navigationTitle)
+      .task {
+        _ = await loadCustomFonts()
+      }
       .sheet(isPresented: $showCustomFontsSheet) {
         CustomFontsSheet()
           .onDisappear {
-            FontProvider.refresh()
-            fontListRefreshId = UUID()
+            Task {
+              FontProvider.refresh()
+              fontListRefreshId = UUID()
 
-            let customFontNames = customFonts.map { $0.name }
-            if let selectedFontName = draft.fontFamily.fontName {
-              let isKnownCustomFont = customFontNames.contains(selectedFontName)
-              let isKnownChoice = FontProvider.allChoices.contains(where: {
-                $0.fontName == selectedFontName
-              })
-              if !isKnownCustomFont && !isKnownChoice {
-                draft.fontFamily = .publisher
+              let loadedFonts = await loadCustomFonts()
+              let customFontNames = loadedFonts.map(\.name)
+              if let selectedFontName = draft.fontFamily.fontName {
+                let isKnownCustomFont = customFontNames.contains(selectedFontName)
+                let isKnownChoice = FontProvider.allChoices.contains(where: {
+                  $0.fontName == selectedFontName
+                })
+                if !isKnownCustomFont && !isKnownChoice {
+                  draft.fontFamily = .publisher
+                }
               }
             }
           }
@@ -438,15 +441,20 @@
       let trimmed = newPresetName.trimmingCharacters(in: .whitespaces)
       guard !trimmed.isEmpty else { return }
 
-      let preset = EpubThemePreset.create(
-        name: trimmed,
-        preferences: draft
-      )
-      modelContext.insert(preset)
-      try? modelContext.save()
-
-      ErrorManager.shared.notify(message: String(localized: "Preset saved: \(trimmed)"))
-      newPresetName = ""
+      Task {
+        do {
+          let database = try await DatabaseOperator.database()
+          try await database.createEpubThemePreset(
+            name: trimmed,
+            preferencesJSON: draft.rawValue
+          )
+          try await database.commit()
+          ErrorManager.shared.notify(message: String(localized: "Preset saved: \(trimmed)"))
+          newPresetName = ""
+        } catch {
+          ErrorManager.shared.alert(error: error)
+        }
+      }
     }
 
     private func savePreferences() {
@@ -479,6 +487,20 @@
       onThemePreferencesCleared?()
       ErrorManager.shared.notify(message: String(localized: "Reset to Global"))
       dismiss()
+    }
+
+    private func loadCustomFonts() async -> [CustomFontDisplayItem] {
+      do {
+        let database = try await DatabaseOperator.database()
+        let loadedFonts = try await database.fetchCustomFontDisplayItems()
+        if customFonts != loadedFonts {
+          customFonts = loadedFonts
+        }
+        return loadedFonts
+      } catch {
+        ErrorManager.shared.alert(error: error)
+        return customFonts
+      }
     }
   }
 

--- a/KMReader/Features/Sync/Services/ProgressSyncService.swift
+++ b/KMReader/Features/Sync/Services/ProgressSyncService.swift
@@ -63,7 +63,7 @@ actor ProgressSyncService {
       do {
         let outcome = try await syncProgressItem(item)
         await database.deletePendingProgress(id: item.id)
-        await database.commit()
+        try? await database.commit()
 
         switch outcome {
         case .replayed:
@@ -84,7 +84,7 @@ actor ProgressSyncService {
               "⏭️ Ignored progress conflict (409) for book \(item.bookId) (pending id=\(item.id))"
             )
             await database.deletePendingProgress(id: item.id)
-            await database.commit()
+            try? await database.commit()
             ignoredConflictCount += 1
             if item.completed {
               completedBookIds.insert(item.bookId)
@@ -99,7 +99,7 @@ actor ProgressSyncService {
               "⏭️ Ignored non-retryable progress error (\(statusCode)) for book \(item.bookId) (pending id=\(item.id))"
             )
             await database.deletePendingProgress(id: item.id)
-            await database.commit()
+            try? await database.commit()
             ignoredNonRetryableCount += 1
             continue
           }

--- a/KMReader/Features/Sync/Services/SyncService.swift
+++ b/KMReader/Features/Sync/Services/SyncService.swift
@@ -27,7 +27,7 @@ nonisolated enum SyncService {
       let libraries = try await LibraryService.getLibraries()
       let libraryInfos = libraries.map { LibraryInfo(id: $0.id, name: $0.name) }
       try await database.replaceLibraries(libraryInfos, for: instanceId)
-      await database.commit()
+      try? await database.commit()
       logger.info("📚 Synced \(libraries.count) libraries")
     } catch {
       logger.error("❌ Failed to sync libraries: \(error)")
@@ -52,7 +52,7 @@ nonisolated enum SyncService {
         remoteCollectionIds,
         instanceId: instanceId
       )
-      await database.commit()
+      try? await database.commit()
       if deletedCount > 0 {
         logger.info("🧹 Removed \(deletedCount) stale collections")
       }
@@ -80,7 +80,7 @@ nonisolated enum SyncService {
         remoteReadListIds,
         instanceId: instanceId
       )
-      await database.commit()
+      try? await database.commit()
       if deletedCount > 0 {
         logger.info("🧹 Removed \(deletedCount) stale read lists")
       }
@@ -104,7 +104,7 @@ nonisolated enum SyncService {
         await database.upsertSeriesList(result.content, instanceId: instanceId)
         hasMore = !result.last
         page += 1
-        await database.commit()
+        try? await database.commit()
       }
       logger.info("📚 Synced series for library \(libraryId)")
     } catch {
@@ -130,7 +130,7 @@ nonisolated enum SyncService {
 
     let instanceId = AppConfig.current.instanceId
     await database.upsertSeriesList(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
 
     return result
   }
@@ -141,12 +141,12 @@ nonisolated enum SyncService {
       let series = try await SeriesService.getOneSeries(id: seriesId)
       let instanceId = AppConfig.current.instanceId
       await database.upsertSeries(dto: series, instanceId: instanceId)
-      await database.commit()
+      try? await database.commit()
       return series
     } catch APIError.notFound {
       let instanceId = AppConfig.current.instanceId
       await database.deleteSeries(id: seriesId, instanceId: instanceId)
-      await database.commit()
+      try? await database.commit()
       throw APIError.notFound(message: "Series not found", url: nil, response: nil, request: nil)
     }
   }
@@ -157,7 +157,7 @@ nonisolated enum SyncService {
       libraryIds: libraryIds, page: page, size: size)
     let instanceId = AppConfig.current.instanceId
     await database.upsertSeriesList(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
     return result
   }
 
@@ -167,7 +167,7 @@ nonisolated enum SyncService {
       libraryIds: libraryIds, page: page, size: size)
     let instanceId = AppConfig.current.instanceId
     await database.upsertSeriesList(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
     return result
   }
 
@@ -186,7 +186,7 @@ nonisolated enum SyncService {
     )
     let instanceId = AppConfig.current.instanceId
     await database.upsertBooks(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
     return result
   }
 
@@ -206,7 +206,7 @@ nonisolated enum SyncService {
 
     let instanceId = AppConfig.current.instanceId
     await database.upsertBooks(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
 
     return result
   }
@@ -229,7 +229,7 @@ nonisolated enum SyncService {
 
     let instanceId = AppConfig.current.instanceId
     await database.upsertBooks(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
 
     return result
   }
@@ -240,7 +240,7 @@ nonisolated enum SyncService {
       libraryIds: libraryIds, page: page, size: size)
     let instanceId = AppConfig.current.instanceId
     await database.upsertBooks(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
     return result
   }
 
@@ -250,7 +250,7 @@ nonisolated enum SyncService {
       libraryIds: libraryIds, page: page, size: size)
     let instanceId = AppConfig.current.instanceId
     await database.upsertBooks(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
     return result
   }
 
@@ -262,7 +262,7 @@ nonisolated enum SyncService {
       libraryIds: libraryIds, page: page, size: size)
     let instanceId = AppConfig.current.instanceId
     await database.upsertBooks(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
     return result
   }
 
@@ -274,7 +274,7 @@ nonisolated enum SyncService {
       libraryIds: libraryIds, page: page, size: size)
     let instanceId = AppConfig.current.instanceId
     await database.upsertBooks(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
     return result
   }
 
@@ -296,7 +296,7 @@ nonisolated enum SyncService {
       hasMore = !result.last
       page += 1
     }
-    await database.commit()
+    try? await database.commit()
     logger.info("📚 Synced all books for series \(seriesId)")
   }
 
@@ -319,7 +319,7 @@ nonisolated enum SyncService {
       hasMore = !result.last
       page += 1
     }
-    await database.commit()
+    try? await database.commit()
     logger.info("📖 Synced all books for readlist \(readListId)")
   }
 
@@ -329,12 +329,12 @@ nonisolated enum SyncService {
       let book = try await BookService.getBook(id: bookId)
       let instanceId = AppConfig.current.instanceId
       await database.upsertBook(dto: book, instanceId: instanceId)
-      await database.commit()
+      try? await database.commit()
       return book
     } catch APIError.notFound {
       let instanceId = AppConfig.current.instanceId
       await database.deleteBook(id: bookId, instanceId: instanceId)
-      await database.commit()
+      try? await database.commit()
       throw APIError.notFound(message: "Book not found", url: nil, response: nil, request: nil)
     }
   }
@@ -350,7 +350,7 @@ nonisolated enum SyncService {
     let instanceId = AppConfig.current.instanceId
     await database.upsertBook(dto: book, instanceId: instanceId)
     await database.upsertSeries(dto: series, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
   }
 
   /// Batch sync multiple books and series concurrently with a single commit
@@ -387,7 +387,7 @@ nonisolated enum SyncService {
       }
 
       // Single commit after all fetches complete
-      await database.commit()
+      try? await database.commit()
     } catch {
       logger.error("❌ Failed to sync visited items: \(error)")
     }
@@ -399,7 +399,7 @@ nonisolated enum SyncService {
       if let book = try await BookService.getNextBook(bookId: bookId, readListId: readListId) {
         let instanceId = AppConfig.current.instanceId
         await database.upsertBook(dto: book, instanceId: instanceId)
-        await database.commit()
+        try? await database.commit()
         return book
       }
     } catch {
@@ -417,7 +417,7 @@ nonisolated enum SyncService {
       ) {
         let instanceId = AppConfig.current.instanceId
         await database.upsertBook(dto: book, instanceId: instanceId)
-        await database.commit()
+        try? await database.commit()
         return book
       }
     } catch {
@@ -443,7 +443,7 @@ nonisolated enum SyncService {
     )
     let instanceId = AppConfig.current.instanceId
     await database.upsertCollections(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
     return result
   }
 
@@ -453,12 +453,12 @@ nonisolated enum SyncService {
       let collection = try await CollectionService.getCollection(id: id)
       let instanceId = AppConfig.current.instanceId
       await database.upsertCollection(dto: collection, instanceId: instanceId)
-      await database.commit()
+      try? await database.commit()
       return collection
     } catch APIError.notFound {
       let instanceId = AppConfig.current.instanceId
       await database.deleteCollection(id: id, instanceId: instanceId)
-      await database.commit()
+      try? await database.commit()
       throw APIError.notFound(message: "Collection not found", url: nil, response: nil, request: nil)
     }
   }
@@ -473,7 +473,7 @@ nonisolated enum SyncService {
       let collectionIds = collections.map { $0.id }
       await database.updateSeriesCollectionIds(
         seriesId: seriesId, collectionIds: collectionIds, instanceId: instanceId)
-      await database.commit()
+      try? await database.commit()
     } catch {
       logger.error("❌ Failed to sync series collections: \(error)")
     }
@@ -496,7 +496,7 @@ nonisolated enum SyncService {
     )
     let instanceId = AppConfig.current.instanceId
     await database.upsertSeriesList(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
     return result
   }
 
@@ -517,7 +517,7 @@ nonisolated enum SyncService {
     )
     let instanceId = AppConfig.current.instanceId
     await database.upsertReadLists(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
     return result
   }
 
@@ -527,12 +527,12 @@ nonisolated enum SyncService {
       let readList = try await ReadListService.getReadList(id: id)
       let instanceId = AppConfig.current.instanceId
       await database.upsertReadList(dto: readList, instanceId: instanceId)
-      await database.commit()
+      try? await database.commit()
       return readList
     } catch APIError.notFound {
       let instanceId = AppConfig.current.instanceId
       await database.deleteReadList(id: id, instanceId: instanceId)
-      await database.commit()
+      try? await database.commit()
       throw APIError.notFound(message: "Read list not found", url: nil, response: nil, request: nil)
     }
   }
@@ -554,7 +554,7 @@ nonisolated enum SyncService {
     )
     let instanceId = AppConfig.current.instanceId
     await database.upsertBooks(result.content, instanceId: instanceId)
-    await database.commit()
+    try? await database.commit()
     return result
   }
 
@@ -568,7 +568,7 @@ nonisolated enum SyncService {
       let readListIds = readLists.map { $0.id }
       await database.updateBookReadListIds(
         bookId: bookId, readListIds: readListIds, instanceId: instanceId)
-      await database.commit()
+      try? await database.commit()
     } catch {
       logger.error("❌ Failed to sync book read lists: \(error)")
     }

--- a/KMReader/Features/Sync/Services/SyncService.swift
+++ b/KMReader/Features/Sync/Services/SyncService.swift
@@ -7,10 +7,24 @@ import Foundation
 import OSLog
 import SwiftData
 
+extension Notification.Name {
+  static let sidebarProjectionDidChange = Notification.Name("SidebarProjectionDidChange")
+}
+
 nonisolated enum SyncService {
 
   private static let logger = AppLogger(.sync)
   private static let syncPageSize = 1000
+
+  static func postSidebarProjectionDidChange(instanceId: String) async {
+    await MainActor.run {
+      NotificationCenter.default.post(
+        name: .sidebarProjectionDidChange,
+        object: nil,
+        userInfo: ["instanceId": instanceId]
+      )
+    }
+  }
 
   static func syncAll(instanceId: String) async {
     logger.info("🔄 Starting full sync for instance: \(instanceId)")
@@ -28,6 +42,7 @@ nonisolated enum SyncService {
       let libraryInfos = libraries.map { LibraryInfo(id: $0.id, name: $0.name) }
       try await database.replaceLibraries(libraryInfos, for: instanceId)
       try? await database.commit()
+      await postSidebarProjectionDidChange(instanceId: instanceId)
       logger.info("📚 Synced \(libraries.count) libraries")
     } catch {
       logger.error("❌ Failed to sync libraries: \(error)")
@@ -53,6 +68,7 @@ nonisolated enum SyncService {
         instanceId: instanceId
       )
       try? await database.commit()
+      await postSidebarProjectionDidChange(instanceId: instanceId)
       if deletedCount > 0 {
         logger.info("🧹 Removed \(deletedCount) stale collections")
       }
@@ -81,6 +97,7 @@ nonisolated enum SyncService {
         instanceId: instanceId
       )
       try? await database.commit()
+      await postSidebarProjectionDidChange(instanceId: instanceId)
       if deletedCount > 0 {
         logger.info("🧹 Removed \(deletedCount) stale read lists")
       }

--- a/KMReader/Features/Sync/Services/SyncWorker.swift
+++ b/KMReader/Features/Sync/Services/SyncWorker.swift
@@ -66,7 +66,7 @@ actor SyncWorker {
             instanceId: request.instanceId,
             date: syncStartTime
           )
-          await database.commit()
+          try? await database.commit()
         } catch {
           hasFailures = true
           logger.error("❌ Failed to update series lastSyncedAt: \(error)")
@@ -102,7 +102,7 @@ actor SyncWorker {
             instanceId: request.instanceId,
             date: syncStartTime
           )
-          await database.commit()
+          try? await database.commit()
         } catch {
           hasFailures = true
           logger.error("❌ Failed to update books lastSyncedAt: \(error)")
@@ -188,7 +188,7 @@ actor SyncWorker {
       }
 
       if await database.hasChanges() {
-        try await database.commitImmediately()
+        try await database.commit()
       }
 
       if let latestServerReadDate {
@@ -215,7 +215,7 @@ actor SyncWorker {
       let libraries = try await LibraryService.getLibraries()
       let libraryInfos = libraries.map { LibraryInfo(id: $0.id, name: $0.name) }
       try await database.replaceLibraries(libraryInfos, for: instanceId)
-      await database.commit()
+      try? await database.commit()
       logger.info("📚 Synced \(libraries.count) libraries")
       await report(.libraries, progress: 1.0, onProgress: onProgress)
       return true
@@ -245,7 +245,7 @@ actor SyncWorker {
         )
         remoteCollectionIds.formUnion(result.content.map(\.id))
         await database.upsertCollections(result.content, instanceId: instanceId)
-        await database.commit()
+        try? await database.commit()
 
         totalPages = max(result.totalPages, 1)
         hasMore = !result.last
@@ -263,7 +263,7 @@ actor SyncWorker {
         instanceId: instanceId
       )
       if deletedCount > 0 {
-        await database.commit()
+        try? await database.commit()
         logger.info("🧹 Removed \(deletedCount) stale collections")
       }
       logger.info("📂 Synced collections")
@@ -311,7 +311,7 @@ actor SyncWorker {
 
         if !itemsToSync.isEmpty {
           await database.upsertSeriesList(itemsToSync, instanceId: instanceId)
-          await database.commit()
+          try? await database.commit()
         }
 
         page += 1
@@ -381,7 +381,7 @@ actor SyncWorker {
         instanceId: instanceId
       )
       if deletedCount > 0 {
-        await database.commit()
+        try? await database.commit()
         logger.info("🧹 Removed \(deletedCount) stale series")
       }
       return true
@@ -410,7 +410,7 @@ actor SyncWorker {
         )
         remoteReadListIds.formUnion(result.content.map(\.id))
         await database.upsertReadLists(result.content, instanceId: instanceId)
-        await database.commit()
+        try? await database.commit()
 
         totalPages = max(result.totalPages, 1)
         hasMore = !result.last
@@ -428,7 +428,7 @@ actor SyncWorker {
         instanceId: instanceId
       )
       if deletedCount > 0 {
-        await database.commit()
+        try? await database.commit()
         logger.info("🧹 Removed \(deletedCount) stale read lists")
       }
       logger.info("📖 Synced read lists")
@@ -476,7 +476,7 @@ actor SyncWorker {
 
         if !itemsToSync.isEmpty {
           await database.upsertBooks(itemsToSync, instanceId: instanceId)
-          await database.commit()
+          try? await database.commit()
         }
 
         page += 1
@@ -546,7 +546,7 @@ actor SyncWorker {
         instanceId: instanceId
       )
       if deletedCount > 0 {
-        await database.commit()
+        try? await database.commit()
         let cleanupResult = await OfflineManager.shared.cleanupOrphanedFiles()
         if cleanupResult.deletedCount > 0 {
           logger.info(

--- a/KMReader/Features/Sync/Services/SyncWorker.swift
+++ b/KMReader/Features/Sync/Services/SyncWorker.swift
@@ -216,6 +216,7 @@ actor SyncWorker {
       let libraryInfos = libraries.map { LibraryInfo(id: $0.id, name: $0.name) }
       try await database.replaceLibraries(libraryInfos, for: instanceId)
       try? await database.commit()
+      await SyncService.postSidebarProjectionDidChange(instanceId: instanceId)
       logger.info("📚 Synced \(libraries.count) libraries")
       await report(.libraries, progress: 1.0, onProgress: onProgress)
       return true
@@ -266,6 +267,7 @@ actor SyncWorker {
         try? await database.commit()
         logger.info("🧹 Removed \(deletedCount) stale collections")
       }
+      await SyncService.postSidebarProjectionDidChange(instanceId: instanceId)
       logger.info("📂 Synced collections")
       return true
     } catch {
@@ -431,6 +433,7 @@ actor SyncWorker {
         try? await database.commit()
         logger.info("🧹 Removed \(deletedCount) stale read lists")
       }
+      await SyncService.postSidebarProjectionDidChange(instanceId: instanceId)
       logger.info("📖 Synced read lists")
       return true
     } catch {

--- a/KMReader/Shared/Foundation/Models/LibrarySelection.swift
+++ b/KMReader/Shared/Foundation/Models/LibrarySelection.swift
@@ -11,6 +11,7 @@ struct LibrarySelection: Hashable {
   let fileSize: Double?
   let booksCount: Double?
   let seriesCount: Double?
+  let sidecarsCount: Double?
   let collectionsCount: Double?
   let readlistsCount: Double?
 
@@ -20,7 +21,19 @@ struct LibrarySelection: Hashable {
     fileSize = library.fileSize
     booksCount = library.booksCount
     seriesCount = library.seriesCount
+    sidecarsCount = library.sidecarsCount
     collectionsCount = library.collectionsCount
     readlistsCount = library.readlistsCount
+  }
+
+  init(sidebarItem: SidebarLibraryItem) {
+    libraryId = sidebarItem.libraryId
+    name = sidebarItem.name
+    fileSize = sidebarItem.fileSize
+    booksCount = sidebarItem.booksCount
+    seriesCount = sidebarItem.seriesCount
+    sidecarsCount = sidebarItem.sidecarsCount
+    collectionsCount = sidebarItem.collectionsCount
+    readlistsCount = sidebarItem.readlistsCount
   }
 }

--- a/KMReader/Shared/Foundation/Models/SidebarCollectionItem.swift
+++ b/KMReader/Shared/Foundation/Models/SidebarCollectionItem.swift
@@ -1,0 +1,20 @@
+//
+// SidebarCollectionItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct SidebarCollectionItem: Hashable, Identifiable, Sendable {
+  let id: String
+  let collectionId: String
+  let name: String
+  let seriesCount: Int
+
+  init(collectionId: String, name: String, seriesCount: Int) {
+    id = collectionId
+    self.collectionId = collectionId
+    self.name = name
+    self.seriesCount = seriesCount
+  }
+}

--- a/KMReader/Shared/Foundation/Models/SidebarLibraryItem.swift
+++ b/KMReader/Shared/Foundation/Models/SidebarLibraryItem.swift
@@ -1,0 +1,43 @@
+//
+// SidebarLibraryItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct SidebarLibraryItem: Hashable, Identifiable, Sendable {
+  let id: String
+  let libraryId: String
+  let name: String
+  let fileSize: Double?
+  let booksCount: Double?
+  let seriesCount: Double?
+  let sidecarsCount: Double?
+  let collectionsCount: Double?
+  let readlistsCount: Double?
+
+  init(
+    libraryId: String,
+    name: String,
+    fileSize: Double?,
+    booksCount: Double?,
+    seriesCount: Double?,
+    sidecarsCount: Double?,
+    collectionsCount: Double?,
+    readlistsCount: Double?
+  ) {
+    id = libraryId
+    self.libraryId = libraryId
+    self.name = name
+    self.fileSize = fileSize
+    self.booksCount = booksCount
+    self.seriesCount = seriesCount
+    self.sidecarsCount = sidecarsCount
+    self.collectionsCount = collectionsCount
+    self.readlistsCount = readlistsCount
+  }
+
+  var displayBookCount: Int? {
+    booksCount.map { Int($0) }
+  }
+}

--- a/KMReader/Shared/Foundation/Models/SidebarReadListItem.swift
+++ b/KMReader/Shared/Foundation/Models/SidebarReadListItem.swift
@@ -1,0 +1,20 @@
+//
+// SidebarReadListItem.swift
+//
+//
+
+import Foundation
+
+nonisolated struct SidebarReadListItem: Hashable, Identifiable, Sendable {
+  let id: String
+  let readListId: String
+  let name: String
+  let bookCount: Int
+
+  init(readListId: String, name: String, bookCount: Int) {
+    id = readListId
+    self.readListId = readListId
+    self.name = name
+    self.bookCount = bookCount
+  }
+}

--- a/KMReader/Shared/UI/LibraryListContent.swift
+++ b/KMReader/Shared/UI/LibraryListContent.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct LibraryListContent: View {
@@ -11,12 +10,11 @@ struct LibraryListContent: View {
   @AppStorage("dashboard") private var dashboard: DashboardConfiguration = DashboardConfiguration()
   @AppStorage("isOffline") private var isOffline: Bool = false
 
-  @Query(sort: [SortDescriptor(\KomgaLibrary.name, order: .forward)])
-  private var allLibraries: [KomgaLibrary]
-
   @State private var isLoading = false
   @State private var isLoadingMetrics = false
   @State private var selectedLibraryIds: [String]
+  @State private var libraries: [SidebarLibraryItem] = []
+  @State private var allLibrariesEntry: SidebarLibraryItem?
 
   let selectionEnabled: Bool
   let isSingleSelectionMode: Bool
@@ -27,6 +25,7 @@ struct LibraryListContent: View {
   let onLibrarySelected: ((String?) -> Void)?
   let onEditLibrary: ((String) -> Void)?
   let onDeleteLibrary: ((LibrarySelection) -> Void)?
+  let refreshTrigger: Int
 
   private let metricsLoader = LibraryMetricsLoader.shared
 
@@ -39,7 +38,8 @@ struct LibraryListContent: View {
     enablePullToRefresh: Bool = true,
     onLibrarySelected: ((String?) -> Void)? = nil,
     onEditLibrary: ((String) -> Void)? = nil,
-    onDeleteLibrary: ((LibrarySelection) -> Void)? = nil
+    onDeleteLibrary: ((LibrarySelection) -> Void)? = nil,
+    refreshTrigger: Int = 0
   ) {
     let initialSelection = AppConfig.dashboard.libraryIds
     self.selectionEnabled = selectionEnabled
@@ -51,25 +51,8 @@ struct LibraryListContent: View {
     self.onLibrarySelected = onLibrarySelected
     self.onEditLibrary = onEditLibrary
     self.onDeleteLibrary = onDeleteLibrary
+    self.refreshTrigger = refreshTrigger
     _selectedLibraryIds = State(initialValue: initialSelection)
-  }
-
-  private var libraries: [KomgaLibrary] {
-    guard !current.instanceId.isEmpty else {
-      return []
-    }
-    return allLibraries.filter {
-      $0.instanceId == current.instanceId && $0.libraryId != KomgaLibrary.allLibrariesId
-    }
-  }
-
-  private var allLibrariesEntry: KomgaLibrary? {
-    guard !current.instanceId.isEmpty else {
-      return nil
-    }
-    return allLibraries.first {
-      $0.instanceId == current.instanceId && $0.libraryId == KomgaLibrary.allLibrariesId
-    }
   }
 
   var body: some View {
@@ -129,7 +112,7 @@ struct LibraryListContent: View {
               },
               onEdit: onEditLibrary != nil ? { onEditLibrary?(library.libraryId) } : nil,
               onDelete: onDeleteLibrary != nil
-                ? { onDeleteLibrary?(LibrarySelection(library: library)) } : nil
+                ? { onDeleteLibrary?(LibrarySelection(sidebarItem: library)) } : nil
             )
           }
         }
@@ -137,12 +120,12 @@ struct LibraryListContent: View {
     }
     .animation(.default, value: libraries)
     .formStyle(.grouped)
-    .task {
+    .task(id: current.instanceId) {
       await refreshLibraries(forceMetrics: forceMetricsOnAppear)
     }
-    .onChange(of: libraries) { _, _ in
+    .onChange(of: refreshTrigger) { _, _ in
       Task {
-        await triggerMetricsUpdate(force: false)
+        await refreshLibraries(forceMetrics: true)
       }
     }
     .onChange(of: isSingleSelectionMode) { _, newValue in
@@ -163,8 +146,35 @@ struct LibraryListContent: View {
   func refreshLibraries(forceMetrics: Bool) async {
     isLoading = true
     await LibraryManager.shared.refreshLibraries()
+    await loadLibraryItems()
     await triggerMetricsUpdate(force: forceMetrics)
+    await loadLibraryItems()
     isLoading = false
+  }
+
+  private func loadLibraryItems() async {
+    guard !current.instanceId.isEmpty else {
+      if !libraries.isEmpty { libraries = [] }
+      if allLibrariesEntry != nil { allLibrariesEntry = nil }
+      return
+    }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedLibraries = try await database.fetchSidebarLibraries(instanceId: current.instanceId)
+      let loadedAllLibrariesEntry = try await database.fetchAllLibrariesItem(
+        instanceId: current.instanceId
+      )
+
+      if libraries != loadedLibraries {
+        libraries = loadedLibraries
+      }
+      if allLibrariesEntry != loadedAllLibrariesEntry {
+        allLibrariesEntry = loadedAllLibrariesEntry
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
   }
 
   private func triggerMetricsUpdate(force: Bool) async {
@@ -189,12 +199,15 @@ struct LibraryListContent: View {
       ensureAllLibrariesEntry: hasAllEntry
     )
 
-    for library in libraries {
-      guard let metrics = metricsByLibrary[library.libraryId] else { continue }
-      library.fileSize = metrics.fileSize
-      library.booksCount = metrics.booksCount
-      library.seriesCount = metrics.seriesCount
-      library.sidecarsCount = metrics.sidecarsCount
+    do {
+      let database = try await DatabaseOperator.database()
+      try await database.updateLibraryMetrics(
+        instanceId: current.instanceId,
+        metricsByLibrary: metricsByLibrary
+      )
+      try await database.commit()
+    } catch {
+      ErrorManager.shared.alert(error: error)
     }
 
     isLoadingMetrics = false
@@ -354,7 +367,7 @@ struct LibraryListContent: View {
 
   // MARK: - Helper Functions
 
-  private func hasMetrics(_ library: KomgaLibrary) -> Bool {
+  private func hasMetrics(_ library: SidebarLibraryItem) -> Bool {
     library.seriesCount != nil || library.booksCount != nil || library.fileSize != nil
       || library.sidecarsCount != nil
   }
@@ -370,14 +383,14 @@ struct LibraryListContent: View {
     return ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .binary)
   }
 
-  private func hasAllLibrariesMetrics(_ entry: KomgaLibrary?) -> Bool {
+  private func hasAllLibrariesMetrics(_ entry: SidebarLibraryItem?) -> Bool {
     guard let entry else { return false }
     return entry.seriesCount != nil || entry.booksCount != nil || entry.fileSize != nil
       || entry.sidecarsCount != nil || entry.collectionsCount != nil
       || entry.readlistsCount != nil
   }
 
-  private func allLibrariesMetricsView(_ entry: KomgaLibrary?) -> Text? {
+  private func allLibrariesMetricsView(_ entry: SidebarLibraryItem?) -> Text? {
     guard let entry else { return nil }
     var lines: [Text] = []
 

--- a/KMReader/Shared/UI/LibraryListContent.swift
+++ b/KMReader/Shared/UI/LibraryListContent.swift
@@ -145,6 +145,7 @@ struct LibraryListContent: View {
 
   func refreshLibraries(forceMetrics: Bool) async {
     isLoading = true
+    await loadLibraryItems()
     await LibraryManager.shared.refreshLibraries()
     await loadLibraryItems()
     await triggerMetricsUpdate(force: forceMetrics)

--- a/KMReader/Shared/UI/LibraryRowView.swift
+++ b/KMReader/Shared/UI/LibraryRowView.swift
@@ -3,13 +3,12 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct LibraryRowView: View {
   @AppStorage("isOffline") private var isOffline: Bool = false
   @AppStorage("currentAccount") private var current: Current = .init()
-  @Bindable var library: KomgaLibrary
+  let library: SidebarLibraryItem
   let selectionEnabled: Bool
   let isSingleSelectionMode: Bool
   let isSelected: Bool
@@ -19,7 +18,7 @@ struct LibraryRowView: View {
   let onDelete: (() -> Void)?
 
   init(
-    library: KomgaLibrary,
+    library: SidebarLibraryItem,
     selectionEnabled: Bool = false,
     isSingleSelectionMode: Bool = false,
     isSelected: Bool,

--- a/KMReader/SidebarView.swift
+++ b/KMReader/SidebarView.swift
@@ -3,7 +3,6 @@
 //
 //
 
-import SwiftData
 import SwiftUI
 
 struct SidebarView: View {
@@ -11,10 +10,6 @@ struct SidebarView: View {
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("isOffline") private var isOffline: Bool = false
-  @Query(sort: [SortDescriptor(\KomgaLibrary.name, order: .forward)]) private var allLibraries: [KomgaLibrary]
-  @Query(sort: [SortDescriptor(\KomgaCollection.name, order: .forward)]) private
-    var allCollections: [KomgaCollection]
-  @Query(sort: [SortDescriptor(\KomgaReadList.name, order: .forward)]) private var allReadLists: [KomgaReadList]
 
   @AppStorage("sidebarBrowseExpanded") private var browseExpanded: Bool = true
   @AppStorage("sidebarLibrariesExpanded") private var librariesExpanded: Bool = true
@@ -22,6 +17,9 @@ struct SidebarView: View {
   @AppStorage("sidebarReadListsExpanded") private var readListsExpanded: Bool = false
 
   @State private var isRefreshing: Bool = false
+  @State private var libraries: [SidebarLibraryItem] = []
+  @State private var collections: [SidebarCollectionItem] = []
+  @State private var readLists: [SidebarReadListItem] = []
 
   private var showsSettingsLink: Bool {
     #if os(iOS)
@@ -29,23 +27,6 @@ struct SidebarView: View {
     #else
       return false
     #endif
-  }
-
-  private var libraries: [KomgaLibrary] {
-    guard !current.instanceId.isEmpty else { return [] }
-    return allLibraries.filter {
-      $0.instanceId == current.instanceId && $0.libraryId != KomgaLibrary.allLibrariesId
-    }
-  }
-
-  private var collections: [KomgaCollection] {
-    guard !current.instanceId.isEmpty else { return [] }
-    return allCollections.filter { $0.instanceId == current.instanceId }
-  }
-
-  private var readLists: [KomgaReadList] {
-    guard !current.instanceId.isEmpty else { return [] }
-    return allReadLists.filter { $0.instanceId == current.instanceId }
   }
 
   private func refreshSidebar() async {
@@ -59,6 +40,29 @@ struct SidebarView: View {
     await SyncService.syncLibraries(instanceId: current.instanceId)
     await SyncService.syncCollections(instanceId: current.instanceId)
     await SyncService.syncReadLists(instanceId: current.instanceId)
+    await loadSidebarItems(instanceId: current.instanceId)
+  }
+
+  private func loadSidebarItems(instanceId: String) async {
+    guard !instanceId.isEmpty else {
+      if !libraries.isEmpty { libraries = [] }
+      if !collections.isEmpty { collections = [] }
+      if !readLists.isEmpty { readLists = [] }
+      return
+    }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedLibraries = try await database.fetchSidebarLibraries(instanceId: instanceId)
+      let loadedCollections = try await database.fetchSidebarCollections(instanceId: instanceId)
+      let loadedReadLists = try await database.fetchSidebarReadLists(instanceId: instanceId)
+
+      if libraries != loadedLibraries { libraries = loadedLibraries }
+      if collections != loadedCollections { collections = loadedCollections }
+      if readLists != loadedReadLists { readLists = loadedReadLists }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
   }
 
   var body: some View {
@@ -82,6 +86,9 @@ struct SidebarView: View {
         await refreshSidebar()
       }
     #endif
+    .task(id: current.instanceId) {
+      await loadSidebarItems(instanceId: current.instanceId)
+    }
     #if os(macOS)
       .safeAreaInset(edge: .bottom) {
         Button {
@@ -143,11 +150,11 @@ struct SidebarView: View {
       Section(isExpanded: $librariesExpanded) {
         ForEach(libraries) { library in
           NavigationLink(
-            value: NavDestination.browseLibrary(selection: LibrarySelection(library: library))
+            value: NavDestination.browseLibrary(selection: LibrarySelection(sidebarItem: library))
           ) {
             SidebarItemLabel(
               title: library.name,
-              count: library.booksCount.map { Int($0) }
+              count: library.displayBookCount
             )
             .contextMenu {
               if current.isAdmin && !isOffline {
@@ -175,7 +182,7 @@ struct SidebarView: View {
           ) {
             SidebarItemLabel(
               title: collection.name,
-              count: collection.seriesIds.count
+              count: collection.seriesCount
             )
           }
         }
@@ -192,7 +199,7 @@ struct SidebarView: View {
           ) {
             SidebarItemLabel(
               title: readList.name,
-              count: readList.bookIds.count
+              count: readList.bookCount
             )
           }
         }

--- a/KMReader/SidebarView.swift
+++ b/KMReader/SidebarView.swift
@@ -89,6 +89,13 @@ struct SidebarView: View {
     .task(id: current.instanceId) {
       await loadSidebarItems(instanceId: current.instanceId)
     }
+    .onReceive(NotificationCenter.default.publisher(for: .sidebarProjectionDidChange)) {
+      notification in
+      guard notification.userInfo?["instanceId"] as? String == current.instanceId else { return }
+      Task {
+        await loadSidebarItems(instanceId: current.instanceId)
+      }
+    }
     #if os(macOS)
       .safeAreaInset(edge: .bottom) {
         Button {


### PR DESCRIPTION
## Problem

On iOS/iPadOS 27 beta, SwiftData has a known issue where `@Query` can deadlock when a background `ModelContext` save happens while async `ModelActor` work is scheduled. KMReader was still rendering many pages from live SwiftData observations, so heavy sync/offline writes could interact with page-level invalidation and hang the UI during startup or refresh.

- Related #860

## Approach

Move SwiftUI screens off live SwiftData model observation and render plain display DTOs loaded through `DatabaseOperator` instead. Mutations now explicitly reload DTO state after saving, and offline/local browse paths fetch IDs through the database actor rather than page-level `ModelContext` access.

Persistence is also simplified to a single throwing `commit()` path with direct `modelContext.save()`, removing the previous debounced commit scheduler and the duplicate `commitImmediately()` API.

## Validation

- [x] `git diff --check`
- [x] No page/view-model `@Query`, `modelContext`, `FetchDescriptor`, or SwiftData import remains in the checked UI scope
- [x] No repository-wide `@Query`, `commitImmediately`, `pendingCommitTask`, or old 500ms commit debounce remains
- [x] `make build-ios`
- [x] `make build-macos`
- [x] `make build-tvos`
