### PR TITLE
fix: refresh read progress lists

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 465;
+				CURRENT_PROJECT_VERSION = 466;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 465;
+				CURRENT_PROJECT_VERSION = 466;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 465;
+				CURRENT_PROJECT_VERSION = 466;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 465;
+				CURRENT_PROJECT_VERSION = 466;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -2723,7 +2723,8 @@ actor DatabaseOperator {
 
   // MARK: - Saved Filter Operations
 
-  func fetchSavedFilterDisplayItems(filterType: SavedFilterType) throws -> [SavedFilterDisplayItem] {
+  func fetchSavedFilterDisplayItems(filterType: SavedFilterType) throws -> [SavedFilterDisplayItem]
+  {
     let filterTypeRaw = filterType.rawValue
     let descriptor = FetchDescriptor<SavedFilter>(
       predicate: #Predicate { filter in
@@ -3202,7 +3203,8 @@ actor DatabaseOperator {
     fetchBooksCount(instanceId: instanceId, status: "downloaded")
   }
 
-  func fetchOfflineDownloadedBooksSnapshot(instanceId: String) throws -> OfflineDownloadedBooksSnapshot {
+  func fetchOfflineDownloadedBooksSnapshot(instanceId: String) throws -> OfflineDownloadedBooksSnapshot
+  {
     guard !instanceId.isEmpty else { return .empty }
 
     let bookDescriptor = FetchDescriptor<KomgaBook>(
@@ -3258,8 +3260,7 @@ actor DatabaseOperator {
       let seriesBooksMap = Dictionary(grouping: libraryBooks.filter { !$0.oneshot }) { $0.seriesId }
       var seriesGroups: [OfflineDownloadedSeriesGroup] = []
       for (seriesId, seriesBooks) in seriesBooksMap {
-        let bookItems =
-          seriesBooks
+        let bookItems = seriesBooks
           .map(Self.makeOfflineDownloadedBookItem)
           .sorted { $0.metaNumberSort < $1.metaNumberSort }
         seriesGroups.append(
@@ -3303,7 +3304,8 @@ actor DatabaseOperator {
     }
   }
 
-  private static func makeOfflineDownloadedBookItem(_ book: KomgaBook) -> OfflineDownloadedBookItem {
+  private static func makeOfflineDownloadedBookItem(_ book: KomgaBook) -> OfflineDownloadedBookItem
+  {
     OfflineDownloadedBookItem(
       id: book.id,
       instanceId: book.instanceId,

--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -2723,8 +2723,7 @@ actor DatabaseOperator {
 
   // MARK: - Saved Filter Operations
 
-  func fetchSavedFilterDisplayItems(filterType: SavedFilterType) throws -> [SavedFilterDisplayItem]
-  {
+  func fetchSavedFilterDisplayItems(filterType: SavedFilterType) throws -> [SavedFilterDisplayItem] {
     let filterTypeRaw = filterType.rawValue
     let descriptor = FetchDescriptor<SavedFilter>(
       predicate: #Predicate { filter in
@@ -3203,8 +3202,7 @@ actor DatabaseOperator {
     fetchBooksCount(instanceId: instanceId, status: "downloaded")
   }
 
-  func fetchOfflineDownloadedBooksSnapshot(instanceId: String) throws -> OfflineDownloadedBooksSnapshot
-  {
+  func fetchOfflineDownloadedBooksSnapshot(instanceId: String) throws -> OfflineDownloadedBooksSnapshot {
     guard !instanceId.isEmpty else { return .empty }
 
     let bookDescriptor = FetchDescriptor<KomgaBook>(
@@ -3260,7 +3258,8 @@ actor DatabaseOperator {
       let seriesBooksMap = Dictionary(grouping: libraryBooks.filter { !$0.oneshot }) { $0.seriesId }
       var seriesGroups: [OfflineDownloadedSeriesGroup] = []
       for (seriesId, seriesBooks) in seriesBooksMap {
-        let bookItems = seriesBooks
+        let bookItems =
+          seriesBooks
           .map(Self.makeOfflineDownloadedBookItem)
           .sorted { $0.metaNumberSort < $1.metaNumberSort }
         seriesGroups.append(
@@ -3304,8 +3303,7 @@ actor DatabaseOperator {
     }
   }
 
-  private static func makeOfflineDownloadedBookItem(_ book: KomgaBook) -> OfflineDownloadedBookItem
-  {
+  private static func makeOfflineDownloadedBookItem(_ book: KomgaBook) -> OfflineDownloadedBookItem {
     OfflineDownloadedBookItem(
       id: book.id,
       instanceId: book.instanceId,

--- a/KMReader/Features/Auth/Views/LandingView.swift
+++ b/KMReader/Features/Auth/Views/LandingView.swift
@@ -26,7 +26,7 @@ struct LandingView: View {
         .foregroundStyle(.primary)
 
       // Tagline
-      Text("Your personal manga and comic reader")
+      Text("Your Komga library, ready to read")
         .font(.title3)
         .foregroundStyle(.secondary)
         .multilineTextAlignment(.center)

--- a/KMReader/Features/Book/ViewModels/BookViewModel.swift
+++ b/KMReader/Features/Book/ViewModels/BookViewModel.swift
@@ -93,9 +93,14 @@ class BookViewModel {
     do {
       try await BookService.markAsRead(bookId: bookId)
       let updatedBook = try await SyncService.syncBook(bookId: bookId)
+      _ = try? await SyncService.syncSeriesDetail(seriesId: updatedBook.seriesId)
       if currentBook?.id == bookId {
         currentBook = updatedBook
       }
+      await ContentProjectionNotifier.postBookAndSeriesDidChange(
+        bookId: bookId,
+        seriesId: updatedBook.seriesId
+      )
       ErrorManager.shared.notify(message: String(localized: "notification.book.markedRead"))
     } catch {
       ErrorManager.shared.alert(error: error)
@@ -106,9 +111,14 @@ class BookViewModel {
     do {
       try await BookService.markAsUnread(bookId: bookId)
       let updatedBook = try await SyncService.syncBook(bookId: bookId)
+      _ = try? await SyncService.syncSeriesDetail(seriesId: updatedBook.seriesId)
       if currentBook?.id == bookId {
         currentBook = updatedBook
       }
+      await ContentProjectionNotifier.postBookAndSeriesDidChange(
+        bookId: bookId,
+        seriesId: updatedBook.seriesId
+      )
       ErrorManager.shared.notify(message: String(localized: "notification.book.markedUnread"))
     } catch {
       ErrorManager.shared.alert(error: error)

--- a/KMReader/Features/Book/Views/BookContextMenu.swift
+++ b/KMReader/Features/Book/Views/BookContextMenu.swift
@@ -152,6 +152,10 @@ struct BookContextMenu: View {
       do {
         try await BookService.markAsRead(bookId: bookId)
         _ = try await SyncService.syncBookAndSeries(bookId: bookId, seriesId: book.seriesId)
+        await ContentProjectionNotifier.postBookAndSeriesDidChange(
+          bookId: bookId,
+          seriesId: book.seriesId
+        )
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedRead"))
         onMutationCompleted?()
       } catch {
@@ -164,7 +168,11 @@ struct BookContextMenu: View {
     Task {
       do {
         try await BookService.markAsUnread(bookId: bookId)
-        _ = try await SyncService.syncBook(bookId: bookId)
+        _ = try await SyncService.syncBookAndSeries(bookId: bookId, seriesId: book.seriesId)
+        await ContentProjectionNotifier.postBookAndSeriesDidChange(
+          bookId: bookId,
+          seriesId: book.seriesId
+        )
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedUnread"))
         onMutationCompleted?()
       } catch {

--- a/KMReader/Features/Book/Views/BookDetailView.swift
+++ b/KMReader/Features/Book/Views/BookDetailView.swift
@@ -162,6 +162,12 @@ struct BookDetailView: View {
         if let book {
           _ = try? await SyncService.syncBookAndSeries(
             bookId: bookId, seriesId: book.seriesId)
+          await ContentProjectionNotifier.postBookAndSeriesDidChange(
+            bookId: bookId,
+            seriesId: book.seriesId
+          )
+        } else {
+          await ContentProjectionNotifier.postBookDidChange(bookId: bookId)
         }
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedRead"))
         await loadBook()
@@ -175,6 +181,19 @@ struct BookDetailView: View {
     Task {
       do {
         try await BookService.markAsUnread(bookId: bookId)
+        if let book {
+          _ = try? await SyncService.syncBookAndSeries(
+            bookId: bookId,
+            seriesId: book.seriesId
+          )
+          await ContentProjectionNotifier.postBookAndSeriesDidChange(
+            bookId: bookId,
+            seriesId: book.seriesId
+          )
+        } else {
+          _ = try? await SyncService.syncBook(bookId: bookId)
+          await ContentProjectionNotifier.postBookDidChange(bookId: bookId)
+        }
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedUnread"))
         await loadBook()
       } catch {

--- a/KMReader/Features/Book/Views/BookQueryItemView.swift
+++ b/KMReader/Features/Book/Views/BookQueryItemView.swift
@@ -74,9 +74,22 @@ struct BookQueryItemView: View {
     }
     .onReceive(NotificationCenter.default.publisher(for: .bookProjectionDidChange)) {
       notification in
-      guard notification.userInfo?["bookId"] as? String == bookId else { return }
+      guard shouldReload(for: notification) else { return }
       reloadItem()
     }
+  }
+
+  private func shouldReload(for notification: Notification) -> Bool {
+    if notification.userInfo?["bookId"] as? String == bookId {
+      return true
+    }
+    if let bookIds = notification.userInfo?["bookIds"] as? Set<String> {
+      return bookIds.contains(bookId)
+    }
+    if let bookIds = notification.userInfo?["bookIds"] as? [String] {
+      return bookIds.contains(bookId)
+    }
+    return false
   }
 
   private func reloadItem() {

--- a/KMReader/Features/Book/Views/ListViews/BooksListViewForReadList.swift
+++ b/KMReader/Features/Book/Views/ListViews/BooksListViewForReadList.swift
@@ -8,6 +8,7 @@ import SwiftUI
 // Books list view for read list
 struct BooksListViewForReadList: View {
   let readListId: String
+  let readerPresentation: ReaderPresentationManager
   @Binding var showFilterSheet: Bool
   @Binding var showSavedFilters: Bool
 
@@ -21,18 +22,30 @@ struct BooksListViewForReadList: View {
   @State private var isSelectionMode = false
   @State private var isDeleting = false
   @State private var readListItem: ReadListDisplayItem?
+  @State private var projectionRefreshTask: Task<Void, Never>?
+  @State private var readerCloseRefreshTask: Task<Void, Never>?
+  @State private var shouldRefreshAfterReading = false
+
+  private static let localProjectionRefreshDelay: UInt64 = 750_000_000
+  private static let remoteProjectionRefreshDelay: UInt64 = 5_000_000_000
 
   private var readListContext: ReaderReadListContext? {
     guard let readListItem else { return nil }
     return ReaderReadListContext(id: readListItem.readListId, name: readListItem.name)
   }
 
+  private var isReaderActive: Bool {
+    readerPresentation.currentSession != nil
+  }
+
   init(
     readListId: String,
+    readerPresentation: ReaderPresentationManager,
     showFilterSheet: Binding<Bool>,
     showSavedFilters: Binding<Bool>
   ) {
     self.readListId = readListId
+    self.readerPresentation = readerPresentation
     self._showFilterSheet = showFilterSheet
     self._showSavedFilters = showSavedFilters
   }
@@ -145,6 +158,24 @@ struct BooksListViewForReadList: View {
         await refreshBooks()
       }
     }
+    .onReceive(NotificationCenter.default.publisher(for: .bookProjectionDidChange)) {
+      notification in
+      guard shouldRefreshForBookProjection(notification) else { return }
+      scheduleProjectionRefresh()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .sseEventReceived)) { notification in
+      guard let info = notification.userInfo?["info"] as? SSEEventInfo else { return }
+      handleSSEEvent(info)
+    }
+    .onChange(of: readerPresentation.currentSession) { oldSession, newSession in
+      handleReaderSessionChange(oldSession: oldSession, newSession: newSession)
+    }
+    .onDisappear {
+      projectionRefreshTask?.cancel()
+      projectionRefreshTask = nil
+      readerCloseRefreshTask?.cancel()
+      readerCloseRefreshTask = nil
+    }
   }
 
   private func refreshBooks() async {
@@ -195,6 +226,98 @@ struct BooksListViewForReadList: View {
       await refreshBooks()
     } catch {
       ErrorManager.shared.alert(error: error)
+    }
+  }
+
+  private func shouldRefreshForBookProjection(_ notification: Notification) -> Bool {
+    let changedIds = changedBookIds(from: notification)
+    guard !changedIds.isEmpty else { return true }
+    guard let currentIds = readListItem?.bookIds else { return true }
+    return !changedIds.isDisjoint(with: currentIds)
+  }
+
+  private func changedBookIds(from notification: Notification) -> Set<String> {
+    if let ids = notification.userInfo?["bookIds"] as? Set<String> {
+      return ids
+    }
+    if let ids = notification.userInfo?["bookIds"] as? [String] {
+      return Set(ids)
+    }
+    if let id = notification.userInfo?["bookId"] as? String {
+      return [id]
+    }
+    return []
+  }
+
+  private func scheduleProjectionRefresh(after delay: UInt64 = Self.localProjectionRefreshDelay) {
+    projectionRefreshTask?.cancel()
+    projectionRefreshTask = nil
+
+    if isReaderActive {
+      shouldRefreshAfterReading = true
+      return
+    }
+
+    projectionRefreshTask = Task { @MainActor in
+      do {
+        try await Task.sleep(nanoseconds: delay)
+      } catch {
+        return
+      }
+
+      guard !Task.isCancelled else { return }
+      if isReaderActive {
+        shouldRefreshAfterReading = true
+      } else {
+        await refreshBooks()
+      }
+      projectionRefreshTask = nil
+    }
+  }
+
+  private func handleSSEEvent(_ info: SSEEventInfo) {
+    guard AppConfig.enableSSEAutoRefresh else { return }
+
+    switch info.type {
+    case .readProgressChanged, .readProgressDeleted, .readProgressSeriesChanged,
+      .readProgressSeriesDeleted, .bookChanged, .bookDeleted, .readListChanged,
+      .readListDeleted:
+      scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
+    default:
+      break
+    }
+  }
+
+  private func handleReaderSessionChange(oldSession: ReaderSession?, newSession: ReaderSession?) {
+    if newSession != nil {
+      if projectionRefreshTask != nil {
+        shouldRefreshAfterReading = true
+      }
+      projectionRefreshTask?.cancel()
+      projectionRefreshTask = nil
+      readerCloseRefreshTask?.cancel()
+      readerCloseRefreshTask = nil
+      return
+    }
+
+    guard oldSession != nil else { return }
+    let needsRefresh = shouldRefreshAfterReading
+    shouldRefreshAfterReading = false
+    guard needsRefresh else { return }
+
+    let visitedBookIds = oldSession?.visitedBookIds ?? []
+    readerCloseRefreshTask?.cancel()
+    readerCloseRefreshTask = Task { @MainActor in
+      if !visitedBookIds.isEmpty {
+        _ = await ReaderProgressDispatchService.shared.waitUntilSettled(
+          bookIds: visitedBookIds,
+          timeout: .seconds(5)
+        )
+      }
+
+      guard !Task.isCancelled else { return }
+      await refreshBooks()
+      readerCloseRefreshTask = nil
     }
   }
 }

--- a/KMReader/Features/Browse/Views/BrowseView.swift
+++ b/KMReader/Features/Browse/Views/BrowseView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 struct BrowseView: View {
   let authViewModel: AuthViewModel
+  let readerPresentation: ReaderPresentationManager
   let fixedContent: BrowseContentType?
   let metadataFilter: MetadataFilterConfig?
 
@@ -31,6 +32,8 @@ struct BrowseView: View {
   @State private var showFilterSheet = false
   @State private var showSavedFilters = false
   @State private var projectionRefreshTask: Task<Void, Never>?
+  @State private var readerCloseRefreshTask: Task<Void, Never>?
+  @State private var shouldRefreshAfterReading = false
 
   private static let localProjectionRefreshDelay: UInt64 = 750_000_000
   private static let remoteProjectionRefreshDelay: UInt64 = 5_000_000_000
@@ -53,12 +56,18 @@ struct BrowseView: View {
     }
   }
 
+  private var isReaderActive: Bool {
+    readerPresentation.currentSession != nil
+  }
+
   init(
     authViewModel: AuthViewModel,
+    readerPresentation: ReaderPresentationManager,
     fixedContent: BrowseContentType? = nil,
     metadataFilter: MetadataFilterConfig? = nil
   ) {
     self.authViewModel = authViewModel
+    self.readerPresentation = readerPresentation
     self.fixedContent = fixedContent
     self.metadataFilter = metadataFilter
   }
@@ -242,9 +251,14 @@ struct BrowseView: View {
       guard let info = notification.userInfo?["info"] as? SSEEventInfo else { return }
       handleSSEEvent(info)
     }
+    .onChange(of: readerPresentation.currentSession) { oldSession, newSession in
+      handleReaderSessionChange(oldSession: oldSession, newSession: newSession)
+    }
     .onDisappear {
       projectionRefreshTask?.cancel()
       projectionRefreshTask = nil
+      readerCloseRefreshTask?.cancel()
+      readerCloseRefreshTask = nil
     }
   }
 
@@ -261,6 +275,13 @@ struct BrowseView: View {
     guard !authViewModel.isSwitching else { return }
 
     projectionRefreshTask?.cancel()
+    projectionRefreshTask = nil
+
+    if isReaderActive {
+      shouldRefreshAfterReading = true
+      return
+    }
+
     projectionRefreshTask = Task { @MainActor in
       do {
         try await Task.sleep(nanoseconds: delay)
@@ -269,7 +290,11 @@ struct BrowseView: View {
       }
 
       guard !Task.isCancelled else { return }
-      refreshBrowse()
+      if isReaderActive {
+        shouldRefreshAfterReading = true
+      } else {
+        refreshBrowse()
+      }
       projectionRefreshTask = nil
     }
   }
@@ -292,6 +317,39 @@ struct BrowseView: View {
       scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
     default:
       break
+    }
+  }
+
+  private func handleReaderSessionChange(oldSession: ReaderSession?, newSession: ReaderSession?) {
+    if newSession != nil {
+      if projectionRefreshTask != nil {
+        shouldRefreshAfterReading = true
+      }
+      projectionRefreshTask?.cancel()
+      projectionRefreshTask = nil
+      readerCloseRefreshTask?.cancel()
+      readerCloseRefreshTask = nil
+      return
+    }
+
+    guard oldSession != nil else { return }
+    let needsRefresh = shouldRefreshAfterReading
+    shouldRefreshAfterReading = false
+    guard needsRefresh else { return }
+
+    let visitedBookIds = oldSession?.visitedBookIds ?? []
+    readerCloseRefreshTask?.cancel()
+    readerCloseRefreshTask = Task { @MainActor in
+      if !visitedBookIds.isEmpty {
+        _ = await ReaderProgressDispatchService.shared.waitUntilSettled(
+          bookIds: visitedBookIds,
+          timeout: .seconds(5)
+        )
+      }
+
+      guard !Task.isCancelled else { return }
+      refreshBrowse()
+      readerCloseRefreshTask = nil
     }
   }
 

--- a/KMReader/Features/Browse/Views/BrowseView.swift
+++ b/KMReader/Features/Browse/Views/BrowseView.swift
@@ -32,6 +32,9 @@ struct BrowseView: View {
   @State private var showSavedFilters = false
   @State private var projectionRefreshTask: Task<Void, Never>?
 
+  private static let localProjectionRefreshDelay: UInt64 = 750_000_000
+  private static let remoteProjectionRefreshDelay: UInt64 = 5_000_000_000
+
   private var effectiveContent: BrowseContentType {
     fixedContent ?? browseContent
   }
@@ -254,13 +257,13 @@ struct BrowseView: View {
     }
   }
 
-  private func scheduleProjectionRefresh() {
+  private func scheduleProjectionRefresh(after delay: UInt64 = Self.localProjectionRefreshDelay) {
     guard !authViewModel.isSwitching else { return }
 
     projectionRefreshTask?.cancel()
     projectionRefreshTask = Task { @MainActor in
       do {
-        try await Task.sleep(nanoseconds: 750_000_000)
+        try await Task.sleep(nanoseconds: delay)
       } catch {
         return
       }
@@ -277,16 +280,16 @@ struct BrowseView: View {
     switch info.type {
     case .readProgressChanged, .readProgressDeleted:
       guard effectiveContent == .books else { return }
-      scheduleProjectionRefresh()
+      scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
     case .readProgressSeriesChanged, .readProgressSeriesDeleted:
       guard effectiveContent == .series else { return }
-      scheduleProjectionRefresh()
+      scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
     case .bookChanged, .bookDeleted:
       guard effectiveContent == .books else { return }
-      scheduleProjectionRefresh()
+      scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
     case .seriesChanged, .seriesDeleted:
       guard effectiveContent == .series else { return }
-      scheduleProjectionRefresh()
+      scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
     default:
       break
     }

--- a/KMReader/Features/Browse/Views/BrowseView.swift
+++ b/KMReader/Features/Browse/Views/BrowseView.swift
@@ -30,6 +30,7 @@ struct BrowseView: View {
   @State private var showLibraryPicker = false
   @State private var showFilterSheet = false
   @State private var showSavedFilters = false
+  @State private var projectionRefreshTask: Task<Void, Never>?
 
   private var effectiveContent: BrowseContentType {
     fixedContent ?? browseContent
@@ -226,6 +227,22 @@ struct BrowseView: View {
       initializedLibraryIdsKey = resolvedLibraryIdsKey
       refreshBrowse()
     }
+    .onReceive(NotificationCenter.default.publisher(for: .bookProjectionDidChange)) { _ in
+      guard effectiveContent == .books else { return }
+      scheduleProjectionRefresh()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .seriesProjectionDidChange)) { _ in
+      guard effectiveContent == .series else { return }
+      scheduleProjectionRefresh()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .sseEventReceived)) { notification in
+      guard let info = notification.userInfo?["info"] as? SSEEventInfo else { return }
+      handleSSEEvent(info)
+    }
+    .onDisappear {
+      projectionRefreshTask?.cancel()
+      projectionRefreshTask = nil
+    }
   }
 
   private func refreshBrowse() {
@@ -234,6 +251,44 @@ struct BrowseView: View {
     Task {
       try? await Task.sleep(nanoseconds: 2_000_000_000)  // 2 seconds
       isRefreshDisabled = false
+    }
+  }
+
+  private func scheduleProjectionRefresh() {
+    guard !authViewModel.isSwitching else { return }
+
+    projectionRefreshTask?.cancel()
+    projectionRefreshTask = Task { @MainActor in
+      do {
+        try await Task.sleep(nanoseconds: 750_000_000)
+      } catch {
+        return
+      }
+
+      guard !Task.isCancelled else { return }
+      refreshBrowse()
+      projectionRefreshTask = nil
+    }
+  }
+
+  private func handleSSEEvent(_ info: SSEEventInfo) {
+    guard AppConfig.enableSSEAutoRefresh else { return }
+
+    switch info.type {
+    case .readProgressChanged, .readProgressDeleted:
+      guard effectiveContent == .books else { return }
+      scheduleProjectionRefresh()
+    case .readProgressSeriesChanged, .readProgressSeriesDeleted:
+      guard effectiveContent == .series else { return }
+      scheduleProjectionRefresh()
+    case .bookChanged, .bookDeleted:
+      guard effectiveContent == .books else { return }
+      scheduleProjectionRefresh()
+    case .seriesChanged, .seriesDeleted:
+      guard effectiveContent == .series else { return }
+      scheduleProjectionRefresh()
+    default:
+      break
     }
   }
 

--- a/KMReader/Features/Browse/Views/BrowseView.swift
+++ b/KMReader/Features/Browse/Views/BrowseView.swift
@@ -303,17 +303,21 @@ struct BrowseView: View {
     guard AppConfig.enableSSEAutoRefresh else { return }
 
     switch info.type {
-    case .readProgressChanged, .readProgressDeleted:
+    case .readProgressChanged, .readProgressDeleted, .readProgressSeriesChanged,
+      .readProgressSeriesDeleted:
+      guard effectiveContent == .books || effectiveContent == .series else { return }
+      scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
+    case .bookAdded, .bookChanged, .bookDeleted, .bookImported:
       guard effectiveContent == .books else { return }
       scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
-    case .readProgressSeriesChanged, .readProgressSeriesDeleted:
+    case .seriesAdded, .seriesChanged, .seriesDeleted:
       guard effectiveContent == .series else { return }
       scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
-    case .bookChanged, .bookDeleted:
-      guard effectiveContent == .books else { return }
+    case .collectionAdded, .collectionChanged, .collectionDeleted:
+      guard effectiveContent == .collections else { return }
       scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
-    case .seriesChanged, .seriesDeleted:
-      guard effectiveContent == .series else { return }
+    case .readListAdded, .readListChanged, .readListDeleted:
+      guard effectiveContent == .readlists else { return }
       scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
     default:
       break

--- a/KMReader/Features/Collection/Views/CollectionDetailView.swift
+++ b/KMReader/Features/Collection/Views/CollectionDetailView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 struct CollectionDetailView: View {
   let collectionId: String
+  let readerPresentation: ReaderPresentationManager
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("collectionDetailLayout") private var collectionDetailLayout: BrowseLayoutMode = .list
@@ -19,8 +20,12 @@ struct CollectionDetailView: View {
   @State private var showFilterSheet = false
   @State private var showSavedFilters = false
 
-  init(collectionId: String) {
+  init(
+    collectionId: String,
+    readerPresentation: ReaderPresentationManager
+  ) {
     self.collectionId = collectionId
+    self.readerPresentation = readerPresentation
   }
 
   private var collection: SeriesCollection? {
@@ -53,6 +58,7 @@ struct CollectionDetailView: View {
           if item != nil {
             CollectionSeriesListView(
               collectionId: collectionId,
+              readerPresentation: readerPresentation,
               showFilterSheet: $showFilterSheet,
               showSavedFilters: $showSavedFilters
             )

--- a/KMReader/Features/Collection/Views/Sections/CollectionSeriesListView.swift
+++ b/KMReader/Features/Collection/Views/Sections/CollectionSeriesListView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 // Series list view for collection
 struct CollectionSeriesListView: View {
   let collectionId: String
+  let readerPresentation: ReaderPresentationManager
   @Binding var showFilterSheet: Bool
   @Binding var showSavedFilters: Bool
 
@@ -21,15 +22,27 @@ struct CollectionSeriesListView: View {
   @State private var isSelectionMode = false
   @State private var isDeleting = false
   @State private var collectionItem: CollectionDisplayItem?
+  @State private var projectionRefreshTask: Task<Void, Never>?
+  @State private var readerCloseRefreshTask: Task<Void, Never>?
+  @State private var shouldRefreshAfterReading = false
+
+  private static let localProjectionRefreshDelay: UInt64 = 750_000_000
+  private static let remoteProjectionRefreshDelay: UInt64 = 5_000_000_000
 
   init(
     collectionId: String,
+    readerPresentation: ReaderPresentationManager,
     showFilterSheet: Binding<Bool>,
     showSavedFilters: Binding<Bool>
   ) {
     self.collectionId = collectionId
+    self.readerPresentation = readerPresentation
     self._showFilterSheet = showFilterSheet
     self._showSavedFilters = showSavedFilters
+  }
+
+  private var isReaderActive: Bool {
+    readerPresentation.currentSession != nil
   }
 
   private var supportsSelectionMode: Bool {
@@ -123,6 +136,24 @@ struct CollectionSeriesListView: View {
         await refreshSeries()
       }
     }
+    .onReceive(NotificationCenter.default.publisher(for: .seriesProjectionDidChange)) {
+      notification in
+      guard shouldRefreshForSeriesProjection(notification) else { return }
+      scheduleProjectionRefresh()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .sseEventReceived)) { notification in
+      guard let info = notification.userInfo?["info"] as? SSEEventInfo else { return }
+      handleSSEEvent(info)
+    }
+    .onChange(of: readerPresentation.currentSession) { oldSession, newSession in
+      handleReaderSessionChange(oldSession: oldSession, newSession: newSession)
+    }
+    .onDisappear {
+      projectionRefreshTask?.cancel()
+      projectionRefreshTask = nil
+      readerCloseRefreshTask?.cancel()
+      readerCloseRefreshTask = nil
+    }
   }
 
   private func refreshSeries() async {
@@ -174,6 +205,97 @@ struct CollectionSeriesListView: View {
       await refreshSeries()
     } catch {
       ErrorManager.shared.alert(error: error)
+    }
+  }
+
+  private func shouldRefreshForSeriesProjection(_ notification: Notification) -> Bool {
+    let changedIds = changedSeriesIds(from: notification)
+    guard !changedIds.isEmpty else { return true }
+    guard let currentIds = collectionItem?.seriesIds else { return true }
+    return !changedIds.isDisjoint(with: currentIds)
+  }
+
+  private func changedSeriesIds(from notification: Notification) -> Set<String> {
+    if let ids = notification.userInfo?["seriesIds"] as? Set<String> {
+      return ids
+    }
+    if let ids = notification.userInfo?["seriesIds"] as? [String] {
+      return Set(ids)
+    }
+    if let id = notification.userInfo?["seriesId"] as? String {
+      return [id]
+    }
+    return []
+  }
+
+  private func scheduleProjectionRefresh(after delay: UInt64 = Self.localProjectionRefreshDelay) {
+    projectionRefreshTask?.cancel()
+    projectionRefreshTask = nil
+
+    if isReaderActive {
+      shouldRefreshAfterReading = true
+      return
+    }
+
+    projectionRefreshTask = Task { @MainActor in
+      do {
+        try await Task.sleep(nanoseconds: delay)
+      } catch {
+        return
+      }
+
+      guard !Task.isCancelled else { return }
+      if isReaderActive {
+        shouldRefreshAfterReading = true
+      } else {
+        await refreshSeries()
+      }
+      projectionRefreshTask = nil
+    }
+  }
+
+  private func handleSSEEvent(_ info: SSEEventInfo) {
+    guard AppConfig.enableSSEAutoRefresh else { return }
+
+    switch info.type {
+    case .readProgressSeriesChanged, .readProgressSeriesDeleted, .seriesChanged,
+      .seriesDeleted, .collectionChanged, .collectionDeleted:
+      scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
+    default:
+      break
+    }
+  }
+
+  private func handleReaderSessionChange(oldSession: ReaderSession?, newSession: ReaderSession?) {
+    if newSession != nil {
+      if projectionRefreshTask != nil {
+        shouldRefreshAfterReading = true
+      }
+      projectionRefreshTask?.cancel()
+      projectionRefreshTask = nil
+      readerCloseRefreshTask?.cancel()
+      readerCloseRefreshTask = nil
+      return
+    }
+
+    guard oldSession != nil else { return }
+    let needsRefresh = shouldRefreshAfterReading
+    shouldRefreshAfterReading = false
+    guard needsRefresh else { return }
+
+    let visitedBookIds = oldSession?.visitedBookIds ?? []
+    readerCloseRefreshTask?.cancel()
+    readerCloseRefreshTask = Task { @MainActor in
+      if !visitedBookIds.isEmpty {
+        _ = await ReaderProgressDispatchService.shared.waitUntilSettled(
+          bookIds: visitedBookIds,
+          timeout: .seconds(5)
+        )
+      }
+
+      guard !Task.isCancelled else { return }
+      await refreshSeries()
+      readerCloseRefreshTask = nil
     }
   }
 }

--- a/KMReader/Features/Collection/Views/Sections/CollectionSeriesListView.swift
+++ b/KMReader/Features/Collection/Views/Sections/CollectionSeriesListView.swift
@@ -258,8 +258,9 @@ struct CollectionSeriesListView: View {
     guard AppConfig.enableSSEAutoRefresh else { return }
 
     switch info.type {
-    case .readProgressSeriesChanged, .readProgressSeriesDeleted, .seriesChanged,
-      .seriesDeleted, .collectionChanged, .collectionDeleted:
+    case .readProgressChanged, .readProgressDeleted, .readProgressSeriesChanged,
+      .readProgressSeriesDeleted, .seriesAdded, .seriesChanged, .seriesDeleted,
+      .collectionChanged, .collectionDeleted:
       scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
     default:
       break

--- a/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
@@ -337,10 +337,10 @@ struct DashboardSectionDetailView: View {
     case .readProgressChanged, .readProgressDeleted, .readProgressSeriesChanged,
       .readProgressSeriesDeleted:
       scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
-    case .bookChanged, .bookDeleted:
+    case .bookAdded, .bookChanged, .bookDeleted, .bookImported:
       guard section.contentKind == .books else { return }
       scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
-    case .seriesChanged, .seriesDeleted:
+    case .seriesAdded, .seriesChanged, .seriesDeleted:
       guard section.contentKind == .series else { return }
       scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
     default:

--- a/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
@@ -18,6 +18,7 @@ struct DashboardSectionDetailView: View {
   @State private var isLoading = false
   @State private var isQueueingAllOffline = false
   @State private var hasLoadedInitial = false
+  @State private var projectionRefreshTask: Task<Void, Never>?
 
   private var columns: [GridItem] {
     LayoutConfig.adaptiveColumns(for: gridDensity)
@@ -67,6 +68,22 @@ struct DashboardSectionDetailView: View {
     }
     .refreshable {
       await loadItems(refresh: true)
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .bookProjectionDidChange)) { _ in
+      guard section.contentKind == .books else { return }
+      scheduleProjectionRefresh()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .seriesProjectionDidChange)) { _ in
+      guard section.contentKind == .series else { return }
+      scheduleProjectionRefresh()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .sseEventReceived)) { notification in
+      guard let info = notification.userInfo?["info"] as? SSEEventInfo else { return }
+      handleSSEEvent(info)
+    }
+    .onDisappear {
+      projectionRefreshTask?.cancel()
+      projectionRefreshTask = nil
     }
     #if os(iOS) || os(macOS)
       .toolbar {
@@ -253,6 +270,39 @@ struct DashboardSectionDetailView: View {
 
     withAnimation {
       isLoading = false
+    }
+  }
+
+  private func scheduleProjectionRefresh() {
+    projectionRefreshTask?.cancel()
+    projectionRefreshTask = Task { @MainActor in
+      do {
+        try await Task.sleep(nanoseconds: 750_000_000)
+      } catch {
+        return
+      }
+
+      guard !Task.isCancelled else { return }
+      await loadItems(refresh: true)
+      projectionRefreshTask = nil
+    }
+  }
+
+  private func handleSSEEvent(_ info: SSEEventInfo) {
+    guard AppConfig.enableSSEAutoRefresh else { return }
+
+    switch info.type {
+    case .readProgressChanged, .readProgressDeleted, .readProgressSeriesChanged,
+      .readProgressSeriesDeleted:
+      scheduleProjectionRefresh()
+    case .bookChanged, .bookDeleted:
+      guard section.contentKind == .books else { return }
+      scheduleProjectionRefresh()
+    case .seriesChanged, .seriesDeleted:
+      guard section.contentKind == .series else { return }
+      scheduleProjectionRefresh()
+    default:
+      break
     }
   }
 

--- a/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 @MainActor
 struct DashboardSectionDetailView: View {
   let section: DashboardSection
+  let readerPresentation: ReaderPresentationManager
 
   @AppStorage("dashboard") private var dashboard: DashboardConfiguration = DashboardConfiguration()
   @AppStorage("dashboardSectionDetailLayout") private var browseLayout: BrowseLayoutMode = .grid
@@ -19,6 +20,9 @@ struct DashboardSectionDetailView: View {
   @State private var isQueueingAllOffline = false
   @State private var hasLoadedInitial = false
   @State private var projectionRefreshTask: Task<Void, Never>?
+  @State private var readerCloseRefreshTask: Task<Void, Never>?
+  @State private var shouldRefreshAfterReading = false
+  @State private var needsRefreshAfterCurrentLoad = false
 
   private static let localProjectionRefreshDelay: UInt64 = 750_000_000
   private static let remoteProjectionRefreshDelay: UInt64 = 5_000_000_000
@@ -29,6 +33,10 @@ struct DashboardSectionDetailView: View {
 
   private var spacing: CGFloat {
     LayoutConfig.spacing(for: gridDensity)
+  }
+
+  private var isReaderActive: Bool {
+    readerPresentation.currentSession != nil
   }
 
   var body: some View {
@@ -84,9 +92,14 @@ struct DashboardSectionDetailView: View {
       guard let info = notification.userInfo?["info"] as? SSEEventInfo else { return }
       handleSSEEvent(info)
     }
+    .onChange(of: readerPresentation.currentSession) { oldSession, newSession in
+      handleReaderSessionChange(oldSession: oldSession, newSession: newSession)
+    }
     .onDisappear {
       projectionRefreshTask?.cancel()
       projectionRefreshTask = nil
+      readerCloseRefreshTask?.cancel()
+      readerCloseRefreshTask = nil
     }
     #if os(iOS) || os(macOS)
       .toolbar {
@@ -213,7 +226,12 @@ struct DashboardSectionDetailView: View {
   }
 
   func loadItems(refresh: Bool) async {
-    guard !isLoading else { return }
+    guard !isLoading else {
+      if refresh {
+        needsRefreshAfterCurrentLoad = true
+      }
+      return
+    }
     guard refresh || pagination.hasMorePages else { return }
 
     isLoading = true
@@ -271,13 +289,30 @@ struct DashboardSectionDetailView: View {
       }
     }
 
+    finishLoading()
+  }
+
+  private func finishLoading() {
     withAnimation {
       isLoading = false
+    }
+
+    guard needsRefreshAfterCurrentLoad else { return }
+    needsRefreshAfterCurrentLoad = false
+    Task {
+      await loadItems(refresh: true)
     }
   }
 
   private func scheduleProjectionRefresh(after delay: UInt64 = Self.localProjectionRefreshDelay) {
     projectionRefreshTask?.cancel()
+    projectionRefreshTask = nil
+
+    if isReaderActive {
+      shouldRefreshAfterReading = true
+      return
+    }
+
     projectionRefreshTask = Task { @MainActor in
       do {
         try await Task.sleep(nanoseconds: delay)
@@ -286,7 +321,11 @@ struct DashboardSectionDetailView: View {
       }
 
       guard !Task.isCancelled else { return }
-      await loadItems(refresh: true)
+      if isReaderActive {
+        shouldRefreshAfterReading = true
+      } else {
+        await loadItems(refresh: true)
+      }
       projectionRefreshTask = nil
     }
   }
@@ -306,6 +345,39 @@ struct DashboardSectionDetailView: View {
       scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
     default:
       break
+    }
+  }
+
+  private func handleReaderSessionChange(oldSession: ReaderSession?, newSession: ReaderSession?) {
+    if newSession != nil {
+      if projectionRefreshTask != nil {
+        shouldRefreshAfterReading = true
+      }
+      projectionRefreshTask?.cancel()
+      projectionRefreshTask = nil
+      readerCloseRefreshTask?.cancel()
+      readerCloseRefreshTask = nil
+      return
+    }
+
+    guard oldSession != nil else { return }
+    let needsRefresh = shouldRefreshAfterReading
+    shouldRefreshAfterReading = false
+    guard needsRefresh else { return }
+
+    let visitedBookIds = oldSession?.visitedBookIds ?? []
+    readerCloseRefreshTask?.cancel()
+    readerCloseRefreshTask = Task { @MainActor in
+      if !visitedBookIds.isEmpty {
+        _ = await ReaderProgressDispatchService.shared.waitUntilSettled(
+          bookIds: visitedBookIds,
+          timeout: .seconds(5)
+        )
+      }
+
+      guard !Task.isCancelled else { return }
+      await loadItems(refresh: true)
+      readerCloseRefreshTask = nil
     }
   }
 

--- a/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
@@ -20,6 +20,9 @@ struct DashboardSectionDetailView: View {
   @State private var hasLoadedInitial = false
   @State private var projectionRefreshTask: Task<Void, Never>?
 
+  private static let localProjectionRefreshDelay: UInt64 = 750_000_000
+  private static let remoteProjectionRefreshDelay: UInt64 = 5_000_000_000
+
   private var columns: [GridItem] {
     LayoutConfig.adaptiveColumns(for: gridDensity)
   }
@@ -273,11 +276,11 @@ struct DashboardSectionDetailView: View {
     }
   }
 
-  private func scheduleProjectionRefresh() {
+  private func scheduleProjectionRefresh(after delay: UInt64 = Self.localProjectionRefreshDelay) {
     projectionRefreshTask?.cancel()
     projectionRefreshTask = Task { @MainActor in
       do {
-        try await Task.sleep(nanoseconds: 750_000_000)
+        try await Task.sleep(nanoseconds: delay)
       } catch {
         return
       }
@@ -294,13 +297,13 @@ struct DashboardSectionDetailView: View {
     switch info.type {
     case .readProgressChanged, .readProgressDeleted, .readProgressSeriesChanged,
       .readProgressSeriesDeleted:
-      scheduleProjectionRefresh()
+      scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
     case .bookChanged, .bookDeleted:
       guard section.contentKind == .books else { return }
-      scheduleProjectionRefresh()
+      scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
     case .seriesChanged, .seriesDeleted:
       guard section.contentKind == .series else { return }
-      scheduleProjectionRefresh()
+      scheduleProjectionRefresh(after: Self.remoteProjectionRefreshDelay)
     default:
       break
     }

--- a/KMReader/Features/Offline/Views/OfflineTasksView.swift
+++ b/KMReader/Features/Offline/Views/OfflineTasksView.swift
@@ -326,8 +326,8 @@ struct OfflineTaskRow: View {
                 ? String(localized: "Downloading")
                 : String(localized: "Pending in queue...")
             )
-              .font(.caption)
-              .foregroundColor(.secondary)
+            .font(.caption)
+            .foregroundColor(.secondary)
           }
         } else if case .failed(let error) = task.downloadStatus {
           Text(error)

--- a/KMReader/Features/Offline/Views/OfflineTasksView.swift
+++ b/KMReader/Features/Offline/Views/OfflineTasksView.swift
@@ -326,8 +326,8 @@ struct OfflineTaskRow: View {
                 ? String(localized: "Downloading")
                 : String(localized: "Pending in queue...")
             )
-            .font(.caption)
-            .foregroundColor(.secondary)
+              .font(.caption)
+              .foregroundColor(.secondary)
           }
         } else if case .failed(let error) = task.downloadStatus {
           Text(error)

--- a/KMReader/Features/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailView.swift
@@ -213,6 +213,10 @@ struct OneshotDetailView: View {
       do {
         try await BookService.markAsRead(bookId: book.id)
         _ = try? await SyncService.syncBookAndSeries(bookId: book.id, seriesId: seriesId)
+        await ContentProjectionNotifier.postBookAndSeriesDidChange(
+          bookId: book.id,
+          seriesId: seriesId
+        )
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedRead"))
         await refreshOneshotData()
       } catch {
@@ -226,6 +230,11 @@ struct OneshotDetailView: View {
     Task {
       do {
         try await BookService.markAsUnread(bookId: book.id)
+        _ = try? await SyncService.syncBookAndSeries(bookId: book.id, seriesId: seriesId)
+        await ContentProjectionNotifier.postBookAndSeriesDidChange(
+          bookId: book.id,
+          seriesId: seriesId
+        )
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedUnread"))
         await refreshOneshotData()
       } catch {

--- a/KMReader/Features/ReadList/Views/ReadListDetailView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListDetailView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 struct ReadListDetailView: View {
   let readListId: String
+  let readerPresentation: ReaderPresentationManager
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("readListDetailLayout") private var readListDetailLayout: BrowseLayoutMode = .list
@@ -19,8 +20,12 @@ struct ReadListDetailView: View {
   @State private var showFilterSheet = false
   @State private var showSavedFilters = false
 
-  init(readListId: String) {
+  init(
+    readListId: String,
+    readerPresentation: ReaderPresentationManager
+  ) {
     self.readListId = readListId
+    self.readerPresentation = readerPresentation
   }
 
   private var readList: ReadList? {
@@ -69,6 +74,7 @@ struct ReadListDetailView: View {
           if item != nil {
             BooksListViewForReadList(
               readListId: readListId,
+              readerPresentation: readerPresentation,
               showFilterSheet: $showFilterSheet,
               showSavedFilters: $showSavedFilters
             )

--- a/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
+++ b/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
@@ -25,6 +25,7 @@ actor ReaderProgressDispatchService {
 
   private enum ProgressUpdateResult {
     case serverUpdated
+    case conflict
     case offlineQueued
     case skipped
     case failed
@@ -423,6 +424,9 @@ actor ReaderProgressDispatchService {
     case .serverUpdated:
       markProgressSettled(bookId: update.bookId, version: update.version, serverSynced: true)
       scheduleLocalPageProgressCacheUpdate(update)
+    case .conflict:
+      let refreshed = await refreshBookAfterPageProgressConflict(update)
+      markProgressSettled(bookId: update.bookId, version: update.version, serverSynced: refreshed)
     case .offlineQueued:
       markProgressSettled(bookId: update.bookId, version: update.version, serverSynced: false)
     case .skipped, .failed:
@@ -455,7 +459,7 @@ actor ReaderProgressDispatchService {
       markProgressSettled(bookId: update.bookId, version: update.version, serverSynced: true)
     case .offlineQueued:
       markProgressSettled(bookId: update.bookId, version: update.version, serverSynced: false)
-    case .skipped, .failed:
+    case .conflict, .skipped, .failed:
       break
     }
 
@@ -492,9 +496,9 @@ actor ReaderProgressDispatchService {
       } catch {
         if let apiError = error as? APIError, apiError.isConflict {
           logger.info(
-            "⏭️ [Progress/Page] Ignored conflict (409): book=\(update.bookId), version=\(update.version), page=\(update.page)"
+            "⏭️ [Progress/Page] Conflict (409), refreshing server state: book=\(update.bookId), version=\(update.version), page=\(update.page)"
           )
-          return .serverUpdated
+          return .conflict
         }
 
         guard Self.isTimeoutError(error) else {
@@ -530,6 +534,26 @@ actor ReaderProgressDispatchService {
           "⏱️ [Progress/Page] Timeout, retrying: book=\(update.bookId), version=\(update.version), page=\(update.page), attempt=\(timeoutRetryAttempt)/\(timeoutRetryLimit)"
         )
       }
+    }
+  }
+
+  private func refreshBookAfterPageProgressConflict(_ update: PageUpdate) async -> Bool {
+    do {
+      let book = try await SyncService.syncBook(bookId: update.bookId)
+      _ = try? await SyncService.syncSeriesDetail(seriesId: book.seriesId)
+      await ContentProjectionNotifier.postBookAndSeriesDidChange(
+        bookId: update.bookId,
+        seriesId: book.seriesId
+      )
+      logger.debug(
+        "🔄 [Progress/Page] Refreshed server state after conflict: book=\(update.bookId), version=\(update.version)"
+      )
+      return true
+    } catch {
+      logger.warning(
+        "⚠️ [Progress/Page] Failed to refresh after conflict: book=\(update.bookId), version=\(update.version), error=\(error.localizedDescription)"
+      )
+      return false
     }
   }
 

--- a/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
+++ b/KMReader/Features/Reader/Services/ReaderProgressDispatchService.swift
@@ -5,11 +5,6 @@
 
 import Foundation
 
-extension Notification.Name {
-  static let bookProjectionDidChange = Notification.Name("BookProjectionDidChange")
-  static let seriesProjectionDidChange = Notification.Name("SeriesProjectionDidChange")
-}
-
 actor ReaderProgressDispatchService {
   static let shared = ReaderProgressDispatchService()
 
@@ -388,11 +383,13 @@ actor ReaderProgressDispatchService {
     guard localPageCacheTokens[update.bookId] == token else { return }
 
     do {
-      try await DatabaseOperator.database().updateReadingProgress(
+      let database = try await DatabaseOperator.database()
+      await database.updateReadingProgress(
         bookId: update.bookId,
         page: update.page,
         completed: update.completed
       )
+      try await database.commit()
     } catch {
       guard localPageCacheTokens[update.bookId] == token else { return }
       localPageCacheTokens.removeValue(forKey: update.bookId)
@@ -407,6 +404,7 @@ actor ReaderProgressDispatchService {
     logger.debug(
       "💾 [Progress/Page] Updated local cache: book=\(update.bookId), version=\(update.version), page=\(update.page), completed=\(update.completed)"
     )
+    await ContentProjectionNotifier.postBookAndSeriesDidChange(bookId: update.bookId)
   }
 
   private func executePageSend(bookId: String, trigger: String, isFlush: Bool) async {
@@ -608,8 +606,7 @@ actor ReaderProgressDispatchService {
       completed: update.completed
     )
     try await database.commit()
-    await Self.postBookProjectionDidChange(bookId: update.bookId)
-    await Self.postSeriesProjectionDidChange(bookId: update.bookId)
+    await ContentProjectionNotifier.postBookAndSeriesDidChange(bookId: update.bookId)
     logger.debug(
       "💾 [Progress/Page] Queued offline sync item: book=\(update.bookId), version=\(update.version), page=\(update.page), completed=\(update.completed)"
     )
@@ -699,8 +696,7 @@ actor ReaderProgressDispatchService {
       } else {
         try? await database.commit()
       }
-      await Self.postBookProjectionDidChange(bookId: update.bookId)
-      await Self.postSeriesProjectionDidChange(bookId: update.bookId)
+      await ContentProjectionNotifier.postBookAndSeriesDidChange(bookId: update.bookId)
     } catch let apiError as APIError {
       if case .badRequest(let message, _, _, _) = apiError,
         message.lowercased().contains("epub extension not found")
@@ -769,33 +765,6 @@ actor ReaderProgressDispatchService {
 
     let nsError = error as NSError
     return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut
-  }
-
-  private nonisolated static func postBookProjectionDidChange(bookId: String) async {
-    await MainActor.run {
-      NotificationCenter.default.post(
-        name: .bookProjectionDidChange,
-        object: nil,
-        userInfo: ["bookId": bookId]
-      )
-    }
-  }
-
-  private nonisolated static func postSeriesProjectionDidChange(bookId: String) async {
-    guard let database = try? await DatabaseOperator.database(),
-      let item = try? await database.fetchBookDisplayItem(
-        bookId: bookId,
-        instanceId: AppConfig.current.instanceId
-      )
-    else { return }
-
-    await MainActor.run {
-      NotificationCenter.default.post(
-        name: .seriesProjectionDidChange,
-        object: nil,
-        userInfo: ["seriesId": item.book.seriesId]
-      )
-    }
   }
 
 }

--- a/KMReader/Features/Series/Views/SeriesContextMenu.swift
+++ b/KMReader/Features/Series/Views/SeriesContextMenu.swift
@@ -242,6 +242,8 @@ struct SeriesContextMenu: View {
     Task {
       do {
         try await SeriesService.markAsRead(seriesId: seriesId)
+        _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
+        await ContentProjectionNotifier.postSeriesDidChange(seriesId: seriesId)
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedRead"))
         onMutationCompleted?()
       } catch {
@@ -254,6 +256,8 @@ struct SeriesContextMenu: View {
     Task {
       do {
         try await SeriesService.markAsUnread(seriesId: seriesId)
+        _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
+        await ContentProjectionNotifier.postSeriesDidChange(seriesId: seriesId)
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedUnread"))
         onMutationCompleted?()
       } catch {

--- a/KMReader/Features/Series/Views/SeriesContextMenu.swift
+++ b/KMReader/Features/Series/Views/SeriesContextMenu.swift
@@ -243,7 +243,8 @@ struct SeriesContextMenu: View {
       do {
         try await SeriesService.markAsRead(seriesId: seriesId)
         _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
-        await ContentProjectionNotifier.postSeriesDidChange(seriesId: seriesId)
+        try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
+        await ContentProjectionNotifier.postSeriesBooksDidChange(seriesId: seriesId)
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedRead"))
         onMutationCompleted?()
       } catch {
@@ -257,7 +258,8 @@ struct SeriesContextMenu: View {
       do {
         try await SeriesService.markAsUnread(seriesId: seriesId)
         _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
-        await ContentProjectionNotifier.postSeriesDidChange(seriesId: seriesId)
+        try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
+        await ContentProjectionNotifier.postSeriesBooksDidChange(seriesId: seriesId)
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedUnread"))
         onMutationCompleted?()
       } catch {

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -232,7 +232,8 @@ extension SeriesDetailView {
       do {
         try await SeriesService.markAsRead(seriesId: seriesId)
         _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
-        await ContentProjectionNotifier.postSeriesDidChange(seriesId: seriesId)
+        try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
+        await ContentProjectionNotifier.postSeriesBooksDidChange(seriesId: seriesId)
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedRead"))
         await refreshSeriesData()
       } catch {
@@ -246,7 +247,8 @@ extension SeriesDetailView {
       do {
         try await SeriesService.markAsUnread(seriesId: seriesId)
         _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
-        await ContentProjectionNotifier.postSeriesDidChange(seriesId: seriesId)
+        try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
+        await ContentProjectionNotifier.postSeriesBooksDidChange(seriesId: seriesId)
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedUnread"))
         await refreshSeriesData()
       } catch {

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -231,6 +231,8 @@ extension SeriesDetailView {
     Task {
       do {
         try await SeriesService.markAsRead(seriesId: seriesId)
+        _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
+        await ContentProjectionNotifier.postSeriesDidChange(seriesId: seriesId)
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedRead"))
         await refreshSeriesData()
       } catch {
@@ -243,6 +245,8 @@ extension SeriesDetailView {
     Task {
       do {
         try await SeriesService.markAsUnread(seriesId: seriesId)
+        _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
+        await ContentProjectionNotifier.postSeriesDidChange(seriesId: seriesId)
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedUnread"))
         await refreshSeriesData()
       } catch {

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -80162,130 +80162,66 @@
         }
       }
     },
-    "Your personal manga and comic reader" : {
+    "Your Komga library, ready to read" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ihr persönlicher Manga- und Comic-Reader"
+            "value" : "Ihre Komga-Bibliothek, bereit zum Lesen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Your personal manga and comic reader"
+            "value" : "Your Komga library, ready to read"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tu lector personal de manga y comics"
+            "value" : "Tu biblioteca Komga, lista para leer"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Votre lecteur personnel de mangas et de BD"
+            "value" : "Votre bibliothèque Komga, prête à lire"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Il tuo lettore personale di manga e fumetti"
+            "value" : "La tua libreria Komga, pronta da leggere"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "あなた専用のマンガ・コミックリーダー"
+            "value" : "Komgaライブラリを、すぐ読める場所に"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "개인 만화 및 코믹 리더"
+            "value" : "Komga 라이브러리를 바로 읽을 수 있게"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ваш персональный ридер манги и комиксов"
+            "value" : "Ваша библиотека Komga всегда готова к чтению"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "你的漫画阅读器"
+            "value" : "你的 Komga 书库，随时开读"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "你的漫畫閱讀器"
-          }
-        }
-      }
-    },
-    "Your personal manga reader" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ihr persönlicher Manga-Reader"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Your personal manga reader"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tu lector personal de manga"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Votre lecteur personnel de mangas"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Il tuo lettore personale di manga"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "あなた専用のマンガリーダー"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개인 만화 리더"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ваш персональный ридер манги"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你的漫画阅读器"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "你的漫畫閱讀器"
+            "value" : "你的 Komga 書庫，隨時開讀"
           }
         }
       }

--- a/KMReader/Shared/Foundation/Models/NavDestination.swift
+++ b/KMReader/Shared/Foundation/Models/NavDestination.swift
@@ -81,13 +81,29 @@ enum NavDestination: Hashable {
         readerPresentation: context.readerPresentation
       )
     case .browseSeries:
-      BrowseView(authViewModel: context.authViewModel, fixedContent: .series)
+      BrowseView(
+        authViewModel: context.authViewModel,
+        readerPresentation: context.readerPresentation,
+        fixedContent: .series
+      )
     case .browseBooks:
-      BrowseView(authViewModel: context.authViewModel, fixedContent: .books)
+      BrowseView(
+        authViewModel: context.authViewModel,
+        readerPresentation: context.readerPresentation,
+        fixedContent: .books
+      )
     case .browseCollections:
-      BrowseView(authViewModel: context.authViewModel, fixedContent: .collections)
+      BrowseView(
+        authViewModel: context.authViewModel,
+        readerPresentation: context.readerPresentation,
+        fixedContent: .collections
+      )
     case .browseReadLists:
-      BrowseView(authViewModel: context.authViewModel, fixedContent: .readlists)
+      BrowseView(
+        authViewModel: context.authViewModel,
+        readerPresentation: context.readerPresentation,
+        fixedContent: .readlists
+      )
     case .offline:
       OfflineView(authViewModel: context.authViewModel)
     case .server:
@@ -97,41 +113,50 @@ enum NavDestination: Hashable {
 
     // NOTE: library selection passed via environment
     case .browseLibrary(_):
-      BrowseView(authViewModel: context.authViewModel)
+      BrowseView(
+        authViewModel: context.authViewModel,
+        readerPresentation: context.readerPresentation
+      )
 
     case .browseSeriesWithPublisher(let publisher):
       BrowseView(
         authViewModel: context.authViewModel,
+        readerPresentation: context.readerPresentation,
         fixedContent: .series,
         metadataFilter: MetadataFilterConfig.forPublisher(publisher)
       )
     case .browseSeriesWithAuthor(let author):
       BrowseView(
         authViewModel: context.authViewModel,
+        readerPresentation: context.readerPresentation,
         fixedContent: .series,
         metadataFilter: MetadataFilterConfig.forAuthors([author])
       )
     case .browseSeriesWithGenre(let genre):
       BrowseView(
         authViewModel: context.authViewModel,
+        readerPresentation: context.readerPresentation,
         fixedContent: .series,
         metadataFilter: MetadataFilterConfig.forGenres([genre])
       )
     case .browseSeriesWithTag(let tag):
       BrowseView(
         authViewModel: context.authViewModel,
+        readerPresentation: context.readerPresentation,
         fixedContent: .series,
         metadataFilter: MetadataFilterConfig.forTags([tag])
       )
     case .browseBooksWithAuthor(let author):
       BrowseView(
         authViewModel: context.authViewModel,
+        readerPresentation: context.readerPresentation,
         fixedContent: .books,
         metadataFilter: MetadataFilterConfig.forAuthors([author])
       )
     case .browseBooksWithTag(let tag):
       BrowseView(
         authViewModel: context.authViewModel,
+        readerPresentation: context.readerPresentation,
         fixedContent: .books,
         metadataFilter: MetadataFilterConfig.forTags([tag])
       )
@@ -143,11 +168,20 @@ enum NavDestination: Hashable {
     case .oneshotDetail(let seriesId):
       OneshotDetailView(seriesId: seriesId)
     case .collectionDetail(let collectionId):
-      CollectionDetailView(collectionId: collectionId)
+      CollectionDetailView(
+        collectionId: collectionId,
+        readerPresentation: context.readerPresentation
+      )
     case .readListDetail(let readListId):
-      ReadListDetailView(readListId: readListId)
+      ReadListDetailView(
+        readListId: readListId,
+        readerPresentation: context.readerPresentation
+      )
     case .dashboardSectionDetail(let section):
-      DashboardSectionDetailView(section: section)
+      DashboardSectionDetailView(
+        section: section,
+        readerPresentation: context.readerPresentation
+      )
 
     case .settingsAppearance:
       SettingsAppearanceView()

--- a/KMReader/Shared/Foundation/Models/TabItem.swift
+++ b/KMReader/Shared/Foundation/Models/TabItem.swift
@@ -65,7 +65,10 @@ enum TabItem: Hashable, Identifiable {
         readerPresentation: context.readerPresentation
       )
     case .browse:
-      BrowseView(authViewModel: context.authViewModel)
+      BrowseView(
+        authViewModel: context.authViewModel,
+        readerPresentation: context.readerPresentation
+      )
     case .offline:
       OfflineView(authViewModel: context.authViewModel)
     case .server:

--- a/KMReader/Shared/Foundation/Services/ContentProjectionNotifier.swift
+++ b/KMReader/Shared/Foundation/Services/ContentProjectionNotifier.swift
@@ -1,0 +1,59 @@
+//
+// ContentProjectionNotifier.swift
+//
+//
+
+import Foundation
+
+extension Notification.Name {
+  static let bookProjectionDidChange = Notification.Name("BookProjectionDidChange")
+  static let seriesProjectionDidChange = Notification.Name("SeriesProjectionDidChange")
+}
+
+nonisolated enum ContentProjectionNotifier {
+  static func postBookDidChange(bookId: String) async {
+    guard !bookId.isEmpty else { return }
+
+    await MainActor.run {
+      NotificationCenter.default.post(
+        name: .bookProjectionDidChange,
+        object: nil,
+        userInfo: ["bookId": bookId]
+      )
+    }
+  }
+
+  static func postSeriesDidChange(seriesId: String) async {
+    guard !seriesId.isEmpty else { return }
+
+    await MainActor.run {
+      NotificationCenter.default.post(
+        name: .seriesProjectionDidChange,
+        object: nil,
+        userInfo: ["seriesId": seriesId]
+      )
+    }
+  }
+
+  static func postBookAndSeriesDidChange(bookId: String, seriesId: String? = nil) async {
+    await postBookDidChange(bookId: bookId)
+
+    if let seriesId {
+      await postSeriesDidChange(seriesId: seriesId)
+    } else {
+      await postSeriesDidChange(forBookId: bookId)
+    }
+  }
+
+  private static func postSeriesDidChange(forBookId bookId: String) async {
+    guard
+      let database = try? await DatabaseOperator.database(),
+      let item = try? await database.fetchBookDisplayItem(
+        bookId: bookId,
+        instanceId: AppConfig.current.instanceId
+      )
+    else { return }
+
+    await postSeriesDidChange(seriesId: item.book.seriesId)
+  }
+}

--- a/KMReader/Shared/Foundation/Services/ContentProjectionNotifier.swift
+++ b/KMReader/Shared/Foundation/Services/ContentProjectionNotifier.swift
@@ -23,6 +23,23 @@ nonisolated enum ContentProjectionNotifier {
     }
   }
 
+  static func postBooksDidChange(bookIds: [String]) async {
+    let ids = Set(bookIds.filter { !$0.isEmpty })
+    guard !ids.isEmpty else { return }
+
+    await MainActor.run {
+      var userInfo: [AnyHashable: Any] = ["bookIds": ids]
+      if ids.count == 1, let bookId = ids.first {
+        userInfo["bookId"] = bookId
+      }
+      NotificationCenter.default.post(
+        name: .bookProjectionDidChange,
+        object: nil,
+        userInfo: userInfo
+      )
+    }
+  }
+
   static func postSeriesDidChange(seriesId: String) async {
     guard !seriesId.isEmpty else { return }
 
@@ -45,6 +62,14 @@ nonisolated enum ContentProjectionNotifier {
     }
   }
 
+  static func postSeriesBooksDidChange(seriesId: String) async {
+    guard !seriesId.isEmpty else { return }
+
+    let bookIds = await fetchSeriesBookIds(seriesId: seriesId)
+    await postBooksDidChange(bookIds: bookIds)
+    await postSeriesDidChange(seriesId: seriesId)
+  }
+
   private static func postSeriesDidChange(forBookId bookId: String) async {
     guard
       let database = try? await DatabaseOperator.database(),
@@ -55,5 +80,28 @@ nonisolated enum ContentProjectionNotifier {
     else { return }
 
     await postSeriesDidChange(seriesId: item.book.seriesId)
+  }
+
+  private static func fetchSeriesBookIds(seriesId: String) async -> [String] {
+    guard let database = try? await DatabaseOperator.database() else { return [] }
+
+    let pageSize = 500
+    var page = 0
+    var ids: [String] = []
+
+    while true {
+      let pageIds = await database.fetchSeriesBookIds(
+        seriesId: seriesId,
+        browseOpts: BookBrowseOptions(),
+        page: page,
+        size: pageSize
+      )
+      ids.append(contentsOf: pageIds)
+
+      guard pageIds.count == pageSize else { break }
+      page += 1
+    }
+
+    return ids
   }
 }

--- a/KMReader/Shared/UI/SplashView.swift
+++ b/KMReader/Shared/UI/SplashView.swift
@@ -95,7 +95,7 @@ struct SplashView: View {
           .opacity(isVisible ? 1.0 : 0.0)
 
         // Tagline
-        Text("Your personal manga reader")
+        Text("Your Komga library, ready to read")
           .font(.subheadline)
           .foregroundStyle(.secondary)
           .tracking(0.5)


### PR DESCRIPTION
## Problem
Reading or marking content could update book and series projections without refreshing the surrounding dashboard detail, browse, read list detail, or collection detail lists. That left read status, filtering, membership-derived ordering, and read-date ordering stale until a manual reload.

The review also caught follow-up gaps around live updates: series read/unread mutations were only notifying series projections, dashboard detail refreshes could be dropped during an active page load, browse pages could reload behind the reader while page progress was still being dispatched, some added/imported SSE events were missed, and page-progress conflicts could write stale local progress.

## Approach
Publish shared book/series projection notifications after reader progress cache updates and manual read-state mutations, including a batched book projection notification for series-level read/unread actions. Dashboard detail, browse, read list detail, and collection detail lists now refresh from local projection events or remote SSE events.

Local projection changes stay responsive, while remote SSE refreshes keep the dashboard-style debounce window for batched server updates. Views that can remain alive behind the reader defer projection-triggered refreshes until the reader closes and progress dispatch has settled. Page-progress 409 conflicts now refresh the authoritative server book projection instead of committing the rejected local page.

## Scope
- Refresh dashboard section detail pages when read-progress related projections change
- Refresh browse pages for book and series read-state changes, deferred while the reader is open
- Refresh read list book lists and collection series lists from projection/SSE events
- Cover added/imported book and added series SSE events in live browse/detail refreshes
- Queue dashboard detail refreshes that arrive during active pagination loads
- Batch affected book projection notifications for series read/unread mutations
- Keep the splash and landing slogan update as incidental copy cleanup
- Bump build version to 466

## Validation
- [x] make build
- [x] make build-macos
- [x] make localize
- [x] ./misc/translate.py list
- [x] git diff --check
