### PR TITLE
fix: show read status for one-shot series

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 466;
+				CURRENT_PROJECT_VERSION = 467;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 466;
+				CURRENT_PROJECT_VERSION = 467;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 466;
+				CURRENT_PROJECT_VERSION = 467;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 466;
+				CURRENT_PROJECT_VERSION = 467;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Series/Models/KomgaSeries.swift
+++ b/KMReader/Features/Series/Models/KomgaSeries.swift
@@ -55,6 +55,14 @@ extension KomgaSeries {
     !hasStartedReading
   }
 
+  var readStatus: ReadStatus {
+    ReadStatus.fromSeriesCounts(
+      booksCount: booksCount,
+      booksReadCount: booksReadCount,
+      booksInProgressCount: booksInProgressCount
+    )
+  }
+
   /// Computed property for offline policy.
   var offlinePolicy: SeriesOfflinePolicy {
     get {

--- a/KMReader/Features/Series/Models/Series+Extensions.swift
+++ b/KMReader/Features/Series/Models/Series+Extensions.swift
@@ -40,19 +40,37 @@ extension Series {
     }
   }
 
+  var readStatus: ReadStatus {
+    if booksCount > 0 && booksReadCount == booksCount {
+      return .read
+    }
+    if booksReadCount > 0 || booksInProgressCount > 0 {
+      return .inProgress
+    }
+    return .unread
+  }
+
+  var readStatusDisplayName: String {
+    readStatus.displayName
+  }
+
+  var readStatusIcon: String {
+    switch readStatus {
+    case .read: return "checkmark.circle.fill"
+    case .inProgress: return "circle.righthalf.filled"
+    case .unread: return "circle"
+    }
+  }
+
   var lastUpdatedDisplay: String {
     lastModified.formatted(date: .abbreviated, time: .omitted)
   }
 
   var readStatusColor: Color {
-    if booksCount == 0 {
-      return .secondary
-    } else if booksReadCount == booksCount {
-      return .green
-    } else if booksReadCount > 0 {
-      return .blue
-    } else {
-      return .secondary
+    switch readStatus {
+    case .read: return .green
+    case .inProgress: return .blue
+    case .unread: return .secondary
     }
   }
 }

--- a/KMReader/Features/Series/Models/Series+Extensions.swift
+++ b/KMReader/Features/Series/Models/Series+Extensions.swift
@@ -41,13 +41,11 @@ extension Series {
   }
 
   var readStatus: ReadStatus {
-    if booksCount > 0 && booksReadCount == booksCount {
-      return .read
-    }
-    if booksReadCount > 0 || booksInProgressCount > 0 {
-      return .inProgress
-    }
-    return .unread
+    ReadStatus.fromSeriesCounts(
+      booksCount: booksCount,
+      booksReadCount: booksReadCount,
+      booksInProgressCount: booksInProgressCount
+    )
   }
 
   var readStatusDisplayName: String {

--- a/KMReader/Features/Series/Services/KomgaSeriesStore.swift
+++ b/KMReader/Features/Series/Services/KomgaSeriesStore.swift
@@ -168,14 +168,7 @@ enum KomgaSeriesStore {
         }
 
         // Filter by Read Status
-        let status: ReadStatus
-        if series.booksReadCount == series.booksCount && series.booksCount > 0 {
-          status = .read
-        } else if series.booksReadCount > 0 {
-          status = .inProgress
-        } else {
-          status = .unread
-        }
+        let status = series.readStatus
 
         if !browseOpts.includeReadStatuses.isEmpty {
           if !browseOpts.includeReadStatuses.contains(status) { return false }
@@ -342,14 +335,7 @@ enum KomgaSeriesStore {
       }
 
       // Filter by Read Status
-      let status: ReadStatus
-      if series.booksReadCount == series.booksCount && series.booksCount > 0 {
-        status = .read
-      } else if series.booksReadCount > 0 {
-        status = .inProgress
-      } else {
-        status = .unread
-      }
+      let status = series.readStatus
 
       if !browseOpts.includeReadStatuses.isEmpty {
         if !browseOpts.includeReadStatuses.contains(status) { return false }

--- a/KMReader/Features/Series/Views/SeriesCardView.swift
+++ b/KMReader/Features/Series/Views/SeriesCardView.swift
@@ -96,8 +96,8 @@ struct SeriesCardView: View {
               Text("Unavailable")
                 .foregroundColor(.red)
             } else if item.oneshot {
-              Text("Oneshot")
-                .foregroundColor(.blue)
+              Label(item.series.readStatusDisplayName, systemImage: item.series.readStatusIcon)
+                .foregroundColor(item.series.readStatusColor)
             } else {
               if progress > 0 && progress < 1 {
                 Text("\(progress * 100, specifier: "%.0f")%")
@@ -156,8 +156,8 @@ struct SeriesCardView: View {
           Text("Unavailable")
             .foregroundColor(.red)
         } else if item.oneshot {
-          Text("Oneshot")
-            .foregroundColor(.blue)
+          Label(item.series.readStatusDisplayName, systemImage: item.series.readStatusIcon)
+            .foregroundColor(item.series.readStatusColor)
         } else {
           if progress > 0 && progress < 1 {
             Text("\(progress * 100, specifier: "%.0f")%")

--- a/KMReader/Features/Series/Views/SeriesRowView.swift
+++ b/KMReader/Features/Series/Views/SeriesRowView.swift
@@ -62,9 +62,15 @@ struct SeriesRowView: View {
 
         HStack {
           VStack(alignment: .leading, spacing: 4) {
-            Label(series.statusDisplayName, systemImage: series.statusIcon)
-              .font(.footnote)
-              .foregroundColor(series.statusColor)
+            if series.oneshot {
+              Label(series.readStatusDisplayName, systemImage: series.readStatusIcon)
+                .font(.footnote)
+                .foregroundColor(series.readStatusColor)
+            } else {
+              Label(series.statusDisplayName, systemImage: series.statusIcon)
+                .font(.footnote)
+                .foregroundColor(series.statusColor)
+            }
 
             if let releaseDate = series.booksMetadata.releaseDate {
               Label("Release: \(releaseDate)", systemImage: "calendar")

--- a/KMReader/Shared/Foundation/Models/ReadStatusSelectionHelper.swift
+++ b/KMReader/Shared/Foundation/Models/ReadStatusSelectionHelper.swift
@@ -10,6 +10,20 @@ enum ReadStatus: String, Codable, CaseIterable, Sendable {
   case inProgress = "IN_PROGRESS"
   case read = "READ"
 
+  nonisolated static func fromSeriesCounts(
+    booksCount: Int,
+    booksReadCount: Int,
+    booksInProgressCount: Int
+  ) -> ReadStatus {
+    if booksCount > 0 && booksReadCount == booksCount {
+      return .read
+    }
+    if booksReadCount > 0 || booksInProgressCount > 0 {
+      return .inProgress
+    }
+    return .unread
+  }
+
   var displayName: String {
     switch self {
     case .read: return String(localized: "readStatus.read")


### PR DESCRIPTION
## Problem
One-shot series always showed the lifecycle status such as Ended in the primary status line, while the read state was hidden behind a generic Oneshot label. That made read and unread one-shots look the same in Browse.

## Approach
Use the series aggregate read state for one-shot entries in row and card layouts, while keeping normal series on the existing lifecycle status display. The read-state label reuses the existing readStatus localizations and icons.

## Scope
- Show Read, In Progress, or Unread for one-shot series rows
- Apply the same status display to series cards and card text overlays
- Bump build version to 467

Refs #865

## Validation
- make format
- git diff --check
- make build
