### PR TITLE
fix: keep one-shot read summary placement

### DIFF
--- a/KMReader/Features/Series/Views/SeriesCardView.swift
+++ b/KMReader/Features/Series/Views/SeriesCardView.swift
@@ -95,9 +95,6 @@ struct SeriesCardView: View {
             if item.isUnavailable {
               Text("Unavailable")
                 .foregroundColor(.red)
-            } else if item.oneshot {
-              Label(item.series.readStatusDisplayName, systemImage: item.series.readStatusIcon)
-                .foregroundColor(item.series.readStatusColor)
             } else {
               if progress > 0 && progress < 1 {
                 Text("\(progress * 100, specifier: "%.0f")%")
@@ -155,9 +152,6 @@ struct SeriesCardView: View {
         if item.isUnavailable {
           Text("Unavailable")
             .foregroundColor(.red)
-        } else if item.oneshot {
-          Label(item.series.readStatusDisplayName, systemImage: item.series.readStatusIcon)
-            .foregroundColor(item.series.readStatusColor)
         } else {
           if progress > 0 && progress < 1 {
             Text("\(progress * 100, specifier: "%.0f")%")

--- a/KMReader/Features/Series/Views/SeriesRowView.swift
+++ b/KMReader/Features/Series/Views/SeriesRowView.swift
@@ -63,9 +63,9 @@ struct SeriesRowView: View {
         HStack {
           VStack(alignment: .leading, spacing: 4) {
             if series.oneshot {
-              Label(series.readStatusDisplayName, systemImage: series.readStatusIcon)
+              Label("Oneshot", systemImage: "book.closed")
                 .font(.footnote)
-                .foregroundColor(series.readStatusColor)
+                .foregroundColor(.blue)
             } else {
               Label(series.statusDisplayName, systemImage: series.statusIcon)
                 .font(.footnote)
@@ -86,25 +86,8 @@ struct SeriesRowView: View {
               if series.deleted {
                 Text("Unavailable")
                   .foregroundColor(.red)
-              } else if series.oneshot {
-                Text("Oneshot")
-                  .foregroundColor(.blue)
               } else {
-                HStack(spacing: 4) {
-                  Label("\(series.booksCount) books", systemImage: ContentIcon.book)
-                  Text("•")
-                  if series.booksUnreadCount > 0 {
-                    Image(systemName: "circle.righthalf.filled")
-                      .foregroundColor(series.readStatusColor)
-                    Text("\(series.booksUnreadCount) unread")
-                      .foregroundColor(series.readStatusColor)
-                    Text("•")
-                    Text("\(progress * 100, specifier: "%.0f")%")
-                  } else {
-                    Label("All read", systemImage: "checkmark.circle.fill")
-                      .foregroundColor(series.readStatusColor)
-                  }
-                }
+                readingProgressSummary
               }
             }
             .font(.footnote)
@@ -161,6 +144,34 @@ struct SeriesRowView: View {
     }
     .sheet(isPresented: $showEditSheet) {
       SeriesEditSheet(series: series)
+    }
+  }
+
+  @ViewBuilder
+  private var readingProgressSummary: some View {
+    HStack(spacing: 4) {
+      Label("\(series.booksCount) books", systemImage: ContentIcon.book)
+      Text("•")
+
+      switch series.readStatus {
+      case .read:
+        Label("All read", systemImage: series.readStatusIcon)
+          .foregroundColor(series.readStatusColor)
+      case .inProgress:
+        Image(systemName: series.readStatusIcon)
+          .foregroundColor(series.readStatusColor)
+        Text(series.booksUnreadCount > 0 ? "\(series.booksUnreadCount) unread" : series.readStatusDisplayName)
+          .foregroundColor(series.readStatusColor)
+        Text("•")
+        Text("\(progress * 100, specifier: "%.0f")%")
+      case .unread:
+        Image(systemName: "circle.righthalf.filled")
+          .foregroundColor(series.readStatusColor)
+        Text("\(series.booksUnreadCount) unread")
+          .foregroundColor(series.readStatusColor)
+        Text("•")
+        Text("\(progress * 100, specifier: "%.0f")%")
+      }
     }
   }
 


### PR DESCRIPTION
## Problem
The previous one-shot status fix moved read state into the primary series status row. That made the one-shot type replace the wrong piece of information: one-shots should replace lifecycle status such as Ongoing or Ended, while read progress should stay in the normal series summary row.

## Approach
Show Oneshot in the lifecycle/status row for one-shot series, and let one-shot rows reuse the same books, unread count, progress, and all-read summary used by normal series. Card summaries also return to the normal series progress/books placement.

## Scope
- Adjust one-shot series row status placement
- Keep read progress summary in the normal series summary row
- Restore series card and overlay summaries to the shared progress/books display

Refs #865
Follow-up to #866

## Validation
- make format
- git diff --check
- make build
