### PR TITLE
fix: refresh offline download status in lists

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 467;
+				CURRENT_PROJECT_VERSION = 468;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -496,7 +496,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 467;
+				CURRENT_PROJECT_VERSION = 468;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -556,7 +556,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 467;
+				CURRENT_PROJECT_VERSION = 468;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -590,7 +590,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 467;
+				CURRENT_PROJECT_VERSION = 468;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -348,6 +348,7 @@ actor OfflineManager {
         downloadAt: .now
       )
       try? await DatabaseOperator.database().commit()
+      await postDownloadProjectionDidChange(bookId: info.bookId, instanceId: instanceId)
       await refreshQueueStatus(instanceId: instanceId)
       await syncDownloadQueue(instanceId: instanceId)
     }
@@ -361,6 +362,7 @@ actor OfflineManager {
       downloadAt: .now
     )
     try? await DatabaseOperator.database().commit()
+    await postDownloadProjectionDidChange(bookId: bookId, instanceId: instanceId)
     await refreshQueueStatus(instanceId: instanceId)
     await syncDownloadQueue(instanceId: instanceId)
   }
@@ -380,6 +382,7 @@ actor OfflineManager {
         downloadAt: .now
       )
       try? await DatabaseOperator.database().commit()
+      await postDownloadProjectionDidChange(bookId: info.bookId, instanceId: instanceId)
     case .pending:
       break
     }
@@ -403,6 +406,7 @@ actor OfflineManager {
     )
     if commit {
       try? await DatabaseOperator.database().commit()
+      await postDownloadProjectionDidChange(bookId: bookId, instanceId: instanceId)
       await refreshQueueStatus(instanceId: instanceId)
     }
 
@@ -452,6 +456,7 @@ actor OfflineManager {
     try? await DatabaseOperator.database().syncReadListsContainingBooks(
       bookIds: bookIds, instanceId: instanceId)
     try? await DatabaseOperator.database().commit()
+    await postDownloadProjectionsDidChange(bookIds: bookIds, instanceId: instanceId)
     await refreshQueueStatus(instanceId: instanceId)
   }
 
@@ -485,6 +490,10 @@ actor OfflineManager {
     try? await DatabaseOperator.database().syncReadListsContainingBooks(
       bookIds: books.map { $0.id }, instanceId: instanceId)
     try? await DatabaseOperator.database().commit()
+    await postDownloadProjectionsDidChange(
+      bookIds: books.map { $0.id },
+      instanceId: instanceId
+    )
     await refreshQueueStatus(instanceId: instanceId)
 
     #if os(iOS) || os(macOS)
@@ -526,6 +535,10 @@ actor OfflineManager {
     try? await DatabaseOperator.database().syncReadListsContainingBooks(
       bookIds: readBooks.map { $0.id }, instanceId: instanceId)
     try? await DatabaseOperator.database().commit()
+    await postDownloadProjectionsDidChange(
+      bookIds: readBooks.map { $0.id },
+      instanceId: instanceId
+    )
     await refreshQueueStatus(instanceId: instanceId)
   }
 
@@ -593,6 +606,7 @@ actor OfflineManager {
     )
     if commit {
       try? await DatabaseOperator.database().commit()
+      await postDownloadProjectionDidChange(bookId: bookId, instanceId: resolvedInstanceId)
       await refreshQueueStatus(instanceId: resolvedInstanceId)
     }
   }
@@ -609,6 +623,7 @@ actor OfflineManager {
       try? await DatabaseOperator.database().commit()
     }
     activeTasks.removeAll()
+    await postDownloadProjectionsDidChange(bookIds: bookIds, instanceId: instanceId)
     await MainActor.run {
       for bookId in bookIds {
         DownloadProgressTracker.shared.clearProgress(bookId: bookId)
@@ -622,15 +637,25 @@ actor OfflineManager {
   }
 
   func retryFailedDownloads(instanceId: String) async {
+    let failedBookIds =
+      ((try? await DatabaseOperator.database().fetchOfflineTaskItems(instanceId: instanceId)) ?? [])
+      .filter { $0.isFailed }
+      .map(\.bookId)
     try? await DatabaseOperator.database().retryFailedBooks(instanceId: instanceId)
     try? await DatabaseOperator.database().commit()
+    await postDownloadProjectionsDidChange(bookIds: failedBookIds, instanceId: instanceId)
     await refreshQueueStatus(instanceId: instanceId)
     await syncDownloadQueue(instanceId: instanceId)
   }
 
   func cancelFailedDownloads(instanceId: String) async {
+    let failedBookIds =
+      ((try? await DatabaseOperator.database().fetchOfflineTaskItems(instanceId: instanceId)) ?? [])
+      .filter { $0.isFailed }
+      .map(\.bookId)
     try? await DatabaseOperator.database().cancelFailedBooks(instanceId: instanceId)
     try? await DatabaseOperator.database().commit()
+    await postDownloadProjectionsDidChange(bookIds: failedBookIds, instanceId: instanceId)
     await refreshQueueStatus(instanceId: instanceId)
   }
 
@@ -957,6 +982,7 @@ actor OfflineManager {
           status: .failed(error: error.localizedDescription)
         )
         try? await DatabaseOperator.database().commit()
+        await postDownloadProjectionDidChange(bookId: info.bookId, instanceId: instanceId)
         await refreshQueueStatus(instanceId: instanceId)
         await syncDownloadQueue(instanceId: instanceId)
       }
@@ -1316,6 +1342,7 @@ actor OfflineManager {
               status: .failed(error: error.localizedDescription)
             )
             try? await DatabaseOperator.database().commit()
+            await self.postDownloadProjectionDidChange(bookId: info.bookId, instanceId: instanceId)
             await self.refreshQueueStatus(instanceId: instanceId)
           }
         }
@@ -1411,6 +1438,7 @@ actor OfflineManager {
       downloadedSize: size
     )
     try? await DatabaseOperator.database().commit()
+    await postDownloadProjectionDidChange(bookId: bookId, instanceId: instanceId)
   }
 
   func readOfflinePDFPreparationStamp(instanceId: String, bookId: String) async -> String? {
@@ -1582,6 +1610,20 @@ actor OfflineManager {
         failed: summary.failedCount
       )
     }
+  }
+
+  private func postDownloadProjectionDidChange(bookId: String, instanceId: String) async {
+    await ContentProjectionNotifier.postBookAndSeriesDidChange(
+      bookId: bookId,
+      instanceId: instanceId
+    )
+  }
+
+  private func postDownloadProjectionsDidChange(bookIds: [String], instanceId: String) async {
+    await ContentProjectionNotifier.postBooksAndSeriesDidChange(
+      bookIds: bookIds,
+      instanceId: instanceId
+    )
   }
 
   private func removeBookAfterPermanentNotFound(bookId: String, instanceId: String) async {
@@ -1934,6 +1976,7 @@ actor OfflineManager {
         status: .failed(error: error.localizedDescription)
       )
       try? await DatabaseOperator.database().commit()
+      await postDownloadProjectionDidChange(bookId: bookId, instanceId: info.instanceId)
       await refreshQueueStatus(instanceId: info.instanceId)
 
       // Cancel remaining downloads for this book
@@ -2044,6 +2087,7 @@ actor OfflineManager {
           try? await DatabaseOperator.database().updateBookDownloadStatus(
             bookId: bookId, instanceId: info.instanceId, status: .failed(error: message))
           try? await DatabaseOperator.database().commit()
+          await postDownloadProjectionDidChange(bookId: bookId, instanceId: info.instanceId)
           clearBackgroundDownloadContext(bookId: bookId)
           removeActiveTask(bookId)
           await refreshQueueStatus(instanceId: info.instanceId)
@@ -2081,6 +2125,7 @@ actor OfflineManager {
           try? await DatabaseOperator.database().updateBookDownloadStatus(
             bookId: bookId, instanceId: info.instanceId, status: .failed(error: message))
           try? await DatabaseOperator.database().commit()
+          await postDownloadProjectionDidChange(bookId: bookId, instanceId: info.instanceId)
           clearBackgroundDownloadContext(bookId: bookId)
           removeActiveTask(bookId)
           await refreshQueueStatus(instanceId: info.instanceId)
@@ -2118,6 +2163,7 @@ actor OfflineManager {
             status: .failed(error: "Offline EPUB download is incomplete. Please retry downloading this book.")
           )
           try? await DatabaseOperator.database().commit()
+          await postDownloadProjectionDidChange(bookId: bookId, instanceId: info.instanceId)
           clearBackgroundDownloadContext(bookId: bookId)
           removeActiveTask(bookId)
           await refreshQueueStatus(instanceId: info.instanceId)
@@ -2809,6 +2855,7 @@ actor OfflineManager {
       downloadAt: .now
     )
     try? await DatabaseOperator.database().commit()
+    await postDownloadProjectionDidChange(bookId: bookId, instanceId: instanceId)
     await refreshQueueStatus(instanceId: instanceId)
     await clearCachesAfterDownload(bookId: bookId)
     completedDownloadsSinceLastNotification += 1

--- a/KMReader/Shared/Foundation/Services/ContentProjectionNotifier.swift
+++ b/KMReader/Shared/Foundation/Services/ContentProjectionNotifier.swift
@@ -53,12 +53,35 @@ nonisolated enum ContentProjectionNotifier {
   }
 
   static func postBookAndSeriesDidChange(bookId: String, seriesId: String? = nil) async {
+    await postBookAndSeriesDidChange(
+      bookId: bookId,
+      instanceId: AppConfig.current.instanceId,
+      seriesId: seriesId
+    )
+  }
+
+  static func postBookAndSeriesDidChange(
+    bookId: String,
+    instanceId: String,
+    seriesId: String? = nil
+  ) async {
     await postBookDidChange(bookId: bookId)
 
     if let seriesId {
       await postSeriesDidChange(seriesId: seriesId)
     } else {
-      await postSeriesDidChange(forBookId: bookId)
+      await postSeriesDidChange(forBookId: bookId, instanceId: instanceId)
+    }
+  }
+
+  static func postBooksAndSeriesDidChange(bookIds: [String], instanceId: String) async {
+    let ids = Set(bookIds.filter { !$0.isEmpty })
+    guard !ids.isEmpty else { return }
+
+    await postBooksDidChange(bookIds: Array(ids))
+    let seriesIds = await fetchSeriesIds(forBookIds: Array(ids), instanceId: instanceId)
+    for seriesId in seriesIds {
+      await postSeriesDidChange(seriesId: seriesId)
     }
   }
 
@@ -70,16 +93,37 @@ nonisolated enum ContentProjectionNotifier {
     await postSeriesDidChange(seriesId: seriesId)
   }
 
-  private static func postSeriesDidChange(forBookId bookId: String) async {
+  private static func postSeriesDidChange(forBookId bookId: String, instanceId: String) async {
+    guard let seriesId = await fetchSeriesId(forBookId: bookId, instanceId: instanceId) else {
+      return
+    }
+
+    await postSeriesDidChange(seriesId: seriesId)
+  }
+
+  private static func fetchSeriesId(forBookId bookId: String, instanceId: String) async -> String? {
     guard
       let database = try? await DatabaseOperator.database(),
       let item = try? await database.fetchBookDisplayItem(
         bookId: bookId,
-        instanceId: AppConfig.current.instanceId
+        instanceId: instanceId
       )
-    else { return }
+    else { return nil }
 
-    await postSeriesDidChange(seriesId: item.book.seriesId)
+    return item.book.seriesId
+  }
+
+  private static func fetchSeriesIds(forBookIds bookIds: [String], instanceId: String) async
+    -> Set<String>
+  {
+    var seriesIds = Set<String>()
+    for bookId in Set(bookIds) {
+      if let seriesId = await fetchSeriesId(forBookId: bookId, instanceId: instanceId) {
+        seriesIds.insert(seriesId)
+      }
+    }
+
+    return seriesIds
   }
 
   private static func fetchSeriesBookIds(seriesId: String) async -> [String] {


### PR DESCRIPTION
## Problem
Offline book rows on the dashboard and browse surfaces could stay stuck at the queued state after the background or foreground download finished. The persisted `downloadStatus` changed, but the DTO projection views were not invalidated after OfflineManager committed the status update.

## Approach
Route offline download status commits through the existing content projection notification path. OfflineManager now posts book and series projection changes after queued, completed, failed, retried, canceled, and removed download states are committed. Batch paths use a grouped notification so large offline cleanup operations do not trigger one full refresh per book.

## Scope
- Add instance-aware book/series projection invalidation helpers.
- Notify projection consumers after offline download status transitions.
- Bump build version to 468.

## Validation
- [x] `make build`
