### PR TITLE
fix: use locale-aware percent formatting

### DIFF
--- a/KMReader/Core/Storage/DatabaseOperator+Books.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Books.swift
@@ -36,33 +36,34 @@ extension DatabaseOperator {
   ) -> [String] {
     guard !instanceId.isEmpty else { return [] }
     guard limit > 0 else { return [] }
-    return (try? read { db in
-      var sql = """
-        SELECT book_id
-        FROM \(KomgaBook.databaseTableName)
-        WHERE instance_id = ?
-        """
-      var arguments: StatementArguments = [instanceId]
+    return
+      (try? read { db in
+        var sql = """
+          SELECT book_id
+          FROM \(KomgaBook.databaseTableName)
+          WHERE instance_id = ?
+          """
+        var arguments: StatementArguments = [instanceId]
 
-      Self.appendSQLInFilter(
-        column: "library_id",
-        values: libraryIds ?? [],
-        sql: &sql,
-        arguments: &arguments
-      )
-      Self.appendBookBrowseSQLFilters(
-        searchText: searchText,
-        browseOpts: browseOpts,
-        offlineOnly: offlineOnly,
-        sql: &sql,
-        arguments: &arguments
-      )
-      sql += "\nORDER BY \(Self.bookBrowseOrderSQL(sort: browseOpts.sortString))"
-      sql += "\nLIMIT ? OFFSET ?"
-      arguments += StatementArguments([limit, max(0, offset)])
+        Self.appendSQLInFilter(
+          column: "library_id",
+          values: libraryIds ?? [],
+          sql: &sql,
+          arguments: &arguments
+        )
+        Self.appendBookBrowseSQLFilters(
+          searchText: searchText,
+          browseOpts: browseOpts,
+          offlineOnly: offlineOnly,
+          sql: &sql,
+          arguments: &arguments
+        )
+        sql += "\nORDER BY \(Self.bookBrowseOrderSQL(sort: browseOpts.sortString))"
+        sql += "\nLIMIT ? OFFSET ?"
+        arguments += StatementArguments([limit, max(0, offset)])
 
-      return try String.fetchAll(db, sql: sql, arguments: arguments)
-    }) ?? []
+        return try String.fetchAll(db, sql: sql, arguments: arguments)
+      }) ?? []
   }
 
   func fetchSeriesBookIds(
@@ -72,19 +73,20 @@ extension DatabaseOperator {
     size: Int
   ) -> [String] {
     let instanceId = AppConfig.current.instanceId
-    return (try? read { db in
-      let books = try fetchBooks(db: db, instanceId: instanceId, seriesId: seriesId)
-      return Self.paginate(
-        Self.filteredBrowseBooks(
-          books,
-          libraryIds: nil,
-          searchText: "",
-          browseOpts: browseOpts
-        ),
-        offset: page * size,
-        limit: size
-      ).map(\.bookId)
-    }) ?? []
+    return
+      (try? read { db in
+        let books = try fetchBooks(db: db, instanceId: instanceId, seriesId: seriesId)
+        return Self.paginate(
+          Self.filteredBrowseBooks(
+            books,
+            libraryIds: nil,
+            searchText: "",
+            browseOpts: browseOpts
+          ),
+          offset: page * size,
+          limit: size
+        ).map(\.bookId)
+      }) ?? []
   }
 
   func fetchReadListBookIds(
@@ -94,14 +96,15 @@ extension DatabaseOperator {
     size: Int
   ) -> [String] {
     let instanceId = AppConfig.current.instanceId
-    return (try? read { db in
-      guard let readList = try fetchReadListRecord(db: db, id: readListId, instanceId: instanceId) else {
-        return []
-      }
-      let books = try fetchBooksByIds(db: db, ids: readList.bookIds, instanceId: instanceId)
-      let filtered = books.filter { Self.matchesBook($0, readListBrowseOpts: browseOpts) }
-      return Self.paginate(filtered, offset: page * size, limit: size).map(\.bookId)
-    }) ?? []
+    return
+      (try? read { db in
+        guard let readList = try fetchReadListRecord(db: db, id: readListId, instanceId: instanceId) else {
+          return []
+        }
+        let books = try fetchBooksByIds(db: db, ids: readList.bookIds, instanceId: instanceId)
+        let filtered = books.filter { Self.matchesBook($0, readListBrowseOpts: browseOpts) }
+        return Self.paginate(filtered, offset: page * size, limit: size).map(\.bookId)
+      }) ?? []
   }
 
   func fetchDashboardOfflineBookIds(
@@ -112,40 +115,41 @@ extension DatabaseOperator {
   ) -> [String] {
     guard limit > 0 else { return [] }
     let instanceId = AppConfig.current.instanceId
-    return (try? read { db in
-      var sql = """
-        SELECT book_id
-        FROM \(KomgaBook.databaseTableName)
-        WHERE instance_id = ?
-        """
-      var arguments: StatementArguments = [instanceId]
+    return
+      (try? read { db in
+        var sql = """
+          SELECT book_id
+          FROM \(KomgaBook.databaseTableName)
+          WHERE instance_id = ?
+          """
+        var arguments: StatementArguments = [instanceId]
 
-      if !libraryIds.isEmpty {
-        let placeholders = Array(repeating: "?", count: libraryIds.count).joined(separator: ", ")
-        sql += "\nAND library_id IN (\(placeholders))"
-        arguments += StatementArguments(libraryIds)
-      }
+        if !libraryIds.isEmpty {
+          let placeholders = Array(repeating: "?", count: libraryIds.count).joined(separator: ", ")
+          sql += "\nAND library_id IN (\(placeholders))"
+          arguments += StatementArguments(libraryIds)
+        }
 
-      switch section {
-      case .keepReading:
-        sql += "\nAND progress_read_date IS NOT NULL AND progress_completed = 0"
-        sql += "\nORDER BY progress_read_date DESC, id ASC"
-      case .recentlyReadBooks:
-        sql += "\nAND progress_read_date IS NOT NULL AND progress_completed = 1"
-        sql += "\nORDER BY progress_read_date DESC, id ASC"
-      case .recentlyReleasedBooks:
-        sql += "\nORDER BY COALESCE(meta_release_date, '') DESC, id ASC"
-      case .recentlyAddedBooks:
-        sql += "\nORDER BY created DESC, id ASC"
-      default:
-        return []
-      }
+        switch section {
+        case .keepReading:
+          sql += "\nAND progress_read_date IS NOT NULL AND progress_completed = 0"
+          sql += "\nORDER BY progress_read_date DESC, id ASC"
+        case .recentlyReadBooks:
+          sql += "\nAND progress_read_date IS NOT NULL AND progress_completed = 1"
+          sql += "\nORDER BY progress_read_date DESC, id ASC"
+        case .recentlyReleasedBooks:
+          sql += "\nORDER BY COALESCE(meta_release_date, '') DESC, id ASC"
+        case .recentlyAddedBooks:
+          sql += "\nORDER BY created DESC, id ASC"
+        default:
+          return []
+        }
 
-      sql += "\nLIMIT ? OFFSET ?"
-      arguments += StatementArguments([limit, max(0, offset)])
+        sql += "\nLIMIT ? OFFSET ?"
+        arguments += StatementArguments([limit, max(0, offset)])
 
-      return try String.fetchAll(db, sql: sql, arguments: arguments)
-    }) ?? []
+        return try String.fetchAll(db, sql: sql, arguments: arguments)
+      }) ?? []
   }
 
   func fetchOfflineContinueReadingBook(seriesId: String, instanceId: String) -> Book? {
@@ -237,26 +241,28 @@ extension DatabaseOperator {
         let existingById = Dictionary(uniqueKeysWithValues: existingBooks.map { ($0.bookId, $0) })
 
         for book in books {
-          var record = existingById[book.id] ?? KomgaBook(
-            id: CompositeID.generate(instanceId: instanceId, id: book.id),
-            bookId: book.id,
-            seriesId: book.seriesId,
-            libraryId: book.libraryId,
-            instanceId: instanceId,
-            name: book.name,
-            url: book.url,
-            number: book.number,
-            created: book.created,
-            lastModified: book.lastModified,
-            sizeBytes: book.sizeBytes,
-            size: book.size,
-            media: book.media,
-            metadata: book.metadata,
-            readProgress: book.readProgress,
-            isUnavailable: book.deleted,
-            oneshot: book.oneshot,
-            seriesTitle: book.seriesTitle
-          )
+          var record =
+            existingById[book.id]
+            ?? KomgaBook(
+              id: CompositeID.generate(instanceId: instanceId, id: book.id),
+              bookId: book.id,
+              seriesId: book.seriesId,
+              libraryId: book.libraryId,
+              instanceId: instanceId,
+              name: book.name,
+              url: book.url,
+              number: book.number,
+              created: book.created,
+              lastModified: book.lastModified,
+              sizeBytes: book.sizeBytes,
+              size: book.size,
+              media: book.media,
+              metadata: book.metadata,
+              readProgress: book.readProgress,
+              isUnavailable: book.deleted,
+              oneshot: book.oneshot,
+              seriesTitle: book.seriesTitle
+            )
           applyBook(dto: book, to: &record)
           try save(record, db: db)
         }
@@ -350,7 +356,8 @@ extension DatabaseOperator {
       var lastScannedId: String?
 
       while true {
-        var request = KomgaBook
+        var request =
+          KomgaBook
           .filter(KomgaBook.Columns.instanceId == instanceId)
           .order(KomgaBook.Columns.id)
           .limit(Self.recordFetchChunkSize)
@@ -388,7 +395,8 @@ extension DatabaseOperator {
       if let readListId {
         books = try fetchReadListBooks(db: db, readListId: readListId, instanceId: instanceId, page: 0, size: 1000)
       } else {
-        books = try fetchSeriesBooks(db: db, seriesId: currentBook.seriesId, instanceId: instanceId, page: 0, size: 1000)
+        books = try fetchSeriesBooks(
+          db: db, seriesId: currentBook.seriesId, instanceId: instanceId, page: 0, size: 1000)
       }
       guard let currentIndex = books.firstIndex(where: { $0.id == bookId }),
         currentIndex < books.count - 1
@@ -408,7 +416,8 @@ extension DatabaseOperator {
       if let readListId {
         books = try fetchReadListBooks(db: db, readListId: readListId, instanceId: instanceId, page: 0, size: 1000)
       } else {
-        books = try fetchSeriesBooks(db: db, seriesId: currentBook.seriesId, instanceId: instanceId, page: 0, size: 1000)
+        books = try fetchSeriesBooks(
+          db: db, seriesId: currentBook.seriesId, instanceId: instanceId, page: 0, size: 1000)
       }
       guard let currentIndex = books.firstIndex(where: { $0.id == bookId }), currentIndex > 0 else {
         return nil
@@ -843,7 +852,8 @@ extension DatabaseOperator {
   nonisolated static func bookBrowseOrderSQL(sort: String) -> String {
     let direction = sort.contains("desc") ? "DESC" : "ASC"
     if sort.contains("series") && sort.contains("metadata.numberSort") {
-      return "COALESCE(NULLIF(series_title, ''), series_id) \(direction), meta_number_sort \(direction), name \(direction), id ASC"
+      return
+        "COALESCE(NULLIF(series_title, ''), series_id) \(direction), meta_number_sort \(direction), name \(direction), id ASC"
     }
     if sort.contains("createdDate") {
       return "created \(direction), id ASC"
@@ -878,13 +888,25 @@ extension DatabaseOperator {
       return books.sorted { isAsc ? $0.created < $1.created : $0.created > $1.created }
     }
     if sort.contains("metadata.releaseDate") {
-      return books.sorted { isAsc ? ($0.metaReleaseDate ?? "") < ($1.metaReleaseDate ?? "") : ($0.metaReleaseDate ?? "") > ($1.metaReleaseDate ?? "") }
+      return books.sorted {
+        isAsc
+          ? ($0.metaReleaseDate ?? "") < ($1.metaReleaseDate ?? "")
+          : ($0.metaReleaseDate ?? "") > ($1.metaReleaseDate ?? "")
+      }
     }
     if sort.contains("readProgress.readDate") {
-      return books.sorted { isAsc ? ($0.progressReadDate ?? .distantPast) < ($1.progressReadDate ?? .distantPast) : ($0.progressReadDate ?? .distantPast) > ($1.progressReadDate ?? .distantPast) }
+      return books.sorted {
+        isAsc
+          ? ($0.progressReadDate ?? .distantPast) < ($1.progressReadDate ?? .distantPast)
+          : ($0.progressReadDate ?? .distantPast) > ($1.progressReadDate ?? .distantPast)
+      }
     }
     if sort.contains("downloadAt") {
-      return books.sorted { isAsc ? ($0.downloadAt ?? .distantPast) < ($1.downloadAt ?? .distantPast) : ($0.downloadAt ?? .distantPast) > ($1.downloadAt ?? .distantPast) }
+      return books.sorted {
+        isAsc
+          ? ($0.downloadAt ?? .distantPast) < ($1.downloadAt ?? .distantPast)
+          : ($0.downloadAt ?? .distantPast) > ($1.downloadAt ?? .distantPast)
+      }
     }
     if sort.contains("series") && sort.contains("metadata.numberSort") {
       return books.sorted {

--- a/KMReader/Core/Storage/DatabaseOperator+Collections.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Collections.swift
@@ -56,27 +56,28 @@ extension DatabaseOperator {
     limit: Int
   ) -> [String] {
     guard limit > 0 else { return [] }
-    return (try? read { db in
-      var sql = """
-        SELECT collection_id
-        FROM \(KomgaCollection.databaseTableName)
-        WHERE instance_id = ?
-        """
-      var arguments: StatementArguments = [instanceId]
-      let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-      if !trimmedSearch.isEmpty {
-        sql += "\nAND name LIKE ? ESCAPE char(92)"
-        arguments += StatementArguments([Self.sqlContainsPattern(trimmedSearch)])
-      }
-      sql += "\nORDER BY is_pinned DESC, \(Self.collectionOrderSQL(sort: sort))"
-      sql += "\nLIMIT ? OFFSET ?"
-      arguments += StatementArguments([limit, max(0, offset)])
-      return try String.fetchAll(
-        db,
-        sql: sql,
-        arguments: arguments
-      )
-    }) ?? []
+    return
+      (try? read { db in
+        var sql = """
+          SELECT collection_id
+          FROM \(KomgaCollection.databaseTableName)
+          WHERE instance_id = ?
+          """
+        var arguments: StatementArguments = [instanceId]
+        let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedSearch.isEmpty {
+          sql += "\nAND name LIKE ? ESCAPE char(92)"
+          arguments += StatementArguments([Self.sqlContainsPattern(trimmedSearch)])
+        }
+        sql += "\nORDER BY is_pinned DESC, \(Self.collectionOrderSQL(sort: sort))"
+        sql += "\nLIMIT ? OFFSET ?"
+        arguments += StatementArguments([limit, max(0, offset)])
+        return try String.fetchAll(
+          db,
+          sql: sql,
+          arguments: arguments
+        )
+      }) ?? []
   }
 
   func fetchCollectionDisplayItem(collectionId: String, instanceId: String) throws -> CollectionDisplayItem? {
@@ -134,17 +135,19 @@ extension DatabaseOperator {
         let existingCollections = try fetchCollections(db: db, instanceId: instanceId)
         let existingById = Dictionary(uniqueKeysWithValues: existingCollections.map { ($0.collectionId, $0) })
         for collection in collections {
-          var record = existingById[collection.id] ?? KomgaCollection(
-            id: CompositeID.generate(instanceId: instanceId, id: collection.id),
-            collectionId: collection.id,
-            instanceId: instanceId,
-            name: collection.name,
-            ordered: collection.ordered,
-            createdDate: collection.createdDate,
-            lastModifiedDate: collection.lastModifiedDate,
-            filtered: collection.filtered,
-            seriesIds: collection.seriesIds
-          )
+          var record =
+            existingById[collection.id]
+            ?? KomgaCollection(
+              id: CompositeID.generate(instanceId: instanceId, id: collection.id),
+              collectionId: collection.id,
+              instanceId: instanceId,
+              name: collection.name,
+              ordered: collection.ordered,
+              createdDate: collection.createdDate,
+              lastModifiedDate: collection.lastModifiedDate,
+              filtered: collection.filtered,
+              seriesIds: collection.seriesIds
+            )
           applyCollection(dto: collection, to: &record)
           try save(record, db: db)
         }
@@ -217,28 +220,29 @@ extension DatabaseOperator {
     limit: Int
   ) -> [String] {
     guard limit > 0 else { return [] }
-    return (try? read { db in
-      var sql = """
-        SELECT read_list_id
-        FROM \(KomgaReadList.databaseTableName)
-        WHERE instance_id = ?
-        """
-      var arguments: StatementArguments = [instanceId]
-      let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-      if !trimmedSearch.isEmpty {
-        let pattern = Self.sqlContainsPattern(trimmedSearch)
-        sql += "\nAND (name LIKE ? ESCAPE char(92) OR summary LIKE ? ESCAPE char(92))"
-        arguments += StatementArguments([pattern, pattern])
-      }
-      sql += "\nORDER BY is_pinned DESC, \(Self.readListOrderSQL(sort: sort))"
-      sql += "\nLIMIT ? OFFSET ?"
-      arguments += StatementArguments([limit, max(0, offset)])
-      return try String.fetchAll(
-        db,
-        sql: sql,
-        arguments: arguments
-      )
-    }) ?? []
+    return
+      (try? read { db in
+        var sql = """
+          SELECT read_list_id
+          FROM \(KomgaReadList.databaseTableName)
+          WHERE instance_id = ?
+          """
+        var arguments: StatementArguments = [instanceId]
+        let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedSearch.isEmpty {
+          let pattern = Self.sqlContainsPattern(trimmedSearch)
+          sql += "\nAND (name LIKE ? ESCAPE char(92) OR summary LIKE ? ESCAPE char(92))"
+          arguments += StatementArguments([pattern, pattern])
+        }
+        sql += "\nORDER BY is_pinned DESC, \(Self.readListOrderSQL(sort: sort))"
+        sql += "\nLIMIT ? OFFSET ?"
+        arguments += StatementArguments([limit, max(0, offset)])
+        return try String.fetchAll(
+          db,
+          sql: sql,
+          arguments: arguments
+        )
+      }) ?? []
   }
 
   func fetchReadListDisplayItem(readListId: String, instanceId: String) throws -> ReadListDisplayItem? {
@@ -297,18 +301,20 @@ extension DatabaseOperator {
         let existingReadLists = try fetchReadLists(db: db, instanceId: instanceId)
         let existingById = Dictionary(uniqueKeysWithValues: existingReadLists.map { ($0.readListId, $0) })
         for readList in readLists {
-          var record = existingById[readList.id] ?? KomgaReadList(
-            id: CompositeID.generate(instanceId: instanceId, id: readList.id),
-            readListId: readList.id,
-            instanceId: instanceId,
-            name: readList.name,
-            summary: readList.summary,
-            ordered: readList.ordered,
-            createdDate: readList.createdDate,
-            lastModifiedDate: readList.lastModifiedDate,
-            filtered: readList.filtered,
-            bookIds: readList.bookIds
-          )
+          var record =
+            existingById[readList.id]
+            ?? KomgaReadList(
+              id: CompositeID.generate(instanceId: instanceId, id: readList.id),
+              readListId: readList.id,
+              instanceId: instanceId,
+              name: readList.name,
+              summary: readList.summary,
+              ordered: readList.ordered,
+              createdDate: readList.createdDate,
+              lastModifiedDate: readList.lastModifiedDate,
+              filtered: readList.filtered,
+              bookIds: readList.bookIds
+            )
           applyReadList(dto: readList, to: &record)
           try save(record, db: db)
         }
@@ -423,7 +429,9 @@ extension DatabaseOperator {
       return collections.sorted { isAscending ? $0.createdDate < $1.createdDate : $0.createdDate > $1.createdDate }
     }
     if sort?.contains("lastModifiedDate") == true {
-      return collections.sorted { isAscending ? $0.lastModifiedDate < $1.lastModifiedDate : $0.lastModifiedDate > $1.lastModifiedDate }
+      return collections.sorted {
+        isAscending ? $0.lastModifiedDate < $1.lastModifiedDate : $0.lastModifiedDate > $1.lastModifiedDate
+      }
     }
     return collections.sorted { isAscending ? $0.name < $1.name : $0.name > $1.name }
   }
@@ -434,7 +442,9 @@ extension DatabaseOperator {
       return readLists.sorted { isAscending ? $0.createdDate < $1.createdDate : $0.createdDate > $1.createdDate }
     }
     if sort?.contains("lastModifiedDate") == true {
-      return readLists.sorted { isAscending ? $0.lastModifiedDate < $1.lastModifiedDate : $0.lastModifiedDate > $1.lastModifiedDate }
+      return readLists.sorted {
+        isAscending ? $0.lastModifiedDate < $1.lastModifiedDate : $0.lastModifiedDate > $1.lastModifiedDate
+      }
     }
     return readLists.sorted { isAscending ? $0.name < $1.name : $0.name > $1.name }
   }

--- a/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
@@ -112,7 +112,8 @@ extension DatabaseOperator {
   ) throws {
     try write { db in
       let allLibrariesId = KomgaLibrary.allLibrariesId
-      var library = try fetchLibraryRecords(db: db, instanceId: instanceId)
+      var library =
+        try fetchLibraryRecords(db: db, instanceId: instanceId)
         .first { $0.libraryId == allLibrariesId }
         ?? KomgaLibrary(
           instanceId: instanceId,
@@ -131,7 +132,8 @@ extension DatabaseOperator {
 
   func retryFailedBooks(instanceId: String) {
     try? write { db in
-      var books = try KomgaBook
+      var books =
+        try KomgaBook
         .filter(KomgaBook.Columns.instanceId == instanceId && KomgaBook.Columns.downloadStatusRaw == "failed")
         .fetchAll(db)
       for index in books.indices {
@@ -145,7 +147,8 @@ extension DatabaseOperator {
 
   func cancelFailedBooks(instanceId: String) {
     try? write { db in
-      var books = try KomgaBook
+      var books =
+        try KomgaBook
         .filter(KomgaBook.Columns.instanceId == instanceId && KomgaBook.Columns.downloadStatusRaw == "failed")
         .fetchAll(db)
       for index in books.indices {
@@ -426,9 +429,10 @@ extension DatabaseOperator {
 extension DatabaseOperator {
   func getDownloadStatus(bookId: String) -> DownloadStatus {
     let instanceId = AppConfig.current.instanceId
-    return (try? read { db in
-      try fetchBookRecord(db: db, id: bookId, instanceId: instanceId)?.downloadStatus
-    }) ?? .notDownloaded
+    return
+      (try? read { db in
+        try fetchBookRecord(db: db, id: bookId, instanceId: instanceId)?.downloadStatus
+      }) ?? .notDownloaded
   }
 
   func isBookReadCompleted(bookId: String, instanceId: String) -> Bool {
@@ -439,7 +443,8 @@ extension DatabaseOperator {
 
   func fetchPendingBooks(instanceId: String, limit: Int? = nil) -> [Book] {
     (try? read { db in
-      var request = KomgaBook
+      var request =
+        KomgaBook
         .filter(KomgaBook.Columns.instanceId == instanceId && KomgaBook.Columns.downloadStatusRaw == "pending")
         .order(KomgaBook.Columns.downloadAt, KomgaBook.Columns.id)
       if let limit {
@@ -510,7 +515,8 @@ extension DatabaseOperator {
   func fetchOfflineDownloadedBooksSnapshot(instanceId: String) throws -> OfflineDownloadedBooksSnapshot {
     guard !instanceId.isEmpty else { return .empty }
     return try read { db in
-      let downloadedBooks = try KomgaBook
+      let downloadedBooks =
+        try KomgaBook
         .filter(KomgaBook.Columns.instanceId == instanceId && KomgaBook.Columns.downloadStatusRaw == "downloaded")
         .fetchAll(db)
       guard !downloadedBooks.isEmpty else { return .empty }
@@ -544,7 +550,8 @@ extension DatabaseOperator {
         let seriesBooksMap = Dictionary(grouping: libraryBooks.filter { !$0.oneshot }) { $0.seriesId }
         var seriesGroups: [OfflineDownloadedSeriesGroup] = []
         for (seriesId, seriesBooks) in seriesBooksMap {
-          let bookItems = seriesBooks
+          let bookItems =
+            seriesBooks
             .map(Self.makeOfflineDownloadedBookItem)
             .sorted { $0.metaNumberSort < $1.metaNumberSort }
           seriesGroups.append(
@@ -577,20 +584,22 @@ extension DatabaseOperator {
   }
 
   func fetchOfflineEpubBookIdsMissingProgression(instanceId: String) async -> [String] {
-    guard let results = try? read({ db in
-      try KomgaBook.fetchAll(
-        db,
-        sql: """
-          SELECT *
-          FROM \(KomgaBook.databaseTableName)
-          WHERE instance_id = ?
-          AND download_status_raw = 'downloaded'
-          AND media_profile = 'EPUB'
-          AND COALESCE(progress_page, 0) > 0
-          """,
-        arguments: [instanceId]
-      )
-    }) else {
+    guard
+      let results = try? read({ db in
+        try KomgaBook.fetchAll(
+          db,
+          sql: """
+            SELECT *
+            FROM \(KomgaBook.databaseTableName)
+            WHERE instance_id = ?
+            AND download_status_raw = 'downloaded'
+            AND media_profile = 'EPUB'
+            AND COALESCE(progress_page, 0) > 0
+            """,
+          arguments: [instanceId]
+        )
+      })
+    else {
       return []
     }
     var bookIds: [String] = []
@@ -617,11 +626,11 @@ extension DatabaseOperator {
         arguments: [instanceId]
       )
       return books.compactMap { book in
-          if let downloadAt = book.downloadAt, now.timeIntervalSince(downloadAt) < 300 {
-            return nil
-          }
-          return (id: book.bookId, seriesId: book.seriesId)
+        if let downloadAt = book.downloadAt, now.timeIntervalSince(downloadAt) < 300 {
+          return nil
         }
+        return (id: book.bookId, seriesId: book.seriesId)
+      }
     }) ?? []
   }
 }
@@ -780,7 +789,8 @@ extension DatabaseOperator {
 
   func fetchPendingProgress(instanceId: String, limit: Int? = nil) -> [PendingProgressSummary] {
     (try? read { db in
-      var request = PendingProgress
+      var request =
+        PendingProgress
         .filter(Column("instance_id") == instanceId)
         .order(Column("created_at"), Column("id"))
       if let limit {

--- a/KMReader/Core/Storage/DatabaseOperator+Offline.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Offline.swift
@@ -11,10 +11,14 @@ extension DatabaseOperator {
     do {
       try write { db in
         try db.execute(sql: "DELETE FROM \(KomgaBook.databaseTableName) WHERE instance_id = ?", arguments: [instanceId])
-        try db.execute(sql: "DELETE FROM \(KomgaSeries.databaseTableName) WHERE instance_id = ?", arguments: [instanceId])
-        try db.execute(sql: "DELETE FROM \(KomgaCollection.databaseTableName) WHERE instance_id = ?", arguments: [instanceId])
-        try db.execute(sql: "DELETE FROM \(KomgaReadList.databaseTableName) WHERE instance_id = ?", arguments: [instanceId])
-        try db.execute(sql: "DELETE FROM \(PendingProgress.databaseTableName) WHERE instance_id = ?", arguments: [instanceId])
+        try db.execute(
+          sql: "DELETE FROM \(KomgaSeries.databaseTableName) WHERE instance_id = ?", arguments: [instanceId])
+        try db.execute(
+          sql: "DELETE FROM \(KomgaCollection.databaseTableName) WHERE instance_id = ?", arguments: [instanceId])
+        try db.execute(
+          sql: "DELETE FROM \(KomgaReadList.databaseTableName) WHERE instance_id = ?", arguments: [instanceId])
+        try db.execute(
+          sql: "DELETE FROM \(PendingProgress.databaseTableName) WHERE instance_id = ?", arguments: [instanceId])
       }
       logger.info("Cleared GRDB entities for instance: \(instanceId)")
     } catch {
@@ -404,7 +408,8 @@ extension DatabaseOperator {
     var booksToDelete: [KomgaBook] = []
     let policyLimit = max(0, series.offlinePolicyLimit)
     let policySupportsLimit = policy == .unreadOnly || policy == .unreadOnlyAndCleanupRead
-    let sortedBooks = books
+    let sortedBooks =
+      books
       .filter { !$0.isUnavailable }
       .sorted { $0.metaNumberSort < $1.metaNumberSort }
     var allowedUnreadIds = Set<String>()

--- a/KMReader/Core/Storage/DatabaseOperator+Series.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Series.swift
@@ -25,18 +25,19 @@ extension DatabaseOperator {
   ) -> [String] {
     guard !instanceId.isEmpty else { return [] }
     guard limit > 0 else { return [] }
-    return (try? read { db in
-      try fetchBrowseSeriesRecords(
-        db: db,
-        instanceId: instanceId,
-        libraryIds: libraryIds ?? [],
-        searchText: searchText,
-        browseOpts: browseOpts,
-        offset: offset,
-        limit: limit,
-        offlineOnly: offlineOnly
-      ).map(\.seriesId)
-    }) ?? []
+    return
+      (try? read { db in
+        try fetchBrowseSeriesRecords(
+          db: db,
+          instanceId: instanceId,
+          libraryIds: libraryIds ?? [],
+          searchText: searchText,
+          browseOpts: browseOpts,
+          offset: offset,
+          limit: limit,
+          offlineOnly: offlineOnly
+        ).map(\.seriesId)
+      }) ?? []
   }
 
   func fetchCollectionSeriesIds(
@@ -46,14 +47,15 @@ extension DatabaseOperator {
     size: Int
   ) -> [String] {
     let instanceId = AppConfig.current.instanceId
-    return (try? read { db in
-      guard let collection = try fetchCollectionRecord(db: db, id: collectionId, instanceId: instanceId) else {
-        return []
-      }
-      let series = try fetchSeriesByIds(db: db, ids: collection.seriesIds, instanceId: instanceId)
-        .filter { Self.matchesSeries($0, collectionBrowseOpts: browseOpts) }
-      return Self.paginate(series, offset: page * size, limit: size).map(\.seriesId)
-    }) ?? []
+    return
+      (try? read { db in
+        guard let collection = try fetchCollectionRecord(db: db, id: collectionId, instanceId: instanceId) else {
+          return []
+        }
+        let series = try fetchSeriesByIds(db: db, ids: collection.seriesIds, instanceId: instanceId)
+          .filter { Self.matchesSeries($0, collectionBrowseOpts: browseOpts) }
+        return Self.paginate(series, offset: page * size, limit: size).map(\.seriesId)
+      }) ?? []
   }
 
   func fetchDashboardOfflineSeriesIds(
@@ -64,34 +66,35 @@ extension DatabaseOperator {
   ) -> [String] {
     guard limit > 0 else { return [] }
     let instanceId = AppConfig.current.instanceId
-    return (try? read { db in
-      var sql = """
-        SELECT series_id
-        FROM \(KomgaSeries.databaseTableName)
-        WHERE instance_id = ?
-        """
-      var arguments: StatementArguments = [instanceId]
+    return
+      (try? read { db in
+        var sql = """
+          SELECT series_id
+          FROM \(KomgaSeries.databaseTableName)
+          WHERE instance_id = ?
+          """
+        var arguments: StatementArguments = [instanceId]
 
-      if !libraryIds.isEmpty {
-        let placeholders = Array(repeating: "?", count: libraryIds.count).joined(separator: ", ")
-        sql += "\nAND library_id IN (\(placeholders))"
-        arguments += StatementArguments(libraryIds)
-      }
+        if !libraryIds.isEmpty {
+          let placeholders = Array(repeating: "?", count: libraryIds.count).joined(separator: ", ")
+          sql += "\nAND library_id IN (\(placeholders))"
+          arguments += StatementArguments(libraryIds)
+        }
 
-      switch section {
-      case .recentlyAddedSeries:
-        sql += "\nORDER BY created DESC, id ASC"
-      case .recentlyUpdatedSeries:
-        sql += "\nORDER BY last_modified DESC, id ASC"
-      default:
-        return []
-      }
+        switch section {
+        case .recentlyAddedSeries:
+          sql += "\nORDER BY created DESC, id ASC"
+        case .recentlyUpdatedSeries:
+          sql += "\nORDER BY last_modified DESC, id ASC"
+        default:
+          return []
+        }
 
-      sql += "\nLIMIT ? OFFSET ?"
-      arguments += StatementArguments([limit, max(0, offset)])
+        sql += "\nLIMIT ? OFFSET ?"
+        arguments += StatementArguments([limit, max(0, offset)])
 
-      return try String.fetchAll(db, sql: sql, arguments: arguments)
-    }) ?? []
+        return try String.fetchAll(db, sql: sql, arguments: arguments)
+      }) ?? []
   }
 
   func upsertSeries(dto: Series, instanceId: String) {
@@ -145,24 +148,26 @@ extension DatabaseOperator {
         let existingById = Dictionary(uniqueKeysWithValues: existingSeries.map { ($0.seriesId, $0) })
 
         for series in seriesList {
-          var record = existingById[series.id] ?? KomgaSeries(
-            id: CompositeID.generate(instanceId: instanceId, id: series.id),
-            seriesId: series.id,
-            libraryId: series.libraryId,
-            instanceId: instanceId,
-            name: series.name,
-            url: series.url,
-            created: series.created,
-            lastModified: series.lastModified,
-            booksCount: series.booksCount,
-            booksReadCount: series.booksReadCount,
-            booksUnreadCount: series.booksUnreadCount,
-            booksInProgressCount: series.booksInProgressCount,
-            metadata: series.metadata,
-            booksMetadata: series.booksMetadata,
-            isUnavailable: series.deleted,
-            oneshot: series.oneshot
-          )
+          var record =
+            existingById[series.id]
+            ?? KomgaSeries(
+              id: CompositeID.generate(instanceId: instanceId, id: series.id),
+              seriesId: series.id,
+              libraryId: series.libraryId,
+              instanceId: instanceId,
+              name: series.name,
+              url: series.url,
+              created: series.created,
+              lastModified: series.lastModified,
+              booksCount: series.booksCount,
+              booksReadCount: series.booksReadCount,
+              booksUnreadCount: series.booksUnreadCount,
+              booksInProgressCount: series.booksInProgressCount,
+              metadata: series.metadata,
+              booksMetadata: series.booksMetadata,
+              isUnavailable: series.deleted,
+              oneshot: series.oneshot
+            )
           applySeries(dto: series, to: &record)
           try save(record, db: db)
         }
@@ -178,7 +183,8 @@ extension DatabaseOperator {
       var lastScannedId: String?
 
       while true {
-        var request = KomgaSeries
+        var request =
+          KomgaSeries
           .filter(KomgaSeries.Columns.instanceId == instanceId)
           .order(KomgaSeries.Columns.id)
           .limit(Self.recordFetchChunkSize)
@@ -415,10 +421,14 @@ extension DatabaseOperator {
     }
     if !collectionBrowseOpts.includeSeriesStatuses.isEmpty || !collectionBrowseOpts.excludeSeriesStatuses.isEmpty {
       if let seriesStatus = SeriesStatus.fromAPIValue(series.metadata?.status) {
-        if !collectionBrowseOpts.includeSeriesStatuses.isEmpty && !collectionBrowseOpts.includeSeriesStatuses.contains(seriesStatus) {
+        if !collectionBrowseOpts.includeSeriesStatuses.isEmpty
+          && !collectionBrowseOpts.includeSeriesStatuses.contains(seriesStatus)
+        {
           return false
         }
-        if !collectionBrowseOpts.excludeSeriesStatuses.isEmpty && collectionBrowseOpts.excludeSeriesStatuses.contains(seriesStatus) {
+        if !collectionBrowseOpts.excludeSeriesStatuses.isEmpty
+          && collectionBrowseOpts.excludeSeriesStatuses.contains(seriesStatus)
+        {
           return false
         }
       }
@@ -605,7 +615,8 @@ extension DatabaseOperator {
     case .read:
       return "(books_count > 0 AND books_read_count = books_count)"
     case .inProgress:
-      return "(NOT (books_count > 0 AND books_read_count = books_count) AND (books_read_count > 0 OR books_in_progress_count > 0))"
+      return
+        "(NOT (books_count > 0 AND books_read_count = books_count) AND (books_read_count > 0 OR books_in_progress_count > 0))"
     case .unread:
       return "(books_read_count <= 0 AND books_in_progress_count <= 0)"
     }
@@ -693,7 +704,11 @@ extension DatabaseOperator {
       return series.sorted { isAsc ? $0.lastModified < $1.lastModified : $0.lastModified > $1.lastModified }
     }
     if sort.contains("downloadAt") {
-      return series.sorted { isAsc ? ($0.downloadAt ?? .distantPast) < ($1.downloadAt ?? .distantPast) : ($0.downloadAt ?? .distantPast) > ($1.downloadAt ?? .distantPast) }
+      return series.sorted {
+        isAsc
+          ? ($0.downloadAt ?? .distantPast) < ($1.downloadAt ?? .distantPast)
+          : ($0.downloadAt ?? .distantPast) > ($1.downloadAt ?? .distantPast)
+      }
     }
     if sort.contains("booksCount") {
       return series.sorted { isAsc ? $0.booksCount < $1.booksCount : $0.booksCount > $1.booksCount }

--- a/KMReader/Core/Storage/GRDB/LocalDatabase.swift
+++ b/KMReader/Core/Storage/GRDB/LocalDatabase.swift
@@ -319,15 +319,24 @@ nonisolated enum LocalDatabase {
 
   private static nonisolated func createIndexes(_ db: Database) throws {
     try db.create(index: "idx_libraries_instance", on: KomgaLibrary.databaseTableName, columns: ["instance_id"])
-    try db.create(index: "idx_series_instance_library", on: KomgaSeries.databaseTableName, columns: ["instance_id", "library_id"])
-    try db.create(index: "idx_series_sort", on: KomgaSeries.databaseTableName, columns: ["instance_id", "meta_title_sort"])
-    try db.create(index: "idx_books_instance_library", on: KomgaBook.databaseTableName, columns: ["instance_id", "library_id"])
+    try db.create(
+      index: "idx_series_instance_library", on: KomgaSeries.databaseTableName, columns: ["instance_id", "library_id"])
+    try db.create(
+      index: "idx_series_sort", on: KomgaSeries.databaseTableName, columns: ["instance_id", "meta_title_sort"])
+    try db.create(
+      index: "idx_books_instance_library", on: KomgaBook.databaseTableName, columns: ["instance_id", "library_id"])
     try db.create(index: "idx_books_series", on: KomgaBook.databaseTableName, columns: ["instance_id", "series_id"])
-    try db.create(index: "idx_books_progress", on: KomgaBook.databaseTableName, columns: ["instance_id", "progress_read_date"])
-    try db.create(index: "idx_books_download", on: KomgaBook.databaseTableName, columns: ["instance_id", "download_status_raw", "download_at"])
+    try db.create(
+      index: "idx_books_progress", on: KomgaBook.databaseTableName, columns: ["instance_id", "progress_read_date"])
+    try db.create(
+      index: "idx_books_download", on: KomgaBook.databaseTableName,
+      columns: ["instance_id", "download_status_raw", "download_at"])
     try db.create(index: "idx_collections_instance", on: KomgaCollection.databaseTableName, columns: ["instance_id"])
     try db.create(index: "idx_read_lists_instance", on: KomgaReadList.databaseTableName, columns: ["instance_id"])
-    try db.create(index: "idx_pending_progress_instance", on: PendingProgress.databaseTableName, columns: ["instance_id", "created_at"])
-    try db.create(index: "idx_saved_filters_type", on: SavedFilter.databaseTableName, columns: ["filter_type_raw", "updated_at"])
+    try db.create(
+      index: "idx_pending_progress_instance", on: PendingProgress.databaseTableName,
+      columns: ["instance_id", "created_at"])
+    try db.create(
+      index: "idx_saved_filters_type", on: SavedFilter.databaseTableName, columns: ["filter_type_raw", "updated_at"])
   }
 }

--- a/KMReader/Features/Book/Views/BookCardView.swift
+++ b/KMReader/Features/Book/Views/BookCardView.swift
@@ -135,7 +135,7 @@ struct BookCardView: View {
                 .foregroundColor(mediaStatus.color)
             } else {
               if progress > 0 && progress < 1 {
-                Text("\(progress * 100, specifier: "%.0f")%")
+                Text(progress, format: .percent.precision(.fractionLength(0)))
                 Text("•")
               }
               if progress == 1 {
@@ -203,7 +203,7 @@ struct BookCardView: View {
             .foregroundColor(mediaStatus.color)
         } else {
           if progress > 0 && progress < 1 {
-            Text("\(progress * 100, specifier: "%.0f")%")
+            Text(progress, format: .percent.precision(.fractionLength(0)))
             Text("•")
           }
           if progress == 1 {

--- a/KMReader/Features/Book/Views/BookRowView.swift
+++ b/KMReader/Features/Book/Views/BookRowView.swift
@@ -103,7 +103,7 @@ struct BookRowView: View {
                   Text("Page \(progressPage + 1)")
                     .foregroundColor(.blue)
                   Text("•")
-                  Text("\(progress * 100, specifier: "%.0f")%")
+                  Text(progress, format: .percent.precision(.fractionLength(0)))
                 }
               }
             }

--- a/KMReader/Features/Offline/Views/OfflineTasksView.swift
+++ b/KMReader/Features/Offline/Views/OfflineTasksView.swift
@@ -310,14 +310,9 @@ struct OfflineTaskRow: View {
                 .foregroundStyle(.secondary)
             } else {
               ProgressView(value: progress) {
-                Text(
-                  String(
-                    format: String(localized: "Downloading %lld%%"),
-                    Int64(progress * 100)
-                  )
-                )
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                Text("Downloading \(progress.formatted(.percent.precision(.fractionLength(0))))")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
               }
             }
           } else {

--- a/KMReader/Features/Reader/Services/CustomFontStore.swift
+++ b/KMReader/Features/Reader/Services/CustomFontStore.swift
@@ -24,16 +24,18 @@ final class CustomFontStore {
 
   func fetchCustomFonts() -> [String] {
     guard let dbQueue else { return [] }
-    return (try? dbQueue.read { db in
-      try CustomFont.fetchAll(db).sorted { $0.name < $1.name }.map(\.name)
-    }) ?? []
+    return
+      (try? dbQueue.read { db in
+        try CustomFont.fetchAll(db).sorted { $0.name < $1.name }.map(\.name)
+      }) ?? []
   }
 
   func customFontCount() -> Int {
     guard let dbQueue else { return 0 }
-    return (try? dbQueue.read { db in
-      try CustomFont.fetchCount(db)
-    }) ?? 0
+    return
+      (try? dbQueue.read { db in
+        try CustomFont.fetchCount(db)
+      }) ?? 0
   }
 
   func getFontPath(for fontName: String) -> String? {

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -788,7 +788,7 @@
             showingChapterSheet = true
           } label: {
             HStack {
-              Text("Contents · \(totalProgression * 100, specifier: "%.1f")%")
+              Text("Contents · \(totalProgression, format: .percent.precision(.fractionLength(1)))")
                 .font(.callout)
               Image(systemName: "list.bullet")
             }

--- a/KMReader/Features/Reader/Views/Epub/WebPubInfoOverlaySupport.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubInfoOverlaySupport.swift
@@ -51,7 +51,7 @@
         : visibleEntry(bookTitle)
       let topProgress: Entry
       if showingControls, let totalProgression {
-        let percentage = String(format: "%.2f%%", totalProgression * 100)
+        let percentage = totalProgression.formatted(.percent.precision(.fractionLength(2)))
         topProgress = Entry(
           text: String(localized: "Book Progress \(percentage)"),
           isVisible: true
@@ -129,7 +129,7 @@
           currentPageIndex: currentPageIndex,
           totalPagesInChapter: totalPagesInChapter
         )
-        let percentage = String(format: "%.1f%%", progress * 100)
+        let percentage = progress.formatted(.percent.precision(.fractionLength(1)))
         return Entry(
           text: String(localized: "Chapter Progress \(percentage)"),
           isVisible: true
@@ -155,7 +155,7 @@
           currentPageIndex: currentPageIndex,
           totalPagesInChapter: totalPagesInChapter
         )
-        let remaining = String(format: "%.1f%%", (1.0 - progress) * 100)
+        let remaining = (1.0 - progress).formatted(.percent.precision(.fractionLength(1)))
         return Entry(text: String(localized: "\(remaining) left"), isVisible: true)
       }
     }

--- a/KMReader/Features/Reader/Views/Models/EpubThemePreferences.swift
+++ b/KMReader/Features/Reader/Views/Models/EpubThemePreferences.swift
@@ -243,12 +243,12 @@ nonisolated struct EpubThemePreferences: RawRepresentable, Equatable, Sendable {
 
       properties["--USER__textAlign"] = textAlignment.readiumTextAlign
       properties["--USER__bodyHyphens"] = textAlignment.readiumBodyHyphens
-      properties["--USER__fontSize"] = String(format: "%.2f%%", fontSizePercent)
-      properties["--USER__lineHeight"] = String(format: "%.2f", lineHeight)
-      properties["--USER__paraSpacing"] = String(format: "%.2frem", paragraphSpacingRem)
-      properties["--USER__paraIndent"] = String(format: "%.2frem", paragraphIndentRem)
-      properties["--USER__wordSpacing"] = String(format: "%.2frem", wordSpacingRem)
-      properties["--USER__letterSpacing"] = String(format: "%.2frem", letterSpacingRem)
+      properties["--USER__fontSize"] = cssPercentage(fontSizePercent)
+      properties["--USER__lineHeight"] = cssNumber(lineHeight)
+      properties["--USER__paraSpacing"] = cssRem(paragraphSpacingRem)
+      properties["--USER__paraIndent"] = cssRem(paragraphIndentRem)
+      properties["--USER__wordSpacing"] = cssRem(wordSpacingRem)
+      properties["--USER__letterSpacing"] = cssRem(letterSpacingRem)
     } else {
       properties["--USER__fontSize"] = nil
       properties["--USER__lineHeight"] = nil
@@ -347,7 +347,19 @@ nonisolated struct EpubThemePreferences: RawRepresentable, Equatable, Sendable {
     let normalizedMargins = max(0, pageMargins)
     let horizontalPadding = normalizedMargins * 20.0
     let totalInset = max(0, horizontalPadding * 2.0)
-    return "calc(100% - \(String(format: "%.2f", totalInset))px)"
+    return "calc(100% - \(cssNumber(totalInset))px)"
+  }
+
+  private func cssNumber(_ value: Double) -> String {
+    String(format: "%.2f", locale: Locale(identifier: "en_US_POSIX"), value)
+  }
+
+  private func cssPercentage(_ value: Double) -> String {
+    "\(cssNumber(value))%"
+  }
+
+  private func cssRem(_ value: Double) -> String {
+    "\(cssNumber(value))rem"
   }
 
   private func makeDarkTextColorOverrideCSS(theme: ReaderTheme) -> String {

--- a/KMReader/Features/Reader/Views/ReaderLoadingView.swift
+++ b/KMReader/Features/Reader/Views/ReaderLoadingView.swift
@@ -34,12 +34,9 @@ struct ReaderLoadingView: View {
             .rotationEffect(.degrees(-90))
             .animation(.spring(duration: 0.6, bounce: 0.3), value: progress)
 
-          Text("\(Int(progress * 100))")
+          Text(progress, format: .percent.precision(.fractionLength(0)))
             .font(.system(.subheadline, design: .rounded).bold())
             .monospacedDigit()
-            + Text("%")
-            .font(.system(.caption2, design: .rounded).bold())
-            .foregroundStyle(.secondary)
         } else {
           // Indeterminate State
           LoadingIcon()

--- a/KMReader/Features/Reader/Views/Sheets/EpubReaderSettingsView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubReaderSettingsView_macOS.swift
@@ -80,7 +80,7 @@
             HStack {
               Text(String(localized: "epub.scrolled.tap_scroll_height"))
               Spacer()
-              Text("\(Int(tapScrollPercentage))%")
+              Text(tapScrollPercentage / 100, format: .percent.precision(.fractionLength(0)))
                 .foregroundStyle(.secondary)
             }
             Slider(value: $tapScrollPercentage, in: 25...100, step: 5)

--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -94,7 +94,7 @@ struct ReaderSettingsSheet: View {
                 HStack {
                   Text("Webtoon Page Width")
                   Spacer()
-                  Text("\(Int(webtoonPageWidthPercentage))%")
+                  Text(webtoonPageWidthPercentage / 100, format: .percent.precision(.fractionLength(0)))
                     .foregroundColor(.secondary)
                 }
                 Slider(
@@ -162,7 +162,7 @@ struct ReaderSettingsSheet: View {
                   HStack {
                     Text("Webtoon Tap Scroll Height")
                     Spacer()
-                    Text("\(Int(webtoonTapScrollPercentage))%")
+                    Text(webtoonTapScrollPercentage / 100, format: .percent.precision(.fractionLength(0)))
                       .foregroundColor(.secondary)
                   }
                   Slider(

--- a/KMReader/Features/Series/Views/SeriesCardView.swift
+++ b/KMReader/Features/Series/Views/SeriesCardView.swift
@@ -97,7 +97,7 @@ struct SeriesCardView: View {
                 .foregroundColor(.red)
             } else {
               if progress > 0 && progress < 1 {
-                Text("\(progress * 100, specifier: "%.0f")%")
+                Text(progress, format: .percent.precision(.fractionLength(0)))
                 Text("•")
               }
               if progress == 1 {
@@ -154,7 +154,7 @@ struct SeriesCardView: View {
             .foregroundColor(.red)
         } else {
           if progress > 0 && progress < 1 {
-            Text("\(progress * 100, specifier: "%.0f")%")
+            Text(progress, format: .percent.precision(.fractionLength(0)))
             Text("•")
           }
           if progress == 1 {

--- a/KMReader/Features/Series/Views/SeriesRowView.swift
+++ b/KMReader/Features/Series/Views/SeriesRowView.swift
@@ -163,14 +163,14 @@ struct SeriesRowView: View {
         Text(series.booksUnreadCount > 0 ? "\(series.booksUnreadCount) unread" : series.readStatusDisplayName)
           .foregroundColor(series.readStatusColor)
         Text("•")
-        Text("\(progress * 100, specifier: "%.0f")%")
+        Text(progress, format: .percent.precision(.fractionLength(0)))
       case .unread:
         Image(systemName: "circle.righthalf.filled")
           .foregroundColor(series.readStatusColor)
         Text("\(series.booksUnreadCount) unread")
           .foregroundColor(series.readStatusColor)
         Text("•")
-        Text("\(progress * 100, specifier: "%.0f")%")
+        Text(progress, format: .percent.precision(.fractionLength(0)))
       }
     }
   }

--- a/KMReader/Features/Settings/DivinaPreferencesView.swift
+++ b/KMReader/Features/Settings/DivinaPreferencesView.swift
@@ -187,7 +187,7 @@ struct DivinaPreferencesView: View {
               HStack {
                 Text("Webtoon Page Width")
                 Spacer()
-                Text("\(Int(webtoonPageWidthPercentage))%")
+                Text(webtoonPageWidthPercentage / 100, format: .percent.precision(.fractionLength(0)))
                   .foregroundColor(.secondary)
               }
               Slider(
@@ -291,7 +291,7 @@ struct DivinaPreferencesView: View {
                 HStack {
                   Text("Webtoon Tap Scroll Height")
                   Spacer()
-                  Text("\(Int(webtoonTapScrollPercentage))%")
+                  Text(webtoonTapScrollPercentage / 100, format: .percent.precision(.fractionLength(0)))
                     .foregroundColor(.secondary)
                 }
                 Slider(

--- a/KMReader/Features/Settings/EpubReaderSettingsView.swift
+++ b/KMReader/Features/Settings/EpubReaderSettingsView.swift
@@ -81,7 +81,7 @@
             HStack {
               Text(String(localized: "epub.scrolled.tap_scroll_height"))
               Spacer()
-              Text("\(Int(tapScrollPercentage))%")
+              Text(tapScrollPercentage / 100, format: .percent.precision(.fractionLength(0)))
                 .foregroundStyle(.secondary)
             }
             Slider(value: $tapScrollPercentage, in: 25...100, step: 5)

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -153,44 +153,6 @@
       },
       "shouldTranslate" : false
     },
-    "%" : {
-      "shouldTranslate" : false
-    },
-    "%.0f%%" : {
-      "localizations" : {
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%.0f%%"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%.0f%%"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%.0f%%"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%.0f%%"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%.0f%%"
-          }
-        }
-      },
-      "shouldTranslate" : false
-    },
     "%@ " : {
       "localizations" : {
         "fr" : {
@@ -1543,70 +1505,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%lld."
-          }
-        }
-      }
-    },
-    "%lld%%" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%%"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%%"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%%"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%%"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%%"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%%"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%%"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%%"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%%"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld%%"
           }
         }
       }
@@ -13728,66 +13626,66 @@
         }
       }
     },
-    "Contents · %.1f%%" : {
+    "Contents · %@" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inhalt · %.1f%%"
+            "value" : "Inhalt · %@"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Contents · %.1f%%"
+            "value" : "Contents · %@"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Contenido · %.1f%%"
+            "value" : "Contenido · %@"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Contenu · %.1f%%"
+            "value" : "Contenu · %@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Contenuti · %.1f%%"
+            "value" : "Contenuti · %@"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "目次 · %.1f%%"
+            "value" : "目次 · %@"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "목차 · %.1f%%"
+            "value" : "목차 · %@"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Содержание · %.1f%%"
+            "value" : "Содержание · %@"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "目录 · %.1f%%"
+            "value" : "目录 · %@"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "目錄 · %.1f%%"
+            "value" : "目錄 · %@"
           }
         }
       }
@@ -19104,66 +19002,66 @@
         }
       }
     },
-    "Downloading %lld%%" : {
+    "Downloading %@" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%lld %% heruntergeladen"
+            "value" : "%@ heruntergeladen"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Downloading %lld%%"
+            "value" : "Downloading %@"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Descargando %lld %%"
+            "value" : "Descargando %@"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Téléchargement %lld %%"
+            "value" : "Téléchargement %@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Download %lld %%"
+            "value" : "Download %@"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ダウンロード中 %lld%%"
+            "value" : "ダウンロード中 %@"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "다운로드 중 %lld%%"
+            "value" : "다운로드 중 %@"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Загрузка %lld %%"
+            "value" : "Загрузка %@"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在下载 %lld%%"
+            "value" : "正在下载 %@"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在下載 %lld%%"
+            "value" : "正在下載 %@"
           }
         }
       }

--- a/KMReader/Shared/UI/SplashView.swift
+++ b/KMReader/Shared/UI/SplashView.swift
@@ -116,7 +116,7 @@ struct SplashView: View {
                     .font(.caption)
                     .foregroundStyle(stageTextStyle(for: stage))
                   Spacer()
-                  Text("\(Int(stageProgress(for: stage) * 100))%")
+                  Text(stageProgress(for: stage), format: .percent.precision(.fractionLength(0)))
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
                     .monospacedDigit()

--- a/misc/localize.py
+++ b/misc/localize.py
@@ -72,9 +72,44 @@ def saved_simulator_udid(project_root: Path, platform: str) -> str | None:
     return udid if isinstance(udid, str) and udid else None
 
 
+def simulator_udid_available(platform: str, udid: str) -> bool:
+    runtime_prefixes = {
+        "ios": "com.apple.CoreSimulator.SimRuntime.iOS",
+        "tvos": "com.apple.CoreSimulator.SimRuntime.tvOS",
+    }
+    runtime_prefix = runtime_prefixes.get(platform)
+    if runtime_prefix is None:
+        return False
+
+    try:
+        result = subprocess.run(
+            ["xcrun", "simctl", "list", "devices", "--json"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        data = json.loads(result.stdout)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        eprint(f"Warning: could not list simulators for {platform}: {exc}")
+        return False
+
+    for runtime, devices in (data.get("devices") or {}).items():
+        if not runtime.startswith(runtime_prefix):
+            continue
+        for device in devices:
+            if device.get("udid") == udid and device.get("isAvailable", False):
+                return True
+
+    return False
+
+
 def build_destination_for_platform(project_root: Path, platform: str) -> str:
     if udid := saved_simulator_udid(project_root, platform):
-        return f"id={udid}"
+        if simulator_udid_available(platform, udid):
+            return f"id={udid}"
+        eprint(
+            f"Warning: saved {platform} simulator is no longer available; using generic destination"
+        )
     return DEFAULT_BUILD_DESTINATIONS[platform]
 
 

--- a/misc/xcode.py
+++ b/misc/xcode.py
@@ -469,6 +469,15 @@ class BuildRunner:
         mapping = {"ios": "ios", "macos": "macos", "tvos": "appletvos"}
         return mapping.get(platform, "ios")
 
+    @staticmethod
+    def _generic_simulator_destination(platform: str) -> str:
+        """Return a generic simulator destination for build-only actions."""
+        mapping = {
+            "ios": "generic/platform=iOS Simulator",
+            "tvos": "generic/platform=tvOS Simulator",
+        }
+        return mapping[platform]
+
     def _archive_internal(
         self,
         platform: str,
@@ -889,19 +898,27 @@ class BuildRunner:
 
     def build(self, platform: str, ci_mode: bool = False) -> bool:
         """Build for the specified platform."""
+        normalized = platform.lower()
+        if normalized not in ("ios", "macos", "tvos"):
+            print(f"{Color.RED}Unknown platform: {platform}{Color.NC}")
+            return False
+
         # For iOS and tvOS, select simulator for building
         device_udid = None
-        if platform.lower() in ("ios", "tvos"):
+        destination = None
+        if normalized in ("ios", "tvos"):
             # Always use simulator for builds
             is_simulator = True
             device_udid = self.device_manager.select_device(platform, is_simulator)
-            if not device_udid:
-                print(f"{Color.RED}No device selected{Color.NC}")
-                return False
-
-        if platform.lower() not in ("ios", "macos", "tvos"):
-            print(f"{Color.RED}Unknown platform: {platform}{Color.NC}")
-            return False
+            if device_udid:
+                destination = f"id={device_udid}"
+            else:
+                destination = self._generic_simulator_destination(normalized)
+                print(
+                    f"{Color.YELLOW}No concrete {platform} simulator selected; using {destination}{Color.NC}"
+                )
+        elif normalized == "macos":
+            destination = "platform=macOS"
 
         print(f"{Color.GREEN}Building for {platform.upper()}...{Color.NC}")
 
@@ -916,16 +933,8 @@ class BuildRunner:
             "-quiet",
         ]
 
-        # Add destination for device-specific builds
-        if device_udid:
-            cmd.extend(["-destination", f"id={device_udid}"])
-        elif platform.lower() in ("ios", "tvos"):
-            # Fallback to generic simulator destination
-            cmd.extend(
-                ["-destination", f"generic/platform={platform.upper()} Simulator"]
-            )
-        elif platform.lower() == "macos":
-            cmd.extend(["-destination", "platform=macOS"])
+        if destination:
+            cmd.extend(["-destination", destination])
 
         if ci_mode:
             cmd.extend(self._validation_args(ci_mode=True))


### PR DESCRIPTION
## Problem
Xcode warns when localized strings embed printf-style percent patterns such as `%.0f%%` and `%lld%%`, because percent placement and spacing are locale-sensitive. The same cleanup exposed a local workflow issue where stale saved simulator IDs can block build/localization extraction even though a generic simulator destination is enough for build-only actions.

## Approach
Use Swift percent `FormatStyle` for user-visible progress values, keep EPUB CSS values as POSIX-formatted machine strings, and refresh `Localizable.xcstrings` so progress labels use placeholder-based strings instead of embedded percent format specifiers. Build and localization scripts now fall back to generic simulator destinations when no concrete iOS/tvOS simulator is available.

## Scope
- Replace user-visible hand-built percent strings with locale-aware formatting
- Refresh localized strings for `Contents · %@` and `Downloading %@`
- Add generic simulator fallback to `misc/xcode.py` and stale saved simulator handling to `misc/localize.py`
- Include formatter-only Swift changes from the repository formatter run in a separate commit

## Validation
- [x] `make build`
- [x] `make localize`
- [x] `./misc/translate.py list`
- [x] `python3 -m py_compile misc/xcode.py misc/localize.py`
- [x] `git diff --check`
