### PR TITLE
fix: smooth reader loading progress updates

### DIFF
--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -99,12 +99,14 @@
       let expected = notification.userInfo?[DownloadProgressUserInfo.expectedKey] as? Int64
       let received = notification.userInfo?[DownloadProgressUserInfo.receivedKey] as? Int64 ?? 0
 
-      self.downloadBytesReceived = received
-      self.downloadBytesExpected = expected
       if let expected, expected > 0 {
-        self.downloadProgress = Double(received) / Double(expected)
+        updateDownloadProgress(
+          Double(received) / Double(expected),
+          receivedBytes: received,
+          expectedBytes: expected
+        )
       } else {
-        self.downloadProgress = 0.0
+        updateDownloadProgress(0.0, receivedBytes: received, expectedBytes: expected)
       }
     }
 
@@ -351,9 +353,7 @@
       }
 
       loadingStage = .downloading
-      downloadProgress = 0.0
-      downloadBytesReceived = 0
-      downloadBytesExpected = nil
+      updateDownloadProgress(0.0, receivedBytes: 0, expectedBytes: nil)
 
       switch status {
       case .notDownloaded, .failed, .pending:
@@ -373,7 +373,7 @@
         let currentStatus = await OfflineManager.shared.getDownloadStatus(bookId: bookId)
         switch currentStatus {
         case .downloaded:
-          downloadProgress = 1.0
+          updateDownloadProgress(1.0)
           return
         case .failed(let error):
           throw AppErrorType.operationFailed(message: error)
@@ -383,9 +383,9 @@
           )
         case .pending:
           if let progress = DownloadProgressTracker.shared.progress[bookId] {
-            downloadProgress = progress
+            updateDownloadProgress(progress)
             if progress >= 1 {
-              loadingStage = .processingOfflineFiles
+              updateLoadingStage(.processingOfflineFiles)
             }
           }
         }
@@ -429,15 +429,49 @@
           return
         case .pending:
           if let progress = DownloadProgressTracker.shared.progress[bookId] {
-            downloadProgress = progress
+            updateDownloadProgress(progress)
             if progress >= 1 {
-              loadingStage = .processingOfflineFiles
+              updateLoadingStage(.processingOfflineFiles)
             }
           }
         }
 
         try? await Task.sleep(for: .milliseconds(300))
       }
+    }
+
+    private func updateDownloadProgress(
+      _ progress: Double,
+      receivedBytes: Int64? = nil,
+      expectedBytes: Int64? = nil
+    ) {
+      let displayProgress = ReaderLoadingProgress.displayValue(for: progress)
+      let progressChanged = downloadProgress != displayProgress
+      if progressChanged {
+        downloadProgress = displayProgress
+      }
+      if receivedBytes != nil || expectedBytes != nil {
+        updateDownloadBytesIfNeeded(
+          received: receivedBytes ?? downloadBytesReceived,
+          expected: expectedBytes,
+          progressChanged: progressChanged
+        )
+      }
+    }
+
+    private func updateLoadingStage(_ stage: LoadingStage) {
+      guard loadingStage != stage else { return }
+      loadingStage = stage
+    }
+
+    private func updateDownloadBytesIfNeeded(
+      received: Int64,
+      expected: Int64?,
+      progressChanged: Bool
+    ) {
+      guard progressChanged || downloadBytesReceived == 0 || downloadBytesExpected != expected else { return }
+      downloadBytesReceived = received
+      downloadBytesExpected = expected
     }
 
     func goToNextPage() {

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -469,7 +469,10 @@
       expected: Int64?,
       progressChanged: Bool
     ) {
-      guard progressChanged || downloadBytesReceived == 0 || downloadBytesExpected != expected else { return }
+      guard downloadBytesReceived != received || downloadBytesExpected != expected else { return }
+      guard
+        expected == nil || progressChanged || downloadBytesReceived == 0 || downloadBytesExpected != expected
+      else { return }
       downloadBytesReceived = received
       downloadBytesExpected = expected
     }

--- a/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
@@ -373,7 +373,10 @@
       expected: Int64?,
       progressChanged: Bool
     ) {
-      guard progressChanged || downloadBytesReceived == 0 || downloadBytesExpected != expected else { return }
+      guard downloadBytesReceived != received || downloadBytesExpected != expected else { return }
+      guard
+        expected == nil || progressChanged || downloadBytesReceived == 0 || downloadBytesExpected != expected
+      else { return }
       downloadBytesReceived = received
       downloadBytesExpected = expected
     }

--- a/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
@@ -63,10 +63,14 @@
       let expected = notification.userInfo?[DownloadProgressUserInfo.expectedKey] as? Int64
       let received = notification.userInfo?[DownloadProgressUserInfo.receivedKey] as? Int64 ?? 0
 
-      downloadBytesReceived = received
-      downloadBytesExpected = expected
       if let expected, expected > 0 {
-        downloadProgress = min(1.0, Double(received) / Double(expected))
+        updateDownloadProgress(
+          Double(received) / Double(expected),
+          receivedBytes: received,
+          expectedBytes: expected
+        )
+      } else {
+        updateDownloadProgress(0.0, receivedBytes: received, expectedBytes: expected)
       }
     }
 
@@ -292,7 +296,7 @@
     private func ensureOfflineReady(downloadInfo: DownloadInfo, instanceId: String) async throws {
       let status = await OfflineManager.shared.getDownloadStatus(bookId: downloadInfo.bookId)
       if case .downloaded = status {
-        downloadProgress = 1.0
+        updateDownloadProgress(1.0)
         return
       }
 
@@ -301,15 +305,13 @@
       }
 
       loadingStage = .downloading
-      downloadProgress = 0.0
-      downloadBytesReceived = 0
-      downloadBytesExpected = nil
+      updateDownloadProgress(0.0, receivedBytes: 0, expectedBytes: nil)
 
       switch status {
       case .notDownloaded, .failed, .pending:
         await OfflineManager.shared.downloadForReading(instanceId: instanceId, info: downloadInfo)
       case .downloaded:
-        downloadProgress = 1.0
+        updateDownloadProgress(1.0)
         return
       }
 
@@ -321,7 +323,7 @@
         let currentStatus = await OfflineManager.shared.getDownloadStatus(bookId: bookId)
         switch currentStatus {
         case .downloaded:
-          downloadProgress = 1.0
+          updateDownloadProgress(1.0)
           return
         case .failed(let error):
           throw AppErrorType.operationFailed(message: error)
@@ -331,15 +333,49 @@
           )
         case .pending:
           if let progress = DownloadProgressTracker.shared.progress[bookId] {
-            downloadProgress = progress
+            updateDownloadProgress(progress)
             if progress >= 1 {
-              loadingStage = .processingOfflineFiles
+              updateLoadingStage(.processingOfflineFiles)
             }
           }
         }
 
         try await Task.sleep(for: .milliseconds(200))
       }
+    }
+
+    private func updateDownloadProgress(
+      _ progress: Double,
+      receivedBytes: Int64? = nil,
+      expectedBytes: Int64? = nil
+    ) {
+      let displayProgress = ReaderLoadingProgress.displayValue(for: progress)
+      let progressChanged = downloadProgress != displayProgress
+      if progressChanged {
+        downloadProgress = displayProgress
+      }
+      if receivedBytes != nil || expectedBytes != nil {
+        updateDownloadBytesIfNeeded(
+          received: receivedBytes ?? downloadBytesReceived,
+          expected: expectedBytes,
+          progressChanged: progressChanged
+        )
+      }
+    }
+
+    private func updateLoadingStage(_ stage: PdfLoadingStage) {
+      guard loadingStage != stage else { return }
+      loadingStage = stage
+    }
+
+    private func updateDownloadBytesIfNeeded(
+      received: Int64,
+      expected: Int64?,
+      progressChanged: Bool
+    ) {
+      guard progressChanged || downloadBytesReceived == 0 || downloadBytesExpected != expected else { return }
+      downloadBytesReceived = received
+      downloadBytesExpected = expected
     }
 
     private func buildSnippet(from text: String, matchRange: Range<String.Index>) -> String {

--- a/KMReader/Features/Reader/ViewModels/ReaderLoadingProgress.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderLoadingProgress.swift
@@ -1,0 +1,7 @@
+enum ReaderLoadingProgress {
+  static func displayValue(for progress: Double) -> Double {
+    let normalized = min(max(progress, 0), 1)
+    guard normalized > 0, normalized < 1 else { return normalized }
+    return (normalized * 100).rounded(.down) / 100
+  }
+}

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -937,7 +937,7 @@ class ReaderViewModel {
         onProgress: { [weak self] progress in
           guard let self else { return }
           self.updateLoadingTitle(String(localized: "Offline DIVINA Rendering"))
-          self.clearLoadingProgress()
+          self.updateLoadingProgress(progress.fractionCompleted)
           self.updateLoadingDetail("\(progress.completedPages) / \(progress.totalPages)")
         }
       )

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -823,7 +823,7 @@ class ReaderViewModel {
     let status = await OfflineManager.shared.getDownloadStatus(bookId: book.id)
     if case .downloaded = status {
       if updatesLoadingState {
-        loadingProgress = 1.0
+        updateLoadingProgress(1.0)
       }
       return
     }
@@ -833,9 +833,9 @@ class ReaderViewModel {
     }
 
     if updatesLoadingState {
-      loadingTitle = String(localized: "Downloading book...")
-      loadingDetail = nil
-      loadingProgress = 0.0
+      updateLoadingTitle(String(localized: "Downloading book..."))
+      updateLoadingDetail(nil)
+      updateLoadingProgress(0.0)
     }
 
     switch status {
@@ -845,7 +845,7 @@ class ReaderViewModel {
         info: downloadInfo
       )
     case .downloaded:
-      loadingProgress = 1.0
+      updateLoadingProgress(1.0)
       return
     }
 
@@ -858,8 +858,8 @@ class ReaderViewModel {
       switch currentStatus {
       case .downloaded:
         if updatesLoadingState {
-          loadingProgress = 1.0
-          loadingDetail = nil
+          updateLoadingProgress(1.0)
+          updateLoadingDetail(nil)
         }
         return
       case .failed(let error):
@@ -872,12 +872,12 @@ class ReaderViewModel {
         if updatesLoadingState,
           let progress = DownloadProgressTracker.shared.progress[book.id]
         {
-          loadingProgress = progress
+          updateLoadingProgress(progress)
           if progress >= 1 {
-            loadingTitle = String(localized: "Processing offline files...")
-            loadingDetail = nil
+            updateLoadingTitle(String(localized: "Processing offline files..."))
+            updateLoadingDetail(nil)
           } else {
-            loadingTitle = String(localized: "Downloading book...")
+            updateLoadingTitle(String(localized: "Downloading book..."))
           }
         }
       }
@@ -915,12 +915,12 @@ class ReaderViewModel {
       )
     }
 
-    loadingTitle = String(localized: "Offline DIVINA Rendering")
-    loadingDetail = nil
-    loadingProgress = 0
+    updateLoadingTitle(String(localized: "Offline DIVINA Rendering"))
+    updateLoadingDetail(nil)
+    updateLoadingProgress(0)
     defer {
-      loadingTitle = String(localized: "Loading book...")
-      loadingDetail = nil
+      updateLoadingTitle(String(localized: "Loading book..."))
+      updateLoadingDetail(nil)
       loadingProgress = nil
     }
 
@@ -932,9 +932,9 @@ class ReaderViewModel {
         forceRebuildMetadata: forceRebuildMetadata,
         onProgress: { [weak self] progress in
           guard let self else { return }
-          self.loadingTitle = String(localized: "Offline DIVINA Rendering")
-          self.loadingProgress = progress.fractionCompleted
-          self.loadingDetail = "\(progress.completedPages) / \(progress.totalPages)"
+          self.updateLoadingTitle(String(localized: "Offline DIVINA Rendering"))
+          self.updateLoadingProgress(progress.fractionCompleted)
+          self.updateLoadingDetail("\(progress.completedPages) / \(progress.totalPages)")
         }
       )
     else {
@@ -943,6 +943,22 @@ class ReaderViewModel {
     }
 
     await applyPreparedPDFMetadata(bookId: book.id, result: result)
+  }
+
+  private func updateLoadingTitle(_ title: String) {
+    guard loadingTitle != title else { return }
+    loadingTitle = title
+  }
+
+  private func updateLoadingDetail(_ detail: String?) {
+    guard loadingDetail != detail else { return }
+    loadingDetail = detail
+  }
+
+  private func updateLoadingProgress(_ progress: Double) {
+    let displayProgress = ReaderLoadingProgress.displayValue(for: progress)
+    guard loadingProgress != displayProgress else { return }
+    loadingProgress = displayProgress
   }
 
   private func applyPreparedPDFMetadata(

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -823,7 +823,7 @@ class ReaderViewModel {
     let status = await OfflineManager.shared.getDownloadStatus(bookId: book.id)
     if case .downloaded = status {
       if updatesLoadingState {
-        updateLoadingProgress(1.0)
+        clearLoadingProgress()
       }
       return
     }
@@ -835,7 +835,7 @@ class ReaderViewModel {
     if updatesLoadingState {
       updateLoadingTitle(String(localized: "Downloading book..."))
       updateLoadingDetail(nil)
-      updateLoadingProgress(0.0)
+      clearLoadingProgress()
     }
 
     switch status {
@@ -845,7 +845,7 @@ class ReaderViewModel {
         info: downloadInfo
       )
     case .downloaded:
-      updateLoadingProgress(1.0)
+      clearLoadingProgress()
       return
     }
 
@@ -858,7 +858,7 @@ class ReaderViewModel {
       switch currentStatus {
       case .downloaded:
         if updatesLoadingState {
-          updateLoadingProgress(1.0)
+          clearLoadingProgress()
           updateLoadingDetail(nil)
         }
         return
@@ -872,11 +872,15 @@ class ReaderViewModel {
         if updatesLoadingState,
           let progress = DownloadProgressTracker.shared.progress[book.id]
         {
-          updateLoadingProgress(progress)
           if progress >= 1 {
+            clearLoadingProgress()
             updateLoadingTitle(String(localized: "Processing offline files..."))
             updateLoadingDetail(nil)
+          } else if progress > 0 {
+            updateLoadingProgress(progress)
+            updateLoadingTitle(String(localized: "Downloading book..."))
           } else {
+            clearLoadingProgress()
             updateLoadingTitle(String(localized: "Downloading book..."))
           }
         }
@@ -917,11 +921,11 @@ class ReaderViewModel {
 
     updateLoadingTitle(String(localized: "Offline DIVINA Rendering"))
     updateLoadingDetail(nil)
-    updateLoadingProgress(0)
+    clearLoadingProgress()
     defer {
       updateLoadingTitle(String(localized: "Loading book..."))
       updateLoadingDetail(nil)
-      loadingProgress = nil
+      clearLoadingProgress()
     }
 
     guard
@@ -933,7 +937,7 @@ class ReaderViewModel {
         onProgress: { [weak self] progress in
           guard let self else { return }
           self.updateLoadingTitle(String(localized: "Offline DIVINA Rendering"))
-          self.updateLoadingProgress(progress.fractionCompleted)
+          self.clearLoadingProgress()
           self.updateLoadingDetail("\(progress.completedPages) / \(progress.totalPages)")
         }
       )
@@ -959,6 +963,11 @@ class ReaderViewModel {
     let displayProgress = ReaderLoadingProgress.displayValue(for: progress)
     guard loadingProgress != displayProgress else { return }
     loadingProgress = displayProgress
+  }
+
+  private func clearLoadingProgress() {
+    guard loadingProgress != nil else { return }
+    loadingProgress = nil
   }
 
   private func applyPreparedPDFMetadata(

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -653,10 +653,7 @@
     }
 
     private var loadingProgress: Double? {
-      if viewModel.loadingStage == .processingOfflineFiles {
-        return 1.0
-      }
-
+      guard viewModel.loadingStage == .downloading else { return nil }
       if let expectedBytes = viewModel.downloadBytesExpected, expectedBytes > 0 {
         return viewModel.downloadProgress
       }

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -657,10 +657,11 @@
         return 1.0
       }
 
-      guard viewModel.downloadBytesReceived > 0 || viewModel.downloadProgress > 0 else {
-        return nil
+      if let expectedBytes = viewModel.downloadBytesExpected, expectedBytes > 0 {
+        return viewModel.downloadProgress
       }
-      return viewModel.downloadProgress
+
+      return viewModel.downloadProgress > 0 ? viewModel.downloadProgress : nil
     }
 
     private var loadingDetail: String? {
@@ -668,11 +669,15 @@
       case .fetchingMetadata:
         return String(localized: "Fetching book metadata")
       case .downloading:
-        if let expectedBytes = viewModel.downloadBytesExpected {
+        if let expectedBytes = viewModel.downloadBytesExpected, expectedBytes > 0 {
           let received = Double(viewModel.downloadBytesReceived)
           let expected = Double(expectedBytes)
           return
             "\(String(format: "%.1f", received / 1024 / 1024)) / \(String(format: "%.1f", expected / 1024 / 1024)) MB"
+        }
+        if viewModel.downloadBytesReceived > 0 {
+          let received = Double(viewModel.downloadBytesReceived)
+          return "\(String(format: "%.1f", received / 1024 / 1024)) MB"
         }
         return String(localized: "Downloading book content")
       case .processingOfflineFiles:

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -430,10 +430,11 @@
         return 1.0
       }
 
-      guard viewModel.downloadBytesReceived > 0 || viewModel.downloadProgress > 0 else {
-        return nil
+      if let expectedBytes = viewModel.downloadBytesExpected, expectedBytes > 0 {
+        return viewModel.downloadProgress
       }
-      return viewModel.downloadProgress
+
+      return viewModel.downloadProgress > 0 ? viewModel.downloadProgress : nil
     }
 
     private var loadingDetail: String? {

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -426,10 +426,7 @@
     }
 
     private var loadingProgress: Double? {
-      if viewModel.loadingStage == .processingOfflineFiles {
-        return 1.0
-      }
-
+      guard viewModel.loadingStage == .downloading else { return nil }
       if let expectedBytes = viewModel.downloadBytesExpected, expectedBytes > 0 {
         return viewModel.downloadProgress
       }

--- a/KMReader/Features/Reader/Views/ReaderLoadingView.swift
+++ b/KMReader/Features/Reader/Views/ReaderLoadingView.swift
@@ -15,12 +15,15 @@ struct ReaderLoadingView: View {
   }
 
   private var showsProgress: Bool {
-    guard let normalizedProgress else { return false }
-    return normalizedProgress > 0
+    normalizedProgress != nil
   }
 
   private var progressText: String {
     (normalizedProgress ?? 0).formatted(.percent.precision(.fractionLength(0)))
+  }
+
+  private var numericProgress: Double {
+    normalizedProgress ?? 0
   }
 
   var body: some View {
@@ -45,11 +48,13 @@ struct ReaderLoadingView: View {
           .frame(width: 64, height: 64)
           .rotationEffect(.degrees(-90))
           .opacity(showsProgress ? 1 : 0)
-          .animation(.spring(duration: 0.6, bounce: 0.3), value: normalizedProgress)
+          .animation(.easeOut(duration: 0.16), value: normalizedProgress)
 
         Text(progressText)
           .font(.system(.subheadline, design: .rounded).bold())
           .monospacedDigit()
+          .contentTransition(.numericText(value: numericProgress))
+          .animation(.easeOut(duration: 0.16), value: numericProgress)
           .opacity(showsProgress ? 1 : 0)
           .accessibilityHidden(!showsProgress)
 
@@ -84,7 +89,6 @@ struct ReaderLoadingView: View {
         }
     }
     .shadow(color: Color.black.opacity(0.12), radius: 30, x: 0, y: 15)
-    .transition(.opacity.combined(with: .scale(scale: 0.95)))
   }
 }
 


### PR DESCRIPTION
## Summary
- Normalize reader loading progress updates before they reach the UI
- Preserve byte counters and loading stages while avoiding redundant state writes
- Make the loading indicator animation and percent text transitions smoother

## Testing
- Not run (not requested)