### PR TITLE
fix: persist EPUB reader color scheme

### DIFF
--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -2489,7 +2489,8 @@ actor OfflineManager {
 
   private func existingImageArchiveFileURL(in bookDir: URL) -> URL? {
     let formats: [DownloadedImageArchiveFormat] = [.cbz, .cbr]
-    return formats
+    return
+      formats
       .map { bookDir.appendingPathComponent($0.fileName) }
       .first { FileManager.default.fileExists(atPath: $0.path) }
   }

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -199,7 +199,11 @@
     }
 
     private var readerTheme: ReaderTheme {
-      activeThemePreferences.resolvedTheme(for: colorScheme)
+      activeThemePreferences.resolvedTheme(fallbackColorScheme: colorScheme)
+    }
+
+    private var readerColorScheme: ColorScheme {
+      activeThemePreferences.resolvedColorScheme(fallbackColorScheme: colorScheme)
     }
 
     #if os(macOS)
@@ -250,7 +254,7 @@
         }
         .onAppear {
           updateHandoff()
-          viewModel.applyPreferences(activeThemePreferences, colorScheme: colorScheme)
+          viewModel.applyPreferences(activeThemePreferences, colorScheme: readerColorScheme)
           #if os(macOS)
             configureReaderCommands()
           #endif
@@ -286,14 +290,20 @@
           #endif
         }
         .onChange(of: activeThemePreferences) { _, newPrefs in
-          viewModel.applyPreferences(newPrefs, colorScheme: colorScheme)
+          viewModel.applyPreferences(
+            newPrefs,
+            colorScheme: newPrefs.resolvedColorScheme(fallbackColorScheme: colorScheme)
+          )
         }
         .onChange(of: globalThemePreferences) { _, newPrefs in
           guard !isUsingBookPreferences else { return }
           activeThemePreferences = newPrefs
         }
         .onChange(of: colorScheme) { _, newScheme in
-          viewModel.applyPreferences(activeThemePreferences, colorScheme: newScheme)
+          let newReaderColorScheme = activeThemePreferences.resolvedColorScheme(
+            fallbackColorScheme: newScheme
+          )
+          viewModel.applyPreferences(activeThemePreferences, colorScheme: newReaderColorScheme)
         }
         .onReceive(
           NotificationCenter.default.publisher(for: .fileDownloadProgress)
@@ -408,7 +418,7 @@
         EpubEndPageView(
           bookTitle: currentBook?.metadata.title,
           preferences: activeThemePreferences,
-          colorScheme: colorScheme,
+          colorScheme: readerColorScheme,
           onReturn: {
             // Hide end page first, then navigate to last page
             showingEndPage = false
@@ -500,7 +510,7 @@
             WebPubPagedCoverView(
               viewModel: viewModel,
               preferences: activeThemePreferences,
-              colorScheme: colorScheme,
+              colorScheme: readerColorScheme,
               animateTapTurns: animateEpubTapTurns,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
@@ -519,7 +529,7 @@
               viewModel: viewModel,
               animatePageTransitions: animateEpubTapTurns,
               preferences: activeThemePreferences,
-              colorScheme: colorScheme,
+              colorScheme: readerColorScheme,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
               onCenterTap: {
@@ -537,7 +547,7 @@
           WebPubScrolledView(
             viewModel: viewModel,
             preferences: activeThemePreferences,
-            colorScheme: colorScheme,
+            colorScheme: readerColorScheme,
             tapScrollPercentage: epubTapScrollPercentage,
             animateTapTurns: animateEpubTapTurns,
             showingControls: shouldShowControls,
@@ -562,7 +572,7 @@
               viewModel: viewModel,
               animatePageTransitions: animateEpubTapTurns,
               preferences: activeThemePreferences,
-              colorScheme: colorScheme,
+              colorScheme: readerColorScheme,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
               onCenterTap: {
@@ -579,7 +589,7 @@
             WebPubPagedCoverView(
               viewModel: viewModel,
               preferences: activeThemePreferences,
-              colorScheme: colorScheme,
+              colorScheme: readerColorScheme,
               animateTapTurns: animateEpubTapTurns,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
@@ -597,7 +607,7 @@
             WebPubPagedCurlView(
               viewModel: viewModel,
               preferences: activeThemePreferences,
-              colorScheme: colorScheme,
+              colorScheme: readerColorScheme,
               animateTapTurns: animateEpubTapTurns,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
@@ -616,7 +626,7 @@
           WebPubScrolledView(
             viewModel: viewModel,
             preferences: activeThemePreferences,
-            colorScheme: colorScheme,
+            colorScheme: readerColorScheme,
             tapScrollPercentage: epubTapScrollPercentage,
             animateTapTurns: animateEpubTapTurns,
             showingControls: shouldShowControls,

--- a/KMReader/Features/Reader/Views/Models/EpubThemePreferences.swift
+++ b/KMReader/Features/Reader/Views/Models/EpubThemePreferences.swift
@@ -57,6 +57,7 @@ nonisolated struct EpubThemePreferences: RawRepresentable, Equatable, Sendable {
   ]
 
   var theme: ThemeChoice
+  var colorScheme: AppColorScheme
   var fontFamily: FontFamilyChoice
   var fontWeight: Double?
   var advancedLayout: Bool
@@ -72,6 +73,7 @@ nonisolated struct EpubThemePreferences: RawRepresentable, Equatable, Sendable {
 
   init(
     theme: ThemeChoice = .system,
+    colorScheme: AppColorScheme = .system,
     fontFamily: FontFamilyChoice = .publisher,
     fontWeight: Double? = nil,
     advancedLayout: Bool = false,
@@ -86,6 +88,7 @@ nonisolated struct EpubThemePreferences: RawRepresentable, Equatable, Sendable {
     pageMargins: Double = EpubConstants.defaultPageMargins,
   ) {
     self.theme = theme
+    self.colorScheme = colorScheme
     self.fontFamily = fontFamily
     self.fontSize = fontSize
     self.wordSpacing = wordSpacing
@@ -114,6 +117,7 @@ nonisolated struct EpubThemePreferences: RawRepresentable, Equatable, Sendable {
     }
 
     let theme = (dict["theme"] as? String).flatMap(ThemeChoice.init) ?? .system
+    let colorScheme = (dict["colorScheme"] as? String).flatMap(AppColorScheme.init) ?? .system
     let fontString = dict["fontFamily"] as? String ?? FontFamilyChoice.publisher.rawValue
     let font = FontFamilyChoice(rawValue: fontString)
     let rawFontWeight = dict["fontWeight"] as? Double
@@ -135,6 +139,7 @@ nonisolated struct EpubThemePreferences: RawRepresentable, Equatable, Sendable {
 
     self.init(
       theme: theme,
+      colorScheme: colorScheme,
       fontFamily: font,
       fontWeight: fontWeight,
       advancedLayout: advancedLayout,
@@ -153,6 +158,7 @@ nonisolated struct EpubThemePreferences: RawRepresentable, Equatable, Sendable {
   var rawValue: String {
     var dict: [String: Any] = [
       "theme": theme.rawValue,
+      "colorScheme": colorScheme.rawValue,
       "fontFamily": fontFamily.rawValue,
       "advancedLayout": advancedLayout,
       "fontSize": fontSize,
@@ -178,6 +184,16 @@ nonisolated struct EpubThemePreferences: RawRepresentable, Equatable, Sendable {
 
   func resolvedTheme(for colorScheme: ColorScheme? = nil) -> ReaderTheme {
     theme.resolvedTheme(for: colorScheme)
+  }
+
+  func resolvedColorScheme(fallbackColorScheme: ColorScheme) -> ColorScheme {
+    colorScheme.colorScheme ?? fallbackColorScheme
+  }
+
+  func resolvedTheme(fallbackColorScheme: ColorScheme) -> ReaderTheme {
+    theme.resolvedTheme(
+      for: resolvedColorScheme(fallbackColorScheme: fallbackColorScheme)
+    )
   }
 
   func makeReadiumPayload(

--- a/KMReader/Features/Reader/Views/Sheets/EpubSettingsPreviewView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubSettingsPreviewView.swift
@@ -16,7 +16,7 @@
     var body: some View {
       PlatformPreviewWebView(
         preferences: preferences,
-        colorScheme: colorScheme,
+        colorScheme: resolvedColorScheme,
         customFontPath: customFontPath
       )
       .task(id: customFontName ?? "") {
@@ -44,6 +44,10 @@
           customFontPath = nil
         }
       }
+    }
+
+    private var resolvedColorScheme: ColorScheme {
+      preferences.resolvedColorScheme(fallbackColorScheme: colorScheme)
     }
   }
 

--- a/KMReader/Features/Reader/Views/Sheets/EpubThemePreferencesView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubThemePreferencesView_macOS.swift
@@ -50,7 +50,11 @@
     }
 
     private var readerTheme: ReaderTheme {
-      draft.theme.resolvedTheme(for: colorScheme)
+      draft.resolvedTheme(fallbackColorScheme: colorScheme)
+    }
+
+    private var resolvedColorScheme: ColorScheme {
+      draft.resolvedColorScheme(fallbackColorScheme: colorScheme)
     }
 
     private var backgroundColor: Color {
@@ -119,7 +123,7 @@
 
     @ViewBuilder
     private func themePreviewButton(for choice: ThemeChoice) -> some View {
-      let previewTheme = choice.resolvedTheme(for: colorScheme)
+      let previewTheme = choice.resolvedTheme(for: resolvedColorScheme)
       let isSelected = draft.theme == choice
 
       Button {
@@ -172,6 +176,15 @@
           }
 
           Section(String(localized: "Theme")) {
+            Picker(
+              String(localized: "settings.appearance.colorScheme.title"),
+              selection: $draft.colorScheme
+            ) {
+              ForEach(AppColorScheme.allCases) { scheme in
+                Text(scheme.label).tag(scheme)
+              }
+            }
+
             themePicker
           }
 

--- a/KMReader/Features/Settings/EpubThemePreferencesView.swift
+++ b/KMReader/Features/Settings/EpubThemePreferencesView.swift
@@ -64,7 +64,11 @@
     }
 
     private var readerTheme: ReaderTheme {
-      draft.theme.resolvedTheme(for: colorScheme)
+      draft.resolvedTheme(fallbackColorScheme: colorScheme)
+    }
+
+    private var resolvedColorScheme: ColorScheme {
+      draft.resolvedColorScheme(fallbackColorScheme: colorScheme)
     }
 
     private var backgroundColor: Color {
@@ -123,7 +127,7 @@
 
     @ViewBuilder
     private func themePreviewButton(for choice: ThemeChoice) -> some View {
-      let previewTheme = choice.resolvedTheme(for: colorScheme)
+      let previewTheme = choice.resolvedTheme(for: resolvedColorScheme)
       let isSelected = draft.theme == choice
 
       Button {
@@ -167,6 +171,15 @@
         }
 
         Section(String(localized: "Theme")) {
+          Picker(
+            String(localized: "settings.appearance.colorScheme.title"),
+            selection: $draft.colorScheme
+          ) {
+            ForEach(AppColorScheme.allCases) { scheme in
+              Text(scheme.label).tag(scheme)
+            }
+          }
+
           themePicker
         }
 

--- a/KMReader/Shared/Foundation/Models/AppColorScheme.swift
+++ b/KMReader/Shared/Foundation/Models/AppColorScheme.swift
@@ -5,7 +5,7 @@
 
 import SwiftUI
 
-enum AppColorScheme: String, CaseIterable, Identifiable {
+enum AppColorScheme: String, CaseIterable, Identifiable, Sendable {
   case system
   case light
   case dark
@@ -23,7 +23,7 @@ enum AppColorScheme: String, CaseIterable, Identifiable {
     }
   }
 
-  var colorScheme: ColorScheme? {
+  nonisolated var colorScheme: ColorScheme? {
     switch self {
     case .system:
       return nil


### PR DESCRIPTION
## Summary
- Persist the EPUB reader color scheme alongside theme preferences
- Add a light/dark/system color scheme picker to EPUB theme settings
- Resolve the reader and preview color scheme from the saved EPUB preference, with system falling back to the app-effective scheme

- Related: #874

## Testing
- `make build`
