### PR TITLE
feat: add EPUB overlay customization

### DIFF
--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -1080,15 +1080,17 @@ enum AppConfig {
     }
   }
 
-  static nonisolated var epubShowsProgressFooter: Bool {
+  static nonisolated var epubOverlayPreferences: EpubOverlayPreferences {
     get {
-      if UserDefaults.standard.object(forKey: "epubShowsProgressFooter") != nil {
-        return UserDefaults.standard.bool(forKey: "epubShowsProgressFooter")
+      if let stored = UserDefaults.standard.string(forKey: "epubOverlayPreferences"),
+        let preferences = EpubOverlayPreferences(rawValue: stored)
+      {
+        return preferences
       }
-      return false
+      return EpubOverlayPreferences()
     }
     set {
-      UserDefaults.standard.set(newValue, forKey: "epubShowsProgressFooter")
+      UserDefaults.standard.set(newValue.rawValue, forKey: "epubOverlayPreferences")
     }
   }
 

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -26,6 +26,8 @@
     @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
     @AppStorage("epubShowsStatusBarWhileReading") private var epubShowsStatusBarWhileReading: Bool = false
     @AppStorage("animateEpubTapTurns") private var animateEpubTapTurns: Bool = AppConfig.animateEpubTapTurns
+    @AppStorage("epubOverlayPreferences") private var epubOverlayPreferences: EpubOverlayPreferences = AppConfig
+      .epubOverlayPreferences
     @AppStorage("epubShowKeyboardHelpOverlay")
     private var showKeyboardHelpOverlay: Bool = AppConfig.epubShowKeyboardHelpOverlay
 
@@ -512,6 +514,7 @@
               preferences: activeThemePreferences,
               colorScheme: readerColorScheme,
               animateTapTurns: animateEpubTapTurns,
+              overlayPreferences: epubOverlayPreferences,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
               onCenterTap: {
@@ -530,6 +533,7 @@
               animatePageTransitions: animateEpubTapTurns,
               preferences: activeThemePreferences,
               colorScheme: readerColorScheme,
+              overlayPreferences: epubOverlayPreferences,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
               onCenterTap: {
@@ -550,6 +554,7 @@
             colorScheme: readerColorScheme,
             tapScrollPercentage: epubTapScrollPercentage,
             animateTapTurns: animateEpubTapTurns,
+            overlayPreferences: epubOverlayPreferences,
             showingControls: shouldShowControls,
             bookTitle: currentBook?.metadata.title,
             onCenterTap: {
@@ -573,6 +578,7 @@
               animatePageTransitions: animateEpubTapTurns,
               preferences: activeThemePreferences,
               colorScheme: readerColorScheme,
+              overlayPreferences: epubOverlayPreferences,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
               onCenterTap: {
@@ -591,6 +597,7 @@
               preferences: activeThemePreferences,
               colorScheme: readerColorScheme,
               animateTapTurns: animateEpubTapTurns,
+              overlayPreferences: epubOverlayPreferences,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
               onCenterTap: {
@@ -609,6 +616,7 @@
               preferences: activeThemePreferences,
               colorScheme: readerColorScheme,
               animateTapTurns: animateEpubTapTurns,
+              overlayPreferences: epubOverlayPreferences,
               showingControls: shouldShowControls,
               bookTitle: currentBook?.metadata.title,
               onCenterTap: {
@@ -629,6 +637,7 @@
             colorScheme: readerColorScheme,
             tapScrollPercentage: epubTapScrollPercentage,
             animateTapTurns: animateEpubTapTurns,
+            overlayPreferences: epubOverlayPreferences,
             showingControls: shouldShowControls,
             bookTitle: currentBook?.metadata.title,
             onCenterTap: {

--- a/KMReader/Features/Reader/Views/Epub/WebPubInfoOverlaySupport.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubInfoOverlaySupport.swift
@@ -23,8 +23,9 @@
 
     struct Content: Equatable {
       let showingControls: Bool
-      let topTitle: Entry
-      let topProgress: Entry
+      let topLeading: Entry
+      let topCenter: Entry
+      let topTrailing: Entry
       let bottomLeading: Entry
       let bottomCenter: Entry
       let bottomTrailing: Entry
@@ -43,43 +44,29 @@
       currentPageIndex: Int,
       totalPagesInChapter: Int,
       showingControls: Bool,
-      showProgressFooter: Bool = false
+      overlayPreferences: EpubOverlayPreferences = AppConfig.epubOverlayPreferences
     ) -> Content {
-      let topTitle =
-        showingControls
-        ? Entry.hidden
-        : visibleEntry(bookTitle)
-      let topProgress: Entry
-      if showingControls, let totalProgression {
-        let percentage = totalProgression.formatted(.percent.precision(.fractionLength(2)))
-        topProgress = Entry(
-          text: String(localized: "Book Progress \(percentage)"),
-          isVisible: true
-        )
-      } else {
-        topProgress = .hidden
-      }
-
-      guard totalPagesInChapter > 0 else {
-        return Content(
-          showingControls: showingControls,
-          topTitle: topTitle,
-          topProgress: topProgress,
-          bottomLeading: .hidden,
-          bottomCenter: .hidden,
-          bottomTrailing: .hidden,
-          bottomProgress: nil
-        )
-      }
-
       if showingControls {
         return Content(
           showingControls: showingControls,
-          topTitle: topTitle,
-          topProgress: topProgress,
-          bottomLeading: .hidden,
-          bottomCenter: controlsCenterEntry(
+          topLeading: .hidden,
+          topCenter: entry(
+            for: overlayPreferences.controlsHeaderCenter,
             flowStyle: flowStyle,
+            bookTitle: bookTitle,
+            chapterTitle: chapterTitle,
+            totalProgression: totalProgression,
+            currentPageIndex: currentPageIndex,
+            totalPagesInChapter: totalPagesInChapter
+          ),
+          topTrailing: .hidden,
+          bottomLeading: .hidden,
+          bottomCenter: entry(
+            for: overlayPreferences.controlsFooterCenter,
+            flowStyle: flowStyle,
+            bookTitle: bookTitle,
+            chapterTitle: chapterTitle,
+            totalProgression: totalProgression,
             currentPageIndex: currentPageIndex,
             totalPagesInChapter: totalPagesInChapter
           ),
@@ -88,20 +75,63 @@
         )
       }
 
-      let bottomProgress = showProgressFooter ? totalProgression : nil
-
       return Content(
         showingControls: showingControls,
-        topTitle: topTitle,
-        topProgress: topProgress,
-        bottomLeading: visibleEntry(chapterTitle),
-        bottomCenter: .hidden,
-        bottomTrailing: trailingEntry(
+        topLeading: entry(
+          for: overlayPreferences.readerHeaderLeading,
           flowStyle: flowStyle,
+          bookTitle: bookTitle,
+          chapterTitle: chapterTitle,
+          totalProgression: totalProgression,
           currentPageIndex: currentPageIndex,
           totalPagesInChapter: totalPagesInChapter
         ),
-        bottomProgress: bottomProgress
+        topCenter: entry(
+          for: overlayPreferences.readerHeaderCenter,
+          flowStyle: flowStyle,
+          bookTitle: bookTitle,
+          chapterTitle: chapterTitle,
+          totalProgression: totalProgression,
+          currentPageIndex: currentPageIndex,
+          totalPagesInChapter: totalPagesInChapter
+        ),
+        topTrailing: entry(
+          for: overlayPreferences.readerHeaderTrailing,
+          flowStyle: flowStyle,
+          bookTitle: bookTitle,
+          chapterTitle: chapterTitle,
+          totalProgression: totalProgression,
+          currentPageIndex: currentPageIndex,
+          totalPagesInChapter: totalPagesInChapter
+        ),
+        bottomLeading: entry(
+          for: overlayPreferences.readerFooterLeading,
+          flowStyle: flowStyle,
+          bookTitle: bookTitle,
+          chapterTitle: chapterTitle,
+          totalProgression: totalProgression,
+          currentPageIndex: currentPageIndex,
+          totalPagesInChapter: totalPagesInChapter
+        ),
+        bottomCenter: entry(
+          for: overlayPreferences.readerFooterCenter,
+          flowStyle: flowStyle,
+          bookTitle: bookTitle,
+          chapterTitle: chapterTitle,
+          totalProgression: totalProgression,
+          currentPageIndex: currentPageIndex,
+          totalPagesInChapter: totalPagesInChapter
+        ),
+        bottomTrailing: entry(
+          for: overlayPreferences.readerFooterTrailing,
+          flowStyle: flowStyle,
+          bookTitle: bookTitle,
+          chapterTitle: chapterTitle,
+          totalProgression: totalProgression,
+          currentPageIndex: currentPageIndex,
+          totalPagesInChapter: totalPagesInChapter
+        ),
+        bottomProgress: overlayPreferences.showsReaderProgressBar ? totalProgression.map(clampedProgress) : nil
       )
     }
 
@@ -112,7 +142,62 @@
       return Entry(text: trimmed, isVisible: true)
     }
 
-    private static func controlsCenterEntry(
+    private static func entry(
+      for item: EpubOverlayTextItem,
+      flowStyle: FlowStyle,
+      bookTitle: String?,
+      chapterTitle: String?,
+      totalProgression: Double?,
+      currentPageIndex: Int,
+      totalPagesInChapter: Int
+    ) -> Entry {
+      switch item {
+      case .none:
+        return .hidden
+      case .bookTitle:
+        return visibleEntry(bookTitle)
+      case .chapterTitle:
+        return visibleEntry(chapterTitle)
+      case .bookProgressPercent:
+        guard let totalProgression else { return .hidden }
+        let percentage = clampedProgress(totalProgression).formatted(.percent.precision(.fractionLength(2)))
+        return Entry(
+          text: String(localized: "Book Progress \(percentage)"),
+          isVisible: true
+        )
+      case .bookRemainingPercent:
+        guard let totalProgression else { return .hidden }
+        let remaining = (1.0 - clampedProgress(totalProgression)).formatted(.percent.precision(.fractionLength(2)))
+        return Entry(text: String(localized: "\(remaining) left"), isVisible: true)
+      case .chapterProgressPercent:
+        guard totalPagesInChapter > 0 else { return .hidden }
+        let progress = chapterProgress(
+          currentPageIndex: currentPageIndex,
+          totalPagesInChapter: totalPagesInChapter
+        )
+        let percentage = progress.formatted(.percent.precision(.fractionLength(1)))
+        return Entry(
+          text: String(localized: "Chapter Progress \(percentage)"),
+          isVisible: true
+        )
+      case .chapterRemaining:
+        guard totalPagesInChapter > 0 else { return .hidden }
+        return chapterRemainingEntry(
+          flowStyle: flowStyle,
+          currentPageIndex: currentPageIndex,
+          totalPagesInChapter: totalPagesInChapter
+        )
+      case .chapterPosition:
+        guard totalPagesInChapter > 0 else { return .hidden }
+        return chapterPositionEntry(
+          flowStyle: flowStyle,
+          currentPageIndex: currentPageIndex,
+          totalPagesInChapter: totalPagesInChapter
+        )
+      }
+    }
+
+    private static func chapterPositionEntry(
       flowStyle: FlowStyle,
       currentPageIndex: Int,
       totalPagesInChapter: Int
@@ -137,7 +222,7 @@
       }
     }
 
-    private static func trailingEntry(
+    private static func chapterRemainingEntry(
       flowStyle: FlowStyle,
       currentPageIndex: Int,
       totalPagesInChapter: Int
@@ -164,15 +249,20 @@
       currentPageIndex: Int,
       totalPagesInChapter: Int
     ) -> Double {
-      min(1.0, max(0.0, Double(currentPageIndex + 1) / Double(totalPagesInChapter)))
+      clampedProgress(Double(currentPageIndex + 1) / Double(totalPagesInChapter))
+    }
+
+    private static func clampedProgress(_ value: Double) -> Double {
+      min(1.0, max(0.0, value))
     }
 
     #if os(iOS)
       @MainActor
       final class UIKitOverlay {
         private weak var containerView: UIView?
-        private let topTitleLabel: UILabel
-        private let topProgressLabel: UILabel
+        private let topLeadingLabel: UILabel
+        private let topCenterLabel: UILabel
+        private let topTrailingLabel: UILabel
         private let bottomLeadingLabel: UILabel
         private let bottomCenterLabel: UILabel
         private let bottomTrailingLabel: UILabel
@@ -181,8 +271,9 @@
         private let bottomProgressFillWidthConstraint: NSLayoutConstraint
         private var currentContent = Content(
           showingControls: false,
-          topTitle: .hidden,
-          topProgress: .hidden,
+          topLeading: .hidden,
+          topCenter: .hidden,
+          topTrailing: .hidden,
           bottomLeading: .hidden,
           bottomCenter: .hidden,
           bottomTrailing: .hidden,
@@ -198,8 +289,9 @@
           theme: ReaderTheme
         ) {
           self.containerView = containerView
-          topTitleLabel = Self.makeLabel(fontSize: 14, alignment: .center)
-          topProgressLabel = Self.makeLabel(fontSize: 14, alignment: .center)
+          topLeadingLabel = Self.makeLabel(fontSize: 14, alignment: .left)
+          topCenterLabel = Self.makeLabel(fontSize: 14, alignment: .center)
+          topTrailingLabel = Self.makeLabel(fontSize: 14, alignment: .right)
           bottomLeadingLabel = Self.makeLabel(fontSize: 12, alignment: .left)
           bottomCenterLabel = Self.makeLabel(fontSize: 12, alignment: .center, monospaced: true)
           bottomTrailingLabel = Self.makeLabel(fontSize: 12, alignment: .right, monospaced: true)
@@ -225,30 +317,42 @@
 
           let bottomConstant = -bottomOffset
           [
-            topTitleLabel, topProgressLabel, bottomLeadingLabel, bottomCenterLabel, bottomTrailingLabel,
+            topLeadingLabel, topCenterLabel, topTrailingLabel, bottomLeadingLabel, bottomCenterLabel,
+            bottomTrailingLabel,
             bottomProgressTrackView,
           ]
           .forEach(containerView.addSubview)
 
           NSLayoutConstraint.activate([
-            topTitleLabel.topAnchor.constraint(equalTo: topAnchor, constant: topOffset),
-            topTitleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-            topTitleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            topLeadingLabel.topAnchor.constraint(equalTo: topAnchor, constant: topOffset),
+            topLeadingLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            topLeadingLabel.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor, multiplier: 0.34),
 
-            topProgressLabel.topAnchor.constraint(equalTo: topAnchor, constant: topOffset),
-            topProgressLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-            topProgressLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            topCenterLabel.topAnchor.constraint(equalTo: topAnchor, constant: topOffset),
+            topCenterLabel.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            topCenterLabel.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor, multiplier: 0.45),
+            topCenterLabel.leadingAnchor.constraint(greaterThanOrEqualTo: topLeadingLabel.trailingAnchor, constant: 8),
+
+            topTrailingLabel.topAnchor.constraint(equalTo: topAnchor, constant: topOffset),
+            topTrailingLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            topTrailingLabel.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor, multiplier: 0.34),
+            topTrailingLabel.leadingAnchor.constraint(greaterThanOrEqualTo: topCenterLabel.trailingAnchor, constant: 8),
 
             bottomLeadingLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomConstant),
             bottomLeadingLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            bottomLeadingLabel.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor, multiplier: 0.34),
 
             bottomCenterLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomConstant),
             bottomCenterLabel.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            bottomCenterLabel.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor, multiplier: 0.45),
+            bottomCenterLabel.leadingAnchor.constraint(
+              greaterThanOrEqualTo: bottomLeadingLabel.trailingAnchor, constant: 8),
 
             bottomTrailingLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: bottomConstant),
             bottomTrailingLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            bottomTrailingLabel.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor, multiplier: 0.34),
             bottomTrailingLabel.leadingAnchor.constraint(
-              greaterThanOrEqualTo: bottomLeadingLabel.trailingAnchor, constant: 8),
+              greaterThanOrEqualTo: bottomCenterLabel.trailingAnchor, constant: 8),
 
             bottomProgressTrackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
             bottomProgressTrackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
@@ -268,70 +372,160 @@
           bottomTrailingLabel.setContentHuggingPriority(.required, for: .horizontal)
           bottomCenterLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
           bottomCenterLabel.setContentHuggingPriority(.required, for: .horizontal)
+          topLeadingLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+          topLeadingLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+          topTrailingLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+          topTrailingLabel.setContentHuggingPriority(.required, for: .horizontal)
+          topCenterLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+          topCenterLabel.setContentHuggingPriority(.required, for: .horizontal)
 
           apply(theme: theme)
         }
 
         func apply(theme: ReaderTheme) {
           let labelColor = theme.uiColorText.withAlphaComponent(0.6)
-          [topTitleLabel, topProgressLabel, bottomLeadingLabel, bottomCenterLabel, bottomTrailingLabel]
-            .forEach { $0.textColor = labelColor }
+          [
+            topLeadingLabel, topCenterLabel, topTrailingLabel, bottomLeadingLabel, bottomCenterLabel,
+            bottomTrailingLabel,
+          ]
+          .forEach { $0.textColor = labelColor }
           bottomProgressTrackView.backgroundColor = theme.uiColorText.withAlphaComponent(0.18)
           bottomProgressFillView.backgroundColor = theme.uiColorText.withAlphaComponent(0.85)
         }
 
         func update(content: Content, animated: Bool) {
           guard content != currentContent else { return }
+          let previousContent = currentContent
           currentContent = content
-          let updates = {
-            if let text = content.topTitle.text {
-              self.topTitleLabel.text = text
-            }
-            self.topTitleLabel.alpha = content.topTitle.isVisible ? 1.0 : 0.0
+          apply(
+            entry: content.topLeading,
+            previousEntry: previousContent.topLeading,
+            to: topLeadingLabel,
+            animated: animated
+          )
+          apply(
+            entry: content.topCenter,
+            previousEntry: previousContent.topCenter,
+            to: topCenterLabel,
+            animated: animated
+          )
+          apply(
+            entry: content.topTrailing,
+            previousEntry: previousContent.topTrailing,
+            to: topTrailingLabel,
+            animated: animated
+          )
+          apply(
+            entry: content.bottomLeading,
+            previousEntry: previousContent.bottomLeading,
+            to: bottomLeadingLabel,
+            animated: animated
+          )
+          apply(
+            entry: content.bottomCenter,
+            previousEntry: previousContent.bottomCenter,
+            to: bottomCenterLabel,
+            animated: animated
+          )
+          apply(
+            entry: content.bottomTrailing,
+            previousEntry: previousContent.bottomTrailing,
+            to: bottomTrailingLabel,
+            animated: animated
+          )
+          updateProgressBar(progress: content.bottomProgress, animated: animated)
+        }
 
-            if let text = content.topProgress.text {
-              self.topProgressLabel.text = text
-            }
-            self.topProgressLabel.alpha = content.topProgress.isVisible ? 1.0 : 0.0
-
-            if let text = content.bottomLeading.text {
-              self.bottomLeadingLabel.text = text
-            }
-            self.bottomLeadingLabel.alpha = content.bottomLeading.isVisible ? 1.0 : 0.0
-
-            if let text = content.bottomCenter.text {
-              self.bottomCenterLabel.text = text
-            }
-            self.bottomCenterLabel.alpha = content.bottomCenter.isVisible ? 1.0 : 0.0
-
-            if let text = content.bottomTrailing.text {
-              self.bottomTrailingLabel.text = text
-            }
-            self.bottomTrailingLabel.alpha = content.bottomTrailing.isVisible ? 1.0 : 0.0
-
-            self.updateProgressBar(progress: content.bottomProgress)
-          }
-
+        private func apply(
+          entry: Entry,
+          previousEntry: Entry,
+          to label: UILabel,
+          animated: Bool
+        ) {
           guard animated else {
-            updates()
+            apply(entry: entry, to: label)
             return
           }
 
-          UIView.animate {
-            updates()
+          let text = entry.text ?? ""
+
+          if previousEntry.isVisible, entry.isVisible {
+            guard label.text != text else {
+              label.alpha = 1.0
+              return
+            }
+
+            label.alpha = 1.0
+            UIView.transition(
+              with: label,
+              duration: 0.18,
+              options: [.transitionCrossDissolve, .allowUserInteraction, .beginFromCurrentState]
+            ) {
+              UIView.performWithoutAnimation {
+                label.text = text
+                label.superview?.layoutIfNeeded()
+              }
+            }
+            return
+          }
+
+          if entry.isVisible {
+            UIView.performWithoutAnimation {
+              label.text = text
+              label.superview?.layoutIfNeeded()
+            }
+            UIView.animate(
+              withDuration: 0.18,
+              delay: 0,
+              options: [.allowUserInteraction, .beginFromCurrentState]
+            ) {
+              label.alpha = 1.0
+            }
+            return
+          }
+
+          UIView.animate(
+            withDuration: 0.18,
+            delay: 0,
+            options: [.allowUserInteraction, .beginFromCurrentState]
+          ) {
+            label.alpha = 0.0
+          } completion: { _ in
+            guard !entry.isVisible, label.alpha == 0.0 else { return }
+            UIView.performWithoutAnimation {
+              label.text = ""
+              label.superview?.layoutIfNeeded()
+            }
           }
         }
 
-        private func updateProgressBar(progress: Double?) {
+        private func apply(entry: Entry, to label: UILabel) {
+          label.text = entry.text ?? ""
+          label.alpha = entry.isVisible ? 1.0 : 0.0
+        }
+
+        private func updateProgressBar(progress: Double?, animated: Bool) {
           containerView?.layoutIfNeeded()
           let visible = progress != nil
           let normalized = min(max(progress ?? 0, 0), 1)
           let trackWidth = bottomProgressTrackView.bounds.width
           let fillWidth = max(trackWidth * normalized, normalized > 0 ? 4 : 0)
-          bottomProgressFillWidthConstraint.constant = fillWidth
-          bottomProgressTrackView.alpha = visible ? 1.0 : 0.0
-          bottomProgressFillView.alpha = visible ? 1.0 : 0.0
-          containerView?.layoutIfNeeded()
+          let updates = {
+            self.bottomProgressFillWidthConstraint.constant = fillWidth
+            self.bottomProgressTrackView.alpha = visible ? 1.0 : 0.0
+            self.bottomProgressFillView.alpha = visible ? 1.0 : 0.0
+            self.containerView?.layoutIfNeeded()
+          }
+          if animated {
+            UIView.animate(
+              withDuration: 0.18,
+              delay: 0,
+              options: [.allowUserInteraction, .beginFromCurrentState],
+              animations: updates
+            )
+          } else {
+            updates()
+          }
         }
 
         private static func makeLabel(
@@ -357,8 +551,9 @@
       @MainActor
       final class AppKitOverlay {
         private weak var containerView: NSView?
-        private let topTitleLabel: NSTextField
-        private let topProgressLabel: NSTextField
+        private let topLeadingLabel: NSTextField
+        private let topCenterLabel: NSTextField
+        private let topTrailingLabel: NSTextField
         private let bottomLeadingLabel: NSTextField
         private let bottomCenterLabel: NSTextField
         private let bottomTrailingLabel: NSTextField
@@ -367,8 +562,9 @@
         private let bottomProgressFillWidthConstraint: NSLayoutConstraint
         private var currentContent = Content(
           showingControls: false,
-          topTitle: .hidden,
-          topProgress: .hidden,
+          topLeading: .hidden,
+          topCenter: .hidden,
+          topTrailing: .hidden,
           bottomLeading: .hidden,
           bottomCenter: .hidden,
           bottomTrailing: .hidden,
@@ -382,8 +578,9 @@
           theme: ReaderTheme
         ) {
           self.containerView = containerView
-          topTitleLabel = Self.makeLabel(fontSize: 14, alignment: .center)
-          topProgressLabel = Self.makeLabel(fontSize: 14, alignment: .center)
+          topLeadingLabel = Self.makeLabel(fontSize: 14, alignment: .left)
+          topCenterLabel = Self.makeLabel(fontSize: 14, alignment: .center)
+          topTrailingLabel = Self.makeLabel(fontSize: 14, alignment: .right)
           bottomLeadingLabel = Self.makeLabel(fontSize: 12, alignment: .left)
           bottomCenterLabel = Self.makeLabel(fontSize: 12, alignment: .center, monospaced: true)
           bottomTrailingLabel = Self.makeLabel(fontSize: 12, alignment: .right, monospaced: true)
@@ -407,30 +604,42 @@
 
           let bottomConstant = -bottomOffset
           [
-            topTitleLabel, topProgressLabel, bottomLeadingLabel, bottomCenterLabel, bottomTrailingLabel,
+            topLeadingLabel, topCenterLabel, topTrailingLabel, bottomLeadingLabel, bottomCenterLabel,
+            bottomTrailingLabel,
             bottomProgressTrackView,
           ]
           .forEach(containerView.addSubview)
 
           NSLayoutConstraint.activate([
-            topTitleLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: topOffset),
-            topTitleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-            topTitleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            topLeadingLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: topOffset),
+            topLeadingLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            topLeadingLabel.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor, multiplier: 0.34),
 
-            topProgressLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: topOffset),
-            topProgressLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-            topProgressLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            topCenterLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: topOffset),
+            topCenterLabel.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            topCenterLabel.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor, multiplier: 0.45),
+            topCenterLabel.leadingAnchor.constraint(greaterThanOrEqualTo: topLeadingLabel.trailingAnchor, constant: 8),
+
+            topTrailingLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: topOffset),
+            topTrailingLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            topTrailingLabel.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor, multiplier: 0.34),
+            topTrailingLabel.leadingAnchor.constraint(greaterThanOrEqualTo: topCenterLabel.trailingAnchor, constant: 8),
 
             bottomLeadingLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: bottomConstant),
             bottomLeadingLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
+            bottomLeadingLabel.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor, multiplier: 0.34),
 
             bottomCenterLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: bottomConstant),
             bottomCenterLabel.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            bottomCenterLabel.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor, multiplier: 0.45),
+            bottomCenterLabel.leadingAnchor.constraint(
+              greaterThanOrEqualTo: bottomLeadingLabel.trailingAnchor, constant: 8),
 
             bottomTrailingLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: bottomConstant),
             bottomTrailingLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
+            bottomTrailingLabel.widthAnchor.constraint(lessThanOrEqualTo: containerView.widthAnchor, multiplier: 0.34),
             bottomTrailingLabel.leadingAnchor.constraint(
-              greaterThanOrEqualTo: bottomLeadingLabel.trailingAnchor, constant: 8),
+              greaterThanOrEqualTo: bottomCenterLabel.trailingAnchor, constant: 8),
 
             bottomProgressTrackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
             bottomProgressTrackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
@@ -450,60 +659,169 @@
           bottomTrailingLabel.setContentHuggingPriority(.required, for: .horizontal)
           bottomCenterLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
           bottomCenterLabel.setContentHuggingPriority(.required, for: .horizontal)
+          topLeadingLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+          topLeadingLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+          topTrailingLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+          topTrailingLabel.setContentHuggingPriority(.required, for: .horizontal)
+          topCenterLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+          topCenterLabel.setContentHuggingPriority(.required, for: .horizontal)
 
           apply(theme: theme)
         }
 
         func apply(theme: ReaderTheme) {
           let labelColor = (NSColor(hex: theme.textColorHex) ?? .labelColor).withAlphaComponent(0.6)
-          [topTitleLabel, topProgressLabel, bottomLeadingLabel, bottomCenterLabel, bottomTrailingLabel]
-            .forEach { $0.textColor = labelColor }
+          [
+            topLeadingLabel, topCenterLabel, topTrailingLabel, bottomLeadingLabel, bottomCenterLabel,
+            bottomTrailingLabel,
+          ]
+          .forEach { $0.textColor = labelColor }
           bottomProgressTrackView.layer?.backgroundColor = labelColor.withAlphaComponent(0.18).cgColor
           bottomProgressFillView.layer?.backgroundColor = labelColor.withAlphaComponent(0.85).cgColor
         }
 
         func update(content: Content, animated: Bool) {
           guard content != currentContent else { return }
-          let isControlsTransition = currentContent.showingControls != content.showingControls
+          let previousContent = currentContent
           currentContent = content
-          let updates = {
-            self.apply(entry: content.topTitle, to: self.topTitleLabel)
-            self.apply(entry: content.topProgress, to: self.topProgressLabel)
-            self.apply(entry: content.bottomLeading, to: self.bottomLeadingLabel)
-            self.apply(entry: content.bottomCenter, to: self.bottomCenterLabel)
-            self.apply(entry: content.bottomTrailing, to: self.bottomTrailingLabel)
-            self.updateProgressBar(progress: content.bottomProgress)
-          }
+          apply(
+            entry: content.topLeading,
+            previousEntry: previousContent.topLeading,
+            to: topLeadingLabel,
+            animated: animated
+          )
+          apply(
+            entry: content.topCenter,
+            previousEntry: previousContent.topCenter,
+            to: topCenterLabel,
+            animated: animated
+          )
+          apply(
+            entry: content.topTrailing,
+            previousEntry: previousContent.topTrailing,
+            to: topTrailingLabel,
+            animated: animated
+          )
+          apply(
+            entry: content.bottomLeading,
+            previousEntry: previousContent.bottomLeading,
+            to: bottomLeadingLabel,
+            animated: animated
+          )
+          apply(
+            entry: content.bottomCenter,
+            previousEntry: previousContent.bottomCenter,
+            to: bottomCenterLabel,
+            animated: animated
+          )
+          apply(
+            entry: content.bottomTrailing,
+            previousEntry: previousContent.bottomTrailing,
+            to: bottomTrailingLabel,
+            animated: animated
+          )
+          updateProgressBar(progress: content.bottomProgress, animated: animated)
+        }
 
-          guard animated, isControlsTransition else {
-            updates()
+        private func apply(
+          entry: Entry,
+          previousEntry: Entry,
+          to label: NSTextField,
+          animated: Bool
+        ) {
+          guard animated else {
+            apply(entry: entry, to: label)
             return
           }
 
-          NSAnimationContext.runAnimationGroup { context in
-            context.duration = 0.2
-            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-            updates()
+          let text = entry.text ?? ""
+
+          if previousEntry.isVisible, entry.isVisible {
+            guard label.stringValue != text else {
+              label.alphaValue = 1.0
+              return
+            }
+
+            label.alphaValue = 1.0
+            crossDissolveText(text, on: label)
+            return
+          }
+
+          if entry.isVisible {
+            setText(text, on: label)
+            animateAlpha(1.0, on: label)
+            return
+          }
+
+          animateAlpha(0.0, on: label) {
+            guard !entry.isVisible, label.alphaValue == 0.0 else { return }
+            self.setText("", on: label)
           }
         }
 
         private func apply(entry: Entry, to label: NSTextField) {
-          if let text = entry.text {
-            label.stringValue = text
-          }
-          label.animator().alphaValue = entry.isVisible ? 1.0 : 0.0
+          setText(entry.text ?? "", on: label)
+          label.alphaValue = entry.isVisible ? 1.0 : 0.0
         }
 
-        private func updateProgressBar(progress: Double?) {
+        private func crossDissolveText(_ text: String, on label: NSTextField) {
+          let transition = CATransition()
+          transition.duration = 0.18
+          transition.type = .fade
+          transition.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+          label.layer?.add(transition, forKey: "textCrossDissolve")
+          setText(text, on: label)
+        }
+
+        private func setText(_ text: String, on label: NSTextField) {
+          NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0
+            context.allowsImplicitAnimation = false
+            label.stringValue = text
+            label.superview?.layoutSubtreeIfNeeded()
+          }
+        }
+
+        private func animateAlpha(
+          _ alphaValue: CGFloat,
+          on label: NSTextField,
+          completion: (@MainActor @Sendable () -> Void)? = nil
+        ) {
+          NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.18
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            label.animator().alphaValue = alphaValue
+          } completionHandler: {
+            guard let completion else { return }
+            Task { @MainActor in
+              completion()
+            }
+          }
+        }
+
+        private func updateProgressBar(progress: Double?, animated: Bool) {
           containerView?.layoutSubtreeIfNeeded()
           let visible = progress != nil
           let normalized = min(max(progress ?? 0, 0), 1)
           let trackWidth = bottomProgressTrackView.bounds.width
           let fillWidth = max(trackWidth * normalized, normalized > 0 ? 4 : 0)
-          bottomProgressFillWidthConstraint.constant = fillWidth
-          bottomProgressTrackView.alphaValue = visible ? 1.0 : 0.0
-          bottomProgressFillView.alphaValue = visible ? 1.0 : 0.0
-          containerView?.layoutSubtreeIfNeeded()
+          let updates = {
+            self.bottomProgressFillWidthConstraint.constant = fillWidth
+            self.bottomProgressTrackView.alphaValue = visible ? 1.0 : 0.0
+            self.bottomProgressFillView.alphaValue = visible ? 1.0 : 0.0
+            self.containerView?.layoutSubtreeIfNeeded()
+          }
+
+          guard animated else {
+            updates()
+            return
+          }
+
+          NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.18
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            updates()
+          }
         }
 
         private static func makeLabel(
@@ -513,6 +831,7 @@
         ) -> NSTextField {
           let label = NSTextField(labelWithString: "")
           label.translatesAutoresizingMaskIntoConstraints = false
+          label.wantsLayer = true
           label.lineBreakMode = .byTruncatingTail
           label.alignment = alignment
           label.alphaValue = 0

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
@@ -12,6 +12,7 @@
     let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
     let animateTapTurns: Bool
+    let overlayPreferences: EpubOverlayPreferences
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -281,6 +282,7 @@
             bookTitle: parent.bookTitle,
             chapterTitle: location.title,
             totalProgression: totalProgression,
+            overlayPreferences: parent.overlayPreferences,
             showingControls: parent.showingControls,
             labelTopOffset: parent.viewModel.labelTopOffset,
             labelBottomOffset: parent.viewModel.labelBottomOffset,
@@ -318,6 +320,7 @@
             bookTitle: parent.bookTitle,
             chapterTitle: location.title,
             totalProgression: totalProgression,
+            overlayPreferences: parent.overlayPreferences,
             showingControls: parent.showingControls,
             labelTopOffset: parent.viewModel.labelTopOffset,
             labelBottomOffset: parent.viewModel.labelBottomOffset,
@@ -352,6 +355,7 @@
           bookTitle: parent.bookTitle,
           chapterTitle: location.title,
           totalProgression: totalProgression,
+          overlayPreferences: parent.overlayPreferences,
           showingControls: parent.showingControls,
           labelTopOffset: parent.viewModel.labelTopOffset,
           labelBottomOffset: parent.viewModel.labelBottomOffset,
@@ -432,6 +436,7 @@
           bookTitle: parent.bookTitle,
           chapterTitle: location.title,
           totalProgression: totalProgression,
+          overlayPreferences: parent.overlayPreferences,
           showingControls: parent.showingControls,
           labelTopOffset: parent.viewModel.labelTopOffset,
           labelBottomOffset: parent.viewModel.labelBottomOffset,

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView_macOS.swift
@@ -8,6 +8,7 @@
     let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
     let animateTapTurns: Bool
+    let overlayPreferences: EpubOverlayPreferences
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -592,7 +593,7 @@
         currentPageIndex: currentSubPageIndex,
         totalPagesInChapter: totalPagesInChapter,
         showingControls: parent.showingControls,
-        showProgressFooter: AppConfig.epubShowsProgressFooter
+        overlayPreferences: parent.overlayPreferences
       )
       infoOverlay?.update(content: content, animated: true)
     }

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
@@ -13,6 +13,7 @@
     let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
     let animateTapTurns: Bool
+    let overlayPreferences: EpubOverlayPreferences
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -287,6 +288,7 @@
           bookTitle: bookTitle,
           chapterTitle: location.title,
           totalProgression: totalProgression,
+          overlayPreferences: overlayPreferences,
           showingControls: showingControls,
           labelTopOffset: viewModel.labelTopOffset,
           labelBottomOffset: viewModel.labelBottomOffset,
@@ -524,6 +526,7 @@
             bookTitle: parent.bookTitle,
             chapterTitle: location.title,
             totalProgression: totalProgression,
+            overlayPreferences: parent.overlayPreferences,
             showingControls: parent.showingControls,
             labelTopOffset: parent.viewModel.labelTopOffset,
             labelBottomOffset: parent.viewModel.labelBottomOffset,
@@ -559,6 +562,7 @@
             bookTitle: parent.bookTitle,
             chapterTitle: location.title,
             totalProgression: totalProgression,
+            overlayPreferences: parent.overlayPreferences,
             showingControls: parent.showingControls,
             labelTopOffset: parent.viewModel.labelTopOffset,
             labelBottomOffset: parent.viewModel.labelBottomOffset,
@@ -593,6 +597,7 @@
           bookTitle: parent.bookTitle,
           chapterTitle: location.title,
           totalProgression: totalProgression,
+          overlayPreferences: parent.overlayPreferences,
           showingControls: parent.showingControls,
           labelTopOffset: parent.viewModel.labelTopOffset,
           labelBottomOffset: parent.viewModel.labelBottomOffset,
@@ -1152,6 +1157,7 @@
     private var bookTitle: String?
     private var chapterTitle: String?
     private var totalProgression: Double?
+    private var overlayPreferences: EpubOverlayPreferences
     private var showingControls: Bool = false
     private var labelTopOffset: CGFloat
     private var labelBottomOffset: CGFloat
@@ -1180,6 +1186,7 @@
       bookTitle: String?,
       chapterTitle: String?,
       totalProgression: Double?,
+      overlayPreferences: EpubOverlayPreferences,
       showingControls: Bool,
       labelTopOffset: CGFloat,
       labelBottomOffset: CGFloat,
@@ -1202,6 +1209,7 @@
       self.bookTitle = bookTitle
       self.chapterTitle = chapterTitle
       self.totalProgression = totalProgression
+      self.overlayPreferences = overlayPreferences
       self.showingControls = showingControls
       self.labelTopOffset = labelTopOffset
       self.labelBottomOffset = labelBottomOffset
@@ -1292,6 +1300,7 @@
       bookTitle: String?,
       chapterTitle: String?,
       totalProgression: Double?,
+      overlayPreferences: EpubOverlayPreferences,
       showingControls: Bool,
       labelTopOffset: CGFloat,
       labelBottomOffset: CGFloat,
@@ -1338,6 +1347,7 @@
       self.bookTitle = bookTitle
       self.chapterTitle = chapterTitle
       self.totalProgression = totalProgression
+      self.overlayPreferences = overlayPreferences
       self.showingControls = showingControls
       self.labelTopOffset = labelTopOffset
       self.labelBottomOffset = labelBottomOffset
@@ -1405,7 +1415,7 @@
         currentPageIndex: currentSubPageIndex,
         totalPagesInChapter: totalPagesInChapter,
         showingControls: showingControls,
-        showProgressFooter: AppConfig.epubShowsProgressFooter
+        overlayPreferences: overlayPreferences
       )
       infoOverlay?.update(content: content, animated: true)
     }

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
@@ -15,6 +15,7 @@
     let animatePageTransitions: Bool
     let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
+    let overlayPreferences: EpubOverlayPreferences
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -63,6 +64,7 @@
             chapterProgress: nil
           )
         },
+        overlayPreferences: overlayPreferences,
         showingControls: showingControls,
         labelTopOffset: viewModel.labelTopOffset,
         labelBottomOffset: viewModel.labelBottomOffset,
@@ -210,6 +212,7 @@
         bookTitle: bookTitle,
         chapterTitle: currentLocation?.title,
         totalProgression: totalProgression,
+        overlayPreferences: overlayPreferences,
         showingControls: showingControls,
         labelTopOffset: viewModel.labelTopOffset,
         labelBottomOffset: viewModel.labelBottomOffset,
@@ -259,6 +262,7 @@
     private var bookTitle: String?
     private var chapterTitle: String?
     private var totalProgression: Double?
+    private var overlayPreferences: EpubOverlayPreferences
     private var showingControls: Bool = false
     private var labelTopOffset: CGFloat
     private var labelBottomOffset: CGFloat
@@ -320,6 +324,7 @@
       bookTitle: String?,
       chapterTitle: String?,
       totalProgression: Double?,
+      overlayPreferences: EpubOverlayPreferences,
       showingControls: Bool,
       labelTopOffset: CGFloat,
       labelBottomOffset: CGFloat,
@@ -343,6 +348,7 @@
       self.bookTitle = bookTitle
       self.chapterTitle = chapterTitle
       self.totalProgression = totalProgression
+      self.overlayPreferences = overlayPreferences
       self.showingControls = showingControls
       self.labelTopOffset = labelTopOffset
       self.labelBottomOffset = labelBottomOffset
@@ -492,7 +498,7 @@
         currentPageIndex: currentSubPageIndex,
         totalPagesInChapter: totalPagesInChapter,
         showingControls: showingControls,
-        showProgressFooter: AppConfig.epubShowsProgressFooter
+        overlayPreferences: overlayPreferences
       )
       infoOverlay?.update(content: content, animated: true)
     }
@@ -742,6 +748,7 @@
       bookTitle: String?,
       chapterTitle: String?,
       totalProgression: Double?,
+      overlayPreferences: EpubOverlayPreferences,
       showingControls: Bool,
       labelTopOffset: CGFloat,
       labelBottomOffset: CGFloat,
@@ -780,6 +787,7 @@
       self.bookTitle = bookTitle
       self.chapterTitle = chapterTitle
       self.totalProgression = totalProgression
+      self.overlayPreferences = overlayPreferences
       self.showingControls = showingControls
       self.labelTopOffset = labelTopOffset
       self.labelBottomOffset = labelBottomOffset

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView_macOS.swift
@@ -8,6 +8,7 @@
     let animatePageTransitions: Bool
     let preferences: EpubThemePreferences
     let colorScheme: ColorScheme
+    let overlayPreferences: EpubOverlayPreferences
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -216,7 +217,7 @@
         currentPageIndex: currentSubPageIndex,
         totalPagesInChapter: totalPagesInChapter,
         showingControls: parent.showingControls,
-        showProgressFooter: AppConfig.epubShowsProgressFooter
+        overlayPreferences: parent.overlayPreferences
       )
       infoOverlay?.update(content: content, animated: true)
     }

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView.swift
@@ -15,6 +15,7 @@
     let colorScheme: ColorScheme
     let tapScrollPercentage: Double
     let animateTapTurns: Bool
+    let overlayPreferences: EpubOverlayPreferences
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -65,6 +66,7 @@
             chapterProgress: nil
           )
         },
+        overlayPreferences: overlayPreferences,
         showingControls: showingControls,
         labelTopOffset: viewModel.labelTopOffset,
         labelBottomOffset: viewModel.labelBottomOffset,
@@ -214,6 +216,7 @@
         bookTitle: bookTitle,
         chapterTitle: currentLocation?.title,
         totalProgression: totalProgression,
+        overlayPreferences: overlayPreferences,
         showingControls: showingControls,
         labelTopOffset: viewModel.labelTopOffset,
         labelBottomOffset: viewModel.labelBottomOffset,
@@ -272,6 +275,7 @@
     private var bookTitle: String?
     private var chapterTitle: String?
     private var totalProgression: Double?
+    private var overlayPreferences: EpubOverlayPreferences
     private var showingControls: Bool = false
     private var labelTopOffset: CGFloat
     private var labelBottomOffset: CGFloat
@@ -340,6 +344,7 @@
       bookTitle: String?,
       chapterTitle: String?,
       totalProgression: Double?,
+      overlayPreferences: EpubOverlayPreferences,
       showingControls: Bool,
       labelTopOffset: CGFloat,
       labelBottomOffset: CGFloat,
@@ -364,6 +369,7 @@
       self.bookTitle = bookTitle
       self.chapterTitle = chapterTitle
       self.totalProgression = totalProgression
+      self.overlayPreferences = overlayPreferences
       self.showingControls = showingControls
       self.labelTopOffset = labelTopOffset
       self.labelBottomOffset = labelBottomOffset
@@ -563,7 +569,7 @@
         currentPageIndex: currentSubPageIndex,
         totalPagesInChapter: totalPagesInChapter,
         showingControls: showingControls,
-        showProgressFooter: AppConfig.epubShowsProgressFooter
+        overlayPreferences: overlayPreferences
       )
       infoOverlay?.update(content: content, animated: true)
     }
@@ -712,6 +718,7 @@
       bookTitle: String?,
       chapterTitle: String?,
       totalProgression: Double?,
+      overlayPreferences: EpubOverlayPreferences,
       showingControls: Bool,
       labelTopOffset: CGFloat,
       labelBottomOffset: CGFloat,
@@ -754,6 +761,7 @@
       self.bookTitle = bookTitle
       self.chapterTitle = chapterTitle
       self.totalProgression = totalProgression
+      self.overlayPreferences = overlayPreferences
       self.showingControls = showingControls
       self.labelTopOffset = labelTopOffset
       self.labelBottomOffset = labelBottomOffset

--- a/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubScrolledView_macOS.swift
@@ -9,6 +9,7 @@
     let colorScheme: ColorScheme
     let tapScrollPercentage: Double
     let animateTapTurns: Bool
+    let overlayPreferences: EpubOverlayPreferences
     let showingControls: Bool
     let bookTitle: String?
     let onCenterTap: () -> Void
@@ -222,7 +223,7 @@
         currentPageIndex: currentSubPageIndex,
         totalPagesInChapter: totalPagesInChapter,
         showingControls: parent.showingControls,
-        showProgressFooter: AppConfig.epubShowsProgressFooter
+        overlayPreferences: parent.overlayPreferences
       )
       infoOverlay?.update(content: content, animated: true)
     }

--- a/KMReader/Features/Reader/Views/Models/EpubOverlayPreferences.swift
+++ b/KMReader/Features/Reader/Views/Models/EpubOverlayPreferences.swift
@@ -1,0 +1,87 @@
+//
+// EpubOverlayPreferences.swift
+//
+//
+
+import Foundation
+
+nonisolated struct EpubOverlayPreferences: RawRepresentable, Equatable, Sendable {
+  typealias RawValue = String
+
+  var readerHeaderLeading: EpubOverlayTextItem
+  var readerHeaderCenter: EpubOverlayTextItem
+  var readerHeaderTrailing: EpubOverlayTextItem
+  var readerFooterLeading: EpubOverlayTextItem
+  var readerFooterCenter: EpubOverlayTextItem
+  var readerFooterTrailing: EpubOverlayTextItem
+  var showsReaderProgressBar: Bool
+  var controlsHeaderCenter: EpubOverlayTextItem
+  var controlsFooterCenter: EpubOverlayTextItem
+
+  init() {
+    readerHeaderLeading = .none
+    readerHeaderCenter = .bookTitle
+    readerHeaderTrailing = .none
+    readerFooterLeading = .chapterTitle
+    readerFooterCenter = .none
+    readerFooterTrailing = .chapterRemaining
+    showsReaderProgressBar = false
+    controlsHeaderCenter = .bookProgressPercent
+    controlsFooterCenter = .chapterPosition
+  }
+
+  init?(rawValue: String) {
+    guard !rawValue.isEmpty else {
+      self.init()
+      return
+    }
+
+    guard let data = rawValue.data(using: .utf8),
+      let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+      self.init()
+      return
+    }
+
+    self.init()
+    readerHeaderLeading = Self.textItem(dict["readerHeaderLeading"], default: readerHeaderLeading)
+    readerHeaderCenter = Self.textItem(dict["readerHeaderCenter"], default: readerHeaderCenter)
+    readerHeaderTrailing = Self.textItem(dict["readerHeaderTrailing"], default: readerHeaderTrailing)
+    readerFooterLeading = Self.textItem(dict["readerFooterLeading"], default: readerFooterLeading)
+    readerFooterCenter = Self.textItem(dict["readerFooterCenter"], default: readerFooterCenter)
+    readerFooterTrailing = Self.textItem(dict["readerFooterTrailing"], default: readerFooterTrailing)
+    showsReaderProgressBar = Self.bool(dict["showsReaderProgressBar"], default: showsReaderProgressBar)
+    controlsHeaderCenter = Self.textItem(dict["controlsHeaderCenter"], default: controlsHeaderCenter)
+    controlsFooterCenter = Self.textItem(dict["controlsFooterCenter"], default: controlsFooterCenter)
+  }
+
+  var rawValue: String {
+    let dict: [String: Any] = [
+      "readerHeaderLeading": readerHeaderLeading.rawValue,
+      "readerHeaderCenter": readerHeaderCenter.rawValue,
+      "readerHeaderTrailing": readerHeaderTrailing.rawValue,
+      "readerFooterLeading": readerFooterLeading.rawValue,
+      "readerFooterCenter": readerFooterCenter.rawValue,
+      "readerFooterTrailing": readerFooterTrailing.rawValue,
+      "showsReaderProgressBar": showsReaderProgressBar,
+      "controlsHeaderCenter": controlsHeaderCenter.rawValue,
+      "controlsFooterCenter": controlsFooterCenter.rawValue,
+    ]
+    if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+      let json = String(data: data, encoding: .utf8)
+    {
+      return json
+    }
+    return "{}"
+  }
+
+  private static func textItem(_ value: Any?, default defaultValue: EpubOverlayTextItem) -> EpubOverlayTextItem {
+    guard let rawValue = value as? String else { return defaultValue }
+    return EpubOverlayTextItem(rawValue: rawValue) ?? defaultValue
+  }
+
+  private static func bool(_ value: Any?, default defaultValue: Bool) -> Bool {
+    guard let value = value as? Bool else { return defaultValue }
+    return value
+  }
+}

--- a/KMReader/Features/Reader/Views/Models/EpubOverlayTextItem.swift
+++ b/KMReader/Features/Reader/Views/Models/EpubOverlayTextItem.swift
@@ -1,0 +1,40 @@
+//
+// EpubOverlayTextItem.swift
+//
+//
+
+import Foundation
+
+nonisolated enum EpubOverlayTextItem: String, CaseIterable, Identifiable, Sendable {
+  case none
+  case bookTitle
+  case chapterTitle
+  case bookProgressPercent
+  case bookRemainingPercent
+  case chapterProgressPercent
+  case chapterRemaining
+  case chapterPosition
+
+  var id: String { rawValue }
+
+  var displayName: String {
+    switch self {
+    case .none:
+      return String(localized: "epub.overlay.item.none", defaultValue: "None")
+    case .bookTitle:
+      return String(localized: "epub.overlay.item.book_title", defaultValue: "Book Title")
+    case .chapterTitle:
+      return String(localized: "epub.overlay.item.chapter_title", defaultValue: "Chapter Title")
+    case .bookProgressPercent:
+      return String(localized: "epub.overlay.item.book_progress", defaultValue: "Book Progress")
+    case .bookRemainingPercent:
+      return String(localized: "epub.overlay.item.book_remaining", defaultValue: "Book Remaining")
+    case .chapterProgressPercent:
+      return String(localized: "epub.overlay.item.chapter_progress", defaultValue: "Chapter Progress")
+    case .chapterRemaining:
+      return String(localized: "epub.overlay.item.chapter_remaining", defaultValue: "Chapter Remaining")
+    case .chapterPosition:
+      return String(localized: "epub.overlay.item.chapter_page", defaultValue: "Chapter Page")
+    }
+  }
+}

--- a/KMReader/Features/Reader/Views/Sheets/EpubOverlayPreferencesEditor.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubOverlayPreferencesEditor.swift
@@ -1,0 +1,68 @@
+//
+// EpubOverlayPreferencesEditor.swift
+//
+//
+
+#if os(iOS) || os(macOS)
+  import SwiftUI
+
+  struct EpubOverlayPreferencesEditor: View {
+    @Binding var preferences: EpubOverlayPreferences
+
+    var body: some View {
+      Section(String(localized: "epub.overlay.reading", defaultValue: "Reading")) {
+        textPicker(
+          title: String(localized: "epub.overlay.header_left", defaultValue: "Header Left"),
+          selection: $preferences.readerHeaderLeading
+        )
+        textPicker(
+          title: String(localized: "epub.overlay.header_center", defaultValue: "Header Center"),
+          selection: $preferences.readerHeaderCenter
+        )
+        textPicker(
+          title: String(localized: "epub.overlay.header_right", defaultValue: "Header Right"),
+          selection: $preferences.readerHeaderTrailing
+        )
+        textPicker(
+          title: String(localized: "epub.overlay.footer_left", defaultValue: "Footer Left"),
+          selection: $preferences.readerFooterLeading
+        )
+        textPicker(
+          title: String(localized: "epub.overlay.footer_center", defaultValue: "Footer Center"),
+          selection: $preferences.readerFooterCenter
+        )
+        textPicker(
+          title: String(localized: "epub.overlay.footer_right", defaultValue: "Footer Right"),
+          selection: $preferences.readerFooterTrailing
+        )
+        Toggle(
+          String(localized: "epub.overlay.show_reader_progress_bar", defaultValue: "Show Progress Bar"),
+          isOn: $preferences.showsReaderProgressBar
+        )
+      }
+
+      Section(String(localized: "epub.overlay.controls", defaultValue: "Controls")) {
+        textPicker(
+          title: String(localized: "epub.overlay.header_center", defaultValue: "Header Center"),
+          selection: $preferences.controlsHeaderCenter
+        )
+        textPicker(
+          title: String(localized: "epub.overlay.footer_center", defaultValue: "Footer Center"),
+          selection: $preferences.controlsFooterCenter
+        )
+      }
+    }
+
+    private func textPicker(
+      title: String,
+      selection: Binding<EpubOverlayTextItem>
+    ) -> some View {
+      Picker(title, selection: selection) {
+        ForEach(EpubOverlayTextItem.allCases) { item in
+          Text(item.displayName).tag(item)
+        }
+      }
+      .pickerStyle(.menu)
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Views/Sheets/EpubReaderSettingsView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubReaderSettingsView_macOS.swift
@@ -16,7 +16,8 @@
     @AppStorage("epubTapScrollPercentage") private var tapScrollPercentage: Double = AppConfig.epubTapScrollPercentage
     @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
     @AppStorage("animateEpubTapTurns") private var animateEpubTapTurns: Bool = AppConfig.animateEpubTapTurns
-    @AppStorage("epubShowsProgressFooter") private var epubShowsProgressFooter: Bool = false
+    @AppStorage("epubOverlayPreferences") private var epubOverlayPreferences: EpubOverlayPreferences = AppConfig
+      .epubOverlayPreferences
     @AppStorage("epubShowKeyboardHelpOverlay") private var showKeyboardHelpOverlay: Bool = AppConfig
       .epubShowKeyboardHelpOverlay
     @AppStorage("epubTapZoneMode") private var epubTapZoneMode: TapZoneMode = AppConfig.epubTapZoneMode
@@ -117,15 +118,6 @@
       }
 
       Section(String(localized: "Reader Overlay")) {
-        Toggle(isOn: $epubShowsProgressFooter) {
-          VStack(alignment: .leading, spacing: 4) {
-            Text(String(localized: "Show Progress Footer"))
-            Text(String(localized: "Show book progress at the bottom while reading."))
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-        }
-
         Toggle(isOn: $showKeyboardHelpOverlay) {
           VStack(alignment: .leading, spacing: 4) {
             Text("Auto-Show Keyboard Help")
@@ -135,6 +127,8 @@
           }
         }
       }
+
+      EpubOverlayPreferencesEditor(preferences: $epubOverlayPreferences)
     }
   }
 #endif

--- a/KMReader/Features/Settings/EpubReaderSettingsView.swift
+++ b/KMReader/Features/Settings/EpubReaderSettingsView.swift
@@ -17,7 +17,8 @@
     @AppStorage("epubPageTransitionStyle") private var epubPageTransitionStyle: PageTransitionStyle = .scroll
     @AppStorage("animateEpubTapTurns") private var animateEpubTapTurns: Bool = AppConfig.animateEpubTapTurns
     @AppStorage("epubShowsStatusBarWhileReading") private var epubShowsStatusBarWhileReading: Bool = false
-    @AppStorage("epubShowsProgressFooter") private var epubShowsProgressFooter: Bool = false
+    @AppStorage("epubOverlayPreferences") private var epubOverlayPreferences: EpubOverlayPreferences = AppConfig
+      .epubOverlayPreferences
     @AppStorage("epubShowKeyboardHelpOverlay") private var showKeyboardHelpOverlay: Bool = AppConfig
       .epubShowKeyboardHelpOverlay
     @AppStorage("epubTapZoneMode") private var epubTapZoneMode: TapZoneMode = AppConfig.epubTapZoneMode
@@ -127,15 +128,6 @@
           }
         }
 
-        Toggle(isOn: $epubShowsProgressFooter) {
-          VStack(alignment: .leading, spacing: 4) {
-            Text(String(localized: "Show Progress Footer"))
-            Text(String(localized: "Show book progress at the bottom while reading."))
-              .font(.caption)
-              .foregroundStyle(.secondary)
-          }
-        }
-
         Toggle(isOn: $showKeyboardHelpOverlay) {
           VStack(alignment: .leading, spacing: 4) {
             Text("Auto-Show Keyboard Help")
@@ -145,6 +137,8 @@
           }
         }
       }
+
+      EpubOverlayPreferencesEditor(preferences: $epubOverlayPreferences)
     }
   }
 #endif

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -21626,6 +21626,1094 @@
         }
       }
     },
+    "epub.overlay.controls" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Steuerung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controls"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commandes"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Controlli"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コントロール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "컨트롤"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Элементы управления"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "控制項"
+          }
+        }
+      }
+    },
+    "epub.overlay.footer_center" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fußzeile Mitte"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Footer Center"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pie de página central"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pied de page centre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piè di pagina centrale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フッター中央"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "바닥글 가운데"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нижний колонтитул по центру"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "页脚中间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁尾中間"
+          }
+        }
+      }
+    },
+    "epub.overlay.footer_left" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fußzeile links"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Footer Left"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pie de página izquierdo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pied de page gauche"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piè di pagina sinistro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フッター左"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "바닥글 왼쪽"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нижний колонтитул слева"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "页脚左侧"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁尾左側"
+          }
+        }
+      }
+    },
+    "epub.overlay.footer_right" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fußzeile rechts"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Footer Right"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pie de página derecho"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pied de page droite"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Piè di pagina destro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フッター右"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "바닥글 오른쪽"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нижний колонтитул справа"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "页脚右侧"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁尾右側"
+          }
+        }
+      }
+    },
+    "epub.overlay.header_center" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kopfzeile Mitte"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Header Center"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Encabezado central"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En-tête centre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intestazione centrale"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヘッダー中央"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "머리글 가운데"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Верхний колонтитул по центру"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "页眉中间"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁首中間"
+          }
+        }
+      }
+    },
+    "epub.overlay.header_left" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kopfzeile links"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Header Left"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Encabezado izquierdo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En-tête gauche"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intestazione sinistra"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヘッダー左"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "머리글 왼쪽"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Верхний колонтитул слева"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "页眉左侧"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁首左側"
+          }
+        }
+      }
+    },
+    "epub.overlay.header_right" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kopfzeile rechts"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Header Right"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Encabezado derecho"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En-tête droite"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intestazione destra"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ヘッダー右"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "머리글 오른쪽"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Верхний колонтитул справа"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "页眉右侧"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁首右側"
+          }
+        }
+      }
+    },
+    "epub.overlay.item.book_progress" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buchfortschritt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Book Progress"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso del libro"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progression du livre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avanzamento libro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書籍の進捗"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "책 진행률"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прогресс книги"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整本进度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全書進度"
+          }
+        }
+      }
+    },
+    "epub.overlay.item.book_remaining" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbleibendes Buch"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Book Remaining"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libro restante"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Livre restant"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Libro rimanente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書籍の残り"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "책 남은 양"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Осталось в книге"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "整本剩余"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全書剩餘"
+          }
+        }
+      }
+    },
+    "epub.overlay.item.book_title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buchtitel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Book Title"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Título del libro"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titre du livre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titolo libro"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書名"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "책 제목"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название книги"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "书名"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書名"
+          }
+        }
+      }
+    },
+    "epub.overlay.item.chapter_page" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kapitelseite"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chapter Page"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Página del capítulo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page du chapitre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pagina capitolo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章ページ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "챕터 페이지"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Страница главы"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章节页码"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章節頁碼"
+          }
+        }
+      }
+    },
+    "epub.overlay.item.chapter_progress" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kapitelfortschritt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chapter Progress"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso del capítulo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progression du chapitre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avanzamento capitolo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章の進捗"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "챕터 진행률"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прогресс главы"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章节进度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章節進度"
+          }
+        }
+      }
+    },
+    "epub.overlay.item.chapter_remaining" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbleibendes Kapitel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chapter Remaining"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capítulo restante"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chapitre restant"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capitolo rimanente"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章の残り"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "챕터 남은 양"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Осталось в главе"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章节剩余"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章節剩餘"
+          }
+        }
+      }
+    },
+    "epub.overlay.item.chapter_title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kapiteltitel"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chapter Title"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Título del capítulo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titre du chapitre"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Titolo capitolo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章タイトル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "챕터 제목"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Название главы"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章节标题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "章節標題"
+          }
+        }
+      }
+    },
+    "epub.overlay.item.none" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "None"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ninguno"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuno"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "なし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "없음"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "無"
+          }
+        }
+      }
+    },
+    "epub.overlay.reading" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lesen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lectura"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettura"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чтение"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀"
+          }
+        }
+      }
+    },
+    "epub.overlay.show_reader_progress_bar" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fortschrittsleiste anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Progress Bar"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar barra de progreso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher la barre de progression"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra barra di avanzamento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進捗バーを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "진행률 막대 표시"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать индикатор прогресса"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示进度条"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示進度列"
+          }
+        }
+      }
+    },
     "epub.reading_flow" : {
       "localizations" : {
         "de" : {
@@ -69244,70 +70332,6 @@
         }
       }
     },
-    "Show book progress at the bottom while reading." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeige beim Lesen unten den Buchfortschritt an."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show book progress at the bottom while reading."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Muestra el progreso del libro en la parte inferior mientras lees."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Affichez la progression du livre en bas pendant la lecture."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra in basso l’avanzamento del libro durante la lettura."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "読書中に下部へ本全体の進捗を表示します。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "읽는 동안 하단에 책 진행률을 표시합니다."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показывать внизу прогресс книги во время чтения."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "阅读时在底部显示全书进度。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "閱讀時在底部顯示全書進度。"
-          }
-        }
-      }
-    },
     "Show connection status and task completion notifications" : {
       "localizations" : {
         "de" : {
@@ -69752,70 +70776,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀時顯示進度條"
-          }
-        }
-      }
-    },
-    "Show Progress Footer" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fortschrittsleiste unten anzeigen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Progress Footer"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar pie de progreso"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher le pied de progression"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra barra di avanzamento inferiore"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "進捗フッターを表示"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "진행률 푸터 표시"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показывать нижнюю панель прогресса"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示进度页脚"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示進度頁尾"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Add configurable EPUB overlay preferences for the Reading and Controls overlays
- Support reader-state header/footer left, center, and right slots while keeping controls-state customization to header/footer center slots
- Wire the preferences through EPUB overlay rendering on iOS and macOS, remove the old EPUB progress footer setting, and use cross-dissolve text replacement for overlay label changes
- Update app and reader settings plus localization strings for the new controls

## Refs
- #874

## Testing
- make build
- make localize
- ./misc/translate.py list
- jq empty KMReader/Localizable.xcstrings
- git diff --check