### PR TITLE
fix: stabilize reader loading detail

### DIFF
--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -19,7 +19,7 @@ class ReaderViewModel {
   var navigationTarget: ReaderViewItem?
   var isLoading = true
   var loadingTitle = String(localized: "Loading book...")
-  var loadingDetail: String?
+  var loadingDetail = String(localized: "Resolving page metadata")
   var loadingProgress: Double?
   var isDismissing = false
   var incognitoMode: Bool = false
@@ -766,7 +766,7 @@ class ReaderViewModel {
     self.bookMediaProfile = book.media.mediaProfileValue ?? .unknown
     isLoading = true
     loadingTitle = String(localized: "Loading book...")
-    loadingDetail = nil
+    loadingDetail = String(localized: "Resolving page metadata")
     loadingProgress = nil
 
     resetStateForBookLoad()
@@ -824,6 +824,7 @@ class ReaderViewModel {
     if case .downloaded = status {
       if updatesLoadingState {
         clearLoadingProgress()
+        updateLoadingDetail(String(localized: "Using downloaded book files"))
       }
       return
     }
@@ -834,7 +835,7 @@ class ReaderViewModel {
 
     if updatesLoadingState {
       updateLoadingTitle(String(localized: "Downloading book..."))
-      updateLoadingDetail(nil)
+      updateLoadingDetail(String(localized: "Preparing offline download"))
       clearLoadingProgress()
     }
 
@@ -846,6 +847,7 @@ class ReaderViewModel {
       )
     case .downloaded:
       clearLoadingProgress()
+      updateLoadingDetail(String(localized: "Using downloaded book files"))
       return
     }
 
@@ -859,7 +861,7 @@ class ReaderViewModel {
       case .downloaded:
         if updatesLoadingState {
           clearLoadingProgress()
-          updateLoadingDetail(nil)
+          updateLoadingDetail(String(localized: "Using downloaded book files"))
         }
         return
       case .failed(let error):
@@ -875,13 +877,15 @@ class ReaderViewModel {
           if progress >= 1 {
             clearLoadingProgress()
             updateLoadingTitle(String(localized: "Processing offline files..."))
-            updateLoadingDetail(nil)
+            updateLoadingDetail(offlineProcessingDetail)
           } else if progress > 0 {
             updateLoadingProgress(progress)
             updateLoadingTitle(String(localized: "Downloading book..."))
+            updateLoadingDetail(String(localized: "Downloading book content"))
           } else {
             clearLoadingProgress()
             updateLoadingTitle(String(localized: "Downloading book..."))
+            updateLoadingDetail(String(localized: "Waiting for offline download to start"))
           }
         }
       }
@@ -920,11 +924,11 @@ class ReaderViewModel {
     }
 
     updateLoadingTitle(String(localized: "Offline DIVINA Rendering"))
-    updateLoadingDetail(nil)
+    updateLoadingDetail(String(localized: "Rendering PDF pages for DIVINA reader"))
     clearLoadingProgress()
     defer {
       updateLoadingTitle(String(localized: "Loading book..."))
-      updateLoadingDetail(nil)
+      updateLoadingDetail(String(localized: "Resolving page metadata"))
       clearLoadingProgress()
     }
 
@@ -954,7 +958,16 @@ class ReaderViewModel {
     loadingTitle = title
   }
 
-  private func updateLoadingDetail(_ detail: String?) {
+  private var offlineProcessingDetail: String {
+    switch bookMediaProfile {
+    case .pdf:
+      return String(localized: "Finalizing offline PDF file")
+    case .divina, .epub, .unknown:
+      return String(localized: "Verifying offline files against page metadata")
+    }
+  }
+
+  private func updateLoadingDetail(_ detail: String) {
     guard loadingDetail != detail else { return }
     loadingDetail = detail
   }

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -680,7 +680,7 @@
       return viewModel.downloadProgress > 0 ? viewModel.downloadProgress : nil
     }
 
-    private var loadingDetail: String? {
+    private var loadingDetail: String {
       switch viewModel.loadingStage {
       case .fetchingMetadata:
         return String(localized: "Fetching book metadata")
@@ -697,7 +697,7 @@
         }
         return String(localized: "Downloading book content")
       case .processingOfflineFiles:
-        return nil
+        return String(localized: "Verifying offline files against page metadata")
       case .preparingReader:
         return String(localized: "Preparing reader view")
       case .paginating:

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -434,9 +434,23 @@
       return viewModel.downloadProgress > 0 ? viewModel.downloadProgress : nil
     }
 
-    private var loadingDetail: String? {
-      guard viewModel.loadingStage == .downloading else { return nil }
-      guard viewModel.downloadBytesReceived > 0 else { return nil }
+    private var loadingDetail: String {
+      switch viewModel.loadingStage {
+      case .fetchingMetadata:
+        return String(localized: "Checking PDF download information")
+      case .processingOfflineFiles:
+        return String(localized: "Finalizing offline PDF file")
+      case .preparingReader:
+        return String(localized: "Opening downloaded PDF file")
+      case .downloading:
+        break
+      case .idle:
+        return String(localized: "Opening downloaded PDF file")
+      }
+
+      guard viewModel.downloadBytesReceived > 0 else {
+        return String(localized: "Downloading book content")
+      }
 
       let formatter = ByteCountFormatter()
       formatter.countStyle = .file

--- a/KMReader/Features/Reader/Views/ReaderLoadingView.swift
+++ b/KMReader/Features/Reader/Views/ReaderLoadingView.swift
@@ -7,8 +7,11 @@ import SwiftUI
 
 struct ReaderLoadingView: View {
   let title: String
-  let detail: String?
+  let detail: String
   let progress: Double?
+
+  private let contentWidth: CGFloat = 260
+  private let textBlockHeight: CGFloat = 64
 
   private var normalizedProgress: Double? {
     progress.map { min(max($0, 0), 1) }
@@ -27,59 +30,13 @@ struct ReaderLoadingView: View {
   }
 
   var body: some View {
-    VStack(spacing: 24) {
-      ZStack {
-        // Background Ring
-        Circle()
-          .stroke(Color.primary.opacity(0.05), lineWidth: 4)
-          .frame(width: 64, height: 64)
-
-        // Determinate Progress Ring
-        Circle()
-          .trim(from: 0, to: normalizedProgress ?? 0)
-          .stroke(
-            LinearGradient(
-              colors: [.accentColor, .accentColor.opacity(0.7)],
-              startPoint: .topLeading,
-              endPoint: .bottomTrailing
-            ),
-            style: StrokeStyle(lineWidth: 4, lineCap: .round)
-          )
-          .frame(width: 64, height: 64)
-          .rotationEffect(.degrees(-90))
-          .opacity(showsProgress ? 1 : 0)
-          .animation(.easeOut(duration: 0.16), value: normalizedProgress)
-
-        Text(progressText)
-          .font(.system(.subheadline, design: .rounded).bold())
-          .monospacedDigit()
-          .contentTransition(.numericText(value: numericProgress))
-          .animation(.easeOut(duration: 0.16), value: numericProgress)
-          .opacity(showsProgress ? 1 : 0)
-          .accessibilityHidden(!showsProgress)
-
-        LoadingIcon()
-          .opacity(showsProgress ? 0 : 1)
-          .accessibilityHidden(showsProgress)
-      }
-      .padding(.top, 8)
-
-      VStack(spacing: 8) {
-        Text(title)
-          .font(.headline)
-          .foregroundStyle(.primary)
-
-        Text(detail ?? " ")
-          .font(.subheadline)
-          .foregroundStyle(.secondary)
-          .multilineTextAlignment(.center)
-          .frame(maxWidth: 280)
-          .opacity(detail == nil ? 0 : 1)
-          .accessibilityHidden(detail == nil)
-      }
+    VStack(spacing: 20) {
+      statusIcon
+      textContent
     }
-    .padding(.vertical, 32)
-    .padding(.horizontal, 40)
+    .frame(width: contentWidth)
+    .padding(.vertical, 24)
+    .padding(.horizontal, 28)
     .background {
       RoundedRectangle(cornerRadius: 28, style: .continuous)
         .fill(.ultraThinMaterial)
@@ -89,6 +46,70 @@ struct ReaderLoadingView: View {
         }
     }
     .shadow(color: Color.black.opacity(0.12), radius: 30, x: 0, y: 15)
+  }
+
+  private var statusIcon: some View {
+    ZStack {
+      Circle()
+        .stroke(Color.primary.opacity(0.05), lineWidth: 4)
+        .frame(width: 64, height: 64)
+
+      Circle()
+        .trim(from: 0, to: normalizedProgress ?? 0)
+        .stroke(
+          LinearGradient(
+            colors: [.accentColor, .accentColor.opacity(0.7)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+          ),
+          style: StrokeStyle(lineWidth: 4, lineCap: .round)
+        )
+        .frame(width: 64, height: 64)
+        .rotationEffect(.degrees(-90))
+        .opacity(showsProgress ? 1 : 0)
+        .animation(.easeOut(duration: 0.16), value: normalizedProgress)
+
+      Text(progressText)
+        .font(.system(.subheadline, design: .rounded).bold())
+        .monospacedDigit()
+        .contentTransition(.numericText(value: numericProgress))
+        .animation(.easeOut(duration: 0.16), value: numericProgress)
+        .opacity(showsProgress ? 1 : 0)
+        .accessibilityHidden(!showsProgress)
+
+      LoadingIcon()
+        .opacity(showsProgress ? 0 : 1)
+        .accessibilityHidden(showsProgress)
+    }
+    .frame(width: 64, height: 64)
+  }
+
+  private var textContent: some View {
+    VStack(spacing: 8) {
+      titleText
+      detailTextView
+    }
+    .frame(width: contentWidth)
+    .frame(height: textBlockHeight)
+  }
+
+  private var titleText: some View {
+    Text(title)
+      .font(.headline)
+      .foregroundStyle(.primary)
+      .multilineTextAlignment(.center)
+      .lineLimit(2)
+      .frame(width: contentWidth)
+  }
+
+  private var detailTextView: some View {
+    Text(detail)
+      .font(.subheadline)
+      .foregroundStyle(.secondary)
+      .multilineTextAlignment(.center)
+      .lineLimit(2)
+      .minimumScaleFactor(0.9)
+      .frame(width: contentWidth)
   }
 }
 

--- a/KMReader/Features/Reader/Views/ReaderLoadingView.swift
+++ b/KMReader/Features/Reader/Views/ReaderLoadingView.swift
@@ -11,7 +11,7 @@ struct ReaderLoadingView: View {
   let progress: Double?
 
   private let contentWidth: CGFloat = 260
-  private let textBlockHeight: CGFloat = 64
+  private let textBlockMinHeight: CGFloat = 64
 
   private var normalizedProgress: Double? {
     progress.map { min(max($0, 0), 1) }
@@ -90,7 +90,7 @@ struct ReaderLoadingView: View {
       detailTextView
     }
     .frame(width: contentWidth)
-    .frame(height: textBlockHeight)
+    .frame(minHeight: textBlockMinHeight)
   }
 
   private var titleText: some View {
@@ -99,6 +99,7 @@ struct ReaderLoadingView: View {
       .foregroundStyle(.primary)
       .multilineTextAlignment(.center)
       .lineLimit(2)
+      .fixedSize(horizontal: false, vertical: true)
       .frame(width: contentWidth)
   }
 
@@ -109,6 +110,7 @@ struct ReaderLoadingView: View {
       .multilineTextAlignment(.center)
       .lineLimit(2)
       .minimumScaleFactor(0.9)
+      .fixedSize(horizontal: false, vertical: true)
       .frame(width: contentWidth)
   }
 }

--- a/KMReader/Features/Reader/Views/ReaderLoadingView.swift
+++ b/KMReader/Features/Reader/Views/ReaderLoadingView.swift
@@ -11,7 +11,6 @@ struct ReaderLoadingView: View {
   let progress: Double?
 
   private let contentWidth: CGFloat = 260
-  private let textBlockMinHeight: CGFloat = 64
 
   private var normalizedProgress: Double? {
     progress.map { min(max($0, 0), 1) }
@@ -90,7 +89,6 @@ struct ReaderLoadingView: View {
       detailTextView
     }
     .frame(width: contentWidth)
-    .frame(minHeight: textBlockMinHeight)
   }
 
   private var titleText: some View {
@@ -98,8 +96,9 @@ struct ReaderLoadingView: View {
       .font(.headline)
       .foregroundStyle(.primary)
       .multilineTextAlignment(.center)
-      .lineLimit(2)
-      .fixedSize(horizontal: false, vertical: true)
+      .lineLimit(1)
+      .truncationMode(.tail)
+      .minimumScaleFactor(0.9)
       .frame(width: contentWidth)
   }
 
@@ -108,9 +107,9 @@ struct ReaderLoadingView: View {
       .font(.subheadline)
       .foregroundStyle(.secondary)
       .multilineTextAlignment(.center)
-      .lineLimit(2)
+      .lineLimit(1)
+      .truncationMode(.tail)
       .minimumScaleFactor(0.9)
-      .fixedSize(horizontal: false, vertical: true)
       .frame(width: contentWidth)
   }
 }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -11258,6 +11258,70 @@
         }
       }
     },
+    "Checking PDF download information" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF-Downloadinformationen werden geprüft"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Checking PDF download information"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprobando la información de descarga del PDF"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérification des informations de téléchargement du PDF"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifica delle informazioni di download del PDF"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDFのダウンロード情報を確認中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF 다운로드 정보를 확인하는 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверка сведений о загрузке PDF"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在检查 PDF 下载信息"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在檢查 PDF 下載資訊"
+          }
+        }
+      }
+    },
     "Choose an existing Komga server or add a new one to begin." : {
       "localizations" : {
         "de" : {
@@ -28662,6 +28726,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "篩選"
+          }
+        }
+      }
+    },
+    "Finalizing offline PDF file" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-PDF-Datei wird abgeschlossen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizing offline PDF file"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizando el archivo PDF sin conexión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalisation du fichier PDF hors ligne"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizzazione del file PDF offline"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインPDFファイルを完了中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 PDF 파일을 마무리하는 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завершение подготовки офлайн-файла PDF"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在完成离线 PDF 文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在完成離線 PDF 檔案"
           }
         }
       }
@@ -50106,6 +50234,70 @@
         }
       }
     },
+    "Opening downloaded PDF file" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heruntergeladene PDF-Datei wird geöffnet"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opening downloaded PDF file"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abriendo el archivo PDF descargado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouverture du fichier PDF téléchargé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apertura del file PDF scaricato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロードしたPDFファイルを開いています"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드한 PDF 파일을 여는 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Открытие загруженного PDF-файла"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在打开已下载的 PDF 文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在開啟已下載的 PDF 檔案"
+          }
+        }
+      }
+    },
     "Operating System" : {
       "localizations" : {
         "de" : {
@@ -52536,6 +52728,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "首選方向"
+          }
+        }
+      }
+    },
+    "Preparing offline download" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Download wird vorbereitet"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing offline download"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando la descarga sin conexión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Préparation du téléchargement hors ligne"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione del download offline"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインダウンロードを準備中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 다운로드를 준비하는 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка офлайн-загрузки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在准备离线下载"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在準備離線下載"
           }
         }
       }
@@ -58812,6 +59068,70 @@
         }
       }
     },
+    "Rendering PDF pages for DIVINA reader" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PDF-Seiten für den DIVINA-Reader werden gerendert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendering PDF pages for DIVINA reader"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renderizando páginas PDF para el lector DIVINA"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendu des pages PDF pour le lecteur DIVINA"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendering delle pagine PDF per il lettore DIVINA"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DIVINAリーダー用にPDFページをレンダリング中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DIVINA 리더용 PDF 페이지를 렌더링하는 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отрисовка страниц PDF для читалки DIVINA"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在为 DIVINA 阅读器渲染 PDF 页面"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在為 DIVINA 閱讀器算繪 PDF 頁面"
+          }
+        }
+      }
+    },
     "Reset" : {
       "localizations" : {
         "de" : {
@@ -58936,6 +59256,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重設為全域設定"
+          }
+        }
+      }
+    },
+    "Resolving page metadata" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seitenmetadaten werden aufgelöst"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resolving page metadata"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resolviendo los metadatos de páginas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Résolution des métadonnées des pages"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Risoluzione dei metadati delle pagine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページメタデータを解決中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 메타데이터를 확인하는 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Определение метаданных страниц"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在解析页面元数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在解析頁面中繼資料"
           }
         }
       }
@@ -79484,6 +79868,70 @@
         }
       }
     },
+    "Using downloaded book files" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heruntergeladene Buchdateien werden verwendet"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Using downloaded book files"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usando los archivos descargados del libro"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilisation des fichiers du livre téléchargés"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uso dei file del libro scaricati"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード済みの書籍ファイルを使用中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드한 책 파일을 사용하는 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Использование загруженных файлов книги"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在使用已下载的书籍文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在使用已下載的書籍檔案"
+          }
+        }
+      }
+    },
     "Validate Connection" : {
       "localizations" : {
         "de" : {
@@ -79804,6 +80252,70 @@
         }
       }
     },
+    "Verifying offline files against page metadata" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Dateien werden mit Seitenmetadaten abgeglichen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifying offline files against page metadata"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificando los archivos sin conexión con los metadatos de páginas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérification des fichiers hors ligne avec les métadonnées des pages"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifica dei file offline con i metadati delle pagine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインファイルをページメタデータと照合中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 파일을 페이지 메타데이터와 대조하는 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сверка офлайн-файлов с метаданными страниц"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在根据页面元数据验证离线文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在根據頁面中繼資料驗證離線檔案"
+          }
+        }
+      }
+    },
     "Version" : {
       "localizations" : {
         "de" : {
@@ -80056,6 +80568,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Waifu2x 模式"
+          }
+        }
+      }
+    },
+    "Waiting for offline download to start" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Warten auf den Start des Offline-Downloads"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Waiting for offline download to start"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esperando a que comience la descarga sin conexión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En attente du démarrage du téléchargement hors ligne"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In attesa dell'avvio del download offline"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインダウンロードの開始を待機中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 다운로드 시작을 기다리는 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ожидание начала офлайн-загрузки"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在等待离线下载开始"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在等待離線下載開始"
           }
         }
       }


### PR DESCRIPTION
## Problem

The reader loading card could still feel unstable when loading states changed, especially when switching between determinate progress and processing states. Some states also lacked detail text, which left the card visually unbalanced.

## Approach

- Require `ReaderLoadingView` to always receive a detail line and keep its icon/text layout fixed.
- Add stage-specific loading details for DIVINA, EPUB, and PDF reader paths.
- Keep PDF details aligned with the native PDF flow: checking download info, downloading content, finalizing the offline PDF, and opening the downloaded file.
- Localize the new reader loading detail strings across supported languages.

## Validation

- `git diff --check`
- `make build`
- `make localize`
- `./misc/translate.py list`
