### PR TITLE
fix: align book card placeholders with card visibility settings

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 472;
+				CURRENT_PROJECT_VERSION = 473;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 472;
+				CURRENT_PROJECT_VERSION = 473;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 472;
+				CURRENT_PROJECT_VERSION = 473;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 472;
+				CURRENT_PROJECT_VERSION = 473;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Views/BookQueryItemView.swift
+++ b/KMReader/Features/Book/Views/BookQueryItemView.swift
@@ -66,7 +66,11 @@ struct BookQueryItemView: View {
           )
         }
       } else {
-        CardPlaceholder(layout: layout, kind: .book)
+        CardPlaceholder(
+          layout: layout,
+          kind: .book,
+          showBookSeriesTitle: showSeriesTitle
+        )
       }
     }
     .task(id: "\(current.instanceId)|\(bookId)") {

--- a/KMReader/Shared/UI/CardPlaceholder.swift
+++ b/KMReader/Shared/UI/CardPlaceholder.swift
@@ -9,9 +9,12 @@ import SwiftUI
 struct CardPlaceholder: View {
   let layout: BrowseLayoutMode
   let kind: CardPlaceholderKind
+  var showBookSeriesTitle: Bool = true
 
+  @AppStorage("showBookCardSeriesTitle") private var showBookCardSeriesTitle: Bool = true
   @AppStorage("coverOnlyCards") private var coverOnlyCards: Bool = false
   @AppStorage("cardTextOverlayMode") private var cardTextOverlayMode: Bool = false
+  @AppStorage("thumbnailShowProgressBar") private var thumbnailShowProgressBar: Bool = true
 
   private let cornerRadius: CGFloat = 8
   private let lineSpacing: CGFloat = 6
@@ -29,6 +32,24 @@ struct CardPlaceholder: View {
     listThumbnailWidth / CoverAspectRatio.widthToHeight
   }
 
+  private var showsBookSeriesTitleLine: Bool {
+    kind == .book && showBookSeriesTitle && showBookCardSeriesTitle
+  }
+
+  private var reservesBookProgressBar: Bool {
+    kind == .book && thumbnailShowProgressBar && !cardTextOverlayMode
+  }
+
+  private var gridContentSpacing: CGFloat {
+    if cardTextOverlayMode {
+      return 0
+    }
+    if reservesBookProgressBar {
+      return 2
+    }
+    return 12
+  }
+
   var body: some View {
     switch layout {
     case .grid:
@@ -39,11 +60,16 @@ struct CardPlaceholder: View {
   }
 
   private var gridPlaceholder: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    VStack(alignment: .leading, spacing: gridContentSpacing) {
       gridThumbnail
 
+      if reservesBookProgressBar {
+        ReadingProgressBar(progress: 0, type: .card)
+          .opacity(0)
+      }
+
       if !cardTextOverlayMode && !coverOnlyCards {
-        VStack(alignment: .leading, spacing: lineSpacing) {
+        VStack(alignment: .leading) {
           ForEach(Array(gridLines.enumerated()), id: \.offset) { item in
             placeholderLine(
               textStyle: item.element.textStyle,
@@ -102,11 +128,14 @@ struct CardPlaceholder: View {
   private var gridLines: [(textStyle: Font.TextStyle, text: String, width: CGFloat, opacity: Double)] {
     switch kind {
     case .book:
-      return [
-        (textStyle: .caption, text: "Series Title", width: 0.55, opacity: 0.18),
+      let titleLines: [(textStyle: Font.TextStyle, text: String, width: CGFloat, opacity: Double)] = [
         (textStyle: .footnote, text: "1 - Book Title", width: 0.85, opacity: 0.2),
         (textStyle: .caption, text: "200 pages", width: 0.6, opacity: 0.15),
       ]
+      guard showsBookSeriesTitleLine else { return titleLines }
+      return [
+        (textStyle: .caption, text: "Series Title", width: 0.55, opacity: 0.18)
+      ] + titleLines
     case .series:
       return [
         (textStyle: .footnote, text: "Series Title", width: 0.8, opacity: 0.2),
@@ -128,12 +157,15 @@ struct CardPlaceholder: View {
   private var listLines: [(textStyle: Font.TextStyle, text: String, width: CGFloat, opacity: Double)] {
     switch kind {
     case .book:
-      return [
-        (textStyle: .footnote, text: "Series Title", width: 0.55, opacity: 0.18),
+      let titleLines: [(textStyle: Font.TextStyle, text: String, width: CGFloat, opacity: Double)] = [
         (textStyle: .body, text: "#12 - Book Title", width: 0.85, opacity: 0.2),
         (textStyle: .caption, text: "Last Updated", width: 0.6, opacity: 0.15),
         (textStyle: .footnote, text: "200 pages 120 MB", width: 0.7, opacity: 0.15),
       ]
+      guard showsBookSeriesTitleLine else { return titleLines }
+      return [
+        (textStyle: .footnote, text: "Series Title", width: 0.55, opacity: 0.18)
+      ] + titleLines
     case .series:
       return [
         (textStyle: .callout, text: "Series Title", width: 0.85, opacity: 0.2),


### PR DESCRIPTION
## Summary
- Pass the book series-title visibility flag into `CardPlaceholder` so loading cards match the real book cards.
- Hide the series-title placeholder line when the setting is off.
- Reserve placeholder space for the progress bar when thumbnails show it, keeping grid card layout stable.

## Testing
- Not run (not requested)