### PR TITLE
fix: stabilize reader loading background

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 473;
+				CURRENT_PROJECT_VERSION = 474;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 473;
+				CURRENT_PROJECT_VERSION = 474;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 473;
+				CURRENT_PROJECT_VERSION = 474;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 473;
+				CURRENT_PROJECT_VERSION = 474;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Models/ReaderBackground.swift
+++ b/KMReader/Features/Reader/Models/ReaderBackground.swift
@@ -49,18 +49,26 @@ enum ReaderBackground: String, CaseIterable, Hashable, Sendable {
     }
   }
 
+  var loadingCardFill: Color {
+    switch self {
+    case .black:
+      return Color(.sRGB, white: 0.12, opacity: 1)
+    case .white:
+      return Color(.sRGB, white: 0.96, opacity: 1)
+    case .gray:
+      return Color(.sRGB, white: 0.42, opacity: 1)
+    case .sepia:
+      return Color(red: 250.0 / 255.0, green: 244.0 / 255.0, blue: 228.0 / 255.0)
+    case .system:
+      return PlatformHelper.secondarySystemBackgroundColor
+    }
+  }
+
+  var loadingContentColor: Color {
+    contentColor
+  }
+
   var appliesImageMultiplyBlend: Bool {
     self == .sepia
-  }
-}
-
-private struct ReaderBackgroundPreferenceKey: EnvironmentKey {
-  static let defaultValue: ReaderBackground = .system
-}
-
-extension EnvironmentValues {
-  var readerBackgroundPreference: ReaderBackground {
-    get { self[ReaderBackgroundPreferenceKey.self] }
-    set { self[ReaderBackgroundPreferenceKey.self] = newValue }
   }
 }

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -739,7 +739,6 @@ struct DivinaReaderView: View {
     #if os(iOS)
       .readerDismissGesture(readingDirection: readingDirection)
     #endif
-    .environment(\.readerBackgroundPreference, readerBackground)
   }
 
   @ViewBuilder
@@ -753,7 +752,9 @@ struct DivinaReaderView: View {
         ReaderLoadingView(
           title: viewModel.loadingTitle,
           detail: viewModel.loadingDetail,
-          progress: viewModel.loadingProgress
+          progress: viewModel.loadingProgress,
+          cardFill: readerBackground.loadingCardFill,
+          contentColor: readerBackground.loadingContentColor
         )
       } else if viewModel.hasPages {
         Group {

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -208,6 +208,31 @@
       activeThemePreferences.resolvedColorScheme(fallbackColorScheme: colorScheme)
     }
 
+    private var loadingCardFill: Color {
+      switch readerTheme {
+      case .white:
+        return Color(.sRGB, white: 0.96, opacity: 1)
+      case .black:
+        return Color(.sRGB, white: 0.12, opacity: 1)
+      case .lightQuiet:
+        return Color(hex: "#F0F0F0") ?? readerTheme.backgroundColor
+      case .darkQuiet:
+        return Color(hex: "#2A2A2A") ?? readerTheme.backgroundColor
+      case .lightSepia:
+        return Color(hex: "#FAF4E4") ?? readerTheme.backgroundColor
+      case .darkSepia:
+        return Color(hex: "#44382D") ?? readerTheme.backgroundColor
+      case .lightGreen:
+        return Color(hex: "#D8F5DC") ?? readerTheme.backgroundColor
+      case .darkGreen:
+        return Color(hex: "#243324") ?? readerTheme.backgroundColor
+      }
+    }
+
+    private var loadingContentColor: Color {
+      readerTheme.textColor
+    }
+
     #if os(macOS)
       private var supportsOverlayControls: Bool {
         false
@@ -452,7 +477,9 @@
                 ReaderLoadingView(
                   title: loadingTitle,
                   detail: loadingDetail,
-                  progress: loadingProgress
+                  progress: loadingProgress,
+                  cardFill: loadingCardFill,
+                  contentColor: loadingContentColor
                 )
               } else if let error = viewModel.errorMessage {
                 VStack(spacing: 12) {
@@ -477,7 +504,9 @@
             ReaderLoadingView(
               title: loadingTitle,
               detail: loadingDetail,
-              progress: loadingProgress
+              progress: loadingProgress,
+              cardFill: loadingCardFill,
+              contentColor: loadingContentColor
             )
           } else if let error = viewModel.errorMessage {
             VStack(spacing: 12) {

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -100,6 +100,7 @@
       #if os(iOS)
         .statusBarHidden(!shouldShowControls)
       #endif
+      .environment(\.readerBackgroundPreference, readerBackground)
       .sheet(isPresented: $showingPageJumpSheet) {
         if let documentURL = viewModel.documentURL {
           PdfPageJumpSheetView(

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -100,7 +100,6 @@
       #if os(iOS)
         .statusBarHidden(!shouldShowControls)
       #endif
-      .environment(\.readerBackgroundPreference, readerBackground)
       .sheet(isPresented: $showingPageJumpSheet) {
         if let documentURL = viewModel.documentURL {
           PdfPageJumpSheetView(
@@ -329,7 +328,9 @@
         ReaderLoadingView(
           title: loadingTitle,
           detail: loadingDetail,
-          progress: loadingProgress
+          progress: loadingProgress,
+          cardFill: readerBackground.loadingCardFill,
+          contentColor: readerBackground.loadingContentColor
         )
       } else if let errorMessage = viewModel.errorMessage {
         VStack(spacing: 16) {

--- a/KMReader/Features/Reader/Views/ReaderLoadingView.swift
+++ b/KMReader/Features/Reader/Views/ReaderLoadingView.swift
@@ -6,6 +6,8 @@
 import SwiftUI
 
 struct ReaderLoadingView: View {
+  @Environment(\.readerBackgroundPreference) private var readerBackground
+
   let title: String
   let detail: String
   let progress: Double?
@@ -38,19 +40,70 @@ struct ReaderLoadingView: View {
     .padding(.horizontal, 28)
     .background {
       RoundedRectangle(cornerRadius: 28, style: .continuous)
-        .fill(.ultraThinMaterial)
+        .fill(cardFill)
         .overlay {
           RoundedRectangle(cornerRadius: 28, style: .continuous)
-            .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
+            .stroke(cardStroke, lineWidth: 0.5)
         }
     }
     .shadow(color: Color.black.opacity(0.12), radius: 30, x: 0, y: 15)
   }
 
+  private var cardFill: Color {
+    switch readerBackground {
+    case .black:
+      return Color(.sRGB, white: 0.12, opacity: 1)
+    case .white:
+      return Color(.sRGB, white: 0.96, opacity: 1)
+    case .gray:
+      return Color(.sRGB, white: 0.42, opacity: 1)
+    case .sepia:
+      return Color(red: 250.0 / 255.0, green: 244.0 / 255.0, blue: 228.0 / 255.0)
+    case .system:
+      return PlatformHelper.secondarySystemBackgroundColor
+    }
+  }
+
+  private var cardStroke: Color {
+    switch readerBackground {
+    case .system:
+      return Color.primary.opacity(0.08)
+    case .black, .white, .gray, .sepia:
+      return readerBackground.contentColor.opacity(0.12)
+    }
+  }
+
+  private var primaryContentColor: Color {
+    switch readerBackground {
+    case .system:
+      return .primary
+    case .black, .white, .gray, .sepia:
+      return readerBackground.contentColor
+    }
+  }
+
+  private var secondaryContentColor: Color {
+    switch readerBackground {
+    case .system:
+      return .secondary
+    case .black, .white, .gray, .sepia:
+      return readerBackground.contentColor.opacity(0.72)
+    }
+  }
+
+  private var progressTrackColor: Color {
+    switch readerBackground {
+    case .system:
+      return Color.primary.opacity(0.05)
+    case .black, .white, .gray, .sepia:
+      return readerBackground.contentColor.opacity(0.14)
+    }
+  }
+
   private var statusIcon: some View {
     ZStack {
       Circle()
-        .stroke(Color.primary.opacity(0.05), lineWidth: 4)
+        .stroke(progressTrackColor, lineWidth: 4)
         .frame(width: 64, height: 64)
 
       Circle()
@@ -66,10 +119,11 @@ struct ReaderLoadingView: View {
         .frame(width: 64, height: 64)
         .rotationEffect(.degrees(-90))
         .opacity(showsProgress ? 1 : 0)
-        .animation(.easeOut(duration: 0.16), value: normalizedProgress)
+        .animation(.easeOut(duration: 0.16), value: numericProgress)
 
       Text(progressText)
         .font(.system(.subheadline, design: .rounded).bold())
+        .foregroundStyle(primaryContentColor)
         .monospacedDigit()
         .contentTransition(.numericText(value: numericProgress))
         .animation(.easeOut(duration: 0.16), value: numericProgress)
@@ -94,7 +148,7 @@ struct ReaderLoadingView: View {
   private var titleText: some View {
     Text(title)
       .font(.headline)
-      .foregroundStyle(.primary)
+      .foregroundStyle(primaryContentColor)
       .multilineTextAlignment(.center)
       .lineLimit(1)
       .truncationMode(.tail)
@@ -105,7 +159,7 @@ struct ReaderLoadingView: View {
   private var detailTextView: some View {
     Text(detail)
       .font(.subheadline)
-      .foregroundStyle(.secondary)
+      .foregroundStyle(secondaryContentColor)
       .multilineTextAlignment(.center)
       .lineLimit(1)
       .truncationMode(.tail)

--- a/KMReader/Features/Reader/Views/ReaderLoadingView.swift
+++ b/KMReader/Features/Reader/Views/ReaderLoadingView.swift
@@ -12,7 +12,23 @@ struct ReaderLoadingView: View {
   let detail: String
   let progress: Double?
 
+  private let customCardFill: Color?
+  private let customContentColor: Color?
   private let contentWidth: CGFloat = 260
+
+  init(
+    title: String,
+    detail: String,
+    progress: Double?,
+    cardFill: Color? = nil,
+    contentColor: Color? = nil
+  ) {
+    self.title = title
+    self.detail = detail
+    self.progress = progress
+    self.customCardFill = cardFill
+    self.customContentColor = contentColor
+  }
 
   private var normalizedProgress: Double? {
     progress.map { min(max($0, 0), 1) }
@@ -50,6 +66,10 @@ struct ReaderLoadingView: View {
   }
 
   private var cardFill: Color {
+    if let customCardFill {
+      return customCardFill
+    }
+
     switch readerBackground {
     case .black:
       return Color(.sRGB, white: 0.12, opacity: 1)
@@ -65,6 +85,10 @@ struct ReaderLoadingView: View {
   }
 
   private var cardStroke: Color {
+    if let customContentColor {
+      return customContentColor.opacity(0.12)
+    }
+
     switch readerBackground {
     case .system:
       return Color.primary.opacity(0.08)
@@ -74,6 +98,10 @@ struct ReaderLoadingView: View {
   }
 
   private var primaryContentColor: Color {
+    if let customContentColor {
+      return customContentColor
+    }
+
     switch readerBackground {
     case .system:
       return .primary
@@ -83,6 +111,10 @@ struct ReaderLoadingView: View {
   }
 
   private var secondaryContentColor: Color {
+    if let customContentColor {
+      return customContentColor.opacity(0.72)
+    }
+
     switch readerBackground {
     case .system:
       return .secondary
@@ -92,6 +124,10 @@ struct ReaderLoadingView: View {
   }
 
   private var progressTrackColor: Color {
+    if let customContentColor {
+      return customContentColor.opacity(0.14)
+    }
+
     switch readerBackground {
     case .system:
       return Color.primary.opacity(0.05)

--- a/KMReader/Features/Reader/Views/ReaderLoadingView.swift
+++ b/KMReader/Features/Reader/Views/ReaderLoadingView.swift
@@ -6,28 +6,26 @@
 import SwiftUI
 
 struct ReaderLoadingView: View {
-  @Environment(\.readerBackgroundPreference) private var readerBackground
-
   let title: String
   let detail: String
   let progress: Double?
+  let cardFill: Color
+  let contentColor: Color
 
-  private let customCardFill: Color?
-  private let customContentColor: Color?
   private let contentWidth: CGFloat = 260
 
   init(
     title: String,
     detail: String,
     progress: Double?,
-    cardFill: Color? = nil,
-    contentColor: Color? = nil
+    cardFill: Color,
+    contentColor: Color
   ) {
     self.title = title
     self.detail = detail
     self.progress = progress
-    self.customCardFill = cardFill
-    self.customContentColor = contentColor
+    self.cardFill = cardFill
+    self.contentColor = contentColor
   }
 
   private var normalizedProgress: Double? {
@@ -65,75 +63,20 @@ struct ReaderLoadingView: View {
     .shadow(color: Color.black.opacity(0.12), radius: 30, x: 0, y: 15)
   }
 
-  private var cardFill: Color {
-    if let customCardFill {
-      return customCardFill
-    }
-
-    switch readerBackground {
-    case .black:
-      return Color(.sRGB, white: 0.12, opacity: 1)
-    case .white:
-      return Color(.sRGB, white: 0.96, opacity: 1)
-    case .gray:
-      return Color(.sRGB, white: 0.42, opacity: 1)
-    case .sepia:
-      return Color(red: 250.0 / 255.0, green: 244.0 / 255.0, blue: 228.0 / 255.0)
-    case .system:
-      return PlatformHelper.secondarySystemBackgroundColor
-    }
-  }
-
   private var cardStroke: Color {
-    if let customContentColor {
-      return customContentColor.opacity(0.12)
-    }
-
-    switch readerBackground {
-    case .system:
-      return Color.primary.opacity(0.08)
-    case .black, .white, .gray, .sepia:
-      return readerBackground.contentColor.opacity(0.12)
-    }
+    contentColor.opacity(0.12)
   }
 
   private var primaryContentColor: Color {
-    if let customContentColor {
-      return customContentColor
-    }
-
-    switch readerBackground {
-    case .system:
-      return .primary
-    case .black, .white, .gray, .sepia:
-      return readerBackground.contentColor
-    }
+    contentColor
   }
 
   private var secondaryContentColor: Color {
-    if let customContentColor {
-      return customContentColor.opacity(0.72)
-    }
-
-    switch readerBackground {
-    case .system:
-      return .secondary
-    case .black, .white, .gray, .sepia:
-      return readerBackground.contentColor.opacity(0.72)
-    }
+    contentColor.opacity(0.72)
   }
 
   private var progressTrackColor: Color {
-    if let customContentColor {
-      return customContentColor.opacity(0.14)
-    }
-
-    switch readerBackground {
-    case .system:
-      return Color.primary.opacity(0.05)
-    case .black, .white, .gray, .sepia:
-      return readerBackground.contentColor.opacity(0.14)
-    }
+    contentColor.opacity(0.14)
   }
 
   private var statusIcon: some View {
@@ -210,7 +153,9 @@ struct ReaderLoadingView: View {
     ReaderLoadingView(
       title: "Downloading book...",
       detail: "45% · 12.4 MB / 28.5 MB",
-      progress: 0.45
+      progress: 0.45,
+      cardFill: ReaderBackground.gray.loadingCardFill,
+      contentColor: ReaderBackground.gray.loadingContentColor
     )
   }
 }


### PR DESCRIPTION
## Problem

Reader loading cards still flicker on iOS 26 when the loading title, detail, or progress changes because live material backgrounds are resampled during content updates.

## Approach

- Replace the reader loading card material with stable colors.
- Make `ReaderLoadingView` take an explicit stable palette instead of reading an implicit reader background environment.
- Have DIVINA and PDF pass palette colors derived from their active `ReaderBackground`.
- Have EPUB pass palette colors derived from the active EPUB `ReaderTheme`.
- Bump the build number from 473 to 474.

## Validation

- `git diff --check`
- `make build`
