### PR TITLE
docs: refresh 5.0 store copy

### DIFF
--- a/.agents/skills/appstore-release/SKILL.md
+++ b/.agents/skills/appstore-release/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: appstore-release
+description: "Coordinate the KMReader App Store release workflow. Use when asked to prepare or run a KMReader App Store release across iOS, macOS, and tvOS: refresh docs and APP_STORE_CHANGELOG.txt, open and merge the release-copy PR, create or update App Store Connect versions, attach builds and submit for review, then run make minor and open/merge the next-version-cycle PR."
+---
+
+# KMReader App Store Release
+
+Run the end-to-end KMReader App Store release workflow while keeping local release copy, App Store Connect metadata, submitted builds, and the next development version in sync.
+
+## Required Inputs
+
+- Release version, for example `4.10`.
+- Build number to submit, for example `439`. If omitted, resolve the latest valid build per platform before attaching anything.
+- Target platforms are always `IOS`, `MAC_OS`, and `TV_OS` unless the user explicitly narrows scope.
+
+KMReader App Store app ID is `6755198424`. Confirm it with `asc apps list --name KMReader` before making remote changes.
+
+## Related Local Skills
+
+Before editing release copy, read and follow:
+
+- `../changelog/SKILL.md` for `APP_STORE_CHANGELOG.txt`
+- `../docs/SKILL.md` for `README.md`, `APP_STORE_DESCRIPTION.txt`, and `static/index.html`
+
+Do not duplicate those instructions here. This skill owns ordering, GitHub PR handling, App Store Connect release actions, and the follow-up version-cycle PR.
+
+## Guardrails
+
+- Work from a clean or understood git state. Do not mix unrelated local changes into release PRs.
+- Use `asc --help` for command shape when uncertain; CLI flags can drift.
+- Do not use raw `xcodebuild`; this repo uses Makefile automation.
+- Do not create duplicate App Store Connect versions. Reuse existing editable versions.
+- Stop before submission if any platform build is not `VALID`, metadata is incomplete, content rights are missing, or encryption compliance is unresolved.
+- Do not rely on `asc submit status --id`; App Store Connect can reject that lookup with a `GET_INSTANCE` limitation. Verify final state through `asc versions get/list` and review submission responses.
+- Keep release notes user-facing. Exclude bump commits, CI, implementation details, file names, class names, and refactor-only work.
+- Use `gh pr create --body-file` and `gh pr edit --body-file`; do not pass Markdown bodies inline.
+
+## Phase 1: Refresh Release Copy
+
+1. Inspect context:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -n 20
+git tag --sort=-creatordate | head -20
+```
+
+2. Generate `APP_STORE_CHANGELOG.txt` from the latest tag to `HEAD`. Read full commit bodies, not only subjects.
+3. Refresh `README.md`, `APP_STORE_DESCRIPTION.txt`, and `static/index.html` from current important product capabilities.
+4. Keep docs evergreen and concise. `APP_STORE_DESCRIPTION.txt` should be store-appropriate; `static/index.html` should align with the same product priorities.
+5. Validate release copy:
+
+```bash
+git diff --check
+wc -c APP_STORE_DESCRIPTION.txt APP_STORE_CHANGELOG.txt
+```
+
+If validation needs stronger proof, run the smallest relevant repo command. Do not run repository-wide formatting just for release copy.
+
+## Phase 2: PR And Merge Release Copy
+
+Create a dedicated branch:
+
+```bash
+git switch -c "docs/refresh-${version//./}-store-copy"
+git add README.md APP_STORE_DESCRIPTION.txt APP_STORE_CHANGELOG.txt static/index.html
+git commit -m "docs: refresh ${version} store copy"
+git push -u origin "docs/refresh-${version//./}-store-copy"
+```
+
+Create the PR with a body file:
+
+```bash
+cat > /tmp/kmreader-release-copy-pr-body.md <<EOF
+## Problem
+The public documentation and App Store release copy need to match the ${version} release.
+
+## Approach
+Refresh README, App Store description, landing page copy, and App Store changelog from the current user-visible product changes.
+
+## Validation
+- [x] Reviewed latest-tag-to-HEAD commits
+- [x] Ran git diff --check
+EOF
+
+gh pr create --title "docs: refresh ${version} store copy" --body-file /tmp/kmreader-release-copy-pr-body.md
+gh pr view <PR_NUMBER> --json url,title,body,headRefName,baseRefName,state,statusCheckRollup
+```
+
+Merge when checks are acceptable or the user has explicitly authorized immediate release workflow completion:
+
+```bash
+gh pr merge <PR_NUMBER> --squash --delete-branch \
+  --subject "docs: refresh ${version} store copy" \
+  --body "Update README, App Store description, landing page copy, and App Store changelog for the ${version} release."
+
+git fetch --prune origin
+git switch main
+git pull --ff-only origin main
+git status --short --branch
+```
+
+Do not continue to App Store Connect metadata updates from an unmerged local-only release-copy branch unless the user explicitly wants that.
+
+## Phase 3: Create Or Reuse ASC Versions
+
+Confirm app and versions:
+
+```bash
+asc apps list --name KMReader --pretty
+asc versions list --app 6755198424 --version "$version" --platform IOS,MAC_OS,TV_OS --pretty
+```
+
+For each missing platform version:
+
+```bash
+asc versions create --app 6755198424 --version "$version" --platform IOS --pretty
+asc versions create --app 6755198424 --version "$version" --platform MAC_OS --pretty
+asc versions create --app 6755198424 --version "$version" --platform TV_OS --pretty
+```
+
+Record the version IDs in a platform map. The version state should be `PREPARE_FOR_SUBMISSION` before metadata/build changes.
+
+## Phase 4: Sync ASC Metadata
+
+For each platform version, update `en-US` localization with local files:
+
+```bash
+description=$(cat APP_STORE_DESCRIPTION.txt)
+whats_new=$(cat APP_STORE_CHANGELOG.txt)
+
+asc localizations update --version "$ios_version_id" --locale en-US \
+  --description "$description" \
+  --whats-new "$whats_new" \
+  --pretty
+```
+
+Repeat for `MAC_OS` and `TV_OS` version IDs.
+
+After update, download or list localizations and compare fields against local files. ASC may trim the final trailing newline; that is acceptable. Preserve unrelated metadata such as keywords, support URL, and marketing URL.
+
+If the user says description must remain unchanged, update only `whatsNew`.
+
+## Phase 5: Attach Builds
+
+Find and validate build IDs:
+
+```bash
+asc builds list --app 6755198424 --version "$version" --build-number "$build_number" --processing-state all --pretty
+```
+
+Map one build ID per platform. Confirm:
+
+- `processingState` is `VALID`.
+- Encryption compliance is resolved, usually `usesNonExemptEncryption=false`.
+- The build belongs to the requested release version/build number.
+
+Attach each build:
+
+```bash
+asc versions attach-build --version-id "$ios_version_id" --build "$ios_build_id" --pretty
+asc versions attach-build --version-id "$macos_version_id" --build "$macos_build_id" --pretty
+asc versions attach-build --version-id "$tvos_version_id" --build "$tvos_build_id" --pretty
+```
+
+Then verify:
+
+```bash
+asc versions get --version-id "$ios_version_id" --include-build --pretty
+asc versions get --version-id "$macos_version_id" --include-build --pretty
+asc versions get --version-id "$tvos_version_id" --include-build --pretty
+```
+
+## Phase 6: Submit For Review
+
+For each platform:
+
+```bash
+submission_id=$(asc review submissions-create --app 6755198424 --platform IOS --pretty \
+  | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data.get("id") or data["data"]["id"])')
+
+asc review items-add --submission "$submission_id" --item-type appStoreVersions --item-id "$ios_version_id" --pretty
+asc review submissions-submit --id "$submission_id" --confirm --pretty
+```
+
+Repeat for `MAC_OS` and `TV_OS`.
+
+Final verification:
+
+```bash
+asc versions list --app 6755198424 --version "$version" --platform IOS,MAC_OS,TV_OS --pretty
+asc versions get --version-id "$ios_version_id" --include-build --pretty
+asc versions get --version-id "$macos_version_id" --include-build --pretty
+asc versions get --version-id "$tvos_version_id" --include-build --pretty
+```
+
+All three versions should be `WAITING_FOR_REVIEW`. Report platform, version ID, build ID, and submission ID.
+
+## Phase 7: Start Next Version Cycle
+
+After the release submissions are verified, start the next development version from clean `main`.
+
+```bash
+git status --short --branch
+git switch -c "release/bump-${next_version}"
+make minor
+git status --short --branch
+```
+
+`make minor` must own the version mutation. Do not edit `MARKETING_VERSION` or `CURRENT_PROJECT_VERSION` manually.
+
+Verify the generated commit and version delta:
+
+```bash
+git log --oneline --decorate -n 3
+git diff --stat HEAD~1..HEAD
+```
+
+Push, open, and merge the version-cycle PR:
+
+```bash
+git push -u origin "release/bump-${next_version}"
+
+cat > /tmp/kmreader-next-version-pr-body.md <<EOF
+## Problem
+The ${version} App Store release has been submitted, so main should move to the next development version.
+
+## Approach
+Run make minor to bump MARKETING_VERSION and CURRENT_PROJECT_VERSION through the repository release script.
+
+## Validation
+- [x] Ran make minor
+- [x] Verified version file diff
+EOF
+
+gh pr create --title "chore: bump version to ${next_version}" --body-file /tmp/kmreader-next-version-pr-body.md
+gh pr view <PR_NUMBER> --json url,title,body,headRefName,baseRefName,state,statusCheckRollup
+
+gh pr merge <PR_NUMBER> --squash --delete-branch \
+  --subject "chore: bump version to ${next_version}" \
+  --body "Bump marketing version to ${next_version} and advance the build number for the next development cycle."
+
+git fetch --prune origin
+git switch main
+git pull --ff-only origin main
+git status --short --branch
+```
+
+## Final Report
+
+Report:
+
+- Release-copy PR URL and merge status.
+- ASC version IDs by platform.
+- Build IDs by platform.
+- Review submission IDs by platform.
+- Final ASC state by platform.
+- Next-version PR URL and merge status.
+- Current local branch, `HEAD`, and whether the worktree is clean.

--- a/.agents/skills/appstore-release/agents/openai.yaml
+++ b/.agents/skills/appstore-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "KMReader App Store Release"
+  short_description: "Coordinate KMReader App Store release workflow"
+  default_prompt: "Use $appstore-release to refresh KMReader release docs, prepare App Store Connect versions, submit builds, and start the next version cycle."

--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,19 +1,16 @@
 New
-- Added optional border cropping for DIVINA pages, helping comics with large empty margins use more of the screen.
-- Added DIVINA image preloading profiles so you can choose between lower memory use and smoother page turns.
-- Added dedicated EPUB settings and EPUB theme controls, separating reading behavior from per-book theme and typography choices.
+- KMReader 5.0 rebuilds local library storage around a dedicated database, improving reliability for large libraries, browsing, dashboards, and offline data.
+- Added EPUB overlay customization for reading progress, controls, headers, and footers.
+- Added smarter offline archive handling so downloaded books stay compact and pages are prepared on demand when reading.
 
 Improvements
-- EPUB books with custom fonts, images, and mixed HTML/XHTML chapters now load publication resources more reliably.
-- EPUB tap zones now have their own settings instead of sharing DIVINA tap zone preferences.
-- DIVINA scroll and page-curl navigation is more stable, especially around rapid taps, animations, and book boundaries.
-- Reader memory handling is improved on iOS, with decoded pages pruned more gracefully under memory pressure.
-- Browse views avoid unnecessary refreshes when returning from detail pages.
-- The Browse tab is now positioned as the trailing search-style entry point on iPhone and Apple TV.
-- macOS Settings keeps its sidebar stable while using EPUB settings and log search.
+- Reader loading states are clearer and more stable, with smoother progress updates and less visual flicker while downloads or page preparation are running.
+- The in-app logs viewer now uses paginated storage, making settings logs easier to browse on long-running installs.
+- Offline download status, read progress lists, and one-shot read summaries refresh more reliably across browsing and detail screens.
+- EPUB theme color scheme choices now persist per book.
 
 Fixes
-- Fixed cases where continuing from one volume into the next could jump back or regress progress for the previous volume.
-- Fixed UTF-8 archive path handling for offline CBZ/ZIP extraction.
-- Fixed EPUB chapters that could appear blank when their manifest media type did not match the file extension.
-- Reduced unnecessary offline downloads for previous-book preloads while keeping forward offline-first preparation.
+- Fixed several reader loading edge cases around unknown download sizes, render progress, and background color transitions.
+- Fixed stale read progress or download indicators after reading, syncing, or returning from detail pages.
+- Fixed one-shot read status and summary placement in series views.
+- Fixed assorted reader control, keyboard, zoom, and tap-zone regressions.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -1,6 +1,6 @@
 KMReader - Native Komga Client for iPhone, iPad, Mac, and Apple TV
 
-KMReader helps you read, browse, download, and manage your Komga library with native Apple-platform readers and practical offline workflows.
+KMReader helps you read, browse, download, and manage your Komga library with native Apple-platform readers, reliable local library storage, and practical offline workflows.
 
 IMPORTANT FEATURES
 
@@ -10,14 +10,15 @@ Rotate individual pages, crop empty page borders in DIVINA, tune preloading for 
 
 - Browse and discover
 Use Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/read lists, reading history, saved filters, advanced metadata filters with all/any matching, optional unread-cover blur, Spotlight indexing, widgets, and Home Screen quick actions.
+KMReader keeps a local database for responsive browsing, dashboards, logs, and downloaded-library workflows, including large libraries.
 
 - Offline and sync
-Download books for offline reading, set per-series download policies, browse downloaded items, queue dashboard sections, keep reading with iOS background downloads and Live Activities, prepare books before opening with offline-first reading, and sync progress when you reconnect.
+Download books for offline reading, set per-series download policies, browse downloaded items, queue dashboard sections, keep reading with iOS background downloads and Live Activities, prepare local pages on demand with offline-first reading, and sync progress when you reconnect.
 
 - Multi-server and admin tools
 Save multiple Komga servers and switch instantly.
 Sign in with password or API key, and manage API keys in the app.
-Edit metadata, manage libraries and media, find missing posters or duplicates, monitor tasks, and view logs.
+Edit metadata, manage libraries and media, find missing posters or duplicates, monitor tasks, and browse paginated logs.
 
 KMReader targets Komga 1.19.0+ and supports API v1/v2.
 KMReader UI is localized in English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.

--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@
 
 - Dashboard sections for Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists, with quick offline actions for current or full book sections where supported.
 - Browse Series, Books, Collections, and Read Lists with metadata filters, all/any matching, saved filters, reading history, and optional unread-cover blur.
+- Local database storage keeps large libraries, dashboards, logs, downloaded content, and offline browsing responsive.
 - Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
 
 ### Offline and Sync
 
 - Download books for offline reading across DIVINA, EPUB, and PDF workflows, with optional offline-first reading that prepares local content before opening the reader.
 - Per-series policies support manual, unread-only, unread + cleanup, and all-books downloads.
-- Large downloads stream to disk, and CBZ, CBR, PDF, and supported EPUB offline flows use local extraction or storage.
+- Large downloads stream to disk, while CBZ, CBR, PDF, and supported EPUB offline flows keep source files available and prepare pages on demand.
 - Progress and offline changes sync when reconnecting, with stale progress protection and automatic recovery from server outages when offline mode was entered automatically. Cache controls cover pages and thumbnails.
 - iOS background downloads and Live Activities show reader progress, incognito status, download progress, and processing state.
 
@@ -45,7 +46,7 @@
 
 - Save multiple Komga servers and switch instantly.
 - Sign in with username/password or API key, and manage Komga API keys inside the app.
-- Admin tools cover metadata editing, library management, media analysis, missing posters, duplicate files/pages, task monitoring, and log viewing/export.
+- Admin tools cover metadata editing, library management, media analysis, missing posters, duplicate files/pages, task monitoring, and paginated log viewing/export.
 
 ### Platform Highlights
 

--- a/static/index.html
+++ b/static/index.html
@@ -6,7 +6,7 @@
         <title>KMReader · Native Komga Client for iOS, macOS & tvOS</title>
         <meta
             name="description"
-            content="KMReader is a native Komga client for iOS, macOS, and tvOS with DIVINA, EPUB, and PDF readers, Webtoon and spread layouts, reader image processing, offline downloads, filtering, multi-server support, and admin tools."
+            content="KMReader is a native Komga client for iOS, macOS, and tvOS with DIVINA, EPUB, and PDF readers, reliable local library storage, offline downloads, filtering, multi-server support, and admin tools."
         />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -28,9 +28,10 @@
                 <p class="tagline">
                     Read, download, browse, and manage your Komga library with
                     native DIVINA, EPUB, and PDF readers, Webtoon and spread
-                    layouts, reader image processing, offline-first reading, dashboard download actions,
-                    advanced filtering, multi-server support, and Apple-platform
-                    integrations on iPhone, iPad, Mac, and Apple TV.
+                    layouts, reader image processing, reliable local storage,
+                    offline-first reading, dashboard download actions, advanced
+                    filtering, multi-server support, and Apple-platform integrations
+                    on iPhone, iPad, Mac, and Apple TV.
                 </p>
                 <div class="cta">
                     <a
@@ -100,9 +101,9 @@
                             Updated, pinned collections/read lists, reading
                             history, metadata filters with all/any matching,
                             saved filters, optional unread-cover blur,
-                            dashboard download actions, widgets, quick actions,
-                            and Spotlight indexing keep the useful parts of your
-                            library close.
+                            dashboard download actions, local database storage,
+                            widgets, quick actions, and Spotlight indexing keep
+                            the useful parts of your library close.
                         </p>
                     </article>
                     <article class="card">
@@ -111,9 +112,9 @@
                         <p>
                             Download books for offline reading, set per-series
                             download policies, prepare local content before the
-                            reader opens, browse downloaded items, use iOS
-                            background downloads and Live Activities, and sync
-                            progress when you reconnect.
+                            reader opens, prepare pages on demand, browse
+                            downloaded items, use iOS background downloads and
+                            Live Activities, and sync progress when you reconnect.
                         </p>
                     </article>
                     <article class="card">
@@ -141,8 +142,8 @@
                         <h3>Manage your server in-app</h3>
                         <p>
                             Edit metadata, manage libraries and media, monitor
-                            tasks, view logs, and find missing posters or
-                            duplicate files/pages.
+                            tasks, browse paginated logs, and find missing
+                            posters or duplicate files/pages.
                         </p>
                     </article>
                 </div>
@@ -215,17 +216,17 @@
                         <h4>How does offline mode work?</h4>
                         <p>
                             Downloaded books stay readable offline, offline-first
-                            reading can prepare local content before the reader
-                            opens, per-series policies help decide what stays on
-                            device, and reading progress syncs when you
-                            reconnect.
+                            reading can keep source files available and prepare
+                            pages on demand, per-series policies help decide
+                            what stays on device, and reading progress syncs
+                            when you reconnect.
                         </p>
                     </article>
                     <article class="faq-item">
                         <h4>Can admins manage library data in-app?</h4>
                         <p>
                             Yes. KMReader includes metadata editing, library
-                            and media management, task monitoring, and logs.
+                            and media management, task monitoring, and paginated logs.
                         </p>
                     </article>
                     <article class="faq-item">


### PR DESCRIPTION
## Summary
- refresh 5.0 App Store changelog and description
- update README and static landing page copy for local storage, offline reading, and paginated logs
- add the repo-local appstore-release skill for the App Store release workflow

## Testing
- git diff --check
- uv run --with pyyaml python /Users/everpcpc/.agents/skills/.system/skill-creator/scripts/quick_validate.py /Users/everpcpc/src/KMReader/.agents/skills/appstore-release