### PR TITLE
fix(reader): smooth overlay transitions

### DIFF
--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -746,8 +746,17 @@ struct DivinaReaderView: View {
     useDualPage: Bool,
     screenSize: CGSize
   ) -> some View {
-    let contentKey = readerContentKey(useDualPage: useDualPage)
-    Group {
+    let showsLoadedContent = viewModel.hasPages && !viewModel.isLoading
+
+    ZStack {
+      if viewModel.hasPages {
+        loadedReaderContent(useDualPage: useDualPage, screenSize: screenSize)
+          .readerLoadingContent(isVisible: showsLoadedContent)
+      } else if !viewModel.isLoading {
+        NoPagesView(onDismiss: { closeReader() })
+          .transition(ReaderLoadingTransition.content)
+      }
+
       if viewModel.isLoading {
         ReaderLoadingView(
           title: viewModel.loadingTitle,
@@ -756,112 +765,121 @@ struct DivinaReaderView: View {
           cardFill: readerBackground.loadingCardFill,
           contentColor: readerBackground.loadingContentColor
         )
-      } else if viewModel.hasPages {
-        Group {
-          if readingDirection == .webtoon {
-            #if os(iOS) || os(macOS)
-              WebtoonPageView(
+        .readerLoadingOverlay()
+      }
+    }
+    .animation(ReaderLoadingTransition.animation, value: viewModel.isLoading)
+    .animation(ReaderLoadingTransition.animation, value: viewModel.hasPages)
+  }
+
+  @ViewBuilder
+  private func loadedReaderContent(
+    useDualPage: Bool,
+    screenSize: CGSize
+  ) -> some View {
+    let contentKey = readerContentKey(useDualPage: useDualPage)
+
+    Group {
+      if readingDirection == .webtoon {
+        #if os(iOS) || os(macOS)
+          WebtoonPageView(
+            viewModel: viewModel,
+            readListContext: readListContext,
+            onDismiss: { closeReader() },
+            onTapZoneTap: handleTapZoneTap,
+            scrollController: webtoonScrollController,
+            pageWidthPercentage: webtoonPageWidthPercentage,
+            renderConfig: renderConfig
+          )
+        #else
+          ScrollPageView(
+            mode: .vertical,
+            viewportSize: screenSize,
+            readingDirection: readingDirection,
+            splitWidePageMode: splitWidePageMode,
+            navigationAnimationDuration: pageTurnAnimationDuration,
+            renderConfig: renderConfig,
+            viewModel: viewModel,
+            readListContext: readListContext,
+            onDismiss: { closeReader() },
+            onTapZoneTap: handleTapZoneTap
+          )
+        #endif
+      } else {
+        switch pageTransitionStyle {
+        case .pageCurl:
+          #if os(iOS)
+            if useDualPage {
+              CurlDualPageView(
                 viewModel: viewModel,
-                readListContext: readListContext,
-                onDismiss: { closeReader() },
-                onTapZoneTap: handleTapZoneTap,
-                scrollController: webtoonScrollController,
-                pageWidthPercentage: webtoonPageWidthPercentage,
-                renderConfig: renderConfig
-              )
-            #else
-              ScrollPageView(
-                mode: .vertical,
-                viewportSize: screenSize,
-                readingDirection: readingDirection,
-                splitWidePageMode: splitWidePageMode,
-                navigationAnimationDuration: pageTurnAnimationDuration,
-                renderConfig: renderConfig,
-                viewModel: viewModel,
-                readListContext: readListContext,
-                onDismiss: { closeReader() },
-                onTapZoneTap: handleTapZoneTap
-              )
-            #endif
-          } else {
-            switch pageTransitionStyle {
-            case .pageCurl:
-              #if os(iOS)
-                if useDualPage {
-                  CurlDualPageView(
-                    viewModel: viewModel,
-                    mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
-                    readingDirection: readingDirection,
-                    splitWidePageMode: splitWidePageMode,
-                    animateTapTurns: animateTapTurns,
-                    renderConfig: renderConfig,
-                    readListContext: readListContext,
-                    onDismiss: { closeReader() },
-                    onTapZoneTap: handleTapZoneTap
-                  )
-                } else {
-                  CurlPageView(
-                    viewModel: viewModel,
-                    mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
-                    readingDirection: readingDirection,
-                    splitWidePageMode: splitWidePageMode,
-                    animateTapTurns: animateTapTurns,
-                    renderConfig: renderConfig,
-                    readListContext: readListContext,
-                    onDismiss: { closeReader() },
-                    onTapZoneTap: handleTapZoneTap
-                  )
-                }
-              #else
-                standardScrollPageView(useDualPage: useDualPage, screenSize: screenSize)
-              #endif
-            case .scroll:
-              standardScrollPageView(useDualPage: useDualPage, screenSize: screenSize)
-            case .cover:
-              NativeCoverPageView(
                 mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
                 readingDirection: readingDirection,
                 splitWidePageMode: splitWidePageMode,
-                tapNavigationAnimationDuration: pageTurnAnimationDuration,
+                animateTapTurns: animateTapTurns,
                 renderConfig: renderConfig,
+                readListContext: readListContext,
+                onDismiss: { closeReader() },
+                onTapZoneTap: handleTapZoneTap
+              )
+            } else {
+              CurlPageView(
                 viewModel: viewModel,
+                mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
+                readingDirection: readingDirection,
+                splitWidePageMode: splitWidePageMode,
+                animateTapTurns: animateTapTurns,
+                renderConfig: renderConfig,
                 readListContext: readListContext,
                 onDismiss: { closeReader() },
                 onTapZoneTap: handleTapZoneTap
               )
             }
-          }
-        }
-        .readerIgnoresSafeArea()
-        .id(contentKey)
-        .onChange(of: viewModel.currentReaderPage?.id) { _, _ in
-          updateHandoff()
-          #if os(iOS)
-            updateReaderLiveActivityProgress()
+          #else
+            standardScrollPageView(useDualPage: useDualPage, screenSize: screenSize)
           #endif
-          // Keep progress sync responsive.
-          Task(priority: .userInitiated) {
-            await viewModel.updateProgress()
-          }
-          schedulePageMaintenanceAfterPageChange()
-          // Treat page changes as user activity: if we're inside the post-
-          // resume auto-hide window, restart the timer so the overlay stays
-          // visible while the user is actively flipping pages and only fades
-          // after a real pause.
-          resetAutoHideAfterResumeIfPending()
+        case .scroll:
+          standardScrollPageView(useDualPage: useDualPage, screenSize: screenSize)
+        case .cover:
+          NativeCoverPageView(
+            mode: PageViewMode(direction: readingDirection, useDualPage: useDualPage),
+            readingDirection: readingDirection,
+            splitWidePageMode: splitWidePageMode,
+            tapNavigationAnimationDuration: pageTurnAnimationDuration,
+            renderConfig: renderConfig,
+            viewModel: viewModel,
+            readListContext: readListContext,
+            onDismiss: { closeReader() },
+            onTapZoneTap: handleTapZoneTap
+          )
         }
-        #if os(tvOS)
-          .onChange(of: isShowingEndPage) { oldValue, newValue in
-            if oldValue && !newValue {
-              tvRemoteCaptureGeneration += 1
-              logger.debug("📺 left end page, restart UIKit capture generation=\(tvRemoteCaptureGeneration)")
-            }
-          }
-        #endif
-      } else {
-        NoPagesView(onDismiss: { closeReader() })
       }
     }
+    .readerIgnoresSafeArea()
+    .id(contentKey)
+    .onChange(of: viewModel.currentReaderPage?.id) { _, _ in
+      updateHandoff()
+      #if os(iOS)
+        updateReaderLiveActivityProgress()
+      #endif
+      // Keep progress sync responsive.
+      Task(priority: .userInitiated) {
+        await viewModel.updateProgress()
+      }
+      schedulePageMaintenanceAfterPageChange()
+      // Treat page changes as user activity: if we're inside the post-
+      // resume auto-hide window, restart the timer so the overlay stays
+      // visible while the user is actively flipping pages and only fades
+      // after a real pause.
+      resetAutoHideAfterResumeIfPending()
+    }
+    #if os(tvOS)
+      .onChange(of: isShowingEndPage) { oldValue, newValue in
+        if oldValue && !newValue {
+          tvRemoteCaptureGeneration += 1
+          logger.debug("📺 left end page, restart UIKit capture generation=\(tvRemoteCaptureGeneration)")
+        }
+      }
+    #endif
   }
 
   @ViewBuilder
@@ -991,29 +1009,23 @@ struct DivinaReaderView: View {
     #endif
   }
 
-  @ViewBuilder
   private var keyboardHelpOverlay: some View {
-    if showKeyboardHelp {
-      KeyboardHelpOverlay(
-        readingDirection: readingDirection,
-        hasTOC: !viewModel.tableOfContents.isEmpty,
-        supportsFullscreenToggle: supportsFullscreenToggle,
-        supportsLiveText: supportsLiveTextKeyboardShortcut,
-        supportsJumpToPage: true,
-        supportsToggleControls: true,
-        hasNextBook: currentSegmentNextBook != nil,
-        isInteractive: keyboardHelpOverlayIsInteractive,
-        onDismiss: {
-          hideKeyboardHelp()
-        }
-      )
-      #if os(tvOS)
-        .allowsHitTesting(false)
-      #else
-        .allowsHitTesting(true)
-      #endif
-      .transition(.opacity)
-    }
+    KeyboardHelpOverlay(
+      readingDirection: readingDirection,
+      hasTOC: !viewModel.tableOfContents.isEmpty,
+      supportsFullscreenToggle: supportsFullscreenToggle,
+      supportsLiveText: supportsLiveTextKeyboardShortcut,
+      supportsJumpToPage: true,
+      supportsToggleControls: true,
+      hasNextBook: currentSegmentNextBook != nil,
+      isInteractive: keyboardHelpOverlayIsInteractive,
+      onDismiss: {
+        hideKeyboardHelp()
+      }
+    )
+    .opacity(showKeyboardHelp ? 1.0 : 0.0)
+    .allowsHitTesting(showKeyboardHelp && keyboardHelpOverlayIsInteractive)
+    .animation(.default, value: showKeyboardHelp)
   }
 
   private var keyboardHelpOverlayIsInteractive: Bool {

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -770,6 +770,9 @@ struct DivinaReaderView: View {
     }
     .animation(ReaderLoadingTransition.animation, value: viewModel.isLoading)
     .animation(ReaderLoadingTransition.animation, value: viewModel.hasPages)
+    .onChange(of: viewModel.currentReaderPage?.id) { _, _ in
+      handleReaderPageChange()
+    }
   }
 
   @ViewBuilder
@@ -856,22 +859,6 @@ struct DivinaReaderView: View {
     }
     .readerIgnoresSafeArea()
     .id(contentKey)
-    .onChange(of: viewModel.currentReaderPage?.id) { _, _ in
-      updateHandoff()
-      #if os(iOS)
-        updateReaderLiveActivityProgress()
-      #endif
-      // Keep progress sync responsive.
-      Task(priority: .userInitiated) {
-        await viewModel.updateProgress()
-      }
-      schedulePageMaintenanceAfterPageChange()
-      // Treat page changes as user activity: if we're inside the post-
-      // resume auto-hide window, restart the timer so the overlay stays
-      // visible while the user is actively flipping pages and only fades
-      // after a real pause.
-      resetAutoHideAfterResumeIfPending()
-    }
     #if os(tvOS)
       .onChange(of: isShowingEndPage) { oldValue, newValue in
         if oldValue && !newValue {
@@ -880,6 +867,23 @@ struct DivinaReaderView: View {
         }
       }
     #endif
+  }
+
+  private func handleReaderPageChange() {
+    updateHandoff()
+    #if os(iOS)
+      updateReaderLiveActivityProgress()
+    #endif
+    // Keep progress sync responsive.
+    Task(priority: .userInitiated) {
+      await viewModel.updateProgress()
+    }
+    schedulePageMaintenanceAfterPageChange()
+    // Treat page changes as user activity: if we're inside the post-
+    // resume auto-hide window, restart the timer so the overlay stays
+    // visible while the user is actively flipping pages and only fades
+    // after a real pause.
+    resetAutoHideAfterResumeIfPending()
   }
 
   @ViewBuilder

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -441,93 +441,80 @@
 
     @ViewBuilder
     private func contentView(for size: CGSize, viewModel: EpubReaderViewModel) -> some View {
-      if showingEndPage {
-        EpubEndPageView(
-          bookTitle: currentBook?.metadata.title,
-          preferences: activeThemePreferences,
-          colorScheme: readerColorScheme,
-          onReturn: {
-            // Hide end page first, then navigate to last page
-            showingEndPage = false
+      Group {
+        if showingEndPage {
+          EpubEndPageView(
+            bookTitle: currentBook?.metadata.title,
+            preferences: activeThemePreferences,
+            colorScheme: readerColorScheme,
+            onReturn: {
+              // Hide end page first, then navigate to last page
+              showingEndPage = false
 
-            // Navigate back to the last page of the last chapter
-            Task { @MainActor in
-              // Small delay to ensure view hierarchy is updated
-              try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1 seconds
-              if let lastPosition = viewModel.lastPagePosition() {
-                viewModel.targetChapterIndex = lastPosition.chapterIndex
-                viewModel.targetPageIndex = lastPosition.pageIndex
+              // Navigate back to the last page of the last chapter
+              Task { @MainActor in
+                // Small delay to ensure view hierarchy is updated
+                try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1 seconds
+                if let lastPosition = viewModel.lastPagePosition() {
+                  viewModel.targetChapterIndex = lastPosition.chapterIndex
+                  viewModel.targetPageIndex = lastPosition.pageIndex
+                }
               }
+            },
+            onClose: {
+              closeReader()
             }
-          },
-          onClose: {
-            closeReader()
-          }
-        )
-      } else {
-        #if os(iOS)
-          readerContent
-            .opacity(viewModel.hasContent && !viewModel.isLoading && viewModel.errorMessage == nil ? 1 : 0)
-            .animation(nil, value: viewModel.isLoading)
-            .animation(nil, value: viewModel.hasContent)
-            .animation(nil, value: viewModel.errorMessage)
-            .allowsHitTesting(viewModel.hasContent && !viewModel.isLoading && viewModel.errorMessage == nil)
-            .overlay {
-              if viewModel.isLoading {
-                ReaderLoadingView(
-                  title: loadingTitle,
-                  detail: loadingDetail,
-                  progress: loadingProgress,
-                  cardFill: loadingCardFill,
-                  contentColor: loadingContentColor
-                )
-              } else if let error = viewModel.errorMessage {
-                VStack(spacing: 12) {
-                  Image(systemName: "exclamationmark.triangle")
-                    .font(.largeTitle)
-                  Text(error)
-                    .multilineTextAlignment(.center)
-                  Button("Retry") {
-                    Task {
-                      await loadBook()
-                    }
+          )
+        } else {
+          let showsReaderContent =
+            viewModel.hasContent && !viewModel.isLoading && viewModel.errorMessage == nil
+
+          ZStack {
+            #if os(iOS)
+              readerContent
+                .readerLoadingContent(isVisible: showsReaderContent)
+            #else
+              if viewModel.hasContent {
+                readerContent
+                  .readerLoadingContent(isVisible: showsReaderContent)
+              }
+            #endif
+
+            if let error = viewModel.errorMessage, !viewModel.isLoading {
+              VStack(spacing: 12) {
+                Image(systemName: "exclamationmark.triangle")
+                  .font(.largeTitle)
+                Text(error)
+                  .multilineTextAlignment(.center)
+                Button("Retry") {
+                  Task {
+                    await loadBook()
                   }
                 }
-                .padding()
-              } else if !viewModel.hasContent {
-                Text("No content available.")
-                  .foregroundStyle(.secondary)
               }
+              .padding()
+              .transition(ReaderLoadingTransition.content)
+            } else if !viewModel.isLoading && !viewModel.hasContent {
+              Text("No content available.")
+                .foregroundStyle(.secondary)
+                .transition(ReaderLoadingTransition.content)
             }
-        #else
-          if viewModel.isLoading {
-            ReaderLoadingView(
-              title: loadingTitle,
-              detail: loadingDetail,
-              progress: loadingProgress,
-              cardFill: loadingCardFill,
-              contentColor: loadingContentColor
-            )
-          } else if let error = viewModel.errorMessage {
-            VStack(spacing: 12) {
-              Image(systemName: "exclamationmark.triangle")
-                .font(.largeTitle)
-              Text(error)
-                .multilineTextAlignment(.center)
-              Button("Retry") {
-                Task {
-                  await loadBook()
-                }
-              }
+
+            if viewModel.isLoading {
+              ReaderLoadingView(
+                title: loadingTitle,
+                detail: loadingDetail,
+                progress: loadingProgress,
+                cardFill: loadingCardFill,
+                contentColor: loadingContentColor
+              )
+              .readerLoadingOverlay()
             }
-            .padding()
-          } else if viewModel.hasContent {
-            readerContent
-          } else {
-            Text("No content available.")
-              .foregroundStyle(.secondary)
           }
-        #endif
+          .animation(ReaderLoadingTransition.animation, value: viewModel.isLoading)
+          .animation(ReaderLoadingTransition.animation, value: viewModel.errorMessage)
+          .animation(ReaderLoadingTransition.animation, value: viewModel.hasContent)
+        }
       }
     }
 

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -474,9 +474,9 @@
               readerContent
                 .readerLoadingContent(isVisible: showsReaderContent)
             #else
-              if viewModel.hasContent {
+              if showsReaderContent {
                 readerContent
-                  .readerLoadingContent(isVisible: showsReaderContent)
+                  .transition(ReaderLoadingTransition.content)
               }
             #endif
 

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -324,68 +324,84 @@
 
     @ViewBuilder
     private var contentView: some View {
-      if viewModel.isLoading {
-        ReaderLoadingView(
-          title: loadingTitle,
-          detail: loadingDetail,
-          progress: loadingProgress,
-          cardFill: readerBackground.loadingCardFill,
-          contentColor: readerBackground.loadingContentColor
-        )
-      } else if let errorMessage = viewModel.errorMessage {
-        VStack(spacing: 16) {
-          Image(systemName: "exclamationmark.triangle")
-            .font(.largeTitle)
+      let showsDocument =
+        viewModel.documentURL != nil && !viewModel.isLoading && viewModel.errorMessage == nil
 
-          Text(errorMessage)
-            .multilineTextAlignment(.center)
-
-          HStack(spacing: 12) {
-            Button("Retry") {
-              Task {
-                await loadBook()
+      ZStack {
+        if let documentURL = viewModel.documentURL {
+          GeometryReader { proxy in
+            let resolvedPresentation = pagePresentation.resolved(for: proxy.size)
+            PdfDocumentView(
+              documentURL: documentURL,
+              pagePresentation: resolvedPresentation,
+              isolateCoverPage: isolateCoverPage,
+              readingDirection: readingDirection,
+              initialPageNumber: documentInitialPage,
+              targetPageNumber: targetPageNumber,
+              navigationToken: navigationToken,
+              onPageChange: { pageNumber, totalPages in
+                viewModel.updateCurrentPage(pageNumber: pageNumber, totalPages: totalPages)
+              },
+              onSingleTap: { normalizedPoint in
+                handleSingleTap(normalizedPoint: normalizedPoint)
               }
-            }
-            .adaptiveButtonStyle(.borderedProminent)
-
-            Button("Close") {
-              closeReader()
-            }
-            .adaptiveButtonStyle(.bordered)
+            )
+            // Rebuild PDFView when the source document or resolved presentation changes.
+            .id(documentViewIdentity(documentURL: documentURL, resolvedPresentation: resolvedPresentation))
+            .readerIgnoresSafeArea()
           }
-        }
-        .padding()
-      } else if let documentURL = viewModel.documentURL {
-        GeometryReader { proxy in
-          let resolvedPresentation = pagePresentation.resolved(for: proxy.size)
-          PdfDocumentView(
-            documentURL: documentURL,
-            pagePresentation: resolvedPresentation,
-            isolateCoverPage: isolateCoverPage,
-            readingDirection: readingDirection,
-            initialPageNumber: documentInitialPage,
-            targetPageNumber: targetPageNumber,
-            navigationToken: navigationToken,
-            onPageChange: { pageNumber, totalPages in
-              viewModel.updateCurrentPage(pageNumber: pageNumber, totalPages: totalPages)
-            },
-            onSingleTap: { normalizedPoint in
-              handleSingleTap(normalizedPoint: normalizedPoint)
-            }
-          )
-          // Rebuild PDFView when the source document or resolved presentation changes.
-          .id(documentViewIdentity(documentURL: documentURL, resolvedPresentation: resolvedPresentation))
           .readerIgnoresSafeArea()
+          .readerLoadingContent(isVisible: showsDocument)
+        } else if !viewModel.isLoading && viewModel.errorMessage == nil {
+          ReaderUnavailableView(
+            icon: "doc.richtext",
+            title: "PDF file unavailable",
+            message: String(localized: "Offline PDF file is missing. Please try downloading again."),
+            onClose: closeReader
+          )
+          .transition(ReaderLoadingTransition.content)
         }
-        .readerIgnoresSafeArea()
-      } else {
-        ReaderUnavailableView(
-          icon: "doc.richtext",
-          title: "PDF file unavailable",
-          message: String(localized: "Offline PDF file is missing. Please try downloading again."),
-          onClose: closeReader
-        )
+
+        if let errorMessage = viewModel.errorMessage, !viewModel.isLoading {
+          VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+              .font(.largeTitle)
+
+            Text(errorMessage)
+              .multilineTextAlignment(.center)
+
+            HStack(spacing: 12) {
+              Button("Retry") {
+                Task {
+                  await loadBook()
+                }
+              }
+              .adaptiveButtonStyle(.borderedProminent)
+
+              Button("Close") {
+                closeReader()
+              }
+              .adaptiveButtonStyle(.bordered)
+            }
+          }
+          .padding()
+          .transition(ReaderLoadingTransition.content)
+        }
+
+        if viewModel.isLoading {
+          ReaderLoadingView(
+            title: loadingTitle,
+            detail: loadingDetail,
+            progress: loadingProgress,
+            cardFill: readerBackground.loadingCardFill,
+            contentColor: readerBackground.loadingContentColor
+          )
+          .readerLoadingOverlay()
+        }
       }
+      .animation(ReaderLoadingTransition.animation, value: viewModel.isLoading)
+      .animation(ReaderLoadingTransition.animation, value: viewModel.documentURL)
+      .animation(ReaderLoadingTransition.animation, value: viewModel.errorMessage)
     }
 
     private var controlsOverlay: some View {

--- a/KMReader/Features/Reader/Views/ReaderLoadingTransition.swift
+++ b/KMReader/Features/Reader/Views/ReaderLoadingTransition.swift
@@ -1,0 +1,25 @@
+//
+// ReaderLoadingTransition.swift
+//
+//
+
+import SwiftUI
+
+enum ReaderLoadingTransition {
+  static let animation: Animation = .default
+  static let content: AnyTransition = .opacity
+  static let loading: AnyTransition = .opacity.combined(with: .scale(scale: 0.98))
+}
+
+extension View {
+  func readerLoadingContent(isVisible: Bool) -> some View {
+    opacity(isVisible ? 1 : 0)
+      .allowsHitTesting(isVisible)
+      .transition(ReaderLoadingTransition.content)
+  }
+
+  func readerLoadingOverlay() -> some View {
+    zIndex(1)
+      .transition(ReaderLoadingTransition.loading)
+  }
+}

--- a/KMReader/Features/Reader/Views/TapZoneOverlay.swift
+++ b/KMReader/Features/Reader/Views/TapZoneOverlay.swift
@@ -13,14 +13,19 @@ struct TapZoneOverlay: View {
   @AppStorage("tapZoneMode") private var tapZoneMode: TapZoneMode = .defaultLayout
   @AppStorage("tapZoneInversionMode") private var tapZoneInversionMode: TapZoneInversionMode = .auto
 
+  private var showsOverlay: Bool {
+    isVisible && showTapZoneHints && !tapZoneMode.isDisabled
+  }
+
   var body: some View {
     TapZoneGridOverlayContent(
       tapZoneMode: tapZoneMode,
       tapZoneInversionMode: tapZoneInversionMode,
       readingDirection: readingDirection
     )
-    .opacity(isVisible && showTapZoneHints && !tapZoneMode.isDisabled ? 1.0 : 0.0)
+    .opacity(showsOverlay ? 1.0 : 0.0)
     .allowsHitTesting(false)
+    .animation(.default, value: showsOverlay)
   }
 }
 


### PR DESCRIPTION
## Problem

Reader startup and helper overlays could feel abrupt because loading views, reader content, and DIVINA keyboard help were being inserted or removed instead of fading through a stable layer.

## Approach

- Layer DIVINA, EPUB, and PDF reader content under the loading overlay so ready content can fade in while loading fades out.
- Add a shared reader loading transition helper for content visibility and overlay stacking.
- Keep DIVINA keyboard help mounted with opacity-driven visibility, matching EPUB/PDF behavior.
- Animate tap-zone hint visibility from the overlay's effective visible state.

## Validation

- `git diff --check`
- `make build`
