### PR TITLE
feat: add protected server access

### DIFF
--- a/KMReader/ContentView.swift
+++ b/KMReader/ContentView.swift
@@ -292,14 +292,7 @@ struct ContentView: View {
       let protected = try await database.isServerProtected(instanceId: current.instanceId)
       guard protected else { return true }
 
-      guard LocalDeviceAuthenticationService.canAuthenticate else {
-        ErrorManager.shared.notify(
-          message: String(localized: "Device authentication is not available on this device."))
-        authViewModel.logout(clearCurrent: true)
-        return false
-      }
-
-      let authenticated = await LocalDeviceAuthenticationService.authenticate(
+      let authenticated = await LocalDeviceAuthenticationService.shared.authenticateProtectedAccess(
         reason: String(localized: "Authenticate to unlock this protected server.")
       )
       guard authenticated else {

--- a/KMReader/ContentView.swift
+++ b/KMReader/ContentView.swift
@@ -77,6 +77,7 @@ struct ContentView: View {
         }
         .task(id: isLoggedIn) {
           guard isLoggedIn else { return }
+          guard await authenticateProtectedCurrentInstanceIfNeeded() else { return }
 
           if authViewModel.bootstrapState == .requiresValidation {
             let serverReachable = await authViewModel.loadCurrentUser()
@@ -281,5 +282,36 @@ struct ContentView: View {
     // `triggerSync` for offline downloads once the flag transitions back to
     // online; nothing else to do here.
     return .recovered
+  }
+
+  private func authenticateProtectedCurrentInstanceIfNeeded() async -> Bool {
+    guard isLoggedIn, !current.instanceId.isEmpty else { return true }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      let protected = try await database.isServerProtected(instanceId: current.instanceId)
+      guard protected else { return true }
+
+      guard LocalDeviceAuthenticationService.canAuthenticate else {
+        ErrorManager.shared.notify(
+          message: String(localized: "Device authentication is not available on this device."))
+        authViewModel.logout(clearCurrent: true)
+        return false
+      }
+
+      let authenticated = await LocalDeviceAuthenticationService.authenticate(
+        reason: String(localized: "Authenticate to unlock this protected server.")
+      )
+      guard authenticated else {
+        authViewModel.logout(clearCurrent: true)
+        return false
+      }
+
+      return true
+    } catch {
+      ErrorManager.shared.alert(error: error)
+      authViewModel.logout(clearCurrent: true)
+      return false
+    }
   }
 }

--- a/KMReader/ContentView.swift
+++ b/KMReader/ContentView.swift
@@ -6,6 +6,11 @@
 import SwiftUI
 
 struct ContentView: View {
+  private enum ProtectedAccessGate: Equatable {
+    case checking
+    case unlocked
+  }
+
   let authViewModel: AuthViewModel
   let readerPresentation: ReaderPresentationManager
   @Environment(\.scenePhase) private var scenePhase
@@ -17,6 +22,7 @@ struct ContentView: View {
   @AppStorage("privacyProtection") private var privacyProtection: Bool = false
 
   @State private var showPrivacyBlur = false
+  @State private var protectedAccessGate: ProtectedAccessGate = .checking
 
   #if os(iOS) || os(tvOS)
     @Namespace private var zoomNamespace
@@ -34,7 +40,14 @@ struct ContentView: View {
   }
 
   private var isReady: Bool {
-    (authViewModel.bootstrapState == .ready || isOffline) && !syncViewModel.isSyncing
+    protectedAccessGate == .unlocked
+      && (authViewModel.bootstrapState == .ready || isOffline)
+      && !syncViewModel.isSyncing
+  }
+
+  private var protectedAccessTaskID: String {
+    guard isLoggedIn else { return "logged-out" }
+    return current.instanceId
   }
 
   private var automaticReadingHistorySyncTrigger: String {
@@ -75,9 +88,11 @@ struct ContentView: View {
             }
           }
         }
-        .task(id: isLoggedIn) {
+        .task(id: protectedAccessTaskID) {
           guard isLoggedIn else { return }
+          protectedAccessGate = .checking
           guard await authenticateProtectedCurrentInstanceIfNeeded() else { return }
+          protectedAccessGate = .unlocked
 
           if authViewModel.bootstrapState == .requiresValidation {
             let serverReachable = await authViewModel.loadCurrentUser()
@@ -95,7 +110,7 @@ struct ContentView: View {
           if enableSSE && !isOffline {
             await SSEService.shared.connect()
           }
-          WidgetDataService.refreshWidgetData()
+          await ExternalContentSurfaceService.refreshWidgetsForCurrentInstance()
 
           // Wire automatic recovery from auto-entered offline mode. The
           // primary mechanism is `OfflineRecoveryService`'s backoff probe
@@ -192,8 +207,8 @@ struct ContentView: View {
             }
             Task(priority: .utility) {
               await SSEService.shared.disconnect(notify: false)
+              await ExternalContentSurfaceService.refreshWidgetsForCurrentInstance()
             }
-            WidgetDataService.refreshWidgetData()
           }
         }
       } else {

--- a/KMReader/ContentView.swift
+++ b/KMReader/ContentView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct ContentView: View {
   private enum ProtectedAccessGate: Equatable {
     case checking
-    case unlocked
+    case unlocked(instanceId: String, protected: Bool)
   }
 
   let authViewModel: AuthViewModel
@@ -40,9 +40,25 @@ struct ContentView: View {
   }
 
   private var isReady: Bool {
-    protectedAccessGate == .unlocked
+    hasRenderableAccessForCurrentInstance
       && (authViewModel.bootstrapState == .ready || isOffline)
       && !syncViewModel.isSyncing
+  }
+
+  private var hasRenderableAccessForCurrentInstance: Bool {
+    guard case .unlocked(let instanceId, _) = protectedAccessGate else {
+      return false
+    }
+    return instanceId == current.instanceId
+  }
+
+  private var shouldReauthenticateProtectedCurrentInstance: Bool {
+    guard case .unlocked(let instanceId, let protected) = protectedAccessGate else {
+      return false
+    }
+    return instanceId == current.instanceId
+      && protected
+      && !LocalDeviceAuthenticationService.shared.hasProtectedAccess
   }
 
   private var protectedAccessTaskID: String {
@@ -90,9 +106,7 @@ struct ContentView: View {
         }
         .task(id: protectedAccessTaskID) {
           guard isLoggedIn else { return }
-          protectedAccessGate = .checking
-          guard await authenticateProtectedCurrentInstanceIfNeeded() else { return }
-          protectedAccessGate = .unlocked
+          guard await unlockProtectedCurrentInstanceForRendering() else { return }
 
           if authViewModel.bootstrapState == .requiresValidation {
             let serverReachable = await authViewModel.loadCurrentUser()
@@ -171,9 +185,15 @@ struct ContentView: View {
         }
         .onChange(of: scenePhase) { _, phase in
           if phase == .active {
+            let shouldReauthenticate = shouldReauthenticateProtectedCurrentInstance
+            if shouldReauthenticate {
+              protectedAccessGate = .checking
+            }
+
             withAnimation(.easeInOut(duration: 0.2)) {
               showPrivacyBlur = false
             }
+
             // Wake the recovery loop if we're in auto-offline. Catches the
             // case where the loop's `Task.sleep` was deferred by iOS while
             // the app was suspended, or where a path-monitor transition fired
@@ -182,6 +202,12 @@ struct ContentView: View {
               OfflineRecoveryService.shared.wakeNow()
             }
             Task {
+              if shouldReauthenticate {
+                guard await unlockProtectedCurrentInstanceForRendering() else { return }
+              } else {
+                guard hasRenderableAccessForCurrentInstance else { return }
+              }
+
               if let database = await DatabaseOperator.databaseIfConfigured() {
                 await database.updateInstanceLastUsed(instanceId: AppConfig.current.instanceId)
               }
@@ -191,9 +217,8 @@ struct ContentView: View {
                   instanceId: AppConfig.current.instanceId, restart: true)
               }
               await syncViewModel.syncReadingProgressOnly()
-            }
-            if enableSSE && !isOffline {
-              Task {
+
+              if enableSSE && !isOffline {
                 await SSEService.shared.connect()
               }
             }
@@ -299,27 +324,51 @@ struct ContentView: View {
     return .recovered
   }
 
-  private func authenticateProtectedCurrentInstanceIfNeeded() async -> Bool {
-    guard isLoggedIn, !current.instanceId.isEmpty else { return true }
+  private func unlockProtectedCurrentInstanceForRendering() async -> Bool {
+    guard isLoggedIn else {
+      protectedAccessGate = .checking
+      return false
+    }
+
+    let instanceId = current.instanceId
+    protectedAccessGate = .checking
+
+    guard !instanceId.isEmpty else {
+      protectedAccessGate = .unlocked(instanceId: instanceId, protected: false)
+      return true
+    }
+
+    let result = await authenticateProtectedCurrentInstanceIfNeeded(instanceId: instanceId)
+    guard result.authenticated else { return false }
+    guard isLoggedIn, current.instanceId == instanceId else { return false }
+
+    protectedAccessGate = .unlocked(instanceId: instanceId, protected: result.protected)
+    return true
+  }
+
+  private func authenticateProtectedCurrentInstanceIfNeeded(
+    instanceId: String
+  ) async -> (authenticated: Bool, protected: Bool) {
+    guard isLoggedIn, !instanceId.isEmpty else { return (true, false) }
 
     do {
       let database = try await DatabaseOperator.database()
-      let protected = try await database.isServerProtected(instanceId: current.instanceId)
-      guard protected else { return true }
+      let protected = try await database.isServerProtected(instanceId: instanceId)
+      guard protected else { return (true, false) }
 
       let authenticated = await LocalDeviceAuthenticationService.shared.authenticateProtectedAccess(
         reason: String(localized: "Authenticate to unlock this protected server.")
       )
       guard authenticated else {
         authViewModel.logout(clearCurrent: true)
-        return false
+        return (false, true)
       }
 
-      return true
+      return (true, true)
     } catch {
       ErrorManager.shared.alert(error: error)
       authViewModel.logout(clearCurrent: true)
-      return false
+      return (false, true)
     }
   }
 }

--- a/KMReader/Core/Storage/AppConfig.swift
+++ b/KMReader/Core/Storage/AppConfig.swift
@@ -85,6 +85,11 @@ enum AppConfig {
     set { UserDefaults.standard.set(newValue, forKey: "isLoggedInV2") }
   }
 
+  static nonisolated var showProtectedServers: Bool {
+    get { UserDefaults.standard.bool(forKey: "showProtectedServers") }
+    set { UserDefaults.standard.set(newValue, forKey: "showProtectedServers") }
+  }
+
   static nonisolated var deviceIdentifier: String {
     get { UserDefaults.standard.string(forKey: "deviceIdentifier") ?? "" }
     set { UserDefaults.standard.set(newValue, forKey: "deviceIdentifier") }
@@ -1303,12 +1308,17 @@ enum AppConfig {
   }
 
   // MARK: - Clear all auth data
-  static func clearAuthData() {
-    var new = current
-    new.reset()
-    current = new
+  static func clearAuthData(clearCurrent: Bool = false) {
+    if clearCurrent {
+      current = Current()
+    } else {
+      var new = current
+      new.reset()
+      current = new
+    }
 
     serverLastUpdate = nil
+    showProtectedServers = false
     dashboard.libraryIds = []
     DashboardSectionCacheStore.shared.reset()
   }

--- a/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
@@ -302,7 +302,11 @@ extension DatabaseOperator {
           existing.name = Self.defaultName(serverURL: serverURL, username: username)
         }
         try save(existing, db: db)
-        return InstanceSummary(id: existing.id, displayName: existing.displayName)
+        return InstanceSummary(
+          id: existing.id,
+          displayName: existing.displayName,
+          protected: existing.protected
+        )
       }
 
       let resolvedName = Self.resolvedName(
@@ -320,7 +324,11 @@ extension DatabaseOperator {
         authMethod: authMethod
       )
       try save(instance, db: db)
-      return InstanceSummary(id: instance.id, displayName: instance.displayName)
+      return InstanceSummary(
+        id: instance.id,
+        displayName: instance.displayName,
+        protected: instance.protected
+      )
     }
   }
 

--- a/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
@@ -333,9 +333,10 @@ extension DatabaseOperator {
     }
   }
 
-  func fetchServerDisplayItems() throws -> [ServerDisplayItem] {
+  func fetchServerDisplayItems(includeProtected: Bool = false) throws -> [ServerDisplayItem] {
     try read { db in
       try KomgaInstance.fetchAll(db)
+        .filter { includeProtected || !$0.protected }
         .sorted {
           if $0.lastUsedAt != $1.lastUsedAt {
             return $0.lastUsedAt > $1.lastUsedAt
@@ -346,13 +347,29 @@ extension DatabaseOperator {
     }
   }
 
+  func fetchProtectedServerCount() throws -> Int {
+    try read { db in
+      try KomgaInstance
+        .filter(Column("protected") == true)
+        .fetchCount(db)
+    }
+  }
+
+  func isServerProtected(instanceId: String) throws -> Bool {
+    guard let uuid = UUID(uuidString: instanceId) else { return false }
+    return try read { db in
+      try KomgaInstance.fetchOne(db, key: uuid)?.protected ?? false
+    }
+  }
+
   func updateServerDisplayItem(
     id: UUID,
     name: String,
     serverURL: String,
     username: String,
     authToken: String,
-    authMethod: AuthenticationMethod
+    authMethod: AuthenticationMethod,
+    protected: Bool
   ) throws -> ServerDisplayItem? {
     try write { db in
       guard var instance = try KomgaInstance.fetchOne(db, key: id) else { return nil }
@@ -361,6 +378,7 @@ extension DatabaseOperator {
       instance.username = username
       instance.authToken = authToken
       instance.authMethod = authMethod
+      instance.protected = protected
       instance.lastUsedAt = Date()
       try save(instance, db: db)
       return Self.makeServerDisplayItem(instance)
@@ -888,6 +906,7 @@ extension DatabaseOperator {
       authToken: instance.authToken,
       isAdmin: instance.isAdmin,
       authMethod: instance.resolvedAuthMethod,
+      protected: instance.protected,
       lastUsedAt: instance.lastUsedAt
     )
   }

--- a/KMReader/Core/Storage/DatabaseOperator.swift
+++ b/KMReader/Core/Storage/DatabaseOperator.swift
@@ -10,6 +10,7 @@ import OSLog
 struct InstanceSummary: Sendable {
   let id: UUID
   let displayName: String
+  let protected: Bool
 }
 
 struct PendingProgressSummary: Sendable {

--- a/KMReader/Core/Storage/ExternalContentSurfaceService.swift
+++ b/KMReader/Core/Storage/ExternalContentSurfaceService.swift
@@ -1,0 +1,63 @@
+//
+// ExternalContentSurfaceService.swift
+//
+//
+
+import Foundation
+
+@MainActor
+enum ExternalContentSurfaceService {
+  static func updateAfterSelectingInstance(instanceId: String, protected: Bool) {
+    guard !instanceId.isEmpty else {
+      clearAll()
+      return
+    }
+
+    guard !protected else {
+      clearAll()
+      return
+    }
+
+    WidgetDataService.refreshWidgetData()
+    #if os(iOS) || os(macOS)
+      SpotlightIndexService.removeAllItems()
+      SpotlightIndexService.indexAllDownloadedBooks(instanceId: instanceId)
+    #endif
+  }
+
+  static func refreshWidgetsForCurrentInstance() async {
+    guard !AppConfig.current.instanceId.isEmpty else {
+      clearAll()
+      return
+    }
+
+    guard !(await isCurrentInstanceProtected()) else {
+      clearAll()
+      return
+    }
+
+    WidgetDataService.refreshWidgetData()
+  }
+
+  static func clearAll() {
+    WidgetDataService.clearWidgetData()
+    #if os(iOS) || os(macOS)
+      SpotlightIndexService.removeAllItems()
+    #endif
+  }
+
+  private static func isCurrentInstanceProtected() async -> Bool {
+    let instanceId = AppConfig.current.instanceId
+    guard !instanceId.isEmpty else { return false }
+
+    do {
+      let database = try await DatabaseOperator.database()
+      return try await database.isServerProtected(instanceId: instanceId)
+    } catch {
+      AppLogger(.app).error(
+        "Failed to check protected server state for external content: \(error.localizedDescription)"
+      )
+      return true
+    }
+  }
+}

--- a/KMReader/Core/Storage/GRDB/GRDBRecords.swift
+++ b/KMReader/Core/Storage/GRDB/GRDBRecords.swift
@@ -21,6 +21,7 @@ nonisolated extension KomgaInstance: FetchableRecord, MutablePersistableRecord {
     case authToken = "auth_token"
     case isAdmin = "is_admin"
     case authMethod = "auth_method"
+    case protected
     case createdAt = "created_at"
     case lastUsedAt = "last_used_at"
     case seriesLastSyncedAt = "series_last_synced_at"

--- a/KMReader/Core/Storage/GRDB/LocalDatabase.swift
+++ b/KMReader/Core/Storage/GRDB/LocalDatabase.swift
@@ -76,6 +76,12 @@ nonisolated enum LocalDatabase {
       try createIndexes(db)
     }
 
+    migrator.registerMigration("00002_add_protected_server_flag") { db in
+      try db.alter(table: KomgaInstance.databaseTableName) { table in
+        table.add(column: "protected", .boolean).notNull().defaults(to: false)
+      }
+    }
+
     try migrator.migrate(writer)
   }
 

--- a/KMReader/Core/Storage/SpotlightIndexService.swift
+++ b/KMReader/Core/Storage/SpotlightIndexService.swift
@@ -34,29 +34,35 @@ import Foundation
 
     static nonisolated func indexBook(_ book: Book, instanceId: String) {
       guard AppConfig.enableSpotlightIndexing else { return }
-      guard shouldIndex(libraryId: book.libraryId, instanceId: instanceId) else {
-        removeBook(bookId: book.id, instanceId: instanceId)
-        if AppConfig.enableSpotlightSeriesIndexing {
-          indexSeries(
-            seriesId: book.seriesId,
-            seriesTitle: book.seriesTitle,
-            instanceId: instanceId
-          )
+      Task.detached(priority: .utility) {
+        guard !(await isProtectedInstance(instanceId)) else {
+          removeBook(bookId: book.id, instanceId: instanceId)
+          removeSeries(seriesId: book.seriesId, instanceId: instanceId)
+          return
         }
-        return
-      }
 
-      if AppConfig.enableSpotlightBookIndexing {
-        let attributeSet = makeBookAttributeSet(for: book)
-        let bookId = book.id
-        let title = book.metadata.title
-        let item = CSSearchableItem(
-          uniqueIdentifier: bookIdentifier(bookId: bookId, instanceId: instanceId),
-          domainIdentifier: domainIdentifier,
-          attributeSet: attributeSet
-        )
+        guard shouldIndex(libraryId: book.libraryId, instanceId: instanceId) else {
+          removeBook(bookId: book.id, instanceId: instanceId)
+          if AppConfig.enableSpotlightSeriesIndexing {
+            indexSeries(
+              seriesId: book.seriesId,
+              seriesTitle: book.seriesTitle,
+              instanceId: instanceId
+            )
+          }
+          return
+        }
 
-        Task.detached(priority: .utility) {
+        if AppConfig.enableSpotlightBookIndexing {
+          let attributeSet = makeBookAttributeSet(for: book)
+          let bookId = book.id
+          let title = book.metadata.title
+          let item = CSSearchableItem(
+            uniqueIdentifier: bookIdentifier(bookId: bookId, instanceId: instanceId),
+            domainIdentifier: domainIdentifier,
+            attributeSet: attributeSet
+          )
+
           do {
             try await CSSearchableIndex.default().indexSearchableItems([item])
             AppLogger(.app).debug("Indexed book for Spotlight: \(title)")
@@ -64,19 +70,19 @@ import Foundation
             AppLogger(.app).error(
               "Failed to index book \(bookId): \(error.localizedDescription)")
           }
+        } else {
+          removeBook(bookId: book.id, instanceId: instanceId)
         }
-      } else {
-        removeBook(bookId: book.id, instanceId: instanceId)
-      }
 
-      if AppConfig.enableSpotlightSeriesIndexing {
-        indexSeries(
-          seriesId: book.seriesId,
-          seriesTitle: book.seriesTitle,
-          instanceId: instanceId
-        )
-      } else {
-        removeSeries(seriesId: book.seriesId, instanceId: instanceId)
+        if AppConfig.enableSpotlightSeriesIndexing {
+          indexSeries(
+            seriesId: book.seriesId,
+            seriesTitle: book.seriesTitle,
+            instanceId: instanceId
+          )
+        } else {
+          removeSeries(seriesId: book.seriesId, instanceId: instanceId)
+        }
       }
     }
 
@@ -116,6 +122,11 @@ import Foundation
       guard AppConfig.enableSpotlightIndexing else { return }
       let domain = domainIdentifier
       Task.detached(priority: .utility) {
+        guard !(await isProtectedInstance(instanceId)) else {
+          removeAllItems()
+          return
+        }
+
         let books =
           (try? await DatabaseOperator.database().fetchDownloadedBooks(instanceId: instanceId)) ?? []
         let filteredBooks = filterBooksForIndexedLibraries(books, instanceId: instanceId)
@@ -178,6 +189,19 @@ import Foundation
         return true
       }
       return selectedLibraryIds.contains(libraryId)
+    }
+
+    private static nonisolated func isProtectedInstance(_ instanceId: String) async -> Bool {
+      guard !instanceId.isEmpty else { return false }
+      do {
+        let database = try await DatabaseOperator.database()
+        return try await database.isServerProtected(instanceId: instanceId)
+      } catch {
+        AppLogger(.app).error(
+          "Failed to check protected server state for Spotlight: \(error.localizedDescription)"
+        )
+        return true
+      }
     }
 
     private static nonisolated func filterBooksForIndexedLibraries(

--- a/KMReader/Core/Storage/WidgetDataService.swift
+++ b/KMReader/Core/Storage/WidgetDataService.swift
@@ -19,6 +19,11 @@ enum WidgetDataService {
     let libraryIds = AppConfig.dashboard.libraryIds
 
     Task.detached(priority: .utility) {
+      guard !(await Self.isProtectedInstance(instanceId)) else {
+        await Self.clearWidgetData()
+        return
+      }
+
       let keepReadingBooks =
         (try? await DatabaseOperator.database().fetchKeepReadingBooksForWidget(
           instanceId: instanceId, libraryIds: libraryIds, limit: 6)) ?? []
@@ -46,6 +51,15 @@ enum WidgetDataService {
         "Widget data refreshed: keepReading=\(keepReadingEntries.count), recentlyAdded=\(recentlyAddedEntries.count), recentlyUpdatedSeries=\(recentlyUpdatedSeriesEntries.count)"
       )
     }
+  }
+
+  @MainActor
+  static func clearWidgetData() {
+    WidgetDataStore.clearAll()
+    #if canImport(WidgetKit)
+      WidgetCenter.shared.reloadAllTimelines()
+    #endif
+    logger.debug("Widget data cleared")
   }
 
   private static nonisolated func bookToEntry(_ book: Book) -> WidgetBookEntry {
@@ -155,5 +169,18 @@ enum WidgetDataService {
 
   private static nonisolated func seriesThumbnailFileName(seriesId: String) -> String {
     "series_\(seriesId).jpg"
+  }
+
+  private static nonisolated func isProtectedInstance(_ instanceId: String) async -> Bool {
+    guard !instanceId.isEmpty else { return false }
+    do {
+      let database = try await DatabaseOperator.database()
+      return try await database.isServerProtected(instanceId: instanceId)
+    } catch {
+      AppLogger(.app).error(
+        "Failed to check protected server state for widget data: \(error.localizedDescription)"
+      )
+      return true
+    }
   }
 }

--- a/KMReader/Features/Auth/Models/KomgaInstance.swift
+++ b/KMReader/Features/Auth/Models/KomgaInstance.swift
@@ -12,6 +12,7 @@ nonisolated struct KomgaInstance: Codable, Equatable, Sendable {
   var authToken: String
   var isAdmin: Bool
   var authMethod: AuthenticationMethod?
+  var protected: Bool
   var createdAt: Date
   var lastUsedAt: Date
   var seriesLastSyncedAt: Date
@@ -25,6 +26,7 @@ nonisolated struct KomgaInstance: Codable, Equatable, Sendable {
     authToken: String,
     isAdmin: Bool,
     authMethod: AuthenticationMethod = .basicAuth,
+    protected: Bool = false,
     createdAt: Date = Date(),
     lastUsedAt: Date = Date(),
     seriesLastSyncedAt: Date = Date(timeIntervalSince1970: 0),
@@ -37,6 +39,7 @@ nonisolated struct KomgaInstance: Codable, Equatable, Sendable {
     self.authToken = authToken
     self.isAdmin = isAdmin
     self.authMethod = authMethod
+    self.protected = protected
     self.createdAt = createdAt
     self.lastUsedAt = lastUsedAt
     self.seriesLastSyncedAt = seriesLastSyncedAt

--- a/KMReader/Features/Auth/Services/AuthService.swift
+++ b/KMReader/Features/Auth/Services/AuthService.swift
@@ -91,7 +91,7 @@ nonisolated enum AuthService {
   }
 
   @concurrent
-  static func logout() async throws {
+  static func logout(clearCurrent: Bool = false) async throws {
     do {
       let _: EmptyResponse = try await apiClient.request(
         path: "/api/logout",
@@ -105,7 +105,7 @@ nonisolated enum AuthService {
     // Clear local data
     apiClient.setAuthToken("")
     await MainActor.run {
-      AppConfig.clearAuthData()
+      AppConfig.clearAuthData(clearCurrent: clearCurrent)
     }
   }
 

--- a/KMReader/Features/Auth/Services/LocalDeviceAuthenticationService.swift
+++ b/KMReader/Features/Auth/Services/LocalDeviceAuthenticationService.swift
@@ -1,0 +1,66 @@
+//
+// LocalDeviceAuthenticationService.swift
+//
+
+import Foundation
+
+#if os(iOS) || os(macOS)
+  import LocalAuthentication
+#endif
+
+@MainActor
+enum LocalDeviceAuthenticationService {
+  static var canAuthenticate: Bool {
+    #if os(iOS) || os(macOS)
+      let context = LAContext()
+      var error: NSError?
+      return context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
+    #else
+      return false
+    #endif
+  }
+
+  static func authenticate(reason: String) async -> Bool {
+    #if os(iOS) || os(macOS)
+      let context = LAContext()
+      do {
+        return try await context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason)
+      } catch {
+        guard !isCancellation(error) else { return false }
+        if isUnavailable(error) {
+          ErrorManager.shared.notify(
+            message: String(localized: "Device authentication is not available on this device."))
+        } else {
+          ErrorManager.shared.notify(message: String(localized: "Authentication failed."))
+        }
+        return false
+      }
+    #else
+      ErrorManager.shared.notify(
+        message: String(localized: "Device authentication is not available on this device."))
+      return false
+    #endif
+  }
+
+  #if os(iOS) || os(macOS)
+    private static func isCancellation(_ error: Error) -> Bool {
+      guard let laError = error as? LAError else { return false }
+      switch laError.code {
+      case .appCancel, .systemCancel, .userCancel:
+        return true
+      default:
+        return false
+      }
+    }
+
+    private static func isUnavailable(_ error: Error) -> Bool {
+      guard let laError = error as? LAError else { return false }
+      switch laError.code {
+      case .biometryLockout, .biometryNotAvailable, .biometryNotEnrolled, .passcodeNotSet:
+        return true
+      default:
+        return false
+      }
+    }
+  #endif
+}

--- a/KMReader/Features/Auth/Services/LocalDeviceAuthenticationService.swift
+++ b/KMReader/Features/Auth/Services/LocalDeviceAuthenticationService.swift
@@ -27,6 +27,11 @@ final class LocalDeviceAuthenticationService {
     #endif
   }
 
+  var hasProtectedAccess: Bool {
+    guard let expiresAt = protectedAccessExpiresAt else { return false }
+    return expiresAt > Date()
+  }
+
   func authenticateProtectedAccess(reason: String) async -> Bool {
     if isProtectedAccessUnlocked {
       return true
@@ -66,8 +71,10 @@ final class LocalDeviceAuthenticationService {
   }
 
   private var isProtectedAccessUnlocked: Bool {
-    guard let expiresAt = protectedAccessExpiresAt else { return false }
-    guard expiresAt > Date() else {
+    guard let expiresAt = protectedAccessExpiresAt else {
+      return false
+    }
+    if expiresAt <= Date() {
       protectedAccessExpiresAt = nil
       return false
     }

--- a/KMReader/Features/Auth/Services/LocalDeviceAuthenticationService.swift
+++ b/KMReader/Features/Auth/Services/LocalDeviceAuthenticationService.swift
@@ -9,8 +9,15 @@ import Foundation
 #endif
 
 @MainActor
-enum LocalDeviceAuthenticationService {
-  static var canAuthenticate: Bool {
+final class LocalDeviceAuthenticationService {
+  static let shared = LocalDeviceAuthenticationService()
+
+  private let protectedAccessCacheDuration: TimeInterval = 5 * 60
+  private var protectedAccessExpiresAt: Date?
+
+  private init() {}
+
+  var canAuthenticate: Bool {
     #if os(iOS) || os(macOS)
       let context = LAContext()
       var error: NSError?
@@ -20,7 +27,23 @@ enum LocalDeviceAuthenticationService {
     #endif
   }
 
-  static func authenticate(reason: String) async -> Bool {
+  func authenticateProtectedAccess(reason: String) async -> Bool {
+    if isProtectedAccessUnlocked {
+      return true
+    }
+
+    let authenticated = await authenticate(reason: reason)
+    if authenticated {
+      markProtectedAccessUnlocked()
+    }
+    return authenticated
+  }
+
+  func clearProtectedAccess() {
+    protectedAccessExpiresAt = nil
+  }
+
+  func authenticate(reason: String) async -> Bool {
     #if os(iOS) || os(macOS)
       let context = LAContext()
       do {
@@ -42,8 +65,21 @@ enum LocalDeviceAuthenticationService {
     #endif
   }
 
+  private var isProtectedAccessUnlocked: Bool {
+    guard let expiresAt = protectedAccessExpiresAt else { return false }
+    guard expiresAt > Date() else {
+      protectedAccessExpiresAt = nil
+      return false
+    }
+    return true
+  }
+
+  private func markProtectedAccessUnlocked() {
+    protectedAccessExpiresAt = Date().addingTimeInterval(protectedAccessCacheDuration)
+  }
+
   #if os(iOS) || os(macOS)
-    private static func isCancellation(_ error: Error) -> Bool {
+    private func isCancellation(_ error: Error) -> Bool {
       guard let laError = error as? LAError else { return false }
       switch laError.code {
       case .appCancel, .systemCancel, .userCancel:
@@ -53,7 +89,7 @@ enum LocalDeviceAuthenticationService {
       }
     }
 
-    private static func isUnavailable(_ error: Error) -> Bool {
+    private func isUnavailable(_ error: Error) -> Bool {
       guard let laError = error as? LAError else { return false }
       switch laError.code {
       case .biometryLockout, .biometryNotAvailable, .biometryNotEnrolled, .passcodeNotSet:

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -182,6 +182,7 @@ class AuthViewModel {
         displayName: instance.displayName,
         instanceId: instance.instanceId,
         shouldPersistInstance: false,
+        protected: instance.protected,
         successMessage: String(localized: "Switched to \(instance.name)")
       )
 
@@ -218,6 +219,9 @@ class AuthViewModel {
         current.clearUserMetadata()
         AppConfig.current = current
         bootstrapState = .ready
+        if instance.protected {
+          ExternalContentSurfaceService.clearAll()
+        }
 
         ErrorManager.shared.notify(
           message: String(localized: "Server unreachable, switched to offline mode")
@@ -243,6 +247,7 @@ class AuthViewModel {
     displayName: String?,
     instanceId: String? = nil,
     shouldPersistInstance: Bool,
+    protected: Bool = false,
     successMessage: String
   ) async throws {
     // Update AppConfig only after validation succeeds
@@ -306,11 +311,10 @@ class AuthViewModel {
     await SSEService.shared.disconnect()
     await SSEService.shared.connect()
 
-    WidgetDataService.refreshWidgetData()
-    #if os(iOS) || os(macOS)
-      SpotlightIndexService.removeAllItems()
-      SpotlightIndexService.indexAllDownloadedBooks(instanceId: finalInstanceId)
-    #endif
+    ExternalContentSurfaceService.updateAfterSelectingInstance(
+      instanceId: finalInstanceId,
+      protected: protected
+    )
   }
 
   func updatePassword(password: String) async throws {

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -75,17 +75,22 @@ class AuthViewModel {
     )
   }
 
-  func logout() {
+  func logout(clearCurrent: Bool = false) {
     Task {
       // Disconnect SSE before logout
       await SSEService.shared.disconnect()
-      try? await AuthService.logout()
+      try? await AuthService.logout(clearCurrent: clearCurrent)
     }
     // ViewModel-specific cleanup
     AppConfig.isLoggedIn = false
-    var current = AppConfig.current
-    current.clearUserMetadata()
-    AppConfig.current = current
+    AppConfig.showProtectedServers = false
+    if clearCurrent {
+      AppConfig.current = Current()
+    } else {
+      var current = AppConfig.current
+      current.clearUserMetadata()
+      AppConfig.current = current
+    }
     bootstrapState = .requiresValidation
   }
 
@@ -139,7 +144,14 @@ class AuthViewModel {
     }
   }
 
-  func switchTo(instance: ServerDisplayItem) async -> Bool {
+  func switchTo(instance: ServerDisplayItem, requiresLocalAuthentication: Bool = true) async -> Bool {
+    if requiresLocalAuthentication && instance.protected {
+      let authenticated = await LocalDeviceAuthenticationService.authenticate(
+        reason: String(localized: "Authenticate to switch to this protected server.")
+      )
+      guard authenticated else { return false }
+    }
+
     isSwitching = true
     switchingInstanceId = instance.instanceId
     defer {

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -256,6 +256,7 @@ class AuthViewModel {
 
     let finalInstanceId: String
     let finalDisplayName: String
+    let finalProtected: Bool
 
     // Persist instance if this is a new login
     if shouldPersistInstance {
@@ -269,9 +270,11 @@ class AuthViewModel {
       )
       finalInstanceId = instanceSummary.id.uuidString
       finalDisplayName = instanceSummary.displayName
+      finalProtected = instanceSummary.protected
     } else {
       finalInstanceId = instanceId ?? AppConfig.current.instanceId
       finalDisplayName = displayName ?? ""
+      finalProtected = protected
     }
 
     AppConfig.current = Current(
@@ -313,7 +316,7 @@ class AuthViewModel {
 
     ExternalContentSurfaceService.updateAfterSelectingInstance(
       instanceId: finalInstanceId,
-      protected: protected
+      protected: finalProtected
     )
   }
 

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -76,6 +76,7 @@ class AuthViewModel {
   }
 
   func logout(clearCurrent: Bool = false) {
+    LocalDeviceAuthenticationService.shared.clearProtectedAccess()
     Task {
       // Disconnect SSE before logout
       await SSEService.shared.disconnect()
@@ -144,9 +145,9 @@ class AuthViewModel {
     }
   }
 
-  func switchTo(instance: ServerDisplayItem, requiresLocalAuthentication: Bool = true) async -> Bool {
-    if requiresLocalAuthentication && instance.protected {
-      let authenticated = await LocalDeviceAuthenticationService.authenticate(
+  func switchTo(instance: ServerDisplayItem) async -> Bool {
+    if instance.protected {
+      let authenticated = await LocalDeviceAuthenticationService.shared.authenticateProtectedAccess(
         reason: String(localized: "Authenticate to switch to this protected server.")
       )
       guard authenticated else { return false }

--- a/KMReader/Features/Server/ServerDisplayItem.swift
+++ b/KMReader/Features/Server/ServerDisplayItem.swift
@@ -13,6 +13,7 @@ nonisolated struct ServerDisplayItem: Equatable, Identifiable, Sendable {
   let authToken: String
   let isAdmin: Bool
   let authMethod: AuthenticationMethod
+  let protected: Bool
   let lastUsedAt: Date
 
   var instanceId: String {

--- a/KMReader/Features/Server/ServerEditView.swift
+++ b/KMReader/Features/Server/ServerEditView.swift
@@ -177,7 +177,7 @@ struct ServerEditView: View {
               .foregroundStyle(.secondary)
             }
           }
-          .disabled(!LocalDeviceAuthenticationService.canAuthenticate && !protected)
+          .disabled(!LocalDeviceAuthenticationService.shared.canAuthenticate && !protected)
         }
       }
       #if os(tvOS)
@@ -278,7 +278,7 @@ struct ServerEditView: View {
     guard canSave else {
       return
     }
-    guard !protected || LocalDeviceAuthenticationService.canAuthenticate else {
+    guard !protected || LocalDeviceAuthenticationService.shared.canAuthenticate else {
       ErrorManager.shared.notify(
         message: String(localized: "Device authentication is not available on this device."))
       return
@@ -309,7 +309,7 @@ struct ServerEditView: View {
 
     Task {
       if protected != instance.protected {
-        let authenticated = await LocalDeviceAuthenticationService.authenticate(
+        let authenticated = await LocalDeviceAuthenticationService.shared.authenticateProtectedAccess(
           reason: String(localized: "Authenticate to change protection for this server.")
         )
         guard authenticated else {
@@ -338,10 +338,7 @@ struct ServerEditView: View {
 
         if current.instanceId == updatedInstance.instanceId {
           Task {
-            _ = await authViewModel.switchTo(
-              instance: updatedInstance,
-              requiresLocalAuthentication: false
-            )
+            _ = await authViewModel.switchTo(instance: updatedInstance)
           }
         }
 

--- a/KMReader/Features/Server/ServerEditView.swift
+++ b/KMReader/Features/Server/ServerEditView.swift
@@ -19,6 +19,7 @@ struct ServerEditView: View {
   @State private var password: String = ""
   @State private var apiKey: String = ""
   @State private var authMethod: AuthenticationMethod
+  @State private var protected: Bool
   @State private var isValidating = false
   @State private var isSaving = false
   @State private var validationMessage: String?
@@ -49,6 +50,7 @@ struct ServerEditView: View {
     _serverURL = State(initialValue: instance.serverURL)
     _username = State(initialValue: instance.username)
     _authMethod = State(initialValue: instance.authMethod)
+    _protected = State(initialValue: instance.protected)
     if instance.authMethod == .apiKey {
       _apiKey = State(initialValue: instance.authToken)
     }
@@ -160,6 +162,23 @@ struct ServerEditView: View {
           .adaptiveButtonStyle(.bordered)
           .disabled(isValidating || !canValidate)
         }
+
+        Section(header: Text(String(localized: "Privacy"))) {
+          Toggle(isOn: $protected) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text(String(localized: "Protected Server"))
+              Text(
+                String(
+                  localized:
+                    "Hide this server from the normal server list and require device authentication before switching to it."
+                )
+              )
+              .font(.caption)
+              .foregroundStyle(.secondary)
+            }
+          }
+          .disabled(!LocalDeviceAuthenticationService.canAuthenticate && !protected)
+        }
       }
       #if os(tvOS)
         .focusSection()
@@ -194,7 +213,7 @@ struct ServerEditView: View {
 
   private var hasChanges: Bool {
     if trimmedName != instance.name || trimmedServerURL != instance.serverURL
-      || authMethod != instance.authMethod
+      || authMethod != instance.authMethod || protected != instance.protected
     {
       return true
     }
@@ -259,6 +278,11 @@ struct ServerEditView: View {
     guard canSave else {
       return
     }
+    guard !protected || LocalDeviceAuthenticationService.canAuthenticate else {
+      ErrorManager.shared.notify(
+        message: String(localized: "Device authentication is not available on this device."))
+      return
+    }
 
     let resolvedName =
       trimmedName.isEmpty
@@ -284,6 +308,16 @@ struct ServerEditView: View {
     isSaving = true
 
     Task {
+      if protected != instance.protected {
+        let authenticated = await LocalDeviceAuthenticationService.authenticate(
+          reason: String(localized: "Authenticate to change protection for this server.")
+        )
+        guard authenticated else {
+          isSaving = false
+          return
+        }
+      }
+
       do {
         let database = try await DatabaseOperator.database()
         guard
@@ -293,7 +327,8 @@ struct ServerEditView: View {
             serverURL: trimmedServerURL,
             username: trimmedUsername,
             authToken: resolvedAuthToken,
-            authMethod: authMethod
+            authMethod: authMethod,
+            protected: protected
           )
         else {
           isSaving = false
@@ -303,7 +338,10 @@ struct ServerEditView: View {
 
         if current.instanceId == updatedInstance.instanceId {
           Task {
-            _ = await authViewModel.switchTo(instance: updatedInstance)
+            _ = await authViewModel.switchTo(
+              instance: updatedInstance,
+              requiresLocalAuthentication: false
+            )
           }
         }
 

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -55,27 +55,6 @@ struct ServerListView: View {
       }
 
       Section(header: introHeader, footer: footerText) {
-        ForEach(visibleInstances) { instance in
-          ServerRowView(
-            instance: instance,
-            isGlobalSwitching: authViewModel.isSwitching,
-            isSwitching: isSwitching(instance),
-            isActive: isActive(instance),
-            onSelect: {
-              withAnimation(.spring(response: 0.45, dampingFraction: 0.85)) {
-                switchTo(instance)
-              }
-            },
-            onEdit: {
-              editingInstance = instance
-            },
-            onDelete: {
-              instancePendingDeletion = instance
-            }
-          )
-          // .tvFocusableHighlight()
-        }
-
         if visibleInstances.isEmpty {
           VStack(spacing: 12) {
             Image(systemName: "list.bullet.rectangle")
@@ -98,12 +77,32 @@ struct ServerListView: View {
           .frame(maxWidth: .infinity)
           .padding(.vertical)
           .listRowBackground(Color.clear)
-          .transition(.opacity)
+        } else {
+          ForEach(visibleInstances) { instance in
+            ServerRowView(
+              instance: instance,
+              isGlobalSwitching: authViewModel.isSwitching,
+              isSwitching: isSwitching(instance),
+              isActive: isActive(instance),
+              onSelect: {
+                withAnimation(.spring(response: 0.45, dampingFraction: 0.85)) {
+                  switchTo(instance)
+                }
+              },
+              onEdit: {
+                editingInstance = instance
+              },
+              onDelete: {
+                instancePendingDeletion = instance
+              }
+            )
+            // .tvFocusableHighlight()
+          }
         }
       }
       .listRowBackground(Color.clear)
 
-      if !allInstances.isEmpty {
+      if !visibleInstances.isEmpty {
         Section {
           Button {
             showLogin = true

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -31,14 +31,9 @@ struct ServerListView: View {
   @State private var showLogoutAlert = false
   @State private var protectedServerCount = 0
   @State private var isAuthenticatingProtectedServers = false
-  @State private var hasLoadedInstances = false
 
   private var activeInstanceId: String? {
     current.instanceId.isEmpty ? nil : current.instanceId
-  }
-
-  private var serverListAnimation: Animation {
-    .spring(response: 0.35, dampingFraction: 0.9)
   }
 
   var body: some View {
@@ -97,13 +92,12 @@ struct ServerListView: View {
                 instancePendingDeletion = instance
               }
             )
-            .transition(.opacity.combined(with: .move(edge: .top)))
             // .tvFocusableHighlight()
           }
         }
       }
       .listRowBackground(Color.clear)
-      .animation(serverListAnimation, value: instances)
+      .animation(.default, value: instances)
 
       if !instances.isEmpty {
         Section {
@@ -316,34 +310,14 @@ struct ServerListView: View {
       let loadedProtectedServerCount = try await database.fetchProtectedServerCount()
       let loadedInstances = try await database.fetchServerDisplayItems(
         includeProtected: showProtectedServers)
-      applyLoadedInstances(
-        loadedInstances,
-        protectedServerCount: loadedProtectedServerCount)
-    } catch {
-      ErrorManager.shared.alert(error: error)
-    }
-  }
-
-  private func applyLoadedInstances(
-    _ loadedInstances: [ServerDisplayItem],
-    protectedServerCount loadedProtectedServerCount: Int
-  ) {
-    let updateState = {
       if protectedServerCount != loadedProtectedServerCount {
         protectedServerCount = loadedProtectedServerCount
       }
       if instances != loadedInstances {
         instances = loadedInstances
       }
-      hasLoadedInstances = true
-    }
-
-    if hasLoadedInstances {
-      withAnimation(serverListAnimation) {
-        updateState()
-      }
-    } else {
-      updateState()
+    } catch {
+      ErrorManager.shared.alert(error: error)
     }
   }
 
@@ -372,7 +346,7 @@ struct ServerListView: View {
 
   private func authenticateAndShowProtectedServers() {
     guard !isAuthenticatingProtectedServers else { return }
-    guard LocalDeviceAuthenticationService.canAuthenticate else {
+    guard LocalDeviceAuthenticationService.shared.canAuthenticate else {
       ErrorManager.shared.notify(
         message: String(localized: "Device authentication is not available on this device."))
       return
@@ -380,7 +354,7 @@ struct ServerListView: View {
 
     isAuthenticatingProtectedServers = true
     Task {
-      let authenticated = await LocalDeviceAuthenticationService.authenticate(
+      let authenticated = await LocalDeviceAuthenticationService.shared.authenticateProtectedAccess(
         reason: String(localized: "Authenticate to show protected servers.")
       )
       if authenticated {

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -36,8 +36,12 @@ struct ServerListView: View {
     current.instanceId.isEmpty ? nil : current.instanceId
   }
 
+  private var canShowProtectedServers: Bool {
+    showProtectedServers && LocalDeviceAuthenticationService.shared.hasProtectedAccess
+  }
+
   private var visibleInstances: [ServerDisplayItem] {
-    showProtectedServers ? allInstances : allInstances.filter { !$0.protected }
+    canShowProtectedServers ? allInstances : allInstances.filter { !$0.protected }
   }
 
   var body: some View {
@@ -47,7 +51,7 @@ struct ServerListView: View {
           Toggle(isOn: showProtectedServersBinding) {
             Label(
               String(localized: "Show Protected Servers"),
-              systemImage: showProtectedServers ? "eye" : "eye.slash"
+              systemImage: canShowProtectedServers ? "eye" : "eye.slash"
             )
           }
           .disabled(isAuthenticatingProtectedServers)
@@ -90,10 +94,10 @@ struct ServerListView: View {
                 }
               },
               onEdit: {
-                editingInstance = instance
+                edit(instance)
               },
               onDelete: {
-                instancePendingDeletion = instance
+                confirmDelete(instance)
               }
             )
             // .tvFocusableHighlight()
@@ -186,7 +190,11 @@ struct ServerListView: View {
       }
     }
     .task {
+      resetProtectedVisibilityIfNeeded()
       await loadInstances()
+    }
+    .onAppear {
+      resetProtectedVisibilityIfNeeded()
     }
     .onChange(of: showLogin) { _, isPresented in
       if !isPresented {
@@ -322,7 +330,7 @@ struct ServerListView: View {
 
   private var showProtectedServersBinding: Binding<Bool> {
     Binding(
-      get: { showProtectedServers },
+      get: { canShowProtectedServers },
       set: { newValue in
         if newValue {
           authenticateAndShowProtectedServers()
@@ -333,6 +341,12 @@ struct ServerListView: View {
         }
       }
     )
+  }
+
+  private func resetProtectedVisibilityIfNeeded() {
+    guard showProtectedServers else { return }
+    guard !LocalDeviceAuthenticationService.shared.hasProtectedAccess else { return }
+    showProtectedServers = false
   }
 
   private var protectedServersFooter: some View {
@@ -365,6 +379,33 @@ struct ServerListView: View {
       }
       isAuthenticatingProtectedServers = false
     }
+  }
+
+  private func edit(_ instance: ServerDisplayItem) {
+    Task {
+      guard await authenticateProtectedServerActionIfNeeded(instance) else { return }
+      editingInstance = instance
+    }
+  }
+
+  private func confirmDelete(_ instance: ServerDisplayItem) {
+    Task {
+      guard await authenticateProtectedServerActionIfNeeded(instance) else { return }
+      instancePendingDeletion = instance
+    }
+  }
+
+  private func authenticateProtectedServerActionIfNeeded(_ instance: ServerDisplayItem) async -> Bool {
+    guard instance.protected else { return true }
+    let authenticated = await LocalDeviceAuthenticationService.shared.authenticateProtectedAccess(
+      reason: String(localized: "Authenticate to show protected servers.")
+    )
+    if !authenticated {
+      withAnimation {
+        showProtectedServers = false
+      }
+    }
+    return authenticated
   }
 
 }

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -31,9 +31,14 @@ struct ServerListView: View {
   @State private var showLogoutAlert = false
   @State private var protectedServerCount = 0
   @State private var isAuthenticatingProtectedServers = false
+  @State private var hasLoadedInstances = false
 
   private var activeInstanceId: String? {
     current.instanceId.isEmpty ? nil : current.instanceId
+  }
+
+  private var serverListAnimation: Animation {
+    .spring(response: 0.35, dampingFraction: 0.9)
   }
 
   var body: some View {
@@ -92,11 +97,13 @@ struct ServerListView: View {
                 instancePendingDeletion = instance
               }
             )
+            .transition(.opacity.combined(with: .move(edge: .top)))
             // .tvFocusableHighlight()
           }
         }
       }
       .listRowBackground(Color.clear)
+      .animation(serverListAnimation, value: instances)
 
       if !instances.isEmpty {
         Section {
@@ -309,14 +316,34 @@ struct ServerListView: View {
       let loadedProtectedServerCount = try await database.fetchProtectedServerCount()
       let loadedInstances = try await database.fetchServerDisplayItems(
         includeProtected: showProtectedServers)
+      applyLoadedInstances(
+        loadedInstances,
+        protectedServerCount: loadedProtectedServerCount)
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
+  }
+
+  private func applyLoadedInstances(
+    _ loadedInstances: [ServerDisplayItem],
+    protectedServerCount loadedProtectedServerCount: Int
+  ) {
+    let updateState = {
       if protectedServerCount != loadedProtectedServerCount {
         protectedServerCount = loadedProtectedServerCount
       }
       if instances != loadedInstances {
         instances = loadedInstances
       }
-    } catch {
-      ErrorManager.shared.alert(error: error)
+      hasLoadedInstances = true
+    }
+
+    if hasLoadedInstances {
+      withAnimation(serverListAnimation) {
+        updateState()
+      }
+    } else {
+      updateState()
     }
   }
 

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -55,6 +55,27 @@ struct ServerListView: View {
       }
 
       Section(header: introHeader, footer: footerText) {
+        ForEach(visibleInstances) { instance in
+          ServerRowView(
+            instance: instance,
+            isGlobalSwitching: authViewModel.isSwitching,
+            isSwitching: isSwitching(instance),
+            isActive: isActive(instance),
+            onSelect: {
+              withAnimation(.spring(response: 0.45, dampingFraction: 0.85)) {
+                switchTo(instance)
+              }
+            },
+            onEdit: {
+              editingInstance = instance
+            },
+            onDelete: {
+              instancePendingDeletion = instance
+            }
+          )
+          // .tvFocusableHighlight()
+        }
+
         if visibleInstances.isEmpty {
           VStack(spacing: 12) {
             Image(systemName: "list.bullet.rectangle")
@@ -77,32 +98,12 @@ struct ServerListView: View {
           .frame(maxWidth: .infinity)
           .padding(.vertical)
           .listRowBackground(Color.clear)
-        } else {
-          ForEach(visibleInstances) { instance in
-            ServerRowView(
-              instance: instance,
-              isGlobalSwitching: authViewModel.isSwitching,
-              isSwitching: isSwitching(instance),
-              isActive: isActive(instance),
-              onSelect: {
-                withAnimation(.spring(response: 0.45, dampingFraction: 0.85)) {
-                  switchTo(instance)
-                }
-              },
-              onEdit: {
-                editingInstance = instance
-              },
-              onDelete: {
-                instancePendingDeletion = instance
-              }
-            )
-            // .tvFocusableHighlight()
-          }
+          .transition(.opacity)
         }
       }
       .listRowBackground(Color.clear)
 
-      if !visibleInstances.isEmpty {
+      if !allInstances.isEmpty {
         Section {
           Button {
             showLogin = true

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -22,12 +22,15 @@ struct ServerListView: View {
   @Environment(\.dismiss) private var dismiss
   @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("isLoggedInV2") private var isLoggedIn: Bool = false
+  @AppStorage("showProtectedServers") private var showProtectedServers: Bool = false
 
   @State private var instances: [ServerDisplayItem] = []
   @State private var instancePendingDeletion: ServerDisplayItem?
   @State private var editingInstance: ServerDisplayItem?
   @State private var showLogin = false
   @State private var showLogoutAlert = false
+  @State private var protectedServerCount = 0
+  @State private var isAuthenticatingProtectedServers = false
 
   private var activeInstanceId: String? {
     current.instanceId.isEmpty ? nil : current.instanceId
@@ -35,6 +38,18 @@ struct ServerListView: View {
 
   var body: some View {
     Form {
+      if protectedServerCount > 0 {
+        Section(footer: protectedServersFooter) {
+          Toggle(isOn: showProtectedServersBinding) {
+            Label(
+              String(localized: "Show Protected Servers"),
+              systemImage: showProtectedServers ? "eye" : "eye.slash"
+            )
+          }
+          .disabled(isAuthenticatingProtectedServers)
+        }
+      }
+
       Section(header: introHeader, footer: footerText) {
         if instances.isEmpty {
           VStack(spacing: 12) {
@@ -184,6 +199,11 @@ struct ServerListView: View {
         dismiss()
       }
     }
+    .onChange(of: showProtectedServers) { _, _ in
+      Task {
+        await loadInstances()
+      }
+    }
   }
 
   private var navigationTitle: String {
@@ -286,12 +306,60 @@ struct ServerListView: View {
   private func loadInstances() async {
     do {
       let database = try await DatabaseOperator.database()
-      let loadedInstances = try await database.fetchServerDisplayItems()
+      let loadedProtectedServerCount = try await database.fetchProtectedServerCount()
+      let loadedInstances = try await database.fetchServerDisplayItems(
+        includeProtected: showProtectedServers)
+      if protectedServerCount != loadedProtectedServerCount {
+        protectedServerCount = loadedProtectedServerCount
+      }
       if instances != loadedInstances {
         instances = loadedInstances
       }
     } catch {
       ErrorManager.shared.alert(error: error)
+    }
+  }
+
+  private var showProtectedServersBinding: Binding<Bool> {
+    Binding(
+      get: { showProtectedServers },
+      set: { newValue in
+        if newValue {
+          authenticateAndShowProtectedServers()
+        } else {
+          showProtectedServers = false
+        }
+      }
+    )
+  }
+
+  private var protectedServersFooter: some View {
+    Text(
+      String(
+        localized:
+          "Protected servers are hidden from this list until you authenticate with device passcode, Touch ID, or Face ID."
+      )
+    )
+    .foregroundStyle(.secondary)
+  }
+
+  private func authenticateAndShowProtectedServers() {
+    guard !isAuthenticatingProtectedServers else { return }
+    guard LocalDeviceAuthenticationService.canAuthenticate else {
+      ErrorManager.shared.notify(
+        message: String(localized: "Device authentication is not available on this device."))
+      return
+    }
+
+    isAuthenticatingProtectedServers = true
+    Task {
+      let authenticated = await LocalDeviceAuthenticationService.authenticate(
+        reason: String(localized: "Authenticate to show protected servers.")
+      )
+      if authenticated {
+        showProtectedServers = true
+      }
+      isAuthenticatingProtectedServers = false
     }
   }
 

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -24,7 +24,7 @@ struct ServerListView: View {
   @AppStorage("isLoggedInV2") private var isLoggedIn: Bool = false
   @AppStorage("showProtectedServers") private var showProtectedServers: Bool = false
 
-  @State private var instances: [ServerDisplayItem] = []
+  @State private var allInstances: [ServerDisplayItem] = []
   @State private var instancePendingDeletion: ServerDisplayItem?
   @State private var editingInstance: ServerDisplayItem?
   @State private var showLogin = false
@@ -34,6 +34,10 @@ struct ServerListView: View {
 
   private var activeInstanceId: String? {
     current.instanceId.isEmpty ? nil : current.instanceId
+  }
+
+  private var visibleInstances: [ServerDisplayItem] {
+    showProtectedServers ? allInstances : allInstances.filter { !$0.protected }
   }
 
   var body: some View {
@@ -51,7 +55,7 @@ struct ServerListView: View {
       }
 
       Section(header: introHeader, footer: footerText) {
-        if instances.isEmpty {
+        if visibleInstances.isEmpty {
           VStack(spacing: 12) {
             Image(systemName: "list.bullet.rectangle")
               .font(.largeTitle)
@@ -74,7 +78,7 @@ struct ServerListView: View {
           .padding(.vertical)
           .listRowBackground(Color.clear)
         } else {
-          ForEach(instances) { instance in
+          ForEach(visibleInstances) { instance in
             ServerRowView(
               instance: instance,
               isGlobalSwitching: authViewModel.isSwitching,
@@ -97,9 +101,9 @@ struct ServerListView: View {
         }
       }
       .listRowBackground(Color.clear)
-      .animation(.default, value: instances)
+      .animation(.default, value: visibleInstances)
 
-      if !instances.isEmpty {
+      if !visibleInstances.isEmpty {
         Section {
           Button {
             showLogin = true
@@ -198,11 +202,6 @@ struct ServerListView: View {
       }
       if loggedIn && mode == .onboarding {
         dismiss()
-      }
-    }
-    .onChange(of: showProtectedServers) { _, _ in
-      Task {
-        await loadInstances()
       }
     }
   }
@@ -307,14 +306,15 @@ struct ServerListView: View {
   private func loadInstances() async {
     do {
       let database = try await DatabaseOperator.database()
-      let loadedProtectedServerCount = try await database.fetchProtectedServerCount()
-      let loadedInstances = try await database.fetchServerDisplayItems(
-        includeProtected: showProtectedServers)
-      if protectedServerCount != loadedProtectedServerCount {
-        protectedServerCount = loadedProtectedServerCount
-      }
-      if instances != loadedInstances {
-        instances = loadedInstances
+      let loadedInstances = try await database.fetchServerDisplayItems(includeProtected: true)
+      let loadedProtectedServerCount = loadedInstances.filter(\.protected).count
+      withAnimation {
+        if protectedServerCount != loadedProtectedServerCount {
+          protectedServerCount = loadedProtectedServerCount
+        }
+        if allInstances != loadedInstances {
+          allInstances = loadedInstances
+        }
       }
     } catch {
       ErrorManager.shared.alert(error: error)
@@ -328,7 +328,9 @@ struct ServerListView: View {
         if newValue {
           authenticateAndShowProtectedServers()
         } else {
-          showProtectedServers = false
+          withAnimation {
+            showProtectedServers = false
+          }
         }
       }
     )
@@ -358,7 +360,9 @@ struct ServerListView: View {
         reason: String(localized: "Authenticate to show protected servers.")
       )
       if authenticated {
-        showProtectedServers = true
+        withAnimation {
+          showProtectedServers = true
+        }
       }
       isAuthenticatingProtectedServers = false
     }

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -101,7 +101,6 @@ struct ServerListView: View {
         }
       }
       .listRowBackground(Color.clear)
-      .animation(.default, value: visibleInstances)
 
       if !visibleInstances.isEmpty {
         Section {

--- a/KMReader/Features/Server/ServerRowView.swift
+++ b/KMReader/Features/Server/ServerRowView.swift
@@ -55,6 +55,13 @@ struct ServerRowView: View {
               ? String(localized: "API Key") : String(localized: "Username & Password"),
             textColor: .secondary
           )
+          if instance.protected {
+            infoDetailRow(
+              icon: "lock.fill",
+              text: String(localized: "Protected"),
+              textColor: .secondary
+            )
+          }
           infoDetailRow(
             icon: "clock.arrow.circlepath", text: lastUsedDescription,
             textColor: .secondary)

--- a/KMReader/Features/Server/ServerRowView.swift
+++ b/KMReader/Features/Server/ServerRowView.swift
@@ -59,7 +59,8 @@ struct ServerRowView: View {
             infoDetailRow(
               icon: "lock.fill",
               text: String(localized: "Protected"),
-              textColor: .secondary
+              textColor: .orange,
+              iconColor: .orange
             )
           }
           infoDetailRow(
@@ -149,11 +150,16 @@ struct ServerRowView: View {
     )
   }
 
-  private func infoDetailRow(icon: String, text: String, textColor: Color = .primary) -> some View {
+  private func infoDetailRow(
+    icon: String,
+    text: String,
+    textColor: Color = .primary,
+    iconColor: Color = .secondary
+  ) -> some View {
     HStack(alignment: .top, spacing: 8) {
       Image(systemName: icon)
         .font(.footnote.weight(.semibold))
-        .foregroundStyle(.secondary)
+        .foregroundStyle(iconColor)
         .frame(width: 16)
       Text(text)
         .font(.footnote)

--- a/KMReader/Info.plist
+++ b/KMReader/Info.plist
@@ -7,6 +7,8 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Use Face ID to unlock protected Komga servers.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -5754,6 +5754,262 @@
         }
       }
     },
+    "Authenticate to change protection for this server." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentifiziere dich, um den Schutz für diesen Server zu ändern."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to change protection for this server."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autentícate para cambiar la protección de este servidor."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentifiez-vous pour modifier la protection de ce serveur."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autenticati per modificare la protezione di questo server."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このサーバーの保護を変更するには認証してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 서버의 보호 설정을 변경하려면 인증하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аутентифицируйтесь, чтобы изменить защиту этого сервера."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "认证以更改此服务器的保护设置。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "認證以變更此伺服器的保護設定。"
+          }
+        }
+      }
+    },
+    "Authenticate to show protected servers." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentifiziere dich, um geschützte Server anzuzeigen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to show protected servers."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autentícate para mostrar servidores protegidos."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentifiez-vous pour afficher les serveurs protégés."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autenticati per mostrare i server protetti."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保護されたサーバーを表示するには認証してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보호된 서버를 표시하려면 인증하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аутентифицируйтесь, чтобы показать защищенные серверы."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "认证以显示受保护的服务器。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "認證以顯示受保護的伺服器。"
+          }
+        }
+      }
+    },
+    "Authenticate to switch to this protected server." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentifiziere dich, um zu diesem geschützten Server zu wechseln."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to switch to this protected server."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autentícate para cambiar a este servidor protegido."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentifiez-vous pour basculer vers ce serveur protégé."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autenticati per passare a questo server protetto."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この保護されたサーバーに切り替えるには認証してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 보호된 서버로 전환하려면 인증하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аутентифицируйтесь, чтобы переключиться на этот защищенный сервер."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "认证以切换到此受保护的服务器。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "認證以切換到此受保護的伺服器。"
+          }
+        }
+      }
+    },
+    "Authenticate to unlock this protected server." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentifiziere dich, um diesen geschützten Server zu entsperren."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authenticate to unlock this protected server."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autentícate para desbloquear este servidor protegido."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentifiez-vous pour déverrouiller ce serveur protégé."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autenticati per sbloccare questo server protetto."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この保護されたサーバーのロックを解除するには認証してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 보호된 서버를 잠금 해제하려면 인증하세요."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аутентифицируйтесь, чтобы разблокировать этот защищенный сервер."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "认证以解锁此受保护的服务器。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "認證以解鎖此受保護的伺服器。"
+          }
+        }
+      }
+    },
     "Authentication Activity" : {
       "localizations" : {
         "de" : {
@@ -5814,6 +6070,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "身份驗證活動"
+          }
+        }
+      }
+    },
+    "Authentication failed." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentifizierung fehlgeschlagen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication failed."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error de autenticación."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de l’authentification."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autenticazione non riuscita."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "認証に失敗しました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인증에 실패했습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось пройти аутентификацию."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "认证失败。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "認證失敗。"
           }
         }
       }
@@ -17782,6 +18102,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "詳情"
+          }
+        }
+      }
+    },
+    "Device authentication is not available on this device." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geräteauthentifizierung ist auf diesem Gerät nicht verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Device authentication is not available on this device."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La autenticación del dispositivo no está disponible en este dispositivo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’authentification de l’appareil n’est pas disponible sur cet appareil."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’autenticazione del dispositivo non è disponibile su questo dispositivo."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このデバイスではデバイス認証を利用できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 기기에서는 기기 인증을 사용할 수 없습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Аутентификация устройства недоступна на этом устройстве."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此设备不支持设备认证。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此裝置不支援裝置認證。"
           }
         }
       }
@@ -30006,6 +30390,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "有生之年"
+          }
+        }
+      }
+    },
+    "Hide this server from the normal server list and require device authentication before switching to it." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diesen Server in der normalen Serverliste ausblenden und Geräteauthentifizierung vor dem Wechsel dorthin verlangen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hide this server from the normal server list and require device authentication before switching to it."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oculta este servidor de la lista normal y exige autenticación del dispositivo antes de cambiar a él."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masque ce serveur dans la liste normale et exige l’authentification de l’appareil avant de basculer vers lui."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nascondi questo server dall’elenco normale e richiedi l’autenticazione del dispositivo prima di passarci."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このサーバーを通常のサーバー一覧から非表示にし、切り替える前にデバイス認証を要求します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 서버를 일반 서버 목록에서 숨기고 전환하기 전에 기기 인증을 요구합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скрыть этот сервер из обычного списка серверов и требовать аутентификацию устройства перед переключением на него."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从普通服务器列表中隐藏此服务器，并在切换前要求设备认证。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "從一般伺服器列表中隱藏此伺服器，並在切換前要求裝置認證。"
           }
         }
       }
@@ -53244,6 +53692,70 @@
         }
       }
     },
+    "Privacy" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datenschutz"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacidad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confidentialité"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Privacy"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プライバシー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개인정보 보호"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Конфиденциальность"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐私"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隱私"
+          }
+        }
+      }
+    },
     "Privacy Policy" : {
       "localizations" : {
         "de" : {
@@ -53368,6 +53880,198 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在處理離線檔案..."
+          }
+        }
+      }
+    },
+    "Protected" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geschützt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protected"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protegido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protégé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protetto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保護済み"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보호됨"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Защищено"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受保护"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受保護"
+          }
+        }
+      }
+    },
+    "Protected Server" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geschützter Server"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protected Server"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Servidor protegido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serveur protégé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Server protetto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保護されたサーバー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보호된 서버"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Защищенный сервер"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受保护的服务器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受保護的伺服器"
+          }
+        }
+      }
+    },
+    "Protected servers are hidden from this list until you authenticate with device passcode, Touch ID, or Face ID." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geschützte Server bleiben in dieser Liste verborgen, bis du dich mit Gerätecode, Touch ID oder Face ID authentifizierst."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Protected servers are hidden from this list until you authenticate with device passcode, Touch ID, or Face ID."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los servidores protegidos permanecen ocultos en esta lista hasta que te autentiques con el código del dispositivo, Touch ID o Face ID."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les serveurs protégés restent masqués dans cette liste jusqu’à l’authentification avec le code de l’appareil, Touch ID ou Face ID."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "I server protetti restano nascosti in questo elenco finché non ti autentichi con il codice del dispositivo, Touch ID o Face ID."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保護されたサーバーは、デバイスのパスコード、Touch ID、またはFace IDで認証するまでこの一覧では非表示になります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보호된 서버는 기기 암호, Touch ID 또는 Face ID로 인증할 때까지 이 목록에서 숨겨집니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Защищенные серверы скрыты в этом списке, пока вы не пройдете аутентификацию с помощью кода устройства, Touch ID или Face ID."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受保护的服务器会从此列表隐藏，直到你使用设备密码、Touch ID 或 Face ID 认证。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "受保護的伺服器會從此列表隱藏，直到你使用裝置密碼、Touch ID 或 Face ID 認證。"
           }
         }
       }
@@ -71096,6 +71800,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀時顯示進度條"
+          }
+        }
+      }
+    },
+    "Show Protected Servers" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geschützte Server anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Protected Servers"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar servidores protegidos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les serveurs protégés"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra server protetti"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保護されたサーバーを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보호된 서버 표시"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показать защищенные серверы"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示受保护的服务器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示受保護的伺服器"
           }
         }
       }

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -72,6 +72,7 @@ struct MainApp: App {
     PlatformHelper.setup()
     AnimatedImageSupport.configureCoders()
     AppConfig.migrateOfflineProvenanceIfNeeded()
+    AppConfig.showProtectedServers = false
     _authViewModel = State(initialValue: AuthViewModel())
   }
 


### PR DESCRIPTION
## Problem

Saved Komga servers could be switched from the server list without any local privacy gate, which made private instances visible and accessible to anyone using the device.

## Approach

- Add a GRDB-backed `protected` flag to saved server instances.
- Hide protected servers from the normal server list by default, with a list-level toggle that requires device owner authentication before showing them.
- Require device owner authentication when switching to a protected server, changing a server's protected state, or opening the app when the current server is protected.
- Clear the current account details when startup authentication for a protected server fails.
- Localize all new protected server UI strings.

## Related
- #882

## Validation

- `make format`
- `make build`
- `make localize`
- `./misc/translate.py list`
- `git diff --check`
