### PR TITLE
refactor(dashboard): centralize refresh coordination

### DIFF
--- a/KMReader/Core/Network/SSEService.swift
+++ b/KMReader/Core/Network/SSEService.swift
@@ -207,32 +207,32 @@ actor SSEService {
   private func handleSSEAutoRefreshEvent(_ eventType: SSEEventType, data: String) async {
     switch eventType {
     case .seriesAdded, .seriesChanged, .seriesDeleted:
-      guard await postSeriesProjectionChange(data: data) else {
+      guard await postSeriesDashboardRefresh(data: data) else {
         broadcastNotification(type: eventType, data: data)
         return
       }
     case .bookAdded, .bookChanged, .bookDeleted, .bookImported:
-      guard await postBookProjectionChange(data: data) else {
+      guard await postBookDashboardRefresh(data: data) else {
         broadcastNotification(type: eventType, data: data)
         return
       }
     case .collectionAdded, .collectionChanged, .collectionDeleted:
-      guard await postCollectionProjectionChange(data: data) else {
+      guard await postCollectionDashboardRefresh(data: data) else {
         broadcastNotification(type: eventType, data: data)
         return
       }
     case .readListAdded, .readListChanged, .readListDeleted:
-      guard await postReadListProjectionChange(data: data) else {
+      guard await postReadListDashboardRefresh(data: data) else {
         broadcastNotification(type: eventType, data: data)
         return
       }
     case .readProgressChanged, .readProgressDeleted:
-      guard await postReadProgressProjectionChange(data: data) else {
+      guard await postReadProgressDashboardRefresh(data: data) else {
         broadcastNotification(type: eventType, data: data)
         return
       }
     case .readProgressSeriesChanged, .readProgressSeriesDeleted:
-      guard await postReadProgressSeriesProjectionChange(data: data) else {
+      guard await postReadProgressSeriesDashboardRefresh(data: data) else {
         broadcastNotification(type: eventType, data: data)
         return
       }
@@ -268,65 +268,62 @@ actor SSEService {
     }
   }
 
-  private func postSeriesProjectionChange(data: String) async -> Bool {
-    guard let seriesId = stringValue("seriesId", from: data) else { return false }
-    await ContentProjectionNotifier.postSeriesDidChange(
-      seriesId: seriesId,
-      libraryId: stringValue("libraryId", from: data),
-      refreshDelay: ContentProjectionNotifier.remoteRefreshDelay
+  private func postSeriesDashboardRefresh(data: String) async -> Bool {
+    guard stringValue("seriesId", from: data) != nil else { return false }
+    await DashboardSectionRefreshNotifier.postSeriesContentChanged(
+      source: .auto,
+      reason: "Remote series changed"
     )
     return true
   }
 
-  private func postBookProjectionChange(data: String) async -> Bool {
+  private func postBookDashboardRefresh(data: String) async -> Bool {
     guard
-      let bookId = stringValue("bookId", from: data),
-      let seriesId = stringValue("seriesId", from: data)
+      stringValue("bookId", from: data) != nil,
+      stringValue("seriesId", from: data) != nil
     else { return false }
 
-    await ContentProjectionNotifier.postBookAndSeriesDidChange(
-      bookId: bookId,
-      instanceId: AppConfig.current.instanceId,
-      seriesId: seriesId,
-      libraryId: stringValue("libraryId", from: data),
-      refreshDelay: ContentProjectionNotifier.remoteRefreshDelay
+    await DashboardSectionRefreshNotifier.post(
+      sections: DashboardSectionRefreshNotifier.bookContentSections
+        .union(DashboardSectionRefreshNotifier.seriesContentSections),
+      source: .auto,
+      reason: "Remote book changed"
     )
     return true
   }
 
-  private func postCollectionProjectionChange(data: String) async -> Bool {
-    guard let collectionId = stringValue("collectionId", from: data) else { return false }
-    await ContentProjectionNotifier.postCollectionDidChange(
-      collectionId: collectionId,
-      refreshDelay: ContentProjectionNotifier.remoteRefreshDelay
+  private func postCollectionDashboardRefresh(data: String) async -> Bool {
+    guard stringValue("collectionId", from: data) != nil else { return false }
+    await DashboardSectionRefreshNotifier.postCollectionContentChanged(
+      source: .auto,
+      reason: "Remote collection changed"
     )
     return true
   }
 
-  private func postReadListProjectionChange(data: String) async -> Bool {
-    guard let readListId = stringValue("readListId", from: data) else { return false }
-    await ContentProjectionNotifier.postReadListDidChange(
-      readListId: readListId,
-      refreshDelay: ContentProjectionNotifier.remoteRefreshDelay
+  private func postReadListDashboardRefresh(data: String) async -> Bool {
+    guard stringValue("readListId", from: data) != nil else { return false }
+    await DashboardSectionRefreshNotifier.postReadListContentChanged(
+      source: .auto,
+      reason: "Remote read-list changed"
     )
     return true
   }
 
-  private func postReadProgressProjectionChange(data: String) async -> Bool {
-    guard let bookId = stringValue("bookId", from: data) else { return false }
-    await ContentProjectionNotifier.postBookAndSeriesDidChange(
-      bookId: bookId,
-      refreshDelay: ContentProjectionNotifier.remoteRefreshDelay
+  private func postReadProgressDashboardRefresh(data: String) async -> Bool {
+    guard stringValue("bookId", from: data) != nil else { return false }
+    await DashboardSectionRefreshNotifier.postReadStatusChanged(
+      source: .auto,
+      reason: "Remote read progress changed"
     )
     return true
   }
 
-  private func postReadProgressSeriesProjectionChange(data: String) async -> Bool {
-    guard let seriesId = stringValue("seriesId", from: data) else { return false }
-    await ContentProjectionNotifier.postSeriesDidChange(
-      seriesId: seriesId,
-      libraryId: stringValue("libraryId", from: data),
-      refreshDelay: ContentProjectionNotifier.remoteRefreshDelay
+  private func postReadProgressSeriesDashboardRefresh(data: String) async -> Bool {
+    guard stringValue("seriesId", from: data) != nil else { return false }
+    await DashboardSectionRefreshNotifier.postReadStatusChanged(
+      source: .auto,
+      reason: "Remote series read progress changed"
     )
     return true
   }

--- a/KMReader/Features/Book/ViewModels/BookViewModel.swift
+++ b/KMReader/Features/Book/ViewModels/BookViewModel.swift
@@ -101,6 +101,7 @@ class BookViewModel {
         bookId: bookId,
         seriesId: updatedBook.seriesId
       )
+      await postReadStatusDashboardRefresh()
       ErrorManager.shared.notify(message: String(localized: "notification.book.markedRead"))
     } catch {
       ErrorManager.shared.alert(error: error)
@@ -119,6 +120,7 @@ class BookViewModel {
         bookId: bookId,
         seriesId: updatedBook.seriesId
       )
+      await postReadStatusDashboardRefresh()
       ErrorManager.shared.notify(message: String(localized: "notification.book.markedUnread"))
     } catch {
       ErrorManager.shared.alert(error: error)
@@ -197,6 +199,13 @@ class BookViewModel {
     var fallback = browseOpts
     fallback.sortField = .dateAdded
     return fallback
+  }
+
+  private func postReadStatusDashboardRefresh() async {
+    await DashboardSectionRefreshNotifier.postReadStatusChanged(
+      source: .manual,
+      reason: "Book read status changed"
+    )
   }
 
   func loadReadListBooks(

--- a/KMReader/Features/Book/Views/BookContextMenu.swift
+++ b/KMReader/Features/Book/Views/BookContextMenu.swift
@@ -156,6 +156,10 @@ struct BookContextMenu: View {
           bookId: bookId,
           seriesId: book.seriesId
         )
+        await DashboardSectionRefreshNotifier.postReadStatusChanged(
+          source: .manual,
+          reason: "Book read status changed"
+        )
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedRead"))
         onMutationCompleted?()
       } catch {
@@ -172,6 +176,10 @@ struct BookContextMenu: View {
         await ContentProjectionNotifier.postBookAndSeriesDidChange(
           bookId: bookId,
           seriesId: book.seriesId
+        )
+        await DashboardSectionRefreshNotifier.postReadStatusChanged(
+          source: .manual,
+          reason: "Book read status changed"
         )
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedUnread"))
         onMutationCompleted?()

--- a/KMReader/Features/Book/Views/BookDetailView.swift
+++ b/KMReader/Features/Book/Views/BookDetailView.swift
@@ -169,6 +169,10 @@ struct BookDetailView: View {
         } else {
           await ContentProjectionNotifier.postBookDidChange(bookId: bookId)
         }
+        await DashboardSectionRefreshNotifier.postReadStatusChanged(
+          source: .manual,
+          reason: "Book read status changed"
+        )
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedRead"))
         await loadBook()
       } catch {
@@ -194,6 +198,10 @@ struct BookDetailView: View {
           _ = try? await SyncService.syncBook(bookId: bookId)
           await ContentProjectionNotifier.postBookDidChange(bookId: bookId)
         }
+        await DashboardSectionRefreshNotifier.postReadStatusChanged(
+          source: .manual,
+          reason: "Book read status changed"
+        )
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedUnread"))
         await loadBook()
       } catch {

--- a/KMReader/Features/Dashboard/Models/DashboardRefreshSource.swift
+++ b/KMReader/Features/Dashboard/Models/DashboardRefreshSource.swift
@@ -1,0 +1,9 @@
+//
+// DashboardRefreshSource.swift
+//
+//
+
+enum DashboardRefreshSource: Equatable, Sendable {
+  case manual
+  case auto
+}

--- a/KMReader/Features/Dashboard/Models/DashboardSectionRefreshNotifier.swift
+++ b/KMReader/Features/Dashboard/Models/DashboardSectionRefreshNotifier.swift
@@ -1,0 +1,131 @@
+//
+// DashboardSectionRefreshNotifier.swift
+//
+//
+
+import Foundation
+
+extension Notification.Name {
+  static let dashboardSectionsShouldReload = Notification.Name("DashboardSectionsShouldReload")
+}
+
+nonisolated enum DashboardSectionRefreshNotifier {
+  static let sectionsUserInfoKey = "sections"
+  static let sourceUserInfoKey = "source"
+  static let reasonUserInfoKey = "reason"
+  static let commandUserInfoKey = "command"
+
+  static let bookContentSections: Set<DashboardSection> = [
+    .onDeck,
+    .recentlyReleasedBooks,
+    .recentlyAddedBooks,
+  ]
+
+  static let seriesContentSections: Set<DashboardSection> = [
+    .recentlyAddedSeries,
+    .recentlyUpdatedSeries,
+  ]
+
+  static let readingProgressSections: Set<DashboardSection> = [
+    .keepReading,
+    .onDeck,
+    .recentlyReadBooks,
+  ]
+
+  static func postBookContentChanged(source: DashboardRefreshSource, reason: String) async {
+    await post(sections: bookContentSections, source: source, reason: reason)
+  }
+
+  static func postSeriesContentChanged(source: DashboardRefreshSource, reason: String) async {
+    await post(sections: seriesContentSections, source: source, reason: reason)
+  }
+
+  static func postReadingProgressChanged(source: DashboardRefreshSource, reason: String) async {
+    await post(sections: readingProgressSections, source: source, reason: reason)
+  }
+
+  static func postReadStatusChanged(source: DashboardRefreshSource, reason: String) async {
+    await post(
+      sections: readingProgressSections.union(seriesContentSections),
+      source: source,
+      reason: reason
+    )
+  }
+
+  static func postCollectionContentChanged(source: DashboardRefreshSource, reason: String) async {
+    await post(sections: [.pinnedCollections], source: source, reason: reason)
+  }
+
+  static func postReadListContentChanged(source: DashboardRefreshSource, reason: String) async {
+    await post(sections: [.pinnedReadLists], source: source, reason: reason)
+  }
+
+  static func post(
+    sections: Set<DashboardSection>,
+    source: DashboardRefreshSource,
+    reason: String
+  ) async {
+    guard !sections.isEmpty else { return }
+
+    await DashboardRefreshCoordinator.shared.requestRefresh(
+      sections: sections,
+      source: source,
+      reason: reason
+    )
+  }
+
+  static func postAll(source: DashboardRefreshSource, reason: String) async {
+    await DashboardRefreshCoordinator.shared.requestRefresh(
+      sections: nil,
+      source: source,
+      reason: reason
+    )
+  }
+
+  @MainActor
+  static func postReload(command: DashboardSectionReloadCommand) {
+    var userInfo: [String: Any] = [
+      commandUserInfoKey: command,
+      sourceUserInfoKey: command.source,
+      reasonUserInfoKey: command.reason,
+    ]
+    if let sections = command.sections {
+      userInfo[sectionsUserInfoKey] = sections
+    }
+
+    NotificationCenter.default.post(
+      name: .dashboardSectionsShouldReload,
+      object: nil,
+      userInfo: userInfo
+    )
+  }
+
+  static func reloadCommand(from notification: Notification) -> DashboardSectionReloadCommand? {
+    if let command = notification.userInfo?[commandUserInfoKey] as? DashboardSectionReloadCommand {
+      return command
+    }
+
+    let source =
+      notification.userInfo?[sourceUserInfoKey] as? DashboardRefreshSource
+      ?? .auto
+    let reason =
+      notification.userInfo?[reasonUserInfoKey] as? String
+      ?? "Dashboard section reload"
+
+    if let sections = notification.userInfo?[sectionsUserInfoKey] as? Set<DashboardSection> {
+      return DashboardSectionReloadCommand(
+        id: UUID(),
+        source: source,
+        sections: sections,
+        reason: reason
+      )
+    }
+
+    return DashboardSectionReloadCommand(
+      id: UUID(),
+      source: source,
+      sections: nil,
+      reason: reason
+    )
+  }
+}

--- a/KMReader/Features/Dashboard/Models/DashboardSectionRefreshNotifier.swift
+++ b/KMReader/Features/Dashboard/Models/DashboardSectionRefreshNotifier.swift
@@ -16,7 +16,9 @@ nonisolated enum DashboardSectionRefreshNotifier {
   static let commandUserInfoKey = "command"
 
   static let bookContentSections: Set<DashboardSection> = [
+    .keepReading,
     .onDeck,
+    .recentlyReadBooks,
     .recentlyReleasedBooks,
     .recentlyAddedBooks,
   ]

--- a/KMReader/Features/Dashboard/Models/DashboardSectionReloadCommand.swift
+++ b/KMReader/Features/Dashboard/Models/DashboardSectionReloadCommand.swift
@@ -1,0 +1,17 @@
+//
+// DashboardSectionReloadCommand.swift
+//
+//
+
+import Foundation
+
+struct DashboardSectionReloadCommand: Equatable, Sendable {
+  let id: UUID
+  let source: DashboardRefreshSource
+  let sections: Set<DashboardSection>?
+  let reason: String
+
+  func includes(_ section: DashboardSection) -> Bool {
+    sections?.contains(section) ?? true
+  }
+}

--- a/KMReader/Features/Dashboard/Services/DashboardRefreshCoordinator.swift
+++ b/KMReader/Features/Dashboard/Services/DashboardRefreshCoordinator.swift
@@ -18,8 +18,11 @@ final class DashboardRefreshCoordinator {
   private var pendingAutoSections: Set<DashboardSection>?
   private var hasDeferredAutoRefresh = false
   private var deferredAutoSections: Set<DashboardSection>?
+  private var projectionObserverTasks: [Task<Void, Never>] = []
 
-  private init() {}
+  private init() {
+    startProjectionObservers()
+  }
 
   func configure(autoRefreshEnabled: Bool) {
     setAutoRefreshEnabled(autoRefreshEnabled)
@@ -194,6 +197,44 @@ final class DashboardRefreshCoordinator {
       sections: sections,
       reason: "Reader closed after deferred dashboard refresh",
       delay: 0
+    )
+  }
+
+  private func startProjectionObservers() {
+    observeProjection(
+      named: .bookProjectionDidChange,
+      sections: DashboardSectionRefreshNotifier.bookContentSections
+        .union(DashboardSectionRefreshNotifier.seriesContentSections),
+      reason: "Book projection changed"
+    )
+    observeProjection(
+      named: .seriesProjectionDidChange,
+      sections: DashboardSectionRefreshNotifier.seriesContentSections,
+      reason: "Series projection changed"
+    )
+    observeProjection(
+      named: .collectionProjectionDidChange,
+      sections: [.pinnedCollections],
+      reason: "Collection projection changed"
+    )
+    observeProjection(
+      named: .readListProjectionDidChange,
+      sections: [.pinnedReadLists],
+      reason: "Read list projection changed"
+    )
+  }
+
+  private func observeProjection(
+    named name: Notification.Name,
+    sections: Set<DashboardSection>,
+    reason: String
+  ) {
+    projectionObserverTasks.append(
+      Task { @MainActor [weak self] in
+        for await _ in NotificationCenter.default.notifications(named: name) {
+          self?.requestRefresh(sections: sections, source: .auto, reason: reason)
+        }
+      }
     )
   }
 }

--- a/KMReader/Features/Dashboard/Services/DashboardRefreshCoordinator.swift
+++ b/KMReader/Features/Dashboard/Services/DashboardRefreshCoordinator.swift
@@ -1,0 +1,199 @@
+//
+// DashboardRefreshCoordinator.swift
+//
+//
+
+import Foundation
+
+@MainActor
+final class DashboardRefreshCoordinator {
+  static let shared = DashboardRefreshCoordinator()
+
+  private let debounceInterval: TimeInterval = 5.0
+  private let logger = AppLogger(.dashboard)
+
+  private var isAutoRefreshEnabled = AppConfig.enableSSEAutoRefresh
+  private var activeReaderSessionID: UUID?
+  private var pendingAutoRefreshTask: Task<Void, Never>?
+  private var pendingAutoSections: Set<DashboardSection>?
+  private var hasDeferredAutoRefresh = false
+  private var deferredAutoSections: Set<DashboardSection>?
+
+  private init() {}
+
+  func configure(autoRefreshEnabled: Bool) {
+    setAutoRefreshEnabled(autoRefreshEnabled)
+  }
+
+  func setAutoRefreshEnabled(_ isEnabled: Bool) {
+    isAutoRefreshEnabled = isEnabled
+    guard !isEnabled else { return }
+
+    cancelPendingAutoRefresh(clearDeferred: true)
+  }
+
+  func readerDidOpen(sessionID: UUID) {
+    activeReaderSessionID = sessionID
+    movePendingAutoRefreshToDeferred()
+  }
+
+  func readerDidClose(sessionID: UUID) {
+    guard activeReaderSessionID == sessionID else { return }
+    activeReaderSessionID = nil
+    flushDeferredAutoRefresh()
+  }
+
+  func cancelPendingAutoRefresh(clearDeferred: Bool = false) {
+    pendingAutoRefreshTask?.cancel()
+    pendingAutoRefreshTask = nil
+    pendingAutoSections = nil
+
+    if clearDeferred {
+      hasDeferredAutoRefresh = false
+      deferredAutoSections = nil
+    }
+  }
+
+  func requestRefresh(
+    sections: Set<DashboardSection>?,
+    source: DashboardRefreshSource,
+    reason: String
+  ) {
+    switch source {
+    case .manual:
+      requestManualRefresh(sections: sections, reason: reason)
+    case .auto:
+      scheduleAutoRefresh(sections: sections, reason: reason)
+    }
+  }
+
+  private func requestManualRefresh(
+    sections: Set<DashboardSection>?,
+    reason: String
+  ) {
+    logger.debug("Dashboard manual refresh requested: \(reason)")
+    AppConfig.serverLastUpdate = Date()
+
+    if sections == nil {
+      cancelPendingAutoRefresh(clearDeferred: true)
+    }
+
+    DashboardSectionRefreshNotifier.postReload(
+      command: DashboardSectionReloadCommand(
+        id: UUID(),
+        source: .manual,
+        sections: sections,
+        reason: reason
+      )
+    )
+  }
+
+  private func scheduleAutoRefresh(
+    sections: Set<DashboardSection>?,
+    reason: String,
+    delay: TimeInterval? = nil
+  ) {
+    guard isAutoRefreshEnabled else { return }
+
+    logger.debug("Dashboard auto refresh scheduled: \(reason)")
+    AppConfig.serverLastUpdate = Date()
+
+    if activeReaderSessionID != nil {
+      mergeDeferredAutoSections(sections)
+      return
+    }
+
+    mergePendingAutoSections(sections)
+
+    pendingAutoRefreshTask?.cancel()
+    let refreshDelay = delay ?? debounceInterval
+    pendingAutoRefreshTask = Task { @MainActor in
+      if refreshDelay > 0 {
+        do {
+          try await Task.sleep(nanoseconds: UInt64(refreshDelay * 1_000_000_000))
+        } catch {
+          return
+        }
+      } else {
+        await Task.yield()
+      }
+
+      guard !Task.isCancelled else { return }
+      finishPendingAutoRefresh(reason: reason, refreshDelay: refreshDelay)
+    }
+  }
+
+  private func finishPendingAutoRefresh(reason: String, refreshDelay: TimeInterval) {
+    let sections = pendingAutoSections
+    pendingAutoRefreshTask = nil
+    pendingAutoSections = nil
+
+    if activeReaderSessionID != nil {
+      mergeDeferredAutoSections(sections)
+      return
+    }
+
+    AppConfig.serverLastUpdate = Date()
+    let refreshReason =
+      refreshDelay > 0 ? "Auto after debounce: \(reason)" : "Auto immediately: \(reason)"
+    logger.debug("Dashboard auto refresh executing: \(refreshReason)")
+    DashboardSectionRefreshNotifier.postReload(
+      command: DashboardSectionReloadCommand(
+        id: UUID(),
+        source: .auto,
+        sections: sections,
+        reason: refreshReason
+      )
+    )
+  }
+
+  private func mergePendingAutoSections(_ sections: Set<DashboardSection>?) {
+    if pendingAutoRefreshTask != nil, pendingAutoSections == nil {
+      return
+    }
+    guard let sections else {
+      pendingAutoSections = nil
+      return
+    }
+    if let existingSections = pendingAutoSections {
+      pendingAutoSections = existingSections.union(sections)
+    } else {
+      pendingAutoSections = sections
+    }
+  }
+
+  private func mergeDeferredAutoSections(_ sections: Set<DashboardSection>?) {
+    if hasDeferredAutoRefresh, deferredAutoSections == nil {
+      return
+    }
+    hasDeferredAutoRefresh = true
+    guard let sections else {
+      deferredAutoSections = nil
+      return
+    }
+    if let existingSections = deferredAutoSections {
+      deferredAutoSections = existingSections.union(sections)
+    } else {
+      deferredAutoSections = sections
+    }
+  }
+
+  private func movePendingAutoRefreshToDeferred() {
+    guard pendingAutoRefreshTask != nil else { return }
+    mergeDeferredAutoSections(pendingAutoSections)
+    cancelPendingAutoRefresh()
+    AppConfig.serverLastUpdate = Date()
+  }
+
+  private func flushDeferredAutoRefresh() {
+    guard hasDeferredAutoRefresh else { return }
+    let sections = deferredAutoSections
+    hasDeferredAutoRefresh = false
+    deferredAutoSections = nil
+    scheduleAutoRefresh(
+      sections: sections,
+      reason: "Reader closed after deferred dashboard refresh",
+      delay: 0
+    )
+  }
+}

--- a/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
@@ -8,7 +8,6 @@ import SwiftUI
 @MainActor
 struct DashboardPinnedSectionView: View {
   let section: DashboardSection
-  let refreshTrigger: DashboardRefreshTrigger
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
@@ -24,11 +23,6 @@ struct DashboardPinnedSectionView: View {
   @State private var isHoveringScrollArea = false
   @State private var hoverShowDelayTask: Task<Void, Never>?
   @State private var hoverHideDelayTask: Task<Void, Never>?
-
-  init(section: DashboardSection, refreshTrigger: DashboardRefreshTrigger) {
-    self.section = section
-    self.refreshTrigger = refreshTrigger
-  }
 
   private var isSupportedSection: Bool {
     switch section.contentKind {
@@ -211,8 +205,12 @@ struct DashboardPinnedSectionView: View {
           }
         }
       #endif
-      .onChange(of: refreshTrigger) { _, newTrigger in
-        if let sections = newTrigger.sectionsToRefresh, !sections.contains(section) {
+      .onReceive(NotificationCenter.default.publisher(for: .dashboardSectionsShouldReload)) {
+        notification in
+        guard
+          let command = DashboardSectionRefreshNotifier.reloadCommand(from: notification),
+          command.includes(section)
+        else {
           return
         }
         Task {

--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -5,21 +5,9 @@
 
 import SwiftUI
 
-enum DashboardRefreshSource {
-  case manual
-  case auto
-}
-
-struct DashboardRefreshTrigger: Equatable {
-  let id: UUID
-  let source: DashboardRefreshSource
-  var sectionsToRefresh: Set<DashboardSection>?  // nil means refresh all
-}
-
 @MainActor
 struct DashboardSectionView: View {
   let section: DashboardSection
-  let refreshTrigger: DashboardRefreshTrigger
 
   @AppStorage("dashboard") private var dashboard: DashboardConfiguration = DashboardConfiguration()
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
@@ -156,23 +144,12 @@ struct DashboardSectionView: View {
     #endif
     .opacity(pagination.isEmpty ? 0 : 1)
     .frame(height: pagination.isEmpty ? 0 : nil)
-    .onChange(of: refreshTrigger) { _, newTrigger in
-      // Skip if targeted refresh excludes this section
-      if let sections = newTrigger.sectionsToRefresh, !sections.contains(section) {
-        logger.debug("Dashboard section \(section) skipping refresh: targeted other sections")
+    .onReceive(NotificationCenter.default.publisher(for: .dashboardSectionsShouldReload)) {
+      notification in
+      guard let command = DashboardSectionRefreshNotifier.reloadCommand(from: notification) else {
         return
       }
-
-      if newTrigger.source == .auto, pagination.currentPage > 1 {
-        logger.debug(
-          "Dashboard section \(section) skipping auto-refresh: deep in pagination (page \(pagination.currentPage))"
-        )
-        return
-      }
-      Task {
-        logger.debug("Dashboard section \(section) refreshing")
-        await refresh()
-      }
+      handleReloadCommand(command)
     }
     .task {
       guard !hasLoadedInitial else { return }
@@ -203,6 +180,25 @@ struct DashboardSectionView: View {
   private func refresh() async {
     pagination.reset()
     await loadMore()
+  }
+
+  private func handleReloadCommand(_ command: DashboardSectionReloadCommand) {
+    guard command.includes(section) else {
+      logger.debug("Dashboard section \(section) skipping reload: targeted other sections")
+      return
+    }
+
+    if command.source == .auto, pagination.currentPage > 1 {
+      logger.debug(
+        "Dashboard section \(section) skipping auto-refresh: deep in pagination (page \(pagination.currentPage))"
+      )
+      return
+    }
+
+    Task {
+      logger.debug("Dashboard section \(section) reloading")
+      await refresh()
+    }
   }
 
   private func loadMore() async {

--- a/KMReader/Features/Dashboard/Views/DashboardView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardView.swift
@@ -3,18 +3,13 @@
 //
 //
 
-import Combine
-import OSLog
 import SwiftUI
 
 struct DashboardView: View {
   let authViewModel: AuthViewModel
   let readerPresentation: ReaderPresentationManager
-  @State private var refreshTrigger = DashboardRefreshTrigger(id: UUID(), source: .manual)
   @State private var isRefreshing = false
-  @State private var pendingRefreshTask: Task<Void, Never>?
   @State private var showLibraryPicker = false
-  @State private var shouldRefreshAfterReading = false
   @State private var isCheckingConnection = false
   @State private var offlineQueueingSections: Set<DashboardSection> = []
 
@@ -27,12 +22,7 @@ struct DashboardView: View {
 
   private let sseService = SSEService.shared
   private let sectionCacheStore = DashboardSectionCacheStore.shared
-  private let debounceInterval: TimeInterval = 5.0  // 5 seconds debounce
   private let logger = AppLogger(.dashboard)
-
-  private var isReaderActive: Bool {
-    readerPresentation.currentSession != nil
-  }
 
   private var gridDensityBinding: Binding<GridDensity> {
     Binding(
@@ -74,7 +64,9 @@ struct DashboardView: View {
             .disabled(isCheckingConnection)
           } else {
             Button {
-              refreshDashboard(reason: "Manual tvOS button")
+              Task {
+                await refreshDashboard(reason: "Manual tvOS button")
+              }
             } label: {
               Label("Refresh", systemImage: "arrow.clockwise")
             }
@@ -88,136 +80,36 @@ struct DashboardView: View {
     .padding()
   }
 
-  private func performRefresh(
-    reason: String,
-    source: DashboardRefreshSource,
-    sectionsToRefresh: Set<DashboardSection>? = nil
-  ) {
-    logger.debug("Dashboard refresh start: \(reason)")
-
-    Task {
-      if sectionsToRefresh == nil {
-        isRefreshing = true
-      }
-
-      refreshTrigger = DashboardRefreshTrigger(
-        id: UUID(),
-        source: source,
-        sectionsToRefresh: sectionsToRefresh
-      )
-
-      guard sectionsToRefresh == nil else { return }
-
-      defer { isRefreshing = false }
-      // Wait for 2 seconds to allow any pending refreshes to complete
-      try? await Task.sleep(nanoseconds: 2_000_000_000)  // 2 seconds
-    }
-  }
-
-  private func refreshSections(_ sections: Set<DashboardSection>, reason: String) {
-    performRefresh(
-      reason: "Dashboard partial refresh: \(reason)",
-      source: .manual,
-      sectionsToRefresh: sections
-    )
-  }
-
-  private func refreshDashboard(reason: String) {
+  @MainActor
+  private func refreshDashboard(reason: String) async {
     logger.debug("Dashboard refresh requested: \(reason)")
-
-    // Cancel any pending debounced refresh
-    pendingRefreshTask?.cancel()
-    pendingRefreshTask = nil
-    shouldRefreshAfterReading = false
 
     // Update last event time for manual refreshes
     AppConfig.serverLastUpdate = Date()
 
     // Check SSE connection status and reconnect if disconnected
     if enableSSE {
-      Task {
-        await SSEService.shared.connect()
-      }
+      await SSEService.shared.connect()
     }
 
-    // Perform refresh immediately
-    performRefresh(reason: reason, source: .manual)
-  }
-
-  private func scheduleRefresh(reason: String) {
-    // Skip if auto-refresh is disabled
-    guard enableSSEAutoRefresh else { return }
-
-    logger.debug("Dashboard auto-refresh scheduled: \(reason)")
-
-    // Cancel any existing pending refresh
-    pendingRefreshTask?.cancel()
-    pendingRefreshTask = nil
-
-    // Defer refresh while actively reading
-    if isReaderActive {
-      shouldRefreshAfterReading = true
-      AppConfig.serverLastUpdate = Date()
-      return
-    }
-
-    // Record latest event time immediately
-    AppConfig.serverLastUpdate = Date()
-
-    // Schedule a new refresh after debounce interval
-    // This ensures the last event will always trigger a refresh
-    pendingRefreshTask = Task {
-      do {
-        try await Task.sleep(nanoseconds: UInt64(debounceInterval * 1_000_000_000))
-      } catch {
-        // Task cancelled
-        return
-      }
-
-      // Check if task was cancelled
-      guard !Task.isCancelled else { return }
-
-      // Perform the refresh
-      if isReaderActive {
-        shouldRefreshAfterReading = true
-      } else {
-        logger.debug("Executing scheduled refresh: \(reason)")
-        performRefresh(reason: "Auto after debounce: \(reason)", source: .auto)
-      }
-      pendingRefreshTask = nil
-    }
+    isRefreshing = true
+    await DashboardSectionRefreshNotifier.postAll(source: .manual, reason: reason)
+    try? await Task.sleep(nanoseconds: 2_000_000_000)
+    isRefreshing = false
   }
 
   private func handleSSEEvent(_ info: SSEEventInfo) {
     switch info.type {
     case .libraryAdded, .libraryChanged, .libraryDeleted:
-      scheduleRefresh(reason: "SSE \(info.type.rawValue)")
+      Task {
+        await DashboardSectionRefreshNotifier.postAll(
+          source: .auto,
+          reason: "SSE \(info.type.rawValue)"
+        )
+      }
     default:
       break
     }
-  }
-
-  private func shouldRefreshForProjection(_ notification: Notification) -> Bool {
-    let selectedLibraryIds = Set(dashboard.libraryIds)
-    guard !selectedLibraryIds.isEmpty else { return true }
-
-    let changedLibraryIds = libraryIds(from: notification)
-    guard !changedLibraryIds.isEmpty else { return true }
-
-    return !changedLibraryIds.isDisjoint(with: selectedLibraryIds)
-  }
-
-  private func libraryIds(from notification: Notification) -> Set<String> {
-    if let ids = notification.userInfo?["libraryIds"] as? Set<String> {
-      return ids
-    }
-    if let ids = notification.userInfo?["libraryIds"] as? [String] {
-      return Set(ids)
-    }
-    if let id = notification.userInfo?["libraryId"] as? String {
-      return [id]
-    }
-    return []
   }
 
   var body: some View {
@@ -233,15 +125,9 @@ struct DashboardView: View {
 
         ForEach(dashboard.sections, id: \.id) { section in
           if section.isLocalSection {
-            DashboardPinnedSectionView(
-              section: section,
-              refreshTrigger: refreshTrigger
-            )
+            DashboardPinnedSectionView(section: section)
           } else {
-            DashboardSectionView(
-              section: section,
-              refreshTrigger: refreshTrigger
-            )
+            DashboardSectionView(section: section)
           }
         }
       }
@@ -253,60 +139,31 @@ struct DashboardView: View {
       // Refresh when server switch completes (transitions from switching to not switching)
       // This avoids race condition where refresh happens after logout but before new auth is ready
       if oldValue && !newValue {
-        refreshDashboard(reason: "Server switch completed")
+        Task {
+          await refreshDashboard(reason: "Server switch completed")
+        }
       }
     }
     .onChange(of: dashboard.libraryIds) { _, _ in
       // Skip during server switch - dedicated refresh happens when switch completes
       guard !authViewModel.isSwitching else { return }
       // Bypass auto-refresh setting for configuration changes
-      refreshDashboard(reason: "Library filter changed")
+      Task {
+        await refreshDashboard(reason: "Library filter changed")
+      }
       WidgetDataService.refreshWidgetData()
     }
-    .onDisappear {
-      // Cancel any pending refresh when view disappears
-      pendingRefreshTask?.cancel()
-      pendingRefreshTask = nil
-      shouldRefreshAfterReading = false
+    .task {
+      DashboardRefreshCoordinator.shared.configure(
+        autoRefreshEnabled: enableSSEAutoRefresh
+      )
     }
     .onReceive(NotificationCenter.default.publisher(for: .sseEventReceived)) { notification in
       guard let info = notification.userInfo?["info"] as? SSEEventInfo else { return }
       handleSSEEvent(info)
     }
-    .onReceive(NotificationCenter.default.publisher(for: .bookProjectionDidChange)) { notification in
-      guard shouldRefreshForProjection(notification) else { return }
-      scheduleRefresh(reason: "Local book projection")
-    }
-    .onReceive(NotificationCenter.default.publisher(for: .seriesProjectionDidChange)) { notification in
-      guard shouldRefreshForProjection(notification) else { return }
-      scheduleRefresh(reason: "Local series projection")
-    }
-    .onReceive(NotificationCenter.default.publisher(for: .collectionProjectionDidChange)) { _ in
-      scheduleRefresh(reason: "Local collection projection")
-    }
-    .onReceive(NotificationCenter.default.publisher(for: .readListProjectionDidChange)) { _ in
-      scheduleRefresh(reason: "Local read list projection")
-    }
     .onChange(of: enableSSEAutoRefresh) { _, newValue in
-      // Cancel any pending refresh when auto-refresh is disabled
-      if !newValue {
-        pendingRefreshTask?.cancel()
-        pendingRefreshTask = nil
-      }
-    }
-    .onChange(of: readerPresentation.currentSession) { _, newSession in
-      if newSession != nil {
-        if pendingRefreshTask != nil {
-          shouldRefreshAfterReading = true
-          AppConfig.serverLastUpdate = Date()
-        }
-        // Reader opened - cancel any pending dashboard refresh
-        pendingRefreshTask?.cancel()
-        pendingRefreshTask = nil
-      } else if shouldRefreshAfterReading {
-        shouldRefreshAfterReading = false
-        scheduleRefresh(reason: "Reader closed after deferred dashboard refresh")
-      }
+      DashboardRefreshCoordinator.shared.setAutoRefreshEnabled(newValue)
     }
     #if os(iOS) || os(macOS)
       .toolbar {
@@ -388,7 +245,9 @@ struct DashboardView: View {
               Divider()
 
               Button {
-                refreshDashboard(reason: "Manual toolbar button")
+                Task {
+                  await refreshDashboard(reason: "Manual toolbar button")
+                }
               } label: {
                 Label(String(localized: "Refresh Dashboard"), systemImage: "arrow.clockwise")
               }
@@ -407,7 +266,7 @@ struct DashboardView: View {
         }
       }
       .refreshable {
-        refreshDashboard(reason: "Pull to refresh")
+        await refreshDashboard(reason: "Pull to refresh")
       }
       .sheet(isPresented: $showLibraryPicker) {
         LibraryPickerSheet()
@@ -436,7 +295,7 @@ struct DashboardView: View {
     if reconnected {
       await sseService.connect()
       ErrorManager.shared.notify(message: String(localized: "settings.connection_restored"))
-      refreshDashboard(reason: "Reconnected")
+      await refreshDashboard(reason: "Reconnected")
     }
   }
 
@@ -516,9 +375,7 @@ struct DashboardView: View {
   private func enterOfflineMode() {
     guard !isOffline else { return }
 
-    pendingRefreshTask?.cancel()
-    pendingRefreshTask = nil
-    shouldRefreshAfterReading = false
+    DashboardRefreshCoordinator.shared.cancelPendingAutoRefresh(clearDeferred: true)
     AppConfig.enterManualOfflineMode()
 
     Task {

--- a/KMReader/Features/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailView.swift
@@ -217,6 +217,10 @@ struct OneshotDetailView: View {
           bookId: book.id,
           seriesId: seriesId
         )
+        await DashboardSectionRefreshNotifier.postReadStatusChanged(
+          source: .manual,
+          reason: "Book read status changed"
+        )
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedRead"))
         await refreshOneshotData()
       } catch {
@@ -234,6 +238,10 @@ struct OneshotDetailView: View {
         await ContentProjectionNotifier.postBookAndSeriesDidChange(
           bookId: book.id,
           seriesId: seriesId
+        )
+        await DashboardSectionRefreshNotifier.postReadStatusChanged(
+          source: .manual,
+          reason: "Book read status changed"
         )
         ErrorManager.shared.notify(message: String(localized: "notification.book.markedUnread"))
         await refreshOneshotData()

--- a/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
+++ b/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
@@ -85,6 +85,7 @@ final class ReaderPresentationManager {
     #endif
 
     ContentProjectionNotifier.readerDidOpen(sessionID: session.id)
+    DashboardRefreshCoordinator.shared.readerDidOpen(sessionID: session.id)
 
     #if os(iOS)
       ReaderLiveActivityManager.shared.readerDidOpen(book: book, incognito: incognito)
@@ -373,10 +374,17 @@ final class ReaderPresentationManager {
         )
       }
       await SyncService.syncVisitedItems(bookIds: bookIds, seriesIds: seriesIds)
+      if postsContentProjectionChange {
+        await DashboardSectionRefreshNotifier.postReadingProgressChanged(
+          source: .manual,
+          reason: "Reader closed after progress sync"
+        )
+      }
       WidgetDataService.refreshWidgetData()
       if endsReaderActivity {
         await MainActor.run {
           ContentProjectionNotifier.readerDidClose(sessionID: session.id)
+          DashboardRefreshCoordinator.shared.readerDidClose(sessionID: session.id)
         }
       }
     }
@@ -385,5 +393,6 @@ final class ReaderPresentationManager {
   private func finishReaderActivityIfNeeded(_ endsReaderActivity: Bool, sessionID: UUID) {
     guard endsReaderActivity else { return }
     ContentProjectionNotifier.readerDidClose(sessionID: sessionID)
+    DashboardRefreshCoordinator.shared.readerDidClose(sessionID: sessionID)
   }
 }

--- a/KMReader/Features/Series/Views/SeriesContextMenu.swift
+++ b/KMReader/Features/Series/Views/SeriesContextMenu.swift
@@ -245,6 +245,10 @@ struct SeriesContextMenu: View {
         _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
         try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
         await ContentProjectionNotifier.postSeriesBooksDidChange(seriesId: seriesId)
+        await DashboardSectionRefreshNotifier.postReadStatusChanged(
+          source: .manual,
+          reason: "Series read status changed"
+        )
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedRead"))
         onMutationCompleted?()
       } catch {
@@ -260,6 +264,10 @@ struct SeriesContextMenu: View {
         _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
         try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
         await ContentProjectionNotifier.postSeriesBooksDidChange(seriesId: seriesId)
+        await DashboardSectionRefreshNotifier.postReadStatusChanged(
+          source: .manual,
+          reason: "Series read status changed"
+        )
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedUnread"))
         onMutationCompleted?()
       } catch {

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -289,6 +289,10 @@ extension SeriesDetailView {
         _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
         try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
         await ContentProjectionNotifier.postSeriesBooksDidChange(seriesId: seriesId)
+        await DashboardSectionRefreshNotifier.postReadStatusChanged(
+          source: .manual,
+          reason: "Series read status changed"
+        )
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedRead"))
         await refreshSeriesData()
       } catch {
@@ -304,6 +308,10 @@ extension SeriesDetailView {
         _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
         try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
         await ContentProjectionNotifier.postSeriesBooksDidChange(seriesId: seriesId)
+        await DashboardSectionRefreshNotifier.postReadStatusChanged(
+          source: .manual,
+          reason: "Series read status changed"
+        )
         ErrorManager.shared.notify(message: String(localized: "notification.series.markedUnread"))
         await refreshSeriesData()
       } catch {

--- a/KMReader/Shared/Foundation/Services/ContentProjectionNotifier.swift
+++ b/KMReader/Shared/Foundation/Services/ContentProjectionNotifier.swift
@@ -14,7 +14,6 @@ extension Notification.Name {
 
 nonisolated enum ContentProjectionNotifier {
   static let localRefreshDelay: UInt64 = 750_000_000
-  static let remoteRefreshDelay: UInt64 = 5_000_000_000
 
   @MainActor private static var activeReaderSessionID: UUID?
   @MainActor private static var pendingFlushTask: Task<Void, Never>?
@@ -396,7 +395,6 @@ nonisolated enum ContentProjectionNotifier {
     for readListId in readListIds {
       postReadListNow(readListId)
     }
-
     schedulePendingFlush()
   }
 


### PR DESCRIPTION
Centralizes Dashboard refresh scheduling so high-frequency SSE events only request debounced section reloads, while manual reader-close and read-status changes bypass debounce after their local sync paths finish.

What changed:
- Move Dashboard auto refresh debounce and reader deferral into a dedicated coordinator.
- Let Dashboard sections subscribe to ready reload commands and refresh themselves.
- Keep SSE as Dashboard-only auto refresh requests; it no longer performs per-entity sync work.
- Preserve manual full refresh for toolbar/pull-to-refresh and manual section refresh for reader close/read status changes.

Validation:
- git diff --check
- make build
