### PR TITLE
feat(offline): add pull to refresh

### DIFF
--- a/KMReader/Features/Offline/Views/OfflineView.swift
+++ b/KMReader/Features/Offline/Views/OfflineView.swift
@@ -138,6 +138,9 @@ struct OfflineView: View {
     .inlineNavigationBarTitle(title)
     .searchable(text: $searchQuery)
     #if os(iOS) || os(macOS)
+      .refreshable {
+        await refreshOfflinePage()
+      }
       .toolbar {
         if librarySelection == nil {
           #if os(macOS)
@@ -358,6 +361,13 @@ struct OfflineView: View {
 
   private func refreshBrowse() {
     refreshTrigger = UUID()
+  }
+
+  private func refreshOfflinePage() async {
+    guard !authViewModel.isSwitching else { return }
+    latestReadHistoryTime = AppConfig.recentlyReadRecordTime(instanceId: current.instanceId)
+    refreshBrowse()
+    await loadSyncInfo()
   }
 
   private func loadSyncInfo() async {


### PR DESCRIPTION
## Summary

Adds native pull-to-refresh support to the Offline page on iOS and macOS. Pulling refreshes the current offline browse list and reloads the page-level sync/read-history metadata through the existing refresh path.

## Validation

- `git diff --check`
- `make build-ios`
- `make build-macos`
