### PR TITLE
fix(delete): refresh unavailable content projections

### DIFF
--- a/KMReader/Core/Storage/DatabaseOperator+Books.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Books.swift
@@ -313,6 +313,61 @@ extension DatabaseOperator {
     }
   }
 
+  @discardableResult
+  func markBookUnavailable(bookId: String, instanceId: String) -> Bool {
+    do {
+      return try write { db in
+        guard var book = try fetchBookRecord(db: db, id: bookId, instanceId: instanceId) else {
+          return false
+        }
+        guard !book.isUnavailable else { return true }
+        book.isUnavailable = true
+        try save(book, db: db)
+        return true
+      }
+    } catch {
+      logger.error("Failed to mark book unavailable: \(error)")
+      return false
+    }
+  }
+
+  func markSeriesBooksUnavailable(seriesId: String, instanceId: String) -> [String] {
+    do {
+      return try write { db in
+        let books = try fetchBooks(db: db, instanceId: instanceId, seriesId: seriesId)
+        var changedBookIds: [String] = []
+        for var book in books {
+          if !book.isUnavailable {
+            book.isUnavailable = true
+            try save(book, db: db)
+          }
+          changedBookIds.append(book.bookId)
+        }
+        return changedBookIds
+      }
+    } catch {
+      logger.error("Failed to mark series books unavailable: \(error)")
+      return []
+    }
+  }
+
+  func fetchAllSeriesBookIds(seriesId: String, instanceId: String) -> [String] {
+    guard !seriesId.isEmpty, !instanceId.isEmpty else { return [] }
+    return
+      (try? read { db in
+        try String.fetchAll(
+          db,
+          sql: """
+            SELECT book_id
+            FROM \(KomgaBook.databaseTableName)
+            WHERE instance_id = ? AND series_id = ?
+            ORDER BY meta_number_sort, id
+            """,
+          arguments: [instanceId, seriesId]
+        )
+      }) ?? []
+  }
+
   func upsertBooks(_ books: [Book], instanceId: String) {
     do {
       try write { db in

--- a/KMReader/Core/Storage/DatabaseOperator+Series.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Series.swift
@@ -144,6 +144,24 @@ extension DatabaseOperator {
     }
   }
 
+  @discardableResult
+  func markSeriesUnavailable(seriesId: String, instanceId: String) -> Bool {
+    do {
+      return try write { db in
+        guard var series = try fetchSeriesRecord(db: db, id: seriesId, instanceId: instanceId) else {
+          return false
+        }
+        guard !series.isUnavailable else { return true }
+        series.isUnavailable = true
+        try save(series, db: db)
+        return true
+      }
+    } catch {
+      logger.error("Failed to mark series unavailable: \(error)")
+      return false
+    }
+  }
+
   func upsertSeriesList(_ seriesList: [Series], instanceId: String) {
     do {
       try write { db in

--- a/KMReader/Features/Book/Services/BookDeletionService.swift
+++ b/KMReader/Features/Book/Services/BookDeletionService.swift
@@ -6,8 +6,6 @@
 import Foundation
 
 nonisolated enum BookDeletionService {
-  private static let logger = AppLogger(.api)
-
   static func deleteBook(_ item: BookDisplayItem) async throws {
     try await deleteBook(
       bookId: item.bookId,
@@ -44,34 +42,14 @@ nonisolated enum BookDeletionService {
 
     try await BookService.deleteBook(bookId: bookId)
 
-    let syncedBook = await syncDeletedBookProjection(bookId: bookId, instanceId: instanceId)
     await markBookUnavailable(bookId: bookId, instanceId: instanceId)
-    let resolvedSeriesId = syncedBook?.seriesId ?? scope.seriesId
-    let resolvedLibraryId = syncedBook?.libraryId ?? scope.libraryId
-
-    if let resolvedSeriesId {
-      _ = try? await SyncService.syncSeriesDetail(seriesId: resolvedSeriesId)
-    }
-
     await CacheManager.clearCache(forBookId: bookId)
     await ContentProjectionNotifier.postBookAndSeriesDidChange(
       bookId: bookId,
       instanceId: instanceId,
-      seriesId: resolvedSeriesId,
-      libraryId: resolvedLibraryId,
-      refreshDelay: 0
+      seriesId: scope.seriesId,
+      libraryId: scope.libraryId
     )
-  }
-
-  private static func syncDeletedBookProjection(bookId: String, instanceId: String) async -> Book? {
-    do {
-      return try await SyncService.syncBook(bookId: bookId)
-    } catch APIError.notFound {
-      return nil
-    } catch {
-      logger.error("Failed to sync deleted book projection: \(error)")
-      return nil
-    }
   }
 
   private static func markBookUnavailable(bookId: String, instanceId: String) async {

--- a/KMReader/Features/Book/Services/BookDeletionService.swift
+++ b/KMReader/Features/Book/Services/BookDeletionService.swift
@@ -1,0 +1,104 @@
+//
+// BookDeletionService.swift
+//
+//
+
+import Foundation
+
+nonisolated enum BookDeletionService {
+  private static let logger = AppLogger(.api)
+
+  static func deleteBook(_ item: BookDisplayItem) async throws {
+    try await deleteBook(
+      bookId: item.bookId,
+      instanceId: item.instanceId,
+      seriesId: item.seriesId,
+      libraryId: item.book.libraryId
+    )
+  }
+
+  static func deleteBook(
+    _ book: Book,
+    instanceId: String = AppConfig.current.instanceId
+  ) async throws {
+    try await deleteBook(
+      bookId: book.id,
+      instanceId: instanceId,
+      seriesId: book.seriesId,
+      libraryId: book.libraryId
+    )
+  }
+
+  static func deleteBook(
+    bookId: String,
+    instanceId: String = AppConfig.current.instanceId,
+    seriesId: String? = nil,
+    libraryId: String? = nil
+  ) async throws {
+    let scope = await resolveScope(
+      bookId: bookId,
+      instanceId: instanceId,
+      seriesId: seriesId,
+      libraryId: libraryId
+    )
+
+    try await BookService.deleteBook(bookId: bookId)
+
+    let syncedBook = await syncDeletedBookProjection(bookId: bookId, instanceId: instanceId)
+    await markBookUnavailable(bookId: bookId, instanceId: instanceId)
+    let resolvedSeriesId = syncedBook?.seriesId ?? scope.seriesId
+    let resolvedLibraryId = syncedBook?.libraryId ?? scope.libraryId
+
+    if let resolvedSeriesId {
+      _ = try? await SyncService.syncSeriesDetail(seriesId: resolvedSeriesId)
+    }
+
+    await CacheManager.clearCache(forBookId: bookId)
+    await ContentProjectionNotifier.postBookAndSeriesDidChange(
+      bookId: bookId,
+      instanceId: instanceId,
+      seriesId: resolvedSeriesId,
+      libraryId: resolvedLibraryId,
+      refreshDelay: 0
+    )
+  }
+
+  private static func syncDeletedBookProjection(bookId: String, instanceId: String) async -> Book? {
+    do {
+      return try await SyncService.syncBook(bookId: bookId)
+    } catch APIError.notFound {
+      return nil
+    } catch {
+      logger.error("Failed to sync deleted book projection: \(error)")
+      return nil
+    }
+  }
+
+  private static func markBookUnavailable(bookId: String, instanceId: String) async {
+    guard let database = try? await DatabaseOperator.database() else { return }
+    await database.markBookUnavailable(bookId: bookId, instanceId: instanceId)
+  }
+
+  private static func resolveScope(
+    bookId: String,
+    instanceId: String,
+    seriesId: String?,
+    libraryId: String?
+  ) async -> (seriesId: String?, libraryId: String?) {
+    if seriesId != nil, libraryId != nil {
+      return (seriesId, libraryId)
+    }
+
+    guard
+      let database = try? await DatabaseOperator.database(),
+      let item = try? await database.fetchBookDisplayItem(bookId: bookId, instanceId: instanceId)
+    else {
+      return (seriesId, libraryId)
+    }
+
+    return (
+      seriesId ?? item.seriesId,
+      libraryId ?? item.book.libraryId
+    )
+  }
+}

--- a/KMReader/Features/Book/Views/BookCardView.swift
+++ b/KMReader/Features/Book/Views/BookCardView.swift
@@ -256,8 +256,7 @@ struct BookCardView: View {
   private func deleteBook() {
     Task {
       do {
-        try await BookService.deleteBook(bookId: item.bookId)
-        await CacheManager.clearCache(forBookId: item.bookId)
+        try await BookDeletionService.deleteBook(item)
         ErrorManager.shared.notify(message: String(localized: "notification.book.deleted"))
         onMutationCompleted?()
       } catch {

--- a/KMReader/Features/Book/Views/BookDetailView.swift
+++ b/KMReader/Features/Book/Views/BookDetailView.swift
@@ -145,8 +145,11 @@ struct BookDetailView: View {
   private func deleteBook() {
     Task {
       do {
-        try await BookService.deleteBook(bookId: bookId)
-        await CacheManager.clearCache(forBookId: bookId)
+        if let book {
+          try await BookDeletionService.deleteBook(book, instanceId: current.instanceId)
+        } else {
+          try await BookDeletionService.deleteBook(bookId: bookId, instanceId: current.instanceId)
+        }
         ErrorManager.shared.notify(message: String(localized: "notification.book.deleted"))
         dismiss()
       } catch {

--- a/KMReader/Features/Book/Views/BookRowView.swift
+++ b/KMReader/Features/Book/Views/BookRowView.swift
@@ -197,8 +197,7 @@ struct BookRowView: View {
   private func deleteBook() {
     Task {
       do {
-        try await BookService.deleteBook(bookId: item.bookId)
-        await CacheManager.clearCache(forBookId: item.bookId)
+        try await BookDeletionService.deleteBook(item)
         ErrorManager.shared.notify(message: String(localized: "notification.book.deleted"))
         onMutationCompleted?()
       } catch {

--- a/KMReader/Features/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailView.swift
@@ -254,7 +254,14 @@ struct OneshotDetailView: View {
   private func deleteOneshot() {
     Task {
       do {
-        try await SeriesService.deleteSeries(seriesId: seriesId)
+        if let series = seriesItem?.series {
+          try await SeriesDeletionService.deleteSeries(series, instanceId: current.instanceId)
+        } else {
+          try await SeriesDeletionService.deleteSeries(
+            seriesId: seriesId,
+            instanceId: current.instanceId
+          )
+        }
         ErrorManager.shared.notify(message: String(localized: "notification.series.deleted"))
         dismiss()
       } catch {

--- a/KMReader/Features/Series/Services/SeriesDeletionService.swift
+++ b/KMReader/Features/Series/Services/SeriesDeletionService.swift
@@ -1,0 +1,118 @@
+//
+// SeriesDeletionService.swift
+//
+//
+
+import Foundation
+
+nonisolated enum SeriesDeletionService {
+  private static let logger = AppLogger(.api)
+
+  static func deleteSeries(_ item: SeriesDisplayItem) async throws {
+    try await deleteSeries(
+      seriesId: item.seriesId,
+      instanceId: item.instanceId,
+      libraryId: item.series.libraryId
+    )
+  }
+
+  static func deleteSeries(
+    _ series: Series,
+    instanceId: String = AppConfig.current.instanceId
+  ) async throws {
+    try await deleteSeries(
+      seriesId: series.id,
+      instanceId: instanceId,
+      libraryId: series.libraryId
+    )
+  }
+
+  static func deleteSeries(
+    seriesId: String,
+    instanceId: String = AppConfig.current.instanceId,
+    libraryId: String? = nil
+  ) async throws {
+    let resolvedLibraryId = await resolveLibraryId(
+      seriesId: seriesId,
+      instanceId: instanceId,
+      libraryId: libraryId
+    )
+
+    try await SeriesService.deleteSeries(seriesId: seriesId)
+
+    let syncedSeries = await syncDeletedSeriesProjection(seriesId: seriesId, instanceId: instanceId)
+    await syncDeletedSeriesBooks(seriesId: seriesId, instanceId: instanceId)
+    await markSeriesUnavailable(seriesId: seriesId, instanceId: instanceId)
+    let markedBookIds = await markSeriesBooksUnavailable(seriesId: seriesId, instanceId: instanceId)
+
+    let finalLibraryId = syncedSeries?.libraryId ?? resolvedLibraryId
+    let bookIds =
+      markedBookIds.isEmpty
+      ? await fetchSeriesBookIds(seriesId: seriesId, instanceId: instanceId)
+      : markedBookIds
+
+    await ContentProjectionNotifier.postBooksDidChange(
+      bookIds: bookIds,
+      libraryId: finalLibraryId,
+      refreshDelay: 0
+    )
+    await ContentProjectionNotifier.postSeriesDidChange(
+      seriesId: seriesId,
+      libraryId: finalLibraryId,
+      refreshDelay: 0
+    )
+  }
+
+  private static func syncDeletedSeriesProjection(seriesId: String, instanceId: String) async -> Series? {
+    do {
+      return try await SyncService.syncSeriesDetail(seriesId: seriesId)
+    } catch APIError.notFound {
+      return nil
+    } catch {
+      logger.error("Failed to sync deleted series projection: \(error)")
+      return nil
+    }
+  }
+
+  private static func syncDeletedSeriesBooks(seriesId: String, instanceId: String) async {
+    do {
+      try await SyncService.syncAllSeriesBooks(seriesId: seriesId)
+    } catch {
+      logger.error("Failed to sync deleted series books projection: \(error)")
+    }
+  }
+
+  private static func markSeriesUnavailable(seriesId: String, instanceId: String) async {
+    guard let database = try? await DatabaseOperator.database() else { return }
+    await database.markSeriesUnavailable(seriesId: seriesId, instanceId: instanceId)
+  }
+
+  private static func markSeriesBooksUnavailable(seriesId: String, instanceId: String) async -> [String] {
+    guard let database = try? await DatabaseOperator.database() else { return [] }
+    return await database.markSeriesBooksUnavailable(seriesId: seriesId, instanceId: instanceId)
+  }
+
+  private static func fetchSeriesBookIds(seriesId: String, instanceId: String) async -> [String] {
+    guard let database = try? await DatabaseOperator.database() else { return [] }
+    return await database.fetchAllSeriesBookIds(seriesId: seriesId, instanceId: instanceId)
+  }
+
+  private static func resolveLibraryId(
+    seriesId: String,
+    instanceId: String,
+    libraryId: String?
+  ) async -> String? {
+    if let libraryId {
+      return libraryId
+    }
+
+    guard
+      let database = try? await DatabaseOperator.database(),
+      let item = try? await database.fetchSeriesDisplayItem(seriesId: seriesId, instanceId: instanceId)
+    else {
+      return nil
+    }
+
+    return item.series.libraryId
+  }
+}

--- a/KMReader/Features/Series/Services/SeriesDeletionService.swift
+++ b/KMReader/Features/Series/Services/SeriesDeletionService.swift
@@ -6,8 +6,6 @@
 import Foundation
 
 nonisolated enum SeriesDeletionService {
-  private static let logger = AppLogger(.api)
-
   static func deleteSeries(_ item: SeriesDisplayItem) async throws {
     try await deleteSeries(
       seriesId: item.seriesId,
@@ -40,12 +38,9 @@ nonisolated enum SeriesDeletionService {
 
     try await SeriesService.deleteSeries(seriesId: seriesId)
 
-    let syncedSeries = await syncDeletedSeriesProjection(seriesId: seriesId, instanceId: instanceId)
-    await syncDeletedSeriesBooks(seriesId: seriesId, instanceId: instanceId)
     await markSeriesUnavailable(seriesId: seriesId, instanceId: instanceId)
     let markedBookIds = await markSeriesBooksUnavailable(seriesId: seriesId, instanceId: instanceId)
 
-    let finalLibraryId = syncedSeries?.libraryId ?? resolvedLibraryId
     let bookIds =
       markedBookIds.isEmpty
       ? await fetchSeriesBookIds(seriesId: seriesId, instanceId: instanceId)
@@ -53,33 +48,12 @@ nonisolated enum SeriesDeletionService {
 
     await ContentProjectionNotifier.postBooksDidChange(
       bookIds: bookIds,
-      libraryId: finalLibraryId,
-      refreshDelay: 0
+      libraryId: resolvedLibraryId
     )
     await ContentProjectionNotifier.postSeriesDidChange(
       seriesId: seriesId,
-      libraryId: finalLibraryId,
-      refreshDelay: 0
+      libraryId: resolvedLibraryId
     )
-  }
-
-  private static func syncDeletedSeriesProjection(seriesId: String, instanceId: String) async -> Series? {
-    do {
-      return try await SyncService.syncSeriesDetail(seriesId: seriesId)
-    } catch APIError.notFound {
-      return nil
-    } catch {
-      logger.error("Failed to sync deleted series projection: \(error)")
-      return nil
-    }
-  }
-
-  private static func syncDeletedSeriesBooks(seriesId: String, instanceId: String) async {
-    do {
-      try await SyncService.syncAllSeriesBooks(seriesId: seriesId)
-    } catch {
-      logger.error("Failed to sync deleted series books projection: \(error)")
-    }
   }
 
   private static func markSeriesUnavailable(seriesId: String, instanceId: String) async {

--- a/KMReader/Features/Series/Views/SeriesCardView.swift
+++ b/KMReader/Features/Series/Views/SeriesCardView.swift
@@ -194,7 +194,7 @@ struct SeriesCardView: View {
   private func deleteSeries() {
     Task {
       do {
-        try await SeriesService.deleteSeries(seriesId: item.seriesId)
+        try await SeriesDeletionService.deleteSeries(item)
         ErrorManager.shared.notify(message: String(localized: "notification.series.deleted"))
         onMutationCompleted?()
       } catch {

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -534,8 +534,14 @@ extension SeriesDetailView {
   private func shouldRefreshForBookProjection(_ notification: Notification) -> Bool {
     let changedIds = changedBookIds(from: notification)
     guard !changedIds.isEmpty else { return true }
-    guard let readingTargetBook = readingTargetBookForCurrentContext else { return true }
-    return changedIds.contains(readingTargetBook.id)
+    if let readingTargetBook = readingTargetBookForCurrentContext,
+      changedIds.contains(readingTargetBook.id)
+    {
+      return true
+    }
+    let visibleBookIds = Set(bookViewModel.pagination.items.map(\.id))
+    guard !visibleBookIds.isEmpty else { return true }
+    return !changedIds.isDisjoint(with: visibleBookIds)
   }
 
   private func shouldRefreshForSeriesProjection(_ notification: Notification) -> Bool {

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -28,6 +28,8 @@ struct SeriesDetailView: View {
   @State private var readingTargetIsOffline: Bool?
   @State private var isResolvingReadingTarget = false
   @State private var readingTargetResolutionID = 0
+  @AppStorage("seriesBookBrowseOptions") private var seriesBookBrowseOptions: BookBrowseOptions =
+    BookBrowseOptions()
 
   init(seriesId: String) {
     self.seriesId = seriesId
@@ -211,6 +213,7 @@ struct SeriesDetailView: View {
       guard shouldRefreshForSeriesProjection(notification) else { return }
       Task {
         await refreshLocalSeriesData()
+        await refreshSeriesBooks()
       }
     }
     .onReceive(NotificationCenter.default.publisher(for: .bookProjectionDidChange)) {
@@ -218,6 +221,7 @@ struct SeriesDetailView: View {
       guard shouldRefreshForBookProjection(notification) else { return }
       Task {
         await refreshLocalSeriesData()
+        await refreshSeriesBooks()
       }
     }
   }
@@ -243,6 +247,14 @@ extension SeriesDetailView {
   private func refreshLocalSeriesData() async {
     await loadLocalSeries()
     await refreshReadingTargetBook()
+  }
+
+  private func refreshSeriesBooks() async {
+    await bookViewModel.loadSeriesBooks(
+      seriesId: seriesId,
+      browseOpts: seriesBookBrowseOptions,
+      refresh: true
+    )
   }
 
   private func loadLocalSeries() async {
@@ -323,7 +335,14 @@ extension SeriesDetailView {
   private func deleteSeries() {
     Task {
       do {
-        try await SeriesService.deleteSeries(seriesId: seriesId)
+        if let series {
+          try await SeriesDeletionService.deleteSeries(series, instanceId: current.instanceId)
+        } else {
+          try await SeriesDeletionService.deleteSeries(
+            seriesId: seriesId,
+            instanceId: current.instanceId
+          )
+        }
         ErrorManager.shared.notify(message: String(localized: "notification.series.deleted"))
         dismiss()
       } catch {

--- a/KMReader/Features/Series/Views/SeriesRowView.swift
+++ b/KMReader/Features/Series/Views/SeriesRowView.swift
@@ -194,7 +194,7 @@ struct SeriesRowView: View {
   private func deleteSeries() {
     Task {
       do {
-        try await SeriesService.deleteSeries(seriesId: series.id)
+        try await SeriesDeletionService.deleteSeries(series, instanceId: item.instanceId)
         ErrorManager.shared.notify(message: String(localized: "notification.series.deleted"))
         onMutationCompleted?()
       } catch {


### PR DESCRIPTION
## Summary

Book and series file deletion now refreshes the local content projection without waiting for a manual refresh. The deletion coordinators keep the affected local book or series records marked unavailable in the deleting instance and emit scoped projection invalidations so browse lists, series details, and dashboard sections update after the mutation.

Series deletion also marks the locally known books under that series unavailable, since Komga treats those book files as unavailable as part of the same operation.

## Validation

- `git diff --check`
- `make build`
