### PR TITLE
fix(reader): preserve end page after offline preload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,11 @@ Version execution rules:
 - Do not edit `MARKETING_VERSION` or `CURRENT_PROJECT_VERSION` manually in `KMReader.xcodeproj/project.pbxproj`; use `make bump`, `make minor`, or `make major`.
 - `make minor` / `make major` increment `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` together and commit only the version file.
 - Feature or fix PRs may include one generated `make bump` commit when the change should produce a TestFlight or release-candidate build. This is the normal delivery flow and does not require a separate bump-only PR.
-- Keep the bump isolated as its own commit that only changes `KMReader.xcodeproj/project.pbxproj`. Do not fold the version change into a feature commit, and do not request its removal solely because it triggers publishing.
+- `make bump` isolation is a commit-level rule, not a PR-level rule. A single feature/fix PR may contain both:
+  - one feature/fix commit that changes app code and does not change `KMReader.xcodeproj/project.pbxproj`;
+  - one generated bump commit that changes only `KMReader.xcodeproj/project.pbxproj`.
+- It is expected that the aggregate GitHub PR diff shows both app-code files and `KMReader.xcodeproj/project.pbxproj` when the PR intentionally includes a bump commit. Do not request removing the bump, creating a separate bump-only PR, or treating the PR as invalid solely because the PR-level diff includes both kinds of files. Review the commit list before flagging bump isolation.
+- Do not fold the version change into a feature/fix commit. If the same commit changes `CURRENT_PROJECT_VERSION` and non-version files, split it or remove the bump from that commit.
 - Release automation treats build upload and GitHub Release creation separately:
   - Any `CURRENT_PROJECT_VERSION` change uploads the current HEAD build to App Store Connect. For feature/fix PRs with an intentional `make bump` commit, this upload is expected: the resulting build may be used for TestFlight or as the release build.
   - A major transition such as `4.14 -> 5.0` uploads the `5.0` build but does not create a GitHub Release.

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 479;
+				CURRENT_PROJECT_VERSION = 480;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 479;
+				CURRENT_PROJECT_VERSION = 480;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 479;
+				CURRENT_PROJECT_VERSION = 480;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 479;
+				CURRENT_PROJECT_VERSION = 480;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -638,10 +638,10 @@ class ReaderViewModel {
     return normalized >= 0 ? normalized : normalized + 360
   }
 
-  private func restoreCurrentPosition(using currentPageID: ReaderPageID?) {
-    guard currentPageID != nil else { return }
+  private func restoreCurrentPosition(using currentViewItem: ReaderViewItem?) {
+    guard let currentViewItem else { return }
     guard navigationTarget == nil else { return }
-    updateCurrentPosition(pageID: currentPageID)
+    requestNavigation(toViewItem: currentViewItem)
   }
 
   private func syncPageLoadSchedulerCurrentPage() {
@@ -700,7 +700,7 @@ class ReaderViewModel {
 
     await hydrateIsolatePages(for: nextBook.id)
     await hydratePageRotations(for: nextBook.id)
-    let currentPageID = currentReaderPage?.id
+    let currentViewItem = currentViewItem()
 
     appendSegment(
       currentBook: nextBook,
@@ -709,7 +709,7 @@ class ReaderViewModel {
       pages: fetchedPages
     )
     regenerateViewState()
-    restoreCurrentPosition(using: currentPageID)
+    restoreCurrentPosition(using: currentViewItem)
   }
 
   func preloadPreviousSegmentIfNeeded(
@@ -745,7 +745,7 @@ class ReaderViewModel {
 
     await hydrateIsolatePages(for: previousBook.id)
     await hydratePageRotations(for: previousBook.id)
-    let currentPageID = currentReaderPage?.id
+    let currentViewItem = currentViewItem()
 
     prependSegment(
       currentBook: previousBook,
@@ -754,7 +754,7 @@ class ReaderViewModel {
       pages: fetchedPages
     )
     regenerateViewState()
-    restoreCurrentPosition(using: currentPageID)
+    restoreCurrentPosition(using: currentViewItem)
   }
 
   func loadPages(

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -641,7 +641,7 @@ class ReaderViewModel {
   private func restoreCurrentPosition(using currentViewItem: ReaderViewItem?) {
     guard let currentViewItem else { return }
     guard navigationTarget == nil else { return }
-    requestNavigation(toViewItem: currentViewItem)
+    updateCurrentPosition(viewItem: currentViewItem)
   }
 
   private func syncPageLoadSchedulerCurrentPage() {


### PR DESCRIPTION
## Summary

This keeps the DIVINA reader anchored on the end page when offline-first adjacent-book preload finishes after the user has already reached the boundary.

The reader was preserving only the current page id while appending the newly downloaded next segment. End pages share the last content page id, so the rebuild resolved that id back to the final page instead of the end-page item. The fix preserves the current `ReaderViewItem` without publishing a command-style navigation target, allowing `.end(...)` to survive the segment rebuild while Webtoon reloads keep their existing scroll-offset restoration.

This also clarifies the repository version-management guidance: an intentional `make bump` is allowed in the same feature/fix PR, but it must remain isolated as its own commit that only changes `KMReader.xcodeproj/project.pbxproj`.

## User Impact

In cover/page mode with offline-first reading enabled, reaching the end page while the next book is still downloading no longer jumps back to the last page once that download completes. Webtoon readers avoid an unrelated scroll-to-page-top jump when adjacent segment preload completes during an offset-preserving reload.

## Validation

- `git diff --check`
- `make build`
