### PR TITLE
feat(reader): defer DIVINA PDF rendering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,12 +126,8 @@ make major              # Increment major version (MARKETING_VERSION)
 Version execution rules:
 - Do not edit `MARKETING_VERSION` or `CURRENT_PROJECT_VERSION` manually in `KMReader.xcodeproj/project.pbxproj`; use `make bump`, `make minor`, or `make major`.
 - `make minor` / `make major` increment `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` together and commit only the version file.
-- Feature or fix PRs may include one generated `make bump` commit when the change should produce a TestFlight or release-candidate build. This is the normal delivery flow and does not require a separate bump-only PR.
-- `make bump` isolation is a commit-level rule, not a PR-level rule. A single feature/fix PR may contain both:
-  - one feature/fix commit that changes app code and does not change `KMReader.xcodeproj/project.pbxproj`;
-  - one generated bump commit that changes only `KMReader.xcodeproj/project.pbxproj`.
-- It is expected that the aggregate GitHub PR diff shows both app-code files and `KMReader.xcodeproj/project.pbxproj` when the PR intentionally includes a bump commit. Do not request removing the bump, creating a separate bump-only PR, or treating the PR as invalid solely because the PR-level diff includes both kinds of files. Review the commit list before flagging bump isolation.
-- Do not fold the version change into a feature/fix commit. If the same commit changes `CURRENT_PROJECT_VERSION` and non-version files, split it or remove the bump from that commit.
+- Feature or fix PRs may include a generated `make bump` change when the change should produce a TestFlight or release-candidate build. This is the normal delivery flow and does not require a separate bump-only PR.
+- It is expected that the aggregate PR diff shows both app-code files and `KMReader.xcodeproj/project.pbxproj` when the PR intentionally includes a build-number bump. Do not request removing the bump, creating a separate bump-only PR, or treating the PR as invalid solely because the PR-level diff includes both kinds of files.
 - Release automation treats build upload and GitHub Release creation separately:
   - Any `CURRENT_PROJECT_VERSION` change uploads the current HEAD build to App Store Connect. For feature/fix PRs with an intentional `make bump` commit, this upload is expected: the resulting build may be used for TestFlight or as the release build.
   - A major transition such as `4.14 -> 5.0` uploads the `5.0` build but does not create a GitHub Release.

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 480;
+				CURRENT_PROJECT_VERSION = 481;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 480;
+				CURRENT_PROJECT_VERSION = 481;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 480;
+				CURRENT_PROJECT_VERSION = 481;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 480;
+				CURRENT_PROJECT_VERSION = 481;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/DatabaseOperator+Books.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Books.swift
@@ -561,8 +561,12 @@ extension DatabaseOperator {
   }
 
   func fetchPages(id: String) -> [BookPage]? {
+    fetchPages(id: id, instanceId: AppConfig.current.instanceId)
+  }
+
+  func fetchPages(id: String, instanceId: String) -> [BookPage]? {
     try? read { db in
-      try fetchBookRecord(db: db, id: id)?.pages
+      try fetchBookRecord(db: db, id: id, instanceId: instanceId)?.pages
     }
   }
 
@@ -625,19 +629,31 @@ extension DatabaseOperator {
   }
 
   func fetchTOC(id: String) -> [ReaderTOCEntry]? {
+    fetchTOC(id: id, instanceId: AppConfig.current.instanceId)
+  }
+
+  func fetchTOC(id: String, instanceId: String) -> [ReaderTOCEntry]? {
     try? read { db in
-      try fetchBookRecord(db: db, id: id)?.tableOfContents
+      try fetchBookRecord(db: db, id: id, instanceId: instanceId)?.tableOfContents
     }
   }
 
   func updateBookPages(bookId: String, pages: [BookPage]) {
-    updateBookRecord(bookId: bookId) { book in
+    updateBookPages(bookId: bookId, instanceId: AppConfig.current.instanceId, pages: pages)
+  }
+
+  func updateBookPages(bookId: String, instanceId: String, pages: [BookPage]) {
+    updateBookRecord(bookId: bookId, instanceId: instanceId) { book in
       book.pages = pages
     }
   }
 
   func updateBookTOC(bookId: String, toc: [ReaderTOCEntry]) {
-    updateBookRecord(bookId: bookId) { book in
+    updateBookTOC(bookId: bookId, instanceId: AppConfig.current.instanceId, toc: toc)
+  }
+
+  func updateBookTOC(bookId: String, instanceId: String, toc: [ReaderTOCEntry]) {
+    updateBookRecord(bookId: bookId, instanceId: instanceId) { book in
       book.tableOfContents = toc
     }
   }
@@ -710,9 +726,14 @@ extension DatabaseOperator {
   }
 
   func updateBookRecord(bookId: String, update: (inout KomgaBook) -> Void) {
+    updateBookRecord(bookId: bookId, instanceId: AppConfig.current.instanceId, update: update)
+  }
+
+  func updateBookRecord(bookId: String, instanceId: String, update: (inout KomgaBook) -> Void) {
+    guard !instanceId.isEmpty else { return }
     do {
       try write { db in
-        guard var book = try fetchBookRecord(db: db, id: bookId) else { return }
+        guard var book = try fetchBookRecord(db: db, id: bookId, instanceId: instanceId) else { return }
         update(&book)
         try save(book, db: db)
       }

--- a/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
@@ -454,7 +454,11 @@ extension DatabaseOperator {
 
 extension DatabaseOperator {
   func getDownloadStatus(bookId: String) -> DownloadStatus {
-    let instanceId = AppConfig.current.instanceId
+    getDownloadStatus(bookId: bookId, instanceId: AppConfig.current.instanceId)
+  }
+
+  func getDownloadStatus(bookId: String, instanceId: String) -> DownloadStatus {
+    guard !instanceId.isEmpty else { return .notDownloaded }
     return
       (try? read { db in
         try fetchBookRecord(db: db, id: bookId, instanceId: instanceId)?.downloadStatus

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -1459,29 +1459,6 @@ actor OfflineManager {
     }
   }
 
-  func clearOfflinePageImages(instanceId: String, bookId: String) async {
-    guard await isBookDownloaded(bookId: bookId, instanceId: instanceId) else { return }
-    let dir = bookDirectory(instanceId: instanceId, bookId: bookId)
-
-    guard
-      let fileURLs = try? FileManager.default.contentsOfDirectory(
-        at: dir,
-        includingPropertiesForKeys: nil,
-        options: [.skipsHiddenFiles]
-      )
-    else {
-      return
-    }
-
-    for fileURL in fileURLs where fileURL.lastPathComponent.hasPrefix("page-") {
-      do {
-        try FileManager.default.removeItem(at: fileURL)
-      } catch {
-        logger.error("❌ Failed to remove offline page asset \(fileURL.lastPathComponent): \(error)")
-      }
-    }
-  }
-
   func refreshDownloadedBookSize(instanceId: String, bookId: String) async {
     guard await isBookDownloaded(bookId: bookId, instanceId: instanceId) else { return }
     let bookDir = bookDirectory(instanceId: instanceId, bookId: bookId)

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -2475,7 +2475,7 @@ actor OfflineManager {
     let preferredExtension = page.detectedUTType?.preferredFilenameExtension?.lowercased() ?? "jpg"
     let fallbackExtension = (page.fileName as NSString).pathExtension.lowercased()
     let extensions =
-      ([preferredExtension, fallbackExtension].filter { !$0.isEmpty } + ["jpg"])
+      ([preferredExtension, fallbackExtension].filter { !$0.isEmpty } + ["png", "jpg"])
       .reduce(into: [String]()) { result, fileExtension in
         if !result.contains(fileExtension) {
           result.append(fileExtension)

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -298,12 +298,20 @@ actor OfflineManager {
 
   /// Get the download status of a book from the local database.
   func getDownloadStatus(bookId: String) async -> DownloadStatus {
-    (try? await DatabaseOperator.database().getDownloadStatus(bookId: bookId)) ?? .notDownloaded
+    await getDownloadStatus(bookId: bookId, instanceId: AppConfig.current.instanceId)
+  }
+
+  func getDownloadStatus(bookId: String, instanceId: String) async -> DownloadStatus {
+    (try? await DatabaseOperator.database().getDownloadStatus(bookId: bookId, instanceId: instanceId)) ?? .notDownloaded
   }
 
   /// Check if a book is downloaded.
   func isBookDownloaded(bookId: String) async -> Bool {
-    if case .downloaded = await getDownloadStatus(bookId: bookId) {
+    await isBookDownloaded(bookId: bookId, instanceId: AppConfig.current.instanceId)
+  }
+
+  func isBookDownloaded(bookId: String, instanceId: String) async -> Bool {
+    if case .downloaded = await getDownloadStatus(bookId: bookId, instanceId: instanceId) {
       return true
     }
     return false
@@ -1356,17 +1364,18 @@ actor OfflineManager {
   func getOfflinePageImageURL(
     instanceId: String, bookId: String, pageNumber: Int, fileExtension: String
   ) async -> URL? {
-    guard await isBookDownloaded(bookId: bookId) else { return nil }
+    guard await isBookDownloaded(bookId: bookId, instanceId: instanceId) else { return nil }
     let dir = bookDirectory(instanceId: instanceId, bookId: bookId)
 
     let file = dir.appendingPathComponent("page-\(pageNumber).\(fileExtension)")
     if FileManager.default.fileExists(atPath: file.path) {
       return file
     }
-    if let database = try? await DatabaseOperator.database(),
-      let page = await database.fetchPages(id: bookId)?.first(where: { $0.number == pageNumber })
-    {
-      return await getOfflinePageImageURL(instanceId: instanceId, bookId: bookId, page: page)
+    if let database = try? await DatabaseOperator.database() {
+      let pages = await database.fetchPages(id: bookId, instanceId: instanceId)
+      if let page = pages?.first(where: { $0.number == pageNumber }) {
+        return await getOfflinePageImageURL(instanceId: instanceId, bookId: bookId, page: page)
+      }
     }
     return nil
   }
@@ -1374,7 +1383,7 @@ actor OfflineManager {
   func getOfflinePageImageURL(
     instanceId: String, bookId: String, page: BookPage
   ) async -> URL? {
-    guard await isBookDownloaded(bookId: bookId) else { return nil }
+    guard await isBookDownloaded(bookId: bookId, instanceId: instanceId) else { return nil }
     let dir = bookDirectory(instanceId: instanceId, bookId: bookId)
 
     for file in offlinePageImageFileURLs(bookDir: dir, page: page) {
@@ -1414,7 +1423,7 @@ actor OfflineManager {
     data: Data,
     replaceExisting: Bool = false
   ) async -> URL? {
-    guard await isBookDownloaded(bookId: bookId) else { return nil }
+    guard await isBookDownloaded(bookId: bookId, instanceId: instanceId) else { return nil }
     let dir = bookDirectory(instanceId: instanceId, bookId: bookId)
     let file = dir.appendingPathComponent("page-\(pageNumber).\(fileExtension)")
 
@@ -1433,8 +1442,25 @@ actor OfflineManager {
     }
   }
 
+  func clearOfflinePageImageDerivatives(instanceId: String, bookId: String, pageNumber: Int) async {
+    guard await isBookDownloaded(bookId: bookId, instanceId: instanceId) else { return }
+    let dir = bookDirectory(instanceId: instanceId, bookId: bookId)
+    let baseName = "page-\(pageNumber)@2x"
+    let candidates = ["png", "jpg", "jpeg"].map { fileExtension in
+      dir.appendingPathComponent(baseName).appendingPathExtension(fileExtension)
+    }
+
+    for fileURL in candidates where FileManager.default.fileExists(atPath: fileURL.path) {
+      do {
+        try FileManager.default.removeItem(at: fileURL)
+      } catch {
+        logger.error("❌ Failed to remove offline page derivative \(fileURL.lastPathComponent): \(error)")
+      }
+    }
+  }
+
   func clearOfflinePageImages(instanceId: String, bookId: String) async {
-    guard await isBookDownloaded(bookId: bookId) else { return }
+    guard await isBookDownloaded(bookId: bookId, instanceId: instanceId) else { return }
     let dir = bookDirectory(instanceId: instanceId, bookId: bookId)
 
     guard
@@ -1457,7 +1483,7 @@ actor OfflineManager {
   }
 
   func refreshDownloadedBookSize(instanceId: String, bookId: String) async {
-    guard await isBookDownloaded(bookId: bookId) else { return }
+    guard await isBookDownloaded(bookId: bookId, instanceId: instanceId) else { return }
     let bookDir = bookDirectory(instanceId: instanceId, bookId: bookId)
     guard let size = try? Self.calculateDirectorySize(bookDir) else { return }
 
@@ -1471,7 +1497,7 @@ actor OfflineManager {
   }
 
   func readOfflinePDFPreparationStamp(instanceId: String, bookId: String) async -> String? {
-    guard await isBookDownloaded(bookId: bookId) else { return nil }
+    guard await isBookDownloaded(bookId: bookId, instanceId: instanceId) else { return nil }
     let file = bookDirectory(instanceId: instanceId, bookId: bookId).appendingPathComponent(
       Self.pdfPreparationStampFileName
     )
@@ -1482,7 +1508,7 @@ actor OfflineManager {
   }
 
   func writeOfflinePDFPreparationStamp(instanceId: String, bookId: String, stamp: String) async {
-    guard await isBookDownloaded(bookId: bookId) else { return }
+    guard await isBookDownloaded(bookId: bookId, instanceId: instanceId) else { return }
     let file = bookDirectory(instanceId: instanceId, bookId: bookId).appendingPathComponent(
       Self.pdfPreparationStampFileName
     )
@@ -1504,7 +1530,7 @@ actor OfflineManager {
   }
 
   func getOfflinePDFURL(instanceId: String, bookId: String) async -> URL? {
-    guard await isBookDownloaded(bookId: bookId) else { return nil }
+    guard await isBookDownloaded(bookId: bookId, instanceId: instanceId) else { return nil }
     let file = bookDirectory(instanceId: instanceId, bookId: bookId).appendingPathComponent(
       Self.pdfFileName
     )

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -1411,18 +1411,19 @@ actor OfflineManager {
     bookId: String,
     pageNumber: Int,
     fileExtension: String,
-    data: Data
+    data: Data,
+    replaceExisting: Bool = false
   ) async -> URL? {
     guard await isBookDownloaded(bookId: bookId) else { return nil }
     let dir = bookDirectory(instanceId: instanceId, bookId: bookId)
     let file = dir.appendingPathComponent("page-\(pageNumber).\(fileExtension)")
 
-    if FileManager.default.fileExists(atPath: file.path) {
+    if FileManager.default.fileExists(atPath: file.path), !replaceExisting {
       return file
     }
 
     do {
-      try data.write(to: file)
+      try data.write(to: file, options: .atomic)
       Self.excludeFromBackupIfNeeded(at: file)
       return file
     } catch {

--- a/KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift
+++ b/KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift
@@ -393,6 +393,13 @@ actor PdfOfflinePreparationService {
             data: pageData.data,
             replaceExisting: forceRerenderImages
           ) != nil {
+            if forceRerenderImages {
+              await OfflineManager.shared.clearOfflinePageImageDerivatives(
+                instanceId: instanceId,
+                bookId: bookId,
+                pageNumber: pageNumber
+              )
+            }
             renderedImageCount += 1
           } else {
             skippedImageCount += 1

--- a/KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift
+++ b/KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift
@@ -28,6 +28,7 @@ actor PdfOfflinePreparationService {
     let renderedImageCount: Int
     let reusedImageCount: Int
     let skippedImageCount: Int
+    let rerenderedImages: Bool
   }
 
   struct MetadataResult: Sendable {
@@ -141,7 +142,7 @@ actor PdfOfflinePreparationService {
         instanceId: instanceId,
         bookId: bookId,
         documentURL: documentURL,
-        forceRerenderImages: existingStamp != nil && existingStamp != completionFlag,
+        forceRerenderImages: existingStamp != completionFlag,
         renderQuality: renderQuality,
         onProgress: onProgress
       )
@@ -276,7 +277,8 @@ actor PdfOfflinePreparationService {
             tableOfContents: [],
             renderedImageCount: 0,
             reusedImageCount: 0,
-            skippedImageCount: 0
+            skippedImageCount: 0,
+            rerenderedImages: false
           )
         }
 
@@ -385,14 +387,15 @@ actor PdfOfflinePreparationService {
           )
           pages.append(bookPage)
 
-          if await OfflineManager.shared.storeOfflinePageImage(
+          let storedURL = await OfflineManager.shared.storeOfflinePageImage(
             instanceId: instanceId,
             bookId: bookId,
             pageNumber: pageNumber,
             fileExtension: "png",
             data: pageData.data,
             replaceExisting: forceRerenderImages
-          ) != nil {
+          )
+          if storedURL != nil {
             if forceRerenderImages {
               await OfflineManager.shared.clearOfflinePageImageDerivatives(
                 instanceId: instanceId,
@@ -414,7 +417,8 @@ actor PdfOfflinePreparationService {
           tableOfContents: toc,
           renderedImageCount: renderedImageCount,
           reusedImageCount: reusedImageCount,
-          skippedImageCount: skippedImageCount
+          skippedImageCount: skippedImageCount,
+          rerenderedImages: forceRerenderImages && renderedImageCount > 0
         )
       }.value
     }

--- a/KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift
+++ b/KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift
@@ -141,7 +141,7 @@ actor PdfOfflinePreparationService {
         instanceId: instanceId,
         bookId: bookId,
         documentURL: documentURL,
-        forceRerenderImages: existingStamp != completionFlag,
+        forceRerenderImages: existingStamp != nil && existingStamp != completionFlag,
         renderQuality: renderQuality,
         onProgress: onProgress
       )
@@ -303,10 +303,6 @@ actor PdfOfflinePreparationService {
             )
           }
 
-        if forceRerenderImages {
-          await OfflineManager.shared.clearOfflinePageImages(instanceId: instanceId, bookId: bookId)
-        }
-
         await reportProgress(0, renderedImageCount, reusedImageCount, skippedImageCount)
 
         for pageIndex in 0..<totalPages {
@@ -335,12 +331,14 @@ actor PdfOfflinePreparationService {
 
           let fallbackPixelSize = targetPixelSize(for: pdfPage, renderQuality: renderQuality)
 
-          if let offlineURL = await OfflineManager.shared.getOfflinePageImageURL(
-            instanceId: instanceId,
-            bookId: bookId,
-            pageNumber: pageNumber,
-            fileExtension: "png"
-          ) {
+          if !forceRerenderImages,
+            let offlineURL = await OfflineManager.shared.getOfflinePageImageURL(
+              instanceId: instanceId,
+              bookId: bookId,
+              pageNumber: pageNumber,
+              fileExtension: "png"
+            )
+          {
             let existingPixelSize = imagePixelSize(at: offlineURL) ?? fallbackPixelSize
             let bookPage = BookPage(
               number: pageNumber,
@@ -392,7 +390,8 @@ actor PdfOfflinePreparationService {
             bookId: bookId,
             pageNumber: pageNumber,
             fileExtension: "png",
-            data: pageData.data
+            data: pageData.data,
+            replaceExisting: forceRerenderImages
           ) != nil {
             renderedImageCount += 1
           } else {

--- a/KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift
+++ b/KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift
@@ -30,6 +30,11 @@ actor PdfOfflinePreparationService {
     let skippedImageCount: Int
   }
 
+  struct MetadataResult: Sendable {
+    let pages: [BookPage]
+    let tableOfContents: [ReaderTOCEntry]
+  }
+
   struct PreparationProgress: Sendable {
     let completedPages: Int
     let totalPages: Int
@@ -49,8 +54,58 @@ actor PdfOfflinePreparationService {
 
   private let logger = AppLogger(.reader)
   private var preparationTasks: [String: Task<PreparationResult?, Never>] = [:]
+  private var pageRenderTasks: [String: Task<URL?, Never>] = [:]
 
   private init() {}
+
+  func loadMetadata(
+    documentURL: URL
+  ) async -> MetadataResult? {
+    let renderQuality = AppConfig.pdfOfflineRenderQuality
+    return await Self.loadDocumentMetadata(
+      documentURL: documentURL,
+      renderQuality: renderQuality
+    )
+  }
+
+  func renderPageIfNeeded(
+    instanceId: String,
+    bookId: String,
+    documentURL: URL,
+    pageNumber: Int
+  ) async -> URL? {
+    guard pageNumber > 0 else { return nil }
+
+    if let existingURL = await OfflineManager.shared.getOfflinePageImageURL(
+      instanceId: instanceId,
+      bookId: bookId,
+      pageNumber: pageNumber,
+      fileExtension: "png"
+    ) {
+      return existingURL
+    }
+
+    let taskKey = "\(instanceId)|\(bookId)|\(pageNumber)"
+    if let existingTask = pageRenderTasks[taskKey] {
+      return await existingTask.value
+    }
+
+    let renderQuality = AppConfig.pdfOfflineRenderQuality
+    let task = Task(priority: .userInitiated) {
+      await Self.renderSinglePage(
+        instanceId: instanceId,
+        bookId: bookId,
+        documentURL: documentURL,
+        pageNumber: pageNumber,
+        renderQuality: renderQuality
+      )
+    }
+
+    pageRenderTasks[taskKey] = task
+    let result = await task.value
+    pageRenderTasks.removeValue(forKey: taskKey)
+    return result
+  }
 
   func prepare(
     instanceId: String,
@@ -124,6 +179,83 @@ actor PdfOfflinePreparationService {
   }
 
   #if os(iOS) || os(macOS)
+    nonisolated private static func loadDocumentMetadata(
+      documentURL: URL,
+      renderQuality: PdfOfflineRenderQuality
+    ) async -> MetadataResult? {
+      await Task.detached(priority: .userInitiated) {
+        guard let document = PDFDocument(url: documentURL) else {
+          return nil
+        }
+
+        let totalPages = document.pageCount
+        guard totalPages > 0 else {
+          return MetadataResult(pages: [], tableOfContents: [])
+        }
+
+        var pages: [BookPage] = []
+        pages.reserveCapacity(totalPages)
+
+        for pageIndex in 0..<totalPages {
+          let pageNumber = pageIndex + 1
+          let pixelSize = document.page(at: pageIndex).flatMap {
+            targetPixelSize(for: $0, renderQuality: renderQuality)
+          }
+          pages.append(
+            BookPage(
+              number: pageNumber,
+              fileName: "page-\(pageNumber).png",
+              mediaType: "image/png",
+              width: pixelSize.map { Int($0.width) },
+              height: pixelSize.map { Int($0.height) },
+              sizeBytes: nil,
+              size: "",
+              downloadURL: nil
+            )
+          )
+        }
+
+        return MetadataResult(
+          pages: pages,
+          tableOfContents: buildTableOfContents(from: document)
+        )
+      }.value
+    }
+
+    nonisolated private static func renderSinglePage(
+      instanceId: String,
+      bookId: String,
+      documentURL: URL,
+      pageNumber: Int,
+      renderQuality: PdfOfflineRenderQuality
+    ) async -> URL? {
+      await Task.detached(priority: .userInitiated) {
+        if let existingURL = await OfflineManager.shared.getOfflinePageImageURL(
+          instanceId: instanceId,
+          bookId: bookId,
+          pageNumber: pageNumber,
+          fileExtension: "png"
+        ) {
+          return existingURL
+        }
+
+        guard let document = PDFDocument(url: documentURL),
+          let page = document.page(at: pageNumber - 1),
+          let pageData = renderPageData(page: page, renderQuality: renderQuality)
+        else {
+          return nil
+        }
+
+        return await OfflineManager.shared.storeOfflinePageImage(
+          instanceId: instanceId,
+          bookId: bookId,
+          pageNumber: pageNumber,
+          fileExtension: "png",
+          data: pageData.data
+        )
+      }.value
+    }
+
     nonisolated private static func prepareDocument(
       instanceId: String,
       bookId: String,
@@ -455,6 +587,23 @@ actor PdfOfflinePreparationService {
       return String.localizedStringWithFormat(format, pageNumber)
     }
   #else
+    nonisolated private static func loadDocumentMetadata(
+      documentURL _: URL,
+      renderQuality _: PdfOfflineRenderQuality
+    ) async -> MetadataResult? {
+      nil
+    }
+
+    nonisolated private static func renderSinglePage(
+      instanceId _: String,
+      bookId _: String,
+      documentURL _: URL,
+      pageNumber _: Int,
+      renderQuality _: PdfOfflineRenderQuality
+    ) async -> URL? {
+      nil
+    }
+
     nonisolated private static func prepareDocument(
       instanceId _: String,
       bookId _: String,

--- a/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
+++ b/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
@@ -450,6 +450,21 @@ final class ReaderPageLoadScheduler {
         return cachedFileURL
       }
 
+      if let offlinePDFURL = await OfflineManager.shared.getOfflinePDFURL(
+        instanceId: AppConfig.current.instanceId,
+        bookId: currentBookId
+      ) {
+        if let renderedURL = await PdfOfflinePreparationService.shared.renderPageIfNeeded(
+          instanceId: AppConfig.current.instanceId,
+          bookId: currentBookId,
+          documentURL: offlinePDFURL,
+          pageNumber: page.number
+        ) {
+          self.logger.debug("✅ Rendered PDF page \(page.number) on demand for book \(currentBookId)")
+          return renderedURL
+        }
+      }
+
       if AppConfig.isOffline {
         self.logger.error("❌ Missing offline page \(page.number) for book \(currentBookId)")
         return nil

--- a/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
+++ b/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
@@ -303,6 +303,27 @@ final class ReaderPageLoadScheduler {
     logger.debug("🗑️ Cleared all preloaded images and cancelled tasks")
   }
 
+  func discardPreloadedImages(forBookId bookId: String) {
+    let pageIDs = Set(readerPages.lazy.filter { $0.bookId == bookId }.map(\.id))
+    guard !pageIDs.isEmpty else { return }
+
+    cancelTrackedURLTasks(&upscalingTasks, matching: pageIDs)
+    cancelTrackedImageTasks(&preloadingImageTasks, matching: pageIDs)
+
+    var removedImageCount = 0
+    for pageID in pageIDs {
+      if preloadedImagesByID.removeValue(forKey: pageID) != nil {
+        removedImageCount += 1
+      }
+      animatedPageStates.removeValue(forKey: pageID)
+      animatedPageSourceFileURLs.removeValue(forKey: pageID)
+    }
+
+    logger.debug(
+      "🗑️ Discarded preloaded images for book \(bookId): pages=\(pageIDs.count), removed=\(removedImageCount)"
+    )
+  }
+
   func resetForBookLoad() {
     clearPreloadedImages()
     readerPages.removeAll()
@@ -395,12 +416,34 @@ final class ReaderPageLoadScheduler {
     }
   }
 
+  private func cancelTrackedURLTasks(
+    _ tasks: inout [ReaderPageID: URLLoadTaskRecord],
+    matching pageIDs: Set<ReaderPageID>
+  ) {
+    let matchedPageIDs = tasks.keys.filter { pageIDs.contains($0) }
+    for pageID in matchedPageIDs {
+      tasks[pageID]?.task.cancel()
+      tasks.removeValue(forKey: pageID)
+    }
+  }
+
   private func cancelTrackedImageTasksOutsideWindow(
     _ tasks: inout [ReaderPageID: ImageLoadTaskRecord],
     keeping keepPageIDs: Set<ReaderPageID>
   ) {
     let stalePageIDs = tasks.keys.filter { !keepPageIDs.contains($0) }
     for pageID in stalePageIDs {
+      tasks[pageID]?.task.cancel()
+      tasks.removeValue(forKey: pageID)
+    }
+  }
+
+  private func cancelTrackedImageTasks(
+    _ tasks: inout [ReaderPageID: ImageLoadTaskRecord],
+    matching pageIDs: Set<ReaderPageID>
+  ) {
+    let matchedPageIDs = tasks.keys.filter { pageIDs.contains($0) }
+    for pageID in matchedPageIDs {
       tasks[pageID]?.task.cancel()
       tasks.removeValue(forKey: pageID)
     }

--- a/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
+++ b/KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift
@@ -450,12 +450,13 @@ final class ReaderPageLoadScheduler {
         return cachedFileURL
       }
 
+      let instanceId = AppConfig.current.instanceId
       if let offlinePDFURL = await OfflineManager.shared.getOfflinePDFURL(
-        instanceId: AppConfig.current.instanceId,
+        instanceId: instanceId,
         bookId: currentBookId
       ) {
         if let renderedURL = await PdfOfflinePreparationService.shared.renderPageIfNeeded(
-          instanceId: AppConfig.current.instanceId,
+          instanceId: instanceId,
           bookId: currentBookId,
           documentURL: offlinePDFURL,
           pageNumber: page.number

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -59,6 +59,10 @@ class ReaderViewModel {
   private let pageLoadScheduler: ReaderPageLoadScheduler
   private var bookMediaProfile: MediaProfile = .unknown
 
+  private static func pdfPreparationTaskKey(instanceId: String, bookId: String) -> String {
+    CompositeID.generate(instanceId: instanceId, id: bookId)
+  }
+
   private var readerPageIndexByID: [ReaderPageID: Int] = [:]
   private var segmentPageRangeByBookId: [String: Range<Int>] = [:]
   private(set) var readerPagesVersion: Int = 0
@@ -914,8 +918,8 @@ class ReaderViewModel {
     }
 
     let database = await DatabaseOperator.databaseIfConfigured()
-    let localPages = await database?.fetchPages(id: book.id)
-    let localTOC = await database?.fetchTOC(id: book.id)
+    let localPages = await database?.fetchPages(id: book.id, instanceId: instanceId)
+    let localTOC = await database?.fetchTOC(id: book.id, instanceId: instanceId)
     let hasLocalPages = !(localPages ?? []).isEmpty
     let hasLocalTOC = localTOC != nil
     guard !hasLocalPages || !hasLocalTOC else { return }
@@ -937,10 +941,10 @@ class ReaderViewModel {
     }
 
     if !hasLocalPages {
-      await database?.updateBookPages(bookId: book.id, pages: metadata.pages)
+      await database?.updateBookPages(bookId: book.id, instanceId: instanceId, pages: metadata.pages)
     }
     if !hasLocalTOC {
-      await database?.updateBookTOC(bookId: book.id, toc: metadata.tableOfContents)
+      await database?.updateBookTOC(bookId: book.id, instanceId: instanceId, toc: metadata.tableOfContents)
     }
   }
 
@@ -948,13 +952,15 @@ class ReaderViewModel {
     guard bookMediaProfile == .pdf else {
       return
     }
-    guard pdfPreparationTasks[book.id] == nil else { return }
 
     let instanceId = AppConfig.current.instanceId
-    pdfPreparationTasks[book.id] = Task { [weak self] in
+    let taskKey = Self.pdfPreparationTaskKey(instanceId: instanceId, bookId: book.id)
+    guard pdfPreparationTasks[taskKey] == nil else { return }
+
+    pdfPreparationTasks[taskKey] = Task { [weak self] in
       guard let self else { return }
       await self.prepareOfflinePDFForDivinaInBackground(book: book, instanceId: instanceId)
-      self.pdfPreparationTasks[book.id] = nil
+      self.pdfPreparationTasks[taskKey] = nil
     }
   }
 
@@ -976,8 +982,8 @@ class ReaderViewModel {
     }
 
     let database = await DatabaseOperator.databaseIfConfigured()
-    let localPages = await database?.fetchPages(id: book.id)
-    let localTOC = await database?.fetchTOC(id: book.id)
+    let localPages = await database?.fetchPages(id: book.id, instanceId: instanceId)
+    let localTOC = await database?.fetchTOC(id: book.id, instanceId: instanceId)
     let hasLocalPages = !(localPages ?? []).isEmpty
     let hasLocalTOC = localTOC != nil
     let forceRebuildMetadata = !hasLocalPages || !hasLocalTOC
@@ -1042,11 +1048,9 @@ class ReaderViewModel {
     )
 
     if let database = await DatabaseOperator.databaseIfConfigured() {
-      await database.updateBookPages(bookId: bookId, pages: result.pages)
-      await database.updateBookTOC(bookId: bookId, toc: result.tableOfContents)
+      await database.updateBookPages(bookId: bookId, instanceId: instanceId, pages: result.pages)
+      await database.updateBookTOC(bookId: bookId, instanceId: instanceId, toc: result.tableOfContents)
     }
-    replaceLoadedSegmentPages(bookId: bookId, pages: result.pages)
-    updateLoadedTableOfContents(bookId: bookId, tableOfContents: result.tableOfContents)
     if result.renderedImageCount > 0 {
       await OfflineManager.shared.refreshDownloadedBookSize(
         instanceId: instanceId,
@@ -1055,6 +1059,16 @@ class ReaderViewModel {
     } else {
       logger.debug("⏭️ Skip downloaded size refresh for book \(bookId) because no new PDF page was rendered")
     }
+
+    guard AppConfig.current.instanceId == instanceId else {
+      logger.debug(
+        "⏭️ Skip applying prepared PDF metadata to visible reader because active instance changed for book \(bookId)"
+      )
+      return
+    }
+
+    replaceLoadedSegmentPages(bookId: bookId, pages: result.pages)
+    updateLoadedTableOfContents(bookId: bookId, tableOfContents: result.tableOfContents)
 
     logger.debug(
       "✅ Applied prepared PDF metadata for book \(bookId), rendered=\(result.renderedImageCount), reused=\(result.reusedImageCount), skipped=\(result.skippedImageCount)"

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -1067,6 +1067,10 @@ class ReaderViewModel {
       return
     }
 
+    if result.rerenderedImages {
+      pageLoadScheduler.discardPreloadedImages(forBookId: bookId)
+    }
+
     replaceLoadedSegmentPages(bookId: bookId, pages: result.pages)
     updateLoadedTableOfContents(bookId: bookId, tableOfContents: result.tableOfContents)
 

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -38,6 +38,8 @@ class ReaderViewModel {
   typealias PagePresentationInvalidationHandler = @MainActor (ReaderPagePresentationInvalidation) -> Void
   @ObservationIgnored
   private var pagePresentationInvalidationHandlers: [UUID: PagePresentationInvalidationHandler] = [:]
+  @ObservationIgnored
+  private var pdfPreparationTasks: [String: Task<Void, Never>] = [:]
 
   private enum SegmentFetchPurpose {
     case nextPreload
@@ -775,7 +777,7 @@ class ReaderViewModel {
       if AppConfig.offlineFirstReading {
         try await ensureOfflineReady(book: book, updatesLoadingState: true)
       }
-      await prepareOfflinePDFForDivina(book: book)
+      await ensureOfflinePDFMetadataForDivina(book: book)
       let database = await DatabaseOperator.databaseIfConfigured()
 
       let fetchedPages: [BookPage]
@@ -811,6 +813,7 @@ class ReaderViewModel {
       // Update page pairs and dual page indices after loading pages
       regenerateViewState()
       await ensureTableOfContentsLoaded(for: book)
+      startBackgroundOfflinePDFPreparationIfNeeded(book: book)
     } catch {
       ErrorManager.shared.alert(error: error)
     }
@@ -894,16 +897,77 @@ class ReaderViewModel {
     }
   }
 
-  private func prepareOfflinePDFForDivina(book: Book) async {
+  private func ensureOfflinePDFMetadataForDivina(book: Book) async {
     guard bookMediaProfile == .pdf else {
       return
     }
 
-    logger.debug("🧪 Preparing offline PDF metadata for Divina, book \(book.id)")
+    let instanceId = AppConfig.current.instanceId
+    guard
+      let offlinePDFURL = await OfflineManager.shared.getOfflinePDFURL(
+        instanceId: instanceId,
+        bookId: book.id
+      )
+    else {
+      logger.debug("⏭️ Skip offline PDF preparation because offline PDF file is missing for book \(book.id)")
+      return
+    }
+
+    let database = await DatabaseOperator.databaseIfConfigured()
+    let localPages = await database?.fetchPages(id: book.id)
+    let localTOC = await database?.fetchTOC(id: book.id)
+    let hasLocalPages = !(localPages ?? []).isEmpty
+    let hasLocalTOC = localTOC != nil
+    guard !hasLocalPages || !hasLocalTOC else { return }
+
+    updateLoadingTitle(String(localized: "Preparing PDF..."))
+    updateLoadingDetail(String(localized: "Checking PDF download information"))
+
+    logger.debug(
+      "🧪 Loading PDF metadata for DIVINA reader, book \(book.id), hasPages=\(hasLocalPages), hasTOC=\(hasLocalTOC)"
+    )
+
+    guard
+      let metadata = await PdfOfflinePreparationService.shared.loadMetadata(
+        documentURL: offlinePDFURL
+      )
+    else {
+      logger.debug("⏭️ Skip PDF metadata load because local PDF cannot be opened for book \(book.id)")
+      return
+    }
+
+    if !hasLocalPages {
+      await database?.updateBookPages(bookId: book.id, pages: metadata.pages)
+    }
+    if !hasLocalTOC {
+      await database?.updateBookTOC(bookId: book.id, toc: metadata.tableOfContents)
+    }
+  }
+
+  private func startBackgroundOfflinePDFPreparationIfNeeded(book: Book) {
+    guard bookMediaProfile == .pdf else {
+      return
+    }
+    guard pdfPreparationTasks[book.id] == nil else { return }
+
+    let instanceId = AppConfig.current.instanceId
+    pdfPreparationTasks[book.id] = Task { [weak self] in
+      guard let self else { return }
+      await self.prepareOfflinePDFForDivinaInBackground(book: book, instanceId: instanceId)
+      self.pdfPreparationTasks[book.id] = nil
+    }
+  }
+
+  private func prepareOfflinePDFForDivinaInBackground(book: Book, instanceId: String) async {
+    guard bookMediaProfile == .pdf else {
+      return
+    }
+
+    logger.debug("🧪 Preparing offline PDF assets for DIVINA reader, book \(book.id)")
 
     guard
       let offlinePDFURL = await OfflineManager.shared.getOfflinePDFURL(
-        instanceId: AppConfig.current.instanceId,
+        instanceId: instanceId,
         bookId: book.id
       )
     else {
@@ -923,34 +987,19 @@ class ReaderViewModel {
       )
     }
 
-    updateLoadingTitle(String(localized: "Offline DIVINA Rendering"))
-    updateLoadingDetail(String(localized: "Rendering PDF pages for DIVINA reader"))
-    clearLoadingProgress()
-    defer {
-      updateLoadingTitle(String(localized: "Loading book..."))
-      updateLoadingDetail(String(localized: "Resolving page metadata"))
-      clearLoadingProgress()
-    }
-
     guard
       let result = await PdfOfflinePreparationService.shared.prepare(
-        instanceId: AppConfig.current.instanceId,
+        instanceId: instanceId,
         bookId: book.id,
         documentURL: offlinePDFURL,
-        forceRebuildMetadata: forceRebuildMetadata,
-        onProgress: { [weak self] progress in
-          guard let self else { return }
-          self.updateLoadingTitle(String(localized: "Offline DIVINA Rendering"))
-          self.updateLoadingProgress(progress.fractionCompleted)
-          self.updateLoadingDetail("\(progress.completedPages) / \(progress.totalPages)")
-        }
+        forceRebuildMetadata: forceRebuildMetadata
       )
     else {
       logger.debug("⏭️ Skip offline PDF preparation because assets are already valid for book \(book.id)")
       return
     }
 
-    await applyPreparedPDFMetadata(bookId: book.id, result: result)
+    await applyPreparedPDFMetadata(bookId: book.id, instanceId: instanceId, result: result)
   }
 
   private func updateLoadingTitle(_ title: String) {
@@ -985,6 +1034,7 @@ class ReaderViewModel {
 
   private func applyPreparedPDFMetadata(
     bookId: String,
+    instanceId: String,
     result: PdfOfflinePreparationService.PreparationResult
   ) async {
     logger.debug(
@@ -995,9 +1045,11 @@ class ReaderViewModel {
       await database.updateBookPages(bookId: bookId, pages: result.pages)
       await database.updateBookTOC(bookId: bookId, toc: result.tableOfContents)
     }
+    replaceLoadedSegmentPages(bookId: bookId, pages: result.pages)
+    updateLoadedTableOfContents(bookId: bookId, tableOfContents: result.tableOfContents)
     if result.renderedImageCount > 0 {
       await OfflineManager.shared.refreshDownloadedBookSize(
-        instanceId: AppConfig.current.instanceId,
+        instanceId: instanceId,
         bookId: bookId
       )
     } else {
@@ -1007,6 +1059,34 @@ class ReaderViewModel {
     logger.debug(
       "✅ Applied prepared PDF metadata for book \(bookId), rendered=\(result.renderedImageCount), reused=\(result.reusedImageCount), skipped=\(result.skippedImageCount)"
     )
+  }
+
+  private func replaceLoadedSegmentPages(bookId: String, pages: [BookPage]) {
+    guard !pages.isEmpty else { return }
+    guard let segmentIndex = segmentIndex(forSegmentBookId: bookId) else { return }
+
+    let segment = segments[segmentIndex]
+    let currentItem = currentViewItem()
+    segments[segmentIndex] = ReaderSegment(
+      previousBook: segment.previousBook,
+      currentBook: segment.currentBook,
+      nextBook: segment.nextBook,
+      pages: pages
+    )
+    rebuildReaderPages()
+    regenerateViewState()
+    restoreCurrentPosition(using: currentItem)
+    notifyPagePresentationInvalidation(.all)
+  }
+
+  private func updateLoadedTableOfContents(
+    bookId: String,
+    tableOfContents: [ReaderTOCEntry]
+  ) {
+    tableOfContentsByBookId[bookId] = tableOfContents
+    if activeBookId == bookId || tableOfContentsBookId == bookId {
+      setTableOfContents(tableOfContents, for: bookId)
+    }
   }
 
   func preloadPages(bypassThrottle: Bool = false) async {


### PR DESCRIPTION
## Summary

This changes downloaded PDFs opened with the DIVINA reader so the reader can enter after lightweight PDF metadata preparation instead of waiting for the full Offline DIVINA Rendering pass.

Missing page images are materialized on demand from the local PDF, similar to archive-backed page materialization, while the full PDF asset preparation continues in the background and refreshes the loaded reader segment when it finishes. The loading copy now uses the existing PDF preparation strings during metadata resolution.

Follow-up review fixes stabilize on-demand rendering across server switches, scope background PDF result persistence to the captured instance, avoid deleting page PNGs that may already be in use by the reader, rerender unstamped PDF page images before writing the current quality stamp, clear stale upscaled derivatives during PDF rerenders, drop decoded reader images after rerendering, remove the obsolete bulk page-image clearing helper, and clarify that a feature/fix PR may intentionally include a generated build-number bump.

Refs #864

## Validation

- `swift-format -i KMReader/Features/Reader/ViewModels/ReaderViewModel.swift`
- `swift-format -i KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift KMReader/Features/Reader/ViewModels/ReaderViewModel.swift KMReader/Features/Offline/Services/OfflineManager.swift`
- `swift-format -i KMReader/Features/Offline/Services/OfflineManager.swift KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift`
- `swift-format -i KMReader/Core/Storage/DatabaseOperator+Books.swift KMReader/Core/Storage/DatabaseOperator+Metadata.swift KMReader/Features/Offline/Services/OfflineManager.swift KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift KMReader/Features/Reader/ViewModels/ReaderViewModel.swift`
- `swift-format -i KMReader/Features/Reader/Services/PdfOfflinePreparationService.swift KMReader/Features/Reader/Services/ReaderPageLoadScheduler.swift KMReader/Features/Reader/ViewModels/ReaderViewModel.swift`
- `swift-format -i KMReader/Features/Offline/Services/OfflineManager.swift`
- `git diff --check`
- `make build`
