### PR TITLE
docs: refresh 5.1 store copy

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,16 +1,16 @@
 New
-- KMReader 5.0 rebuilds local library storage around a dedicated database, improving reliability for large libraries, browsing, dashboards, and offline data.
-- Added EPUB overlay customization for reading progress, controls, headers, and footers.
-- Added smarter offline archive handling so downloaded books stay compact and pages are prepared on demand when reading.
+- Protect saved Komga servers with device authentication, so private libraries stay hidden until you unlock them.
+- Add offline download policies for read lists, matching the existing series policy workflow.
+- Add a floating reading action bar on series pages that shows the exact book and progress target before opening the reader.
 
 Improvements
-- Reader loading states are clearer and more stable, with smoother progress updates and less visual flicker while downloads or page preparation are running.
-- The in-app logs viewer now uses paginated storage, making settings logs easier to browse on long-running installs.
-- Offline download status, read progress lists, and one-shot read summaries refresh more reliably across browsing and detail screens.
-- EPUB theme color scheme choices now persist per book.
+- Offline downloaded sections now show clearer book counts alongside storage usage.
+- Offline pages can be refreshed with pull to refresh on iOS and macOS.
+- Downloaded PDFs open faster in DIVINA mode by preparing lightweight metadata first and rendering page images as needed.
+- Dashboard sections now better match Komga web UI behavior and stay current after local reading, deletion, and offline changes.
+- Reader overlays and tap handling are smoother, with fewer abrupt transitions during loading, keyboard help, zoom, and long-press interactions.
 
 Fixes
-- Fixed several reader loading edge cases around unknown download sizes, render progress, and background color transitions.
-- Fixed stale read progress or download indicators after reading, syncing, or returning from detail pages.
-- Fixed one-shot read status and summary placement in series views.
-- Fixed assorted reader control, keyboard, zoom, and tap-zone regressions.
+- Fixed end-page selection after offline preloading, especially for Webtoon reading.
+- Fixed unavailable book and series indicators after deleting local files.
+- Fixed stale dashboard and progress projections after reader close or server events.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -13,10 +13,10 @@ Use Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/
 KMReader keeps a local database for responsive browsing, dashboards, logs, and downloaded-library workflows, including large libraries.
 
 - Offline and sync
-Download books for offline reading, set per-series download policies, browse downloaded items, queue dashboard sections, keep reading with iOS background downloads and Live Activities, prepare local pages on demand with offline-first reading, and sync progress when you reconnect.
+Download books for offline reading, set per-series and per-read-list download policies, browse downloaded items with count and storage summaries, queue dashboard sections, keep reading with iOS background downloads and Live Activities, prepare local pages on demand with offline-first reading, and sync progress when you reconnect.
 
 - Multi-server and admin tools
-Save multiple Komga servers and switch instantly.
+Save multiple Komga servers, protect private servers with device authentication, and switch instantly.
 Sign in with password or API key, and manage API keys in the app.
 Edit metadata, manage libraries and media, find missing posters or duplicates, monitor tasks, and browse paginated logs.
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@
 ### Offline and Sync
 
 - Download books for offline reading across DIVINA, EPUB, and PDF workflows, with optional offline-first reading that prepares local content before opening the reader.
-- Per-series policies support manual, unread-only, unread + cleanup, and all-books downloads.
+- Per-series and per-read-list policies support manual, unread-only, unread + cleanup, and all-books downloads.
+- Downloaded library sections show book counts alongside storage usage, with pull-to-refresh support on iOS and macOS.
 - Large downloads stream to disk, while CBZ, CBR, PDF, and supported EPUB offline flows keep source files available and prepare pages on demand.
 - Progress and offline changes sync when reconnecting, with stale progress protection and automatic recovery from server outages when offline mode was entered automatically. Cache controls cover pages and thumbnails.
 - iOS background downloads and Live Activities show reader progress, incognito status, download progress, and processing state.
 
 ### Multi-Server and Management
 
-- Save multiple Komga servers and switch instantly.
+- Save multiple Komga servers, protect private servers with device authentication, and switch instantly.
 - Sign in with username/password or API key, and manage Komga API keys inside the app.
 - Admin tools cover metadata editing, library management, media analysis, missing posters, duplicate files/pages, task monitoring, and paginated log viewing/export.
 

--- a/static/index.html
+++ b/static/index.html
@@ -29,8 +29,8 @@
                     Read, download, browse, and manage your Komga library with
                     native DIVINA, EPUB, and PDF readers, Webtoon and spread
                     layouts, reader image processing, reliable local storage,
-                    offline-first reading, dashboard download actions, advanced
-                    filtering, multi-server support, and Apple-platform integrations
+                    offline-first reading, dashboard download actions, protected
+                    servers, advanced filtering, multi-server support, and Apple-platform integrations
                     on iPhone, iPad, Mac, and Apple TV.
                 </p>
                 <div class="cta">
@@ -111,9 +111,10 @@
                         <h3>Download and keep reading anywhere</h3>
                         <p>
                             Download books for offline reading, set per-series
-                            download policies, prepare local content before the
-                            reader opens, prepare pages on demand, browse
-                            downloaded items, use iOS background downloads and
+                            and per-read-list download policies, prepare local
+                            content before the reader opens, prepare pages on
+                            demand, browse downloaded items with count and
+                            storage summaries, use iOS background downloads and
                             Live Activities, and sync progress when you reconnect.
                         </p>
                     </article>
@@ -132,9 +133,10 @@
                         <span class="pill">Multi-Server</span>
                         <h3>Switch Komga servers quickly</h3>
                         <p>
-                            Save multiple Komga servers and switch quickly.
-                            Sign in with username/password or API key, and
-                            manage API keys directly in KMReader.
+                            Save multiple Komga servers, protect private servers
+                            with device authentication, and switch quickly. Sign
+                            in with username/password or API key, and manage API
+                            keys directly in KMReader.
                         </p>
                     </article>
                     <article class="card">
@@ -208,8 +210,9 @@
                         <h4>Can I use multiple Komga servers?</h4>
                         <p>
                             Yes. You can save and switch between multiple
-                            servers, authenticate with password or API key, and
-                            manage API keys in the app.
+                            servers, protect private servers with device
+                            authentication, authenticate with password or API
+                            key, and manage API keys in the app.
                         </p>
                     </article>
                     <article class="faq-item">
@@ -217,9 +220,9 @@
                         <p>
                             Downloaded books stay readable offline, offline-first
                             reading can keep source files available and prepare
-                            pages on demand, per-series policies help decide
-                            what stays on device, and reading progress syncs
-                            when you reconnect.
+                            pages on demand, per-series and per-read-list
+                            policies help decide what stays on device, and
+                            reading progress syncs when you reconnect.
                         </p>
                     </article>
                     <article class="faq-item">


### PR DESCRIPTION
## Problem
The public documentation and App Store release copy need to match the 5.1 release.

## Approach
Refresh README, App Store description, landing page copy, and App Store changelog from the current user-visible product changes.

## Validation
- [x] Reviewed v5.0-to-HEAD commits
- [x] Ran git diff --check
