### PR TITLE
fix(offline): stabilize post-download finalization

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 484;
+				CURRENT_PROJECT_VERSION = 485;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 484;
+				CURRENT_PROJECT_VERSION = 485;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 484;
+				CURRENT_PROJECT_VERSION = 485;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 484;
+				CURRENT_PROJECT_VERSION = 485;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/DatabaseOperator+Offline.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Offline.swift
@@ -83,7 +83,8 @@ extension DatabaseOperator {
           metaNumber: book.metaNumber,
           metaTitle: book.metaTitle,
           downloadStatusRaw: book.downloadStatusRaw,
-          downloadStatus: book.downloadStatus
+          downloadStatus: book.downloadStatus,
+          contentKind: book.downloadContentKind
         )
       }
     }

--- a/KMReader/Features/Book/Models/KomgaBook.swift
+++ b/KMReader/Features/Book/Models/KomgaBook.swift
@@ -189,6 +189,46 @@ nonisolated extension KomgaBook {
     }
   }
 
+  var downloadContentKind: DownloadContentKind {
+    if let archiveFormat = downloadedImageArchiveFormat {
+      return .archiveImages(archiveFormat)
+    }
+
+    switch mediaProfile.flatMap(MediaProfile.init(rawValue:)) ?? .unknown {
+    case .pdf:
+      return .pdf
+    case .epub:
+      let isDivinaCompatible = media?.epubDivinaCompatible ?? false
+      return isDivinaCompatible ? .epubDivina : .epubWebPub
+    case .divina, .unknown:
+      return .pages
+    }
+  }
+
+  private var downloadedImageArchiveFormat: DownloadedImageArchiveFormat? {
+    if let urlExtension = URL(string: url)?.pathExtension.lowercased(),
+      let archiveFormat = DownloadedImageArchiveFormat(fileExtension: urlExtension)
+    {
+      return archiveFormat
+    }
+
+    let mediaType = media?.mediaType
+      .split(separator: ";")
+      .first?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
+
+    switch mediaType {
+    case "application/vnd.comicbook+zip", "application/x-cbz", "application/zip":
+      return .cbz
+    case "application/vnd.comicbook-rar", "application/x-cbr", "application/vnd.rar",
+      "application/x-rar-compressed":
+      return .cbr
+    default:
+      return nil
+    }
+  }
+
   var hasStartedReading: Bool {
     readProgress != nil
   }

--- a/KMReader/Features/Offline/Models/OfflineTaskItem.swift
+++ b/KMReader/Features/Offline/Models/OfflineTaskItem.swift
@@ -13,6 +13,7 @@ nonisolated struct OfflineTaskItem: Equatable, Identifiable, Sendable {
   let metaTitle: String
   let downloadStatusRaw: String
   let downloadStatus: DownloadStatus
+  let contentKind: DownloadContentKind
 
   var isDownloading: Bool {
     downloadStatusRaw == "downloading"

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -19,7 +19,7 @@ import UniformTypeIdentifiers
 #endif
 
 /// Simple Sendable struct for download info.
-nonisolated enum DownloadContentKind: Sendable {
+nonisolated enum DownloadContentKind: Equatable, Sendable {
   case pages
   case archiveImages(DownloadedImageArchiveFormat)
   case epubWebPub
@@ -27,9 +27,20 @@ nonisolated enum DownloadContentKind: Sendable {
   case pdf
 }
 
-nonisolated enum DownloadedImageArchiveFormat: Sendable {
+nonisolated enum DownloadedImageArchiveFormat: Equatable, Sendable {
   case cbz
   case cbr
+
+  init?(fileExtension: String) {
+    switch fileExtension.lowercased() {
+    case "cbz":
+      self = .cbz
+    case "cbr":
+      self = .cbr
+    default:
+      return nil
+    }
+  }
 
   var fileName: String {
     switch self {
@@ -1302,7 +1313,8 @@ actor OfflineManager {
           await self.updateDownloadLiveActivityProcessing(
             bookId: info.bookId,
             instanceId: instanceId,
-            seriesTitle: info.seriesTitle
+            seriesTitle: info.seriesTitle,
+            kind: info.kind
           )
         #endif
 
@@ -1834,7 +1846,8 @@ actor OfflineManager {
     private func updateDownloadLiveActivityProcessing(
       bookId: String,
       instanceId: String,
-      seriesTitle: String?
+      seriesTitle: String?,
+      kind: DownloadContentKind
     ) async {
       liveActivityProgressSnapshots.removeValue(forKey: bookId)
       let pendingBooks =
@@ -1844,7 +1857,7 @@ actor OfflineManager {
         ?? 0
       await LiveActivityManager.shared.updateActivity(
         seriesTitle: seriesTitle,
-        bookInfo: String(localized: "Processing offline files..."),
+        bookInfo: postDownloadTitle(for: kind),
         progress: 1.0,
         pendingCount: pendingBooks.count,
         failedCount: failedCount
@@ -1946,10 +1959,13 @@ actor OfflineManager {
 
   #if os(iOS)
     /// Track background download context per book
-    private var backgroundDownloadInfo:
-      [String: (
-        instanceId: String, seriesTitle: String?, bookInfo: String, kind: DownloadContentKind
-      )] = [:]
+    private typealias BackgroundDownloadInfo = (
+      instanceId: String,
+      seriesTitle: String?,
+      bookInfo: String,
+      kind: DownloadContentKind
+    )
+    private var backgroundDownloadInfo: [String: BackgroundDownloadInfo] = [:]
     private var backgroundDownloadTotalTasks: [String: Int] = [:]
     private var backgroundDownloadCompletedTasks: [String: Int] = [:]
     private var backgroundDownloadFinalizingBooks: Set<String> = []
@@ -2003,8 +2019,10 @@ actor OfflineManager {
       )
 
       if completedTasks >= totalTasks {
-        logger.debug(
-          "✅ Final per-file background callback received for book \(bookId); waiting for all-complete callback"
+        await finalizeBackgroundDownloadIfReady(
+          bookId: bookId,
+          info: info,
+          reason: "per-file completion"
         )
       }
     }
@@ -2122,37 +2140,50 @@ actor OfflineManager {
         return
       }
 
+      await finalizeBackgroundDownloadIfReady(
+        bookId: bookId,
+        info: info,
+        reason: "all-complete callback"
+      )
+    }
+
+    private func finalizeBackgroundDownloadIfReady(
+      bookId: String,
+      info: BackgroundDownloadInfo,
+      reason: String
+    ) async {
       let totalTasks = backgroundDownloadTotalTasks[bookId] ?? 0
       let completedTasks = backgroundDownloadCompletedTasks[bookId] ?? 0
       if totalTasks > 0, completedTasks < totalTasks {
         logger.debug(
-          "⏳ Defer all-complete callback: waiting per-file callbacks for book \(bookId), \(completedTasks)/\(totalTasks)"
+          "⏳ Defer \(reason): waiting per-file callbacks for book \(bookId), \(completedTasks)/\(totalTasks)"
         )
         return
       }
 
       if backgroundDownloadFinalizingBooks.contains(bookId) {
         logger.debug(
-          "⏭️ Ignore duplicate all-complete callback while finalizing book \(bookId), completed=\(completedTasks)/\(totalTasks)"
+          "⏭️ Ignore duplicate \(reason) while finalizing book \(bookId), completed=\(completedTasks)/\(totalTasks)"
         )
         return
       }
 
       backgroundDownloadFinalizingBooks.insert(bookId)
       logger.debug(
-        "🔒 Claimed background finalize for book \(bookId), completed=\(completedTasks)/\(totalTasks)"
+        "🔒 Claimed background finalize from \(reason) for book \(bookId), completed=\(completedTasks)/\(totalTasks)"
       )
       await updateDownloadLiveActivityProcessing(
         bookId: bookId,
         instanceId: info.instanceId,
-        seriesTitle: info.seriesTitle
+        seriesTitle: info.seriesTitle,
+        kind: info.kind
       )
       await finalizeBackgroundBookDownload(bookId: bookId, info: info)
     }
 
     private func finalizeBackgroundBookDownload(
       bookId: String,
-      info: (instanceId: String, seriesTitle: String?, bookInfo: String, kind: DownloadContentKind)
+      info: BackgroundDownloadInfo
     ) async {
       defer {
         backgroundDownloadFinalizingBooks.remove(bookId)
@@ -2315,7 +2346,7 @@ actor OfflineManager {
       await updateDownloadLiveActivityProgress(
         bookId: bookId,
         progress: 1.0,
-        bookInfoOverride: String(localized: "Processing offline files...")
+        bookInfoOverride: String(localized: "Validating offline archive...")
       )
     #endif
 
@@ -2968,14 +2999,7 @@ extension Book {
 
   private var downloadedImageArchiveFormat: DownloadedImageArchiveFormat? {
     if let urlExtension = URL(string: url)?.pathExtension.lowercased() {
-      switch urlExtension {
-      case "cbz":
-        return .cbz
-      case "cbr":
-        return .cbr
-      default:
-        break
-      }
+      return DownloadedImageArchiveFormat(fileExtension: urlExtension)
     }
 
     let mediaType = media.mediaType
@@ -2993,5 +3017,18 @@ extension Book {
     default:
       return nil
     }
+  }
+}
+
+private func postDownloadTitle(for kind: DownloadContentKind) -> String {
+  switch kind {
+  case .archiveImages:
+    return String(localized: "Validating offline archive...")
+  case .epubWebPub, .epubDivina:
+    return String(localized: "Finalizing offline EPUB...")
+  case .pdf:
+    return String(localized: "Finalizing offline PDF...")
+  case .pages:
+    return String(localized: "Finalizing offline pages...")
   }
 }

--- a/KMReader/Features/Offline/Views/OfflineTasksView.swift
+++ b/KMReader/Features/Offline/Views/OfflineTasksView.swift
@@ -311,6 +311,19 @@ struct OfflineTaskRow: View {
     progressTracker.progress[task.bookId]
   }
 
+  private var postDownloadStatusText: LocalizedStringResource {
+    switch task.contentKind {
+    case .archiveImages:
+      "Validating offline archive..."
+    case .epubWebPub, .epubDivina:
+      "Finalizing offline EPUB..."
+    case .pdf:
+      "Finalizing offline PDF..."
+    case .pages:
+      "Finalizing offline pages..."
+    }
+  }
+
   var body: some View {
     HStack(alignment: .center, spacing: 12) {
       VStack(alignment: .leading, spacing: 4) {
@@ -323,7 +336,7 @@ struct OfflineTaskRow: View {
         if task.isPending || task.isDownloading {
           if let progress = progress {
             if progress >= 1 {
-              Text(String(localized: "Processing offline files..."))
+              Text(postDownloadStatusText)
                 .font(.caption)
                 .foregroundStyle(.secondary)
             } else {

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -36,7 +36,8 @@
     case idle
     case fetchingMetadata
     case downloading
-    case processingOfflineFiles
+    case finalizingOfflineDownload
+    case preparingOfflineResources
     case preparingReader
     case paginating
   }
@@ -200,7 +201,7 @@
           )
         }
         try await ensureOfflineReady(downloadInfo: downloadInfo, instanceId: instanceId)
-        loadingStage = .processingOfflineFiles
+        loadingStage = .preparingOfflineResources
         _ = try await OfflineManager.shared.prepareOfflineWebPubIfNeeded(
           instanceId: instanceId,
           info: downloadInfo
@@ -385,7 +386,7 @@
           if let progress = DownloadProgressTracker.shared.progress[bookId] {
             updateDownloadProgress(progress)
             if progress >= 1 {
-              updateLoadingStage(.processingOfflineFiles)
+              updateLoadingStage(.finalizingOfflineDownload)
             }
           }
         }
@@ -431,7 +432,7 @@
           if let progress = DownloadProgressTracker.shared.progress[bookId] {
             updateDownloadProgress(progress)
             if progress >= 1 {
-              updateLoadingStage(.processingOfflineFiles)
+              updateLoadingStage(.finalizingOfflineDownload)
             }
           }
         }

--- a/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/PdfReaderViewModel.swift
@@ -7,7 +7,7 @@
     case idle
     case fetchingMetadata
     case downloading
-    case processingOfflineFiles
+    case finalizingOfflineDownload
     case preparingReader
   }
 
@@ -335,7 +335,7 @@
           if let progress = DownloadProgressTracker.shared.progress[bookId] {
             updateDownloadProgress(progress)
             if progress >= 1 {
-              updateLoadingStage(.processingOfflineFiles)
+              updateLoadingStage(.finalizingOfflineDownload)
             }
           }
         }

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -883,8 +883,9 @@ class ReaderViewModel {
         {
           if progress >= 1 {
             clearLoadingProgress()
-            updateLoadingTitle(String(localized: "Processing offline files..."))
-            updateLoadingDetail(offlineProcessingDetail)
+            let status = offlinePostDownloadStatus(for: downloadInfo.kind)
+            updateLoadingTitle(status.title)
+            updateLoadingDetail(status.detail)
           } else if progress > 0 {
             updateLoadingProgress(progress)
             updateLoadingTitle(String(localized: "Downloading book..."))
@@ -1013,12 +1014,30 @@ class ReaderViewModel {
     loadingTitle = title
   }
 
-  private var offlineProcessingDetail: String {
-    switch bookMediaProfile {
+  private func offlinePostDownloadStatus(for kind: DownloadContentKind) -> (
+    title: String, detail: String
+  ) {
+    switch kind {
+    case .archiveImages:
+      return (
+        String(localized: "Validating offline archive..."),
+        String(localized: "Checking archive entries against page metadata")
+      )
+    case .epubWebPub, .epubDivina:
+      return (
+        String(localized: "Finalizing offline EPUB..."),
+        String(localized: "Saving downloaded EPUB for offline reading")
+      )
     case .pdf:
-      return String(localized: "Finalizing offline PDF file")
-    case .divina, .epub, .unknown:
-      return String(localized: "Verifying offline files against page metadata")
+      return (
+        String(localized: "Finalizing offline PDF..."),
+        String(localized: "Saving downloaded PDF for offline reading")
+      )
+    case .pages:
+      return (
+        String(localized: "Finalizing offline pages..."),
+        String(localized: "Saving downloaded page files")
+      )
     }
   }
 

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -676,8 +676,10 @@
         return String(localized: "Fetching book info...")
       case .downloading:
         return String(localized: "Downloading book...")
-      case .processingOfflineFiles:
-        return String(localized: "Processing offline files...")
+      case .finalizingOfflineDownload:
+        return String(localized: "Finalizing offline EPUB...")
+      case .preparingOfflineResources:
+        return String(localized: "Preparing offline EPUB...")
       case .preparingReader:
         return String(localized: "Preparing reader...")
       case .paginating:
@@ -712,8 +714,10 @@
           return "\(String(format: "%.1f", received / 1024 / 1024)) MB"
         }
         return String(localized: "Downloading book content")
-      case .processingOfflineFiles:
-        return String(localized: "Verifying offline files against page metadata")
+      case .finalizingOfflineDownload:
+        return String(localized: "Saving downloaded EPUB for offline reading")
+      case .preparingOfflineResources:
+        return String(localized: "Extracting reader resources from downloaded EPUB")
       case .preparingReader:
         return String(localized: "Preparing reader view")
       case .paginating:

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -434,8 +434,8 @@
         return String(localized: "Fetching book info...")
       case .downloading:
         return String(localized: "Downloading book...")
-      case .processingOfflineFiles:
-        return String(localized: "Processing offline files...")
+      case .finalizingOfflineDownload:
+        return String(localized: "Finalizing offline PDF...")
       case .preparingReader:
         return String(localized: "Preparing PDF...")
       case .idle:
@@ -456,8 +456,8 @@
       switch viewModel.loadingStage {
       case .fetchingMetadata:
         return String(localized: "Checking PDF download information")
-      case .processingOfflineFiles:
-        return String(localized: "Finalizing offline PDF file")
+      case .finalizingOfflineDownload:
+        return String(localized: "Saving downloaded PDF for offline reading")
       case .preparingReader:
         return String(localized: "Opening downloaded PDF file")
       case .downloading:

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -11578,6 +11578,70 @@
         }
       }
     },
+    "Checking archive entries against page metadata" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archiv-Einträge werden mit Seitenmetadaten abgeglichen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Checking archive entries against page metadata"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprobando las entradas del archivo con los metadatos de páginas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérification des entrées de l’archive avec les métadonnées des pages"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifica delle voci dell'archivio con i metadati delle pagine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページメタデータに対してアーカイブ項目を確認中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 메타데이터와 아카이브 항목 확인 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверка записей архива по метаданным страниц"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在根据页面元数据检查归档条目"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在根據頁面中繼資料檢查封存項目"
+          }
+        }
+      }
+    },
     "Checking PDF download information" : {
       "localizations" : {
         "de" : {
@@ -28282,6 +28346,70 @@
         }
       }
     },
+    "Extracting reader resources from downloaded EPUB" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reader-Ressourcen aus heruntergeladenem EPUB werden extrahiert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Extracting reader resources from downloaded EPUB"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Extrayendo recursos de lectura del EPUB descargado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Extraction des ressources de lecture de l’EPUB téléchargé"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estrazione delle risorse del lettore dall'EPUB scaricato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード済みEPUBからリーダーリソースを展開中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드한 EPUB에서 리더 리소스 추출 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Извлечение ресурсов читалки из загруженного EPUB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在从已下载的 EPUB 提取阅读资源"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在從已下載的 EPUB 擷取閱讀資源"
+          }
+        }
+      }
+    },
     "Failed" : {
       "localizations" : {
         "de" : {
@@ -29050,7 +29178,136 @@
         }
       }
     },
+    "Finalizing offline EPUB..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-EPUB wird fertiggestellt..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizing offline EPUB..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizando EPUB sin conexión..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalisation de l’EPUB hors ligne..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizzazione dell'EPUB offline..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインEPUBを仕上げ中..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 EPUB 마무리 중..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завершение офлайн EPUB..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在完成离线 EPUB..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在完成離線 EPUB..."
+          }
+        }
+      }
+    },
+    "Finalizing offline pages..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Seiten werden fertiggestellt..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizing offline pages..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizando páginas sin conexión..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalisation des pages hors ligne..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizzazione delle pagine offline..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインページを仕上げ中..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 페이지 마무리 중..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завершение офлайн страниц..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在完成离线页面..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在完成離線頁面..."
+          }
+        }
+      }
+    },
     "Finalizing offline PDF file" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -29110,6 +29367,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在完成離線 PDF 檔案"
+          }
+        }
+      }
+    },
+    "Finalizing offline PDF..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-PDF wird fertiggestellt..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizing offline PDF..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizando PDF sin conexión..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalisation du PDF hors ligne..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizzazione del PDF offline..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインPDFを仕上げ中..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 PDF 마무리 중..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завершение офлайн PDF..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在完成离线 PDF..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在完成離線 PDF..."
           }
         }
       }
@@ -53116,6 +53437,70 @@
         }
       }
     },
+    "Preparing offline EPUB..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-EPUB wird vorbereitet..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing offline EPUB..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando EPUB sin conexión..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Préparation de l’EPUB hors ligne..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione dell'EPUB offline..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインEPUBを準備中..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 EPUB 준비 중..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка офлайн EPUB..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在准备离线 EPUB..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在準備離線 EPUB..."
+          }
+        }
+      }
+    },
     "Preparing PDF..." : {
       "localizations" : {
         "de" : {
@@ -53693,6 +54078,7 @@
       }
     },
     "Processing offline files..." : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -61304,6 +61690,198 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已儲存的預設"
+          }
+        }
+      }
+    },
+    "Saving downloaded EPUB for offline reading" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heruntergeladenes EPUB wird für das Offline-Lesen gespeichert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saving downloaded EPUB for offline reading"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardando el EPUB descargado para leer sin conexión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrement de l’EPUB téléchargé pour la lecture hors ligne"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salvataggio dell'EPUB scaricato per la lettura offline"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード済みEPUBをオフライン読書用に保存中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드한 EPUB을 오프라인 읽기용으로 저장 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранение загруженного EPUB для офлайн-чтения"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在保存已下载的 EPUB 以供离线阅读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在儲存已下載的 EPUB 以供離線閱讀"
+          }
+        }
+      }
+    },
+    "Saving downloaded page files" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heruntergeladene Seitendateien werden gespeichert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saving downloaded page files"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardando archivos de páginas descargados"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrement des fichiers de pages téléchargés"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salvataggio dei file delle pagine scaricate"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード済みページファイルを保存中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드한 페이지 파일 저장 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранение загруженных файлов страниц"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在保存已下载的页面文件"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在儲存已下載的頁面檔案"
+          }
+        }
+      }
+    },
+    "Saving downloaded PDF for offline reading" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heruntergeladenes PDF wird für das Offline-Lesen gespeichert"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saving downloaded PDF for offline reading"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardando el PDF descargado para leer sin conexión"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrement du PDF téléchargé pour la lecture hors ligne"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salvataggio del PDF scaricato per la lettura offline"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダウンロード済みPDFをオフライン読書用に保存中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다운로드한 PDF를 오프라인 읽기용으로 저장 중"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохранение загруженного PDF для офлайн-чтения"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在保存已下载的 PDF 以供离线阅读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在儲存已下載的 PDF 以供離線閱讀"
           }
         }
       }
@@ -80508,6 +81086,70 @@
         }
       }
     },
+    "Validating offline archive..." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Offline-Archiv wird validiert..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validating offline archive..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validando archivo sin conexión..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validation de l’archive hors ligne..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validazione dell'archivio offline..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフラインアーカイブを検証中..."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오프라인 아카이브 검증 중..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверка офлайн архива..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在验证离线归档..."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在驗證離線封存..."
+          }
+        }
+      }
+    },
     "Validation failed: %@" : {
       "localizations" : {
         "de" : {
@@ -80765,6 +81407,7 @@
       }
     },
     "Verifying offline files against page metadata" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {


### PR DESCRIPTION
## What changed

Fixes an offline-first download finalization race where iOS background URLSession callbacks could arrive at `OfflineManager` out of order. The last per-file callback and the all-complete callback now share the same idempotent finalize gate, so a book should not remain stuck at the post-download stage after the file has finished downloading.

This also replaces the generic "Processing offline files" message with phase-specific reader/task status text for archive validation, EPUB resource preparation, PDF finalization, and page finalization, with updated localizations.

Includes a build-number bump to 485.

## Validation

- `make build`
- `make localize`
- `./misc/translate.py list`
- `git diff --check`
