### PR TITLE
fix(dashboard): stabilize macOS section hover controls

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 485;
+				CURRENT_PROJECT_VERSION = 486;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 485;
+				CURRENT_PROJECT_VERSION = 486;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 485;
+				CURRENT_PROJECT_VERSION = 486;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 485;
+				CURRENT_PROJECT_VERSION = 486;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
@@ -20,9 +20,6 @@ struct DashboardPinnedSectionView: View {
   @State private var isLoading = false
   @State private var pinnedCollections: [CollectionDisplayItem] = []
   @State private var pinnedReadLists: [ReadListDisplayItem] = []
-  @State private var isHoveringScrollArea = false
-  @State private var hoverShowDelayTask: Task<Void, Never>?
-  @State private var hoverHideDelayTask: Task<Void, Never>?
 
   private var isSupportedSection: Bool {
     switch section.contentKind {
@@ -164,44 +161,16 @@ struct DashboardPinnedSectionView: View {
             .contentMargins(.horizontal, spacing, for: .scrollContent)
             .scrollClipDisabled()
             #if os(macOS)
-              .overlay {
-                HorizontalScrollButtons(
-                  scrollProxy: proxy,
-                  itemIds: itemIds,
-                  isVisible: isHoveringScrollArea
-                )
-                .animation(.default, value: isHoveringScrollArea)
-              }
+              .macHorizontalScrollButtons(
+                scrollProxy: proxy,
+                itemIds: itemIds
+              )
             #endif
           }
         }
       }
       .opacity(hasItems ? 1 : 0)
       .frame(height: hasItems ? nil : 0)
-      #if os(macOS)
-        .onContinuousHover { phase in
-          switch phase {
-          case .active:
-            hoverHideDelayTask?.cancel()
-            hoverHideDelayTask = nil
-            hoverShowDelayTask?.cancel()
-            hoverShowDelayTask = Task { @MainActor in
-              try? await Task.sleep(nanoseconds: 100_000_000)
-              guard !Task.isCancelled else { return }
-              isHoveringScrollArea = true
-            }
-          case .ended:
-            hoverShowDelayTask?.cancel()
-            hoverShowDelayTask = nil
-            hoverHideDelayTask?.cancel()
-            hoverHideDelayTask = Task { @MainActor in
-              try? await Task.sleep(nanoseconds: 100_000_000)
-              guard !Task.isCancelled else { return }
-              isHoveringScrollArea = false
-            }
-          }
-        }
-      #endif
       .onReceive(NotificationCenter.default.publisher(for: .dashboardSectionsShouldReload)) {
         notification in
         guard

--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -19,9 +19,6 @@ struct DashboardSectionView: View {
   @State private var pagination = PaginationState<IdentifiedString>(pageSize: 20)
   @State private var isLoading = false
   @State private var didSeedFromCache = false
-  @State private var isHoveringScrollArea = false
-  @State private var hoverShowDelayTask: Task<Void, Never>?
-  @State private var hoverHideDelayTask: Task<Void, Never>?
   @State private var hasLoadedInitial = false
 
   private let logger = AppLogger(.dashboard)
@@ -103,42 +100,14 @@ struct DashboardSectionView: View {
           .contentMargins(.horizontal, spacing, for: .scrollContent)
           .scrollClipDisabled()
           #if os(macOS)
-            .overlay {
-              HorizontalScrollButtons(
-                scrollProxy: proxy,
-                itemIds: pagination.items.map(\.id),
-                isVisible: isHoveringScrollArea
-              )
-              .animation(.default, value: isHoveringScrollArea)
-            }
+            .macHorizontalScrollButtons(
+              scrollProxy: proxy,
+              itemIds: pagination.items.map(\.id)
+            )
           #endif
         }
       }
     }
-    #if os(macOS)
-      .onContinuousHover { phase in
-        switch phase {
-        case .active:
-          hoverHideDelayTask?.cancel()
-          hoverHideDelayTask = nil
-          hoverShowDelayTask?.cancel()
-          hoverShowDelayTask = Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            guard !Task.isCancelled else { return }
-            isHoveringScrollArea = true
-          }
-        case .ended:
-          hoverShowDelayTask?.cancel()
-          hoverShowDelayTask = nil
-          hoverHideDelayTask?.cancel()
-          hoverHideDelayTask = Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            guard !Task.isCancelled else { return }
-            isHoveringScrollArea = false
-          }
-        }
-      }
-    #endif
     .opacity(pagination.isEmpty ? 0 : 1)
     .frame(height: pagination.isEmpty ? 0 : nil)
     .onReceive(NotificationCenter.default.publisher(for: .dashboardSectionsShouldReload)) {

--- a/KMReader/Shared/UI/HorizontalScrollButtonsOverlayModifier.swift
+++ b/KMReader/Shared/UI/HorizontalScrollButtonsOverlayModifier.swift
@@ -1,0 +1,45 @@
+//
+// HorizontalScrollButtonsOverlayModifier.swift
+//
+//
+
+import SwiftUI
+
+#if os(macOS)
+  private struct HorizontalScrollButtonsOverlayModifier<ID: Hashable>: ViewModifier {
+    let scrollProxy: ScrollViewProxy
+    let itemIds: [ID]
+
+    @State private var areButtonsVisible = false
+
+    func body(content: Content) -> some View {
+      content
+        .onHover { hovering in
+          guard areButtonsVisible != hovering else { return }
+          areButtonsVisible = hovering
+        }
+        .overlay {
+          HorizontalScrollButtons(
+            scrollProxy: scrollProxy,
+            itemIds: itemIds,
+            isVisible: areButtonsVisible
+          )
+          .animation(.easeOut(duration: 0.15), value: areButtonsVisible)
+        }
+    }
+  }
+
+  extension View {
+    func macHorizontalScrollButtons<ID: Hashable>(
+      scrollProxy: ScrollViewProxy,
+      itemIds: [ID]
+    ) -> some View {
+      modifier(
+        HorizontalScrollButtonsOverlayModifier(
+          scrollProxy: scrollProxy,
+          itemIds: itemIds
+        )
+      )
+    }
+  }
+#endif

--- a/KMReader/Shared/UI/HorizontalScrollButtonsOverlayModifier.swift
+++ b/KMReader/Shared/UI/HorizontalScrollButtonsOverlayModifier.swift
@@ -14,10 +14,6 @@ import SwiftUI
 
     func body(content: Content) -> some View {
       content
-        .onHover { hovering in
-          guard areButtonsVisible != hovering else { return }
-          areButtonsVisible = hovering
-        }
         .overlay {
           HorizontalScrollButtons(
             scrollProxy: scrollProxy,
@@ -25,6 +21,10 @@ import SwiftUI
             isVisible: areButtonsVisible
           )
           .animation(.easeOut(duration: 0.15), value: areButtonsVisible)
+        }
+        .onHover { hovering in
+          guard areButtonsVisible != hovering else { return }
+          areButtonsVisible = hovering
         }
     }
   }


### PR DESCRIPTION
## What Changed

Stabilizes the macOS dashboard section scroll arrows by moving their hover visibility state into a dedicated overlay modifier. The sections now use regular `onHover` enter/exit handling instead of delayed `onContinuousHover` tasks that could be repeatedly canceled while the pointer moved.

## UX Impact

Dashboard section arrows appear consistently when hovering a horizontal rail on macOS, without reintroducing broad section-level hover state churn during dashboard scrolling.

## Validation

- `make format`
- `git diff --check origin/main...HEAD`
- `make build-macos`
