### PR TITLE
refactor: stabilize deleted content projections

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 488;
+				CURRENT_PROJECT_VERSION = 489;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 488;
+				CURRENT_PROJECT_VERSION = 489;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 488;
+				CURRENT_PROJECT_VERSION = 489;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 488;
+				CURRENT_PROJECT_VERSION = 489;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/DatabaseOperator+Collections.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Collections.swift
@@ -157,16 +157,16 @@ extension DatabaseOperator {
     }
   }
 
-  func deleteCollectionsNotIn(_ collectionIds: Set<String>, instanceId: String) -> Int {
+  func deleteCollectionsNotIn(_ collectionIds: Set<String>, instanceId: String) -> [String] {
     (try? write { db in
       let existingCollections = try fetchCollections(db: db, instanceId: instanceId)
-      var deletedCount = 0
+      var deletedIds: [String] = []
       for collection in existingCollections where !collectionIds.contains(collection.collectionId) {
         try KomgaCollection.deleteOne(db, key: collection.id)
-        deletedCount += 1
+        deletedIds.append(collection.collectionId)
       }
-      return deletedCount
-    }) ?? 0
+      return deletedIds
+    }) ?? []
   }
 }
 
@@ -349,17 +349,17 @@ extension DatabaseOperator {
     return automaticPolicyReadListIds.sorted()
   }
 
-  func deleteReadListsNotIn(_ readListIds: Set<String>, instanceId: String) -> Int {
+  func deleteReadListsNotIn(_ readListIds: Set<String>, instanceId: String) -> [String] {
     (try? write { db in
       let existingReadLists = try fetchReadLists(db: db, instanceId: instanceId)
-      var deletedCount = 0
+      var deletedIds: [String] = []
       for readList in existingReadLists where !readListIds.contains(readList.readListId) {
         try deleteReadListBookMemberships(db: db, readListId: readList.readListId, instanceId: instanceId)
         try KomgaReadList.deleteOne(db, key: readList.id)
-        deletedCount += 1
+        deletedIds.append(readList.readListId)
       }
-      return deletedCount
-    }) ?? 0
+      return deletedIds
+    }) ?? []
   }
 }
 

--- a/KMReader/Features/Book/ViewModels/BookViewModel.swift
+++ b/KMReader/Features/Book/ViewModels/BookViewModel.swift
@@ -70,6 +70,12 @@ class BookViewModel {
     pagination.advance(moreAvailable: moreAvailable)
   }
 
+  func removeBook(id: String) {
+    withAnimation {
+      _ = pagination.removeItems(withIDs: [id])
+    }
+  }
+
   private func beginLoad(refresh: Bool) -> UUID? {
     if refresh {
       withAnimation {

--- a/KMReader/Features/Book/Views/BookCardView.swift
+++ b/KMReader/Features/Book/Views/BookCardView.swift
@@ -9,6 +9,7 @@ struct BookCardView: View {
   let item: BookDisplayItem
   var onReadBook: ((Bool) -> Void)? = nil
   var onMutationCompleted: (() -> Void)? = nil
+  var onDeleteRequested: (() -> Void)? = nil
   var showSeriesTitle: Bool = false
   var showSeriesNavigation: Bool = true
 
@@ -19,7 +20,6 @@ struct BookCardView: View {
   @AppStorage("thumbnailShowProgressBar") private var thumbnailShowProgressBar: Bool = true
   @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
   @State private var showReadListPicker = false
-  @State private var showDeleteConfirmation = false
   @State private var showEditSheet = false
 
   private var progress: Double {
@@ -92,9 +92,7 @@ struct BookCardView: View {
           onShowReadListPicker: {
             showReadListPicker = true
           },
-          onDeleteRequested: {
-            showDeleteConfirmation = true
-          },
+          onDeleteRequested: onDeleteRequested,
           onEditRequested: {
             showEditSheet = true
           },
@@ -159,14 +157,6 @@ struct BookCardView: View {
       }
     }
     .frame(maxHeight: .infinity, alignment: .top)
-    .alert("Delete Book", isPresented: $showDeleteConfirmation) {
-      Button("Cancel", role: .cancel) {}
-      Button("Delete", role: .destructive) {
-        deleteBook()
-      }
-    } message: {
-      Text("Are you sure you want to delete this book? This action cannot be undone.")
-    }
     .sheet(isPresented: $showReadListPicker) {
       ReadListPickerSheet(
         bookId: item.bookId,
@@ -253,15 +243,4 @@ struct BookCardView: View {
     }
   }
 
-  private func deleteBook() {
-    Task {
-      do {
-        try await BookDeletionService.deleteBook(item)
-        ErrorManager.shared.notify(message: String(localized: "notification.book.deleted"))
-        onMutationCompleted?()
-      } catch {
-        ErrorManager.shared.alert(error: error)
-      }
-    }
-  }
 }

--- a/KMReader/Features/Book/Views/BookItemView.swift
+++ b/KMReader/Features/Book/Views/BookItemView.swift
@@ -13,24 +13,54 @@ struct BookItemView: View {
   var showSeriesTitle: Bool = true
   var showSeriesNavigation: Bool = true
 
+  @State private var showDeleteConfirmation = false
+
   var body: some View {
-    switch layout {
-    case .grid:
-      BookCardView(
-        item: item,
-        onReadBook: onReadBook,
-        onMutationCompleted: onMutationCompleted,
-        showSeriesTitle: showSeriesTitle,
-        showSeriesNavigation: showSeriesNavigation
-      )
-    case .list:
-      BookRowView(
-        item: item,
-        onReadBook: onReadBook,
-        onMutationCompleted: onMutationCompleted,
-        showSeriesTitle: showSeriesTitle,
-        showSeriesNavigation: showSeriesNavigation
-      )
+    Group {
+      switch layout {
+      case .grid:
+        BookCardView(
+          item: item,
+          onReadBook: onReadBook,
+          onMutationCompleted: onMutationCompleted,
+          onDeleteRequested: {
+            showDeleteConfirmation = true
+          },
+          showSeriesTitle: showSeriesTitle,
+          showSeriesNavigation: showSeriesNavigation
+        )
+      case .list:
+        BookRowView(
+          item: item,
+          onReadBook: onReadBook,
+          onMutationCompleted: onMutationCompleted,
+          onDeleteRequested: {
+            showDeleteConfirmation = true
+          },
+          showSeriesTitle: showSeriesTitle,
+          showSeriesNavigation: showSeriesNavigation
+        )
+      }
+    }
+    .alert("Delete Book", isPresented: $showDeleteConfirmation) {
+      Button("Cancel", role: .cancel) {}
+      Button("Delete", role: .destructive) {
+        deleteBook()
+      }
+    } message: {
+      Text("Are you sure you want to delete this book? This action cannot be undone.")
+    }
+  }
+
+  private func deleteBook() {
+    Task {
+      do {
+        try await BookDeletionService.deleteBook(item)
+        ErrorManager.shared.notify(message: String(localized: "notification.book.deleted"))
+        onMutationCompleted?()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
     }
   }
 }

--- a/KMReader/Features/Book/Views/BookQueryItemView.swift
+++ b/KMReader/Features/Book/Views/BookQueryItemView.swift
@@ -16,6 +16,7 @@ struct BookQueryItemView: View {
   @AppStorage("currentAccount") private var current: Current = .init()
   @Environment(\.readerActions) private var readerActions
   @State private var item: BookDisplayItem?
+  @State private var showDeleteConfirmation = false
 
   init(
     bookId: String,
@@ -47,6 +48,9 @@ struct BookQueryItemView: View {
               )
             },
             onMutationCompleted: reloadItem,
+            onDeleteRequested: {
+              showDeleteConfirmation = true
+            },
             showSeriesTitle: showSeriesTitle,
             showSeriesNavigation: showSeriesNavigation
           )
@@ -61,6 +65,9 @@ struct BookQueryItemView: View {
               )
             },
             onMutationCompleted: reloadItem,
+            onDeleteRequested: {
+              showDeleteConfirmation = true
+            },
             showSeriesTitle: showSeriesTitle,
             showSeriesNavigation: showSeriesNavigation
           )
@@ -81,6 +88,14 @@ struct BookQueryItemView: View {
       guard shouldReload(for: notification) else { return }
       reloadItem()
     }
+    .alert("Delete Book", isPresented: $showDeleteConfirmation) {
+      Button("Cancel", role: .cancel) {}
+      Button("Delete", role: .destructive) {
+        deleteBook()
+      }
+    } message: {
+      Text("Are you sure you want to delete this book? This action cannot be undone.")
+    }
   }
 
   private func shouldReload(for notification: Notification) -> Bool {
@@ -99,6 +114,22 @@ struct BookQueryItemView: View {
   private func reloadItem() {
     Task {
       await loadItem()
+    }
+  }
+
+  private func deleteBook() {
+    Task {
+      do {
+        if let item {
+          try await BookDeletionService.deleteBook(item)
+        } else {
+          try await BookDeletionService.deleteBook(bookId: bookId, instanceId: current.instanceId)
+        }
+        ErrorManager.shared.notify(message: String(localized: "notification.book.deleted"))
+        await loadItem()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
     }
   }
 

--- a/KMReader/Features/Book/Views/BookQueryItemView.swift
+++ b/KMReader/Features/Book/Views/BookQueryItemView.swift
@@ -12,6 +12,7 @@ struct BookQueryItemView: View {
   var showSeriesTitle: Bool = true
   var showSeriesNavigation: Bool = true
   var readListContext: ReaderReadListContext? = nil
+  var onItemMissing: (() -> Void)? = nil
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @Environment(\.readerActions) private var readerActions
@@ -23,13 +24,15 @@ struct BookQueryItemView: View {
     layout: BrowseLayoutMode,
     showSeriesTitle: Bool = true,
     showSeriesNavigation: Bool = true,
-    readListContext: ReaderReadListContext? = nil
+    readListContext: ReaderReadListContext? = nil,
+    onItemMissing: (() -> Void)? = nil
   ) {
     self.bookId = bookId
     self.layout = layout
     self.showSeriesTitle = showSeriesTitle
     self.showSeriesNavigation = showSeriesNavigation
     self.readListContext = readListContext
+    self.onItemMissing = onItemMissing
 
   }
 
@@ -138,9 +141,13 @@ struct BookQueryItemView: View {
       item = nil
       return
     }
-    item = try? await database.fetchBookDisplayItem(
+    let loadedItem = try? await database.fetchBookDisplayItem(
       bookId: bookId,
       instanceId: current.instanceId
     )
+    item = loadedItem
+    if loadedItem == nil {
+      onItemMissing?()
+    }
   }
 }

--- a/KMReader/Features/Book/Views/BookRowView.swift
+++ b/KMReader/Features/Book/Views/BookRowView.swift
@@ -9,13 +9,13 @@ struct BookRowView: View {
   let item: BookDisplayItem
   var onReadBook: ((Bool) -> Void)?
   var onMutationCompleted: (() -> Void)? = nil
+  var onDeleteRequested: (() -> Void)? = nil
   var showSeriesTitle: Bool = false
   var showSeriesNavigation: Bool = true
 
   @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
 
   @State private var showReadListPicker = false
-  @State private var showDeleteConfirmation = false
   @State private var showEditSheet = false
 
   private var progress: Double {
@@ -142,9 +142,7 @@ struct BookRowView: View {
               onShowReadListPicker: {
                 showReadListPicker = true
               },
-              onDeleteRequested: {
-                showDeleteConfirmation = true
-              },
+              onDeleteRequested: onDeleteRequested,
               onEditRequested: {
                 showEditSheet = true
               },
@@ -155,14 +153,6 @@ struct BookRowView: View {
           }
         }
       }
-    }
-    .alert("Delete Book", isPresented: $showDeleteConfirmation) {
-      Button("Cancel", role: .cancel) {}
-      Button("Delete", role: .destructive) {
-        deleteBook()
-      }
-    } message: {
-      Text("Are you sure you want to delete this book? This action cannot be undone.")
     }
     .sheet(isPresented: $showReadListPicker) {
       ReadListPickerSheet(
@@ -194,15 +184,4 @@ struct BookRowView: View {
     }
   }
 
-  private func deleteBook() {
-    Task {
-      do {
-        try await BookDeletionService.deleteBook(item)
-        ErrorManager.shared.notify(message: String(localized: "notification.book.deleted"))
-        onMutationCompleted?()
-      } catch {
-        ErrorManager.shared.alert(error: error)
-      }
-    }
-  }
 }

--- a/KMReader/Features/Book/Views/BooksQueryView.swift
+++ b/KMReader/Features/Book/Views/BooksQueryView.swift
@@ -59,7 +59,10 @@ struct BooksQueryView: View {
           ForEach(viewModel.pagination.items) { book in
             BookQueryItemView(
               bookId: book.id,
-              layout: .grid
+              layout: .grid,
+              onItemMissing: {
+                viewModel.removeBook(id: book.id)
+              }
             )
             .padding(.bottom)
             .onAppear {
@@ -75,7 +78,10 @@ struct BooksQueryView: View {
           ForEach(viewModel.pagination.items) { book in
             BookQueryItemView(
               bookId: book.id,
-              layout: .list
+              layout: .list,
+              onItemMissing: {
+                viewModel.removeBook(id: book.id)
+              }
             )
             .onAppear {
               if viewModel.pagination.shouldLoadMore(after: book) {

--- a/KMReader/Features/Book/Views/ListViews/BooksListViewForReadList.swift
+++ b/KMReader/Features/Book/Views/ListViews/BooksListViewForReadList.swift
@@ -159,6 +159,7 @@ struct BooksListViewForReadList: View {
 
   private func refreshBooks() async {
     await loadReadList()
+    guard readListItem != nil else { return }
     await bookViewModel.loadReadListBooks(
       readListId: readListId,
       browseOpts: browseOpts,

--- a/KMReader/Features/Book/Views/ListViews/ReadListBooksQueryView.swift
+++ b/KMReader/Features/Book/Views/ListViews/ReadListBooksQueryView.swift
@@ -73,7 +73,10 @@ struct ReadListBooksQueryView: View {
                     bookId: book.id,
                     layout: .grid,
                     showSeriesTitle: true,
-                    readListContext: readListContext
+                    readListContext: readListContext,
+                    onItemMissing: {
+                      bookViewModel.removeBook(id: book.id)
+                    }
                   )
                 }
               }
@@ -103,7 +106,10 @@ struct ReadListBooksQueryView: View {
                     bookId: book.id,
                     layout: .list,
                     showSeriesTitle: true,
-                    readListContext: readListContext
+                    readListContext: readListContext,
+                    onItemMissing: {
+                      bookViewModel.removeBook(id: book.id)
+                    }
                   )
                 }
               }

--- a/KMReader/Features/Book/Views/ListViews/SeriesBooksQueryView.swift
+++ b/KMReader/Features/Book/Views/ListViews/SeriesBooksQueryView.swift
@@ -48,7 +48,10 @@ struct SeriesBooksQueryView: View {
                 bookId: book.id,
                 layout: .grid,
                 showSeriesTitle: false,
-                showSeriesNavigation: false
+                showSeriesNavigation: false,
+                onItemMissing: {
+                  bookViewModel.removeBook(id: book.id)
+                }
               )
               .padding(.bottom)
               .onAppear {
@@ -66,7 +69,10 @@ struct SeriesBooksQueryView: View {
                 bookId: book.id,
                 layout: .list,
                 showSeriesTitle: false,
-                showSeriesNavigation: false
+                showSeriesNavigation: false,
+                onItemMissing: {
+                  bookViewModel.removeBook(id: book.id)
+                }
               )
               .onAppear {
                 if bookViewModel.pagination.shouldLoadMore(after: book) {

--- a/KMReader/Features/Collection/Services/CollectionService.swift
+++ b/KMReader/Features/Collection/Services/CollectionService.swift
@@ -146,6 +146,7 @@ nonisolated enum CollectionService {
     // Delete from local database
     let instanceId = AppConfig.current.instanceId
     try await DatabaseOperator.database().deleteCollection(id: collectionId, instanceId: instanceId)
+    await ContentProjectionNotifier.postCollectionDidChange(collectionId: collectionId, refreshDelay: 0)
   }
 
   static func removeSeriesFromCollection(collectionId: String, seriesIds: [String]) async throws {

--- a/KMReader/Features/Collection/Views/CollectionCardView.swift
+++ b/KMReader/Features/Collection/Views/CollectionCardView.swift
@@ -8,11 +8,11 @@ import SwiftUI
 struct CollectionCardView: View {
   let item: CollectionDisplayItem
   var onMutationCompleted: (() -> Void)? = nil
+  let onDeleteRequested: () -> Void
 
   @AppStorage("coverOnlyCards") private var coverOnlyCards: Bool = false
   @AppStorage("cardTextOverlayMode") private var cardTextOverlayMode: Bool = false
   @State private var showEditSheet = false
-  @State private var showDeleteConfirmation = false
 
   private var contentSpacing: CGFloat {
     cardTextOverlayMode ? 0 : 12
@@ -39,7 +39,7 @@ struct CollectionCardView: View {
           menuTitle: item.name,
           isPinned: item.isPinned,
           onDeleteRequested: {
-            showDeleteConfirmation = true
+            onDeleteRequested()
           },
           onEditRequested: {
             showEditSheet = true
@@ -69,14 +69,6 @@ struct CollectionCardView: View {
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .frame(maxHeight: .infinity, alignment: .top)
-    .alert("Delete Collection", isPresented: $showDeleteConfirmation) {
-      Button("Cancel", role: .cancel) {}
-      Button("Delete", role: .destructive) {
-        deleteCollection()
-      }
-    } message: {
-      Text("Are you sure you want to delete this collection? This action cannot be undone.")
-    }
     .sheet(isPresented: $showEditSheet) {
       CollectionEditSheet(collection: item.collection)
     }
@@ -90,19 +82,6 @@ struct CollectionCardView: View {
     ) {
       HStack(spacing: 4) {
         Text("\(item.seriesCount) series")
-      }
-    }
-  }
-
-  private func deleteCollection() {
-    Task {
-      do {
-        try await CollectionService.deleteCollection(
-          collectionId: item.collectionId)
-        ErrorManager.shared.notify(message: String(localized: "notification.collection.deleted"))
-        onMutationCompleted?()
-      } catch {
-        ErrorManager.shared.alert(error: error)
       }
     }
   }

--- a/KMReader/Features/Collection/Views/CollectionCompactCardView.swift
+++ b/KMReader/Features/Collection/Views/CollectionCompactCardView.swift
@@ -10,9 +10,9 @@ struct CollectionCompactCardView: View {
   let item: CollectionDisplayItem
   var coverWidth: CGFloat = 80
   var onChanged: () -> Void = {}
+  let onDeleteRequested: () -> Void
 
   @State private var showEditSheet = false
-  @State private var showDeleteConfirmation = false
 
   var body: some View {
     NavigationLink(
@@ -59,7 +59,7 @@ struct CollectionCompactCardView: View {
         menuTitle: item.name,
         isPinned: item.isPinned,
         onDeleteRequested: {
-          showDeleteConfirmation = true
+          onDeleteRequested()
         },
         onEditRequested: {
           showEditSheet = true
@@ -69,29 +69,8 @@ struct CollectionCompactCardView: View {
         }
       )
     }
-    .alert("Delete Collection", isPresented: $showDeleteConfirmation) {
-      Button("Cancel", role: .cancel) {}
-      Button("Delete", role: .destructive) {
-        deleteCollection()
-      }
-    } message: {
-      Text("Are you sure you want to delete this collection? This action cannot be undone.")
-    }
     .sheet(isPresented: $showEditSheet, onDismiss: onChanged) {
       CollectionEditSheet(collection: item.collection)
-    }
-  }
-
-  private func deleteCollection() {
-    Task {
-      do {
-        try await CollectionService.deleteCollection(
-          collectionId: item.collectionId)
-        ErrorManager.shared.notify(message: String(localized: "notification.collection.deleted"))
-        onChanged()
-      } catch {
-        ErrorManager.shared.alert(error: error)
-      }
     }
   }
 

--- a/KMReader/Features/Collection/Views/CollectionDetailView.swift
+++ b/KMReader/Features/Collection/Views/CollectionDetailView.swift
@@ -102,6 +102,16 @@ struct CollectionDetailView: View {
     .task {
       await loadCollectionDetails()
     }
+    .onReceive(NotificationCenter.default.publisher(for: .collectionProjectionDidChange)) {
+      notification in
+      guard shouldHandleCollectionProjectionChange(notification) else { return }
+      Task {
+        await loadLocalCollection()
+        if item == nil {
+          dismiss()
+        }
+      }
+    }
   }
 }
 
@@ -130,6 +140,25 @@ extension CollectionDetailView {
       collectionId: collectionId,
       instanceId: current.instanceId
     )
+  }
+
+  private func shouldHandleCollectionProjectionChange(_ notification: Notification) -> Bool {
+    let changedIds = changedCollectionIds(from: notification)
+    guard !changedIds.isEmpty else { return true }
+    return changedIds.contains(collectionId)
+  }
+
+  private func changedCollectionIds(from notification: Notification) -> Set<String> {
+    if let ids = notification.userInfo?["collectionIds"] as? Set<String> {
+      return ids
+    }
+    if let ids = notification.userInfo?["collectionIds"] as? [String] {
+      return Set(ids)
+    }
+    if let id = notification.userInfo?["collectionId"] as? String {
+      return [id]
+    }
+    return []
   }
 
   @MainActor

--- a/KMReader/Features/Collection/Views/CollectionItemQueryView.swift
+++ b/KMReader/Features/Collection/Views/CollectionItemQueryView.swift
@@ -10,21 +10,49 @@ struct CollectionItemQueryView: View {
   var layout: BrowseLayoutMode = .grid
   var onMutationCompleted: (() -> Void)? = nil
 
+  @State private var showDeleteConfirmation = false
+
   var body: some View {
     NavigationLink(value: NavDestination.collectionDetail(collectionId: item.collectionId)) {
       switch layout {
       case .grid:
         CollectionCardView(
           item: item,
-          onMutationCompleted: onMutationCompleted
+          onMutationCompleted: onMutationCompleted,
+          onDeleteRequested: {
+            showDeleteConfirmation = true
+          }
         )
       case .list:
         CollectionRowView(
           item: item,
-          onMutationCompleted: onMutationCompleted
+          onMutationCompleted: onMutationCompleted,
+          onDeleteRequested: {
+            showDeleteConfirmation = true
+          }
         )
       }
     }
     .adaptiveButtonStyle(.plain)
+    .alert("Delete Collection", isPresented: $showDeleteConfirmation) {
+      Button("Cancel", role: .cancel) {}
+      Button("Delete", role: .destructive) {
+        deleteCollection()
+      }
+    } message: {
+      Text("Are you sure you want to delete this collection? This action cannot be undone.")
+    }
+  }
+
+  private func deleteCollection() {
+    Task {
+      do {
+        try await CollectionService.deleteCollection(collectionId: item.collectionId)
+        ErrorManager.shared.notify(message: String(localized: "notification.collection.deleted"))
+        onMutationCompleted?()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
   }
 }

--- a/KMReader/Features/Collection/Views/CollectionQueryItemView.swift
+++ b/KMReader/Features/Collection/Views/CollectionQueryItemView.swift
@@ -12,6 +12,7 @@ struct CollectionQueryItemView: View {
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @State private var item: CollectionDisplayItem?
+  @State private var showDeleteConfirmation = false
 
   init(
     collectionId: String,
@@ -29,12 +30,18 @@ struct CollectionQueryItemView: View {
         case .grid:
           CollectionCardView(
             item: item,
-            onMutationCompleted: reloadItem
+            onMutationCompleted: reloadItem,
+            onDeleteRequested: {
+              showDeleteConfirmation = true
+            }
           )
         case .list:
           CollectionRowView(
             item: item,
-            onMutationCompleted: reloadItem
+            onMutationCompleted: reloadItem,
+            onDeleteRequested: {
+              showDeleteConfirmation = true
+            }
           )
         }
       } else {
@@ -44,11 +51,55 @@ struct CollectionQueryItemView: View {
     .task(id: "\(current.instanceId)|\(collectionId)") {
       await loadItem()
     }
+    .onReceive(NotificationCenter.default.publisher(for: .collectionProjectionDidChange)) {
+      notification in
+      guard shouldReload(for: notification) else { return }
+      reloadItem()
+    }
+    .alert("Delete Collection", isPresented: $showDeleteConfirmation) {
+      Button("Cancel", role: .cancel) {}
+      Button("Delete", role: .destructive) {
+        deleteCollection()
+      }
+    } message: {
+      Text("Are you sure you want to delete this collection? This action cannot be undone.")
+    }
+  }
+
+  private func shouldReload(for notification: Notification) -> Bool {
+    let changedIds = changedCollectionIds(from: notification)
+    guard !changedIds.isEmpty else { return true }
+    return changedIds.contains(collectionId)
+  }
+
+  private func changedCollectionIds(from notification: Notification) -> Set<String> {
+    if let ids = notification.userInfo?["collectionIds"] as? Set<String> {
+      return ids
+    }
+    if let ids = notification.userInfo?["collectionIds"] as? [String] {
+      return Set(ids)
+    }
+    if let id = notification.userInfo?["collectionId"] as? String {
+      return [id]
+    }
+    return []
   }
 
   private func reloadItem() {
     Task {
       await loadItem()
+    }
+  }
+
+  private func deleteCollection() {
+    Task {
+      do {
+        try await CollectionService.deleteCollection(collectionId: collectionId)
+        ErrorManager.shared.notify(message: String(localized: "notification.collection.deleted"))
+        await loadItem()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
     }
   }
 

--- a/KMReader/Features/Collection/Views/CollectionQueryItemView.swift
+++ b/KMReader/Features/Collection/Views/CollectionQueryItemView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct CollectionQueryItemView: View {
   let collectionId: String
   var layout: BrowseLayoutMode = .grid
+  var onItemMissing: (() -> Void)? = nil
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @State private var item: CollectionDisplayItem?
@@ -16,10 +17,12 @@ struct CollectionQueryItemView: View {
 
   init(
     collectionId: String,
-    layout: BrowseLayoutMode = .grid
+    layout: BrowseLayoutMode = .grid,
+    onItemMissing: (() -> Void)? = nil
   ) {
     self.collectionId = collectionId
     self.layout = layout
+    self.onItemMissing = onItemMissing
 
   }
 
@@ -108,9 +111,13 @@ struct CollectionQueryItemView: View {
       item = nil
       return
     }
-    item = try? await database.fetchCollectionDisplayItem(
+    let loadedItem = try? await database.fetchCollectionDisplayItem(
       collectionId: collectionId,
       instanceId: current.instanceId
     )
+    item = loadedItem
+    if loadedItem == nil {
+      onItemMissing?()
+    }
   }
 }

--- a/KMReader/Features/Collection/Views/CollectionRowView.swift
+++ b/KMReader/Features/Collection/Views/CollectionRowView.swift
@@ -8,9 +8,9 @@ import SwiftUI
 struct CollectionRowView: View {
   let item: CollectionDisplayItem
   var onMutationCompleted: (() -> Void)? = nil
+  let onDeleteRequested: () -> Void
 
   @State private var showEditSheet = false
-  @State private var showDeleteConfirmation = false
 
   var body: some View {
     HStack(spacing: 12) {
@@ -59,7 +59,7 @@ struct CollectionRowView: View {
               menuTitle: item.name,
               isPinned: item.isPinned,
               onDeleteRequested: {
-                showDeleteConfirmation = true
+                onDeleteRequested()
               },
               onEditRequested: {
                 showEditSheet = true
@@ -73,29 +73,8 @@ struct CollectionRowView: View {
         }
       }
     }
-    .alert("Delete Collection", isPresented: $showDeleteConfirmation) {
-      Button("Cancel", role: .cancel) {}
-      Button("Delete", role: .destructive) {
-        deleteCollection()
-      }
-    } message: {
-      Text("Are you sure you want to delete this collection? This action cannot be undone.")
-    }
     .sheet(isPresented: $showEditSheet) {
       CollectionEditSheet(collection: item.collection)
-    }
-  }
-
-  private func deleteCollection() {
-    Task {
-      do {
-        try await CollectionService.deleteCollection(
-          collectionId: item.collectionId)
-        ErrorManager.shared.notify(message: String(localized: "notification.collection.deleted"))
-        onMutationCompleted?()
-      } catch {
-        ErrorManager.shared.alert(error: error)
-      }
     }
   }
 

--- a/KMReader/Features/Collection/Views/CollectionsBrowseView.swift
+++ b/KMReader/Features/Collection/Views/CollectionsBrowseView.swift
@@ -53,7 +53,10 @@ struct CollectionsBrowseView: View {
           LazyVGrid(columns: columns, spacing: spacing) {
             ForEach(items) { collection in
               CollectionQueryItemView(
-                collectionId: collection.id
+                collectionId: collection.id,
+                onItemMissing: {
+                  removeCollection(id: collection.id)
+                }
               )
               .padding(.bottom)
             }
@@ -64,7 +67,10 @@ struct CollectionsBrowseView: View {
             ForEach(items) { collection in
               CollectionQueryItemView(
                 collectionId: collection.id,
-                layout: .list
+                layout: .list,
+                onItemMissing: {
+                  removeCollection(id: collection.id)
+                }
               )
               if items.last != collection {
                 Divider()
@@ -122,6 +128,12 @@ struct CollectionsBrowseView: View {
     guard loadID == currentLoadID else { return }
     withAnimation {
       isLoading = false
+    }
+  }
+
+  private func removeCollection(id: String) {
+    withAnimation {
+      items.removeAll { $0.id == id }
     }
   }
 

--- a/KMReader/Features/Collection/Views/Sections/CollectionSeriesListView.swift
+++ b/KMReader/Features/Collection/Views/Sections/CollectionSeriesListView.swift
@@ -137,6 +137,7 @@ struct CollectionSeriesListView: View {
 
   private func refreshSeries() async {
     await loadCollection()
+    guard collectionItem != nil else { return }
     await seriesViewModel.loadCollectionSeries(
       collectionId: collectionId,
       browseOpts: browseOpts,

--- a/KMReader/Features/Collection/Views/Sections/CollectionSeriesQueryView.swift
+++ b/KMReader/Features/Collection/Views/Sections/CollectionSeriesQueryView.swift
@@ -45,7 +45,10 @@ struct CollectionSeriesQueryView: View {
                 } else {
                   SeriesQueryItemView(
                     seriesId: series.id,
-                    layout: .grid
+                    layout: .grid,
+                    onItemMissing: {
+                      seriesViewModel.removeSeries(id: series.id)
+                    }
                   )
                 }
               }
@@ -71,7 +74,10 @@ struct CollectionSeriesQueryView: View {
                 } else {
                   SeriesQueryItemView(
                     seriesId: series.id,
-                    layout: .list
+                    layout: .list,
+                    onItemMissing: {
+                      seriesViewModel.removeSeries(id: series.id)
+                    }
                   )
                 }
               }

--- a/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
@@ -20,6 +20,10 @@ struct DashboardPinnedSectionView: View {
   @State private var isLoading = false
   @State private var pinnedCollections: [CollectionDisplayItem] = []
   @State private var pinnedReadLists: [ReadListDisplayItem] = []
+  @State private var collectionPendingDelete: CollectionDisplayItem?
+  @State private var readListPendingDelete: ReadListDisplayItem?
+  @State private var showCollectionDeleteConfirmation = false
+  @State private var showReadListDeleteConfirmation = false
 
   private var isSupportedSection: Bool {
     switch section.contentKind {
@@ -134,7 +138,11 @@ struct DashboardPinnedSectionView: View {
                     CollectionCompactCardView(
                       item: collection,
                       coverWidth: compactCoverWidth,
-                      onChanged: schedulePinnedItemsReload
+                      onChanged: schedulePinnedItemsReload,
+                      onDeleteRequested: {
+                        collectionPendingDelete = collection
+                        showCollectionDeleteConfirmation = true
+                      }
                     )
                     .id(collection.collectionId)
                     .frame(width: compactCardWidth)
@@ -144,7 +152,11 @@ struct DashboardPinnedSectionView: View {
                     ReadListCompactCardView(
                       item: readList,
                       coverWidth: compactCoverWidth,
-                      onChanged: schedulePinnedItemsReload
+                      onChanged: schedulePinnedItemsReload,
+                      onDeleteRequested: {
+                        readListPendingDelete = readList
+                        showReadListDeleteConfirmation = true
+                      }
                     )
                     .id(readList.readListId)
                     .frame(width: compactCardWidth)
@@ -171,6 +183,26 @@ struct DashboardPinnedSectionView: View {
       }
       .opacity(hasItems ? 1 : 0)
       .frame(height: hasItems ? nil : 0)
+      .alert("Delete Collection", isPresented: $showCollectionDeleteConfirmation) {
+        Button("Cancel", role: .cancel) {
+          collectionPendingDelete = nil
+        }
+        Button("Delete", role: .destructive) {
+          deletePendingCollection()
+        }
+      } message: {
+        Text("Are you sure you want to delete this collection? This action cannot be undone.")
+      }
+      .alert("Delete Read List", isPresented: $showReadListDeleteConfirmation) {
+        Button("Cancel", role: .cancel) {
+          readListPendingDelete = nil
+        }
+        Button("Delete", role: .destructive) {
+          deletePendingReadList()
+        }
+      } message: {
+        Text("Are you sure you want to delete this read list? This action cannot be undone.")
+      }
       .onReceive(NotificationCenter.default.publisher(for: .dashboardSectionsShouldReload)) {
         notification in
         guard
@@ -221,6 +253,34 @@ struct DashboardPinnedSectionView: View {
   private func schedulePinnedItemsReload() {
     Task {
       await loadPinnedItems()
+    }
+  }
+
+  private func deletePendingCollection() {
+    guard let collection = collectionPendingDelete else { return }
+    Task {
+      defer { collectionPendingDelete = nil }
+      do {
+        try await CollectionService.deleteCollection(collectionId: collection.collectionId)
+        ErrorManager.shared.notify(message: String(localized: "notification.collection.deleted"))
+        await loadPinnedItems()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
+  }
+
+  private func deletePendingReadList() {
+    guard let readList = readListPendingDelete else { return }
+    Task {
+      defer { readListPendingDelete = nil }
+      do {
+        try await ReadListService.deleteReadList(readListId: readList.readListId)
+        ErrorManager.shared.notify(message: String(localized: "notification.readList.deleted"))
+        await loadPinnedItems()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
     }
   }
 

--- a/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
@@ -137,7 +137,10 @@ struct DashboardSectionDetailView: View {
           BookQueryItemView(
             bookId: book.id,
             layout: .grid,
-            showSeriesTitle: true
+            showSeriesTitle: true,
+            onItemMissing: {
+              removeItem(id: book.id)
+            }
           )
           .padding(.bottom)
           .onAppear {
@@ -153,7 +156,10 @@ struct DashboardSectionDetailView: View {
           BookQueryItemView(
             bookId: book.id,
             layout: .list,
-            showSeriesTitle: true
+            showSeriesTitle: true,
+            onItemMissing: {
+              removeItem(id: book.id)
+            }
           )
           .onAppear {
             if pagination.shouldLoadMore(after: book) {
@@ -176,7 +182,10 @@ struct DashboardSectionDetailView: View {
         ForEach(pagination.items) { series in
           SeriesQueryItemView(
             seriesId: series.id,
-            layout: .grid
+            layout: .grid,
+            onItemMissing: {
+              removeItem(id: series.id)
+            }
           )
           .padding(.bottom)
           .onAppear {
@@ -191,7 +200,10 @@ struct DashboardSectionDetailView: View {
         ForEach(pagination.items) { series in
           SeriesQueryItemView(
             seriesId: series.id,
-            layout: .list
+            layout: .list,
+            onItemMissing: {
+              removeItem(id: series.id)
+            }
           )
           .onAppear {
             if pagination.shouldLoadMore(after: series) {
@@ -288,6 +300,12 @@ struct DashboardSectionDetailView: View {
     needsRefreshAfterCurrentLoad = false
     Task {
       await loadItems(refresh: true)
+    }
+  }
+
+  private func removeItem(id: String) {
+    withAnimation {
+      _ = pagination.removeItems(withIDs: [id])
     }
   }
 

--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -131,12 +131,18 @@ struct DashboardSectionView: View {
       BookQueryItemView(
         bookId: itemId,
         layout: .grid,
-        showSeriesTitle: true
+        showSeriesTitle: true,
+        onItemMissing: {
+          removeItem(id: itemId)
+        }
       )
     case .series:
       SeriesQueryItemView(
         seriesId: itemId,
-        layout: .grid
+        layout: .grid,
+        onItemMissing: {
+          removeItem(id: itemId)
+        }
       )
     case .collections, .readLists:
       EmptyView()
@@ -268,5 +274,11 @@ struct DashboardSectionView: View {
     }
 
     pagination.advance(moreAvailable: moreAvailable)
+  }
+
+  private func removeItem(id: String) {
+    withAnimation {
+      _ = pagination.removeItems(withIDs: [id])
+    }
   }
 }

--- a/KMReader/Features/ReadList/Services/ReadListService.swift
+++ b/KMReader/Features/ReadList/Services/ReadListService.swift
@@ -122,6 +122,7 @@ nonisolated enum ReadListService {
     // Delete from local database
     let instanceId = AppConfig.current.instanceId
     try await DatabaseOperator.database().deleteReadList(id: readListId, instanceId: instanceId)
+    await ContentProjectionNotifier.postReadListDidChange(readListId: readListId, refreshDelay: 0)
   }
 
   static func removeBooksFromReadList(readListId: String, bookIds: [String]) async throws {

--- a/KMReader/Features/ReadList/Views/ReadListCardView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListCardView.swift
@@ -8,11 +8,11 @@ import SwiftUI
 struct ReadListCardView: View {
   let item: ReadListDisplayItem
   var onMutationCompleted: (() -> Void)? = nil
+  let onDeleteRequested: () -> Void
 
   @AppStorage("coverOnlyCards") private var coverOnlyCards: Bool = false
   @AppStorage("cardTextOverlayMode") private var cardTextOverlayMode: Bool = false
   @State private var showEditSheet = false
-  @State private var showDeleteConfirmation = false
 
   private var contentSpacing: CGFloat {
     cardTextOverlayMode ? 0 : 12
@@ -42,7 +42,7 @@ struct ReadListCardView: View {
           offlinePolicyLimit: item.offlinePolicyLimit,
           isPinned: item.isPinned,
           onDeleteRequested: {
-            showDeleteConfirmation = true
+            onDeleteRequested()
           },
           onEditRequested: {
             showEditSheet = true
@@ -73,14 +73,6 @@ struct ReadListCardView: View {
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .frame(maxHeight: .infinity, alignment: .top)
-    .alert("Delete Read List", isPresented: $showDeleteConfirmation) {
-      Button("Cancel", role: .cancel) {}
-      Button("Delete", role: .destructive) {
-        deleteReadList()
-      }
-    } message: {
-      Text("Are you sure you want to delete this read list? This action cannot be undone.")
-    }
     .sheet(isPresented: $showEditSheet) {
       ReadListEditSheet(readList: item.readList)
     }
@@ -94,18 +86,6 @@ struct ReadListCardView: View {
     ) {
       HStack(spacing: 4) {
         Text("\(item.bookCount) books")
-      }
-    }
-  }
-
-  private func deleteReadList() {
-    Task {
-      do {
-        try await ReadListService.deleteReadList(readListId: item.readListId)
-        ErrorManager.shared.notify(message: String(localized: "notification.readList.deleted"))
-        onMutationCompleted?()
-      } catch {
-        ErrorManager.shared.alert(error: error)
       }
     }
   }

--- a/KMReader/Features/ReadList/Views/ReadListCompactCardView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListCompactCardView.swift
@@ -10,9 +10,9 @@ struct ReadListCompactCardView: View {
   let item: ReadListDisplayItem
   var coverWidth: CGFloat = 80
   var onChanged: () -> Void = {}
+  let onDeleteRequested: () -> Void
 
   @State private var showEditSheet = false
-  @State private var showDeleteConfirmation = false
 
   var body: some View {
     NavigationLink(value: NavDestination.readListDetail(readListId: item.readListId)) {
@@ -60,7 +60,7 @@ struct ReadListCompactCardView: View {
         offlinePolicyLimit: item.offlinePolicyLimit,
         isPinned: item.isPinned,
         onDeleteRequested: {
-          showDeleteConfirmation = true
+          onDeleteRequested()
         },
         onEditRequested: {
           showEditSheet = true
@@ -71,28 +71,8 @@ struct ReadListCompactCardView: View {
         onMutationCompleted: onChanged
       )
     }
-    .alert("Delete Read List", isPresented: $showDeleteConfirmation) {
-      Button("Cancel", role: .cancel) {}
-      Button("Delete", role: .destructive) {
-        deleteReadList()
-      }
-    } message: {
-      Text("Are you sure you want to delete this read list? This action cannot be undone.")
-    }
     .sheet(isPresented: $showEditSheet, onDismiss: onChanged) {
       ReadListEditSheet(readList: item.readList)
-    }
-  }
-
-  private func deleteReadList() {
-    Task {
-      do {
-        try await ReadListService.deleteReadList(readListId: item.readListId)
-        ErrorManager.shared.notify(message: String(localized: "notification.readList.deleted"))
-        onChanged()
-      } catch {
-        ErrorManager.shared.alert(error: error)
-      }
     }
   }
 

--- a/KMReader/Features/ReadList/Views/ReadListDetailView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListDetailView.swift
@@ -120,6 +120,16 @@ struct ReadListDetailView: View {
     .task {
       await loadReadListDetails()
     }
+    .onReceive(NotificationCenter.default.publisher(for: .readListProjectionDidChange)) {
+      notification in
+      guard shouldHandleReadListProjectionChange(notification) else { return }
+      Task {
+        await loadLocalReadList()
+        if item == nil {
+          dismiss()
+        }
+      }
+    }
   }
 }
 
@@ -148,6 +158,25 @@ extension ReadListDetailView {
       readListId: readListId,
       instanceId: current.instanceId
     )
+  }
+
+  private func shouldHandleReadListProjectionChange(_ notification: Notification) -> Bool {
+    let changedIds = changedReadListIds(from: notification)
+    guard !changedIds.isEmpty else { return true }
+    return changedIds.contains(readListId)
+  }
+
+  private func changedReadListIds(from notification: Notification) -> Set<String> {
+    if let ids = notification.userInfo?["readListIds"] as? Set<String> {
+      return ids
+    }
+    if let ids = notification.userInfo?["readListIds"] as? [String] {
+      return Set(ids)
+    }
+    if let id = notification.userInfo?["readListId"] as? String {
+      return [id]
+    }
+    return []
   }
 
   @MainActor

--- a/KMReader/Features/ReadList/Views/ReadListItemQueryView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListItemQueryView.swift
@@ -10,21 +10,49 @@ struct ReadListItemQueryView: View {
   var layout: BrowseLayoutMode = .grid
   var onMutationCompleted: (() -> Void)? = nil
 
+  @State private var showDeleteConfirmation = false
+
   var body: some View {
     NavigationLink(value: NavDestination.readListDetail(readListId: item.readListId)) {
       switch layout {
       case .grid:
         ReadListCardView(
           item: item,
-          onMutationCompleted: onMutationCompleted
+          onMutationCompleted: onMutationCompleted,
+          onDeleteRequested: {
+            showDeleteConfirmation = true
+          }
         )
       case .list:
         ReadListRowView(
           item: item,
-          onMutationCompleted: onMutationCompleted
+          onMutationCompleted: onMutationCompleted,
+          onDeleteRequested: {
+            showDeleteConfirmation = true
+          }
         )
       }
     }
     .adaptiveButtonStyle(.plain)
+    .alert("Delete Read List", isPresented: $showDeleteConfirmation) {
+      Button("Cancel", role: .cancel) {}
+      Button("Delete", role: .destructive) {
+        deleteReadList()
+      }
+    } message: {
+      Text("Are you sure you want to delete this read list? This action cannot be undone.")
+    }
+  }
+
+  private func deleteReadList() {
+    Task {
+      do {
+        try await ReadListService.deleteReadList(readListId: item.readListId)
+        ErrorManager.shared.notify(message: String(localized: "notification.readList.deleted"))
+        onMutationCompleted?()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
   }
 }

--- a/KMReader/Features/ReadList/Views/ReadListQueryItemView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListQueryItemView.swift
@@ -12,6 +12,7 @@ struct ReadListQueryItemView: View {
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @State private var item: ReadListDisplayItem?
+  @State private var showDeleteConfirmation = false
 
   init(
     readListId: String,
@@ -29,12 +30,18 @@ struct ReadListQueryItemView: View {
         case .grid:
           ReadListCardView(
             item: item,
-            onMutationCompleted: reloadItem
+            onMutationCompleted: reloadItem,
+            onDeleteRequested: {
+              showDeleteConfirmation = true
+            }
           )
         case .list:
           ReadListRowView(
             item: item,
-            onMutationCompleted: reloadItem
+            onMutationCompleted: reloadItem,
+            onDeleteRequested: {
+              showDeleteConfirmation = true
+            }
           )
         }
       } else {
@@ -44,11 +51,55 @@ struct ReadListQueryItemView: View {
     .task(id: "\(current.instanceId)|\(readListId)") {
       await loadItem()
     }
+    .onReceive(NotificationCenter.default.publisher(for: .readListProjectionDidChange)) {
+      notification in
+      guard shouldReload(for: notification) else { return }
+      reloadItem()
+    }
+    .alert("Delete Read List", isPresented: $showDeleteConfirmation) {
+      Button("Cancel", role: .cancel) {}
+      Button("Delete", role: .destructive) {
+        deleteReadList()
+      }
+    } message: {
+      Text("Are you sure you want to delete this read list? This action cannot be undone.")
+    }
+  }
+
+  private func shouldReload(for notification: Notification) -> Bool {
+    let changedIds = changedReadListIds(from: notification)
+    guard !changedIds.isEmpty else { return true }
+    return changedIds.contains(readListId)
+  }
+
+  private func changedReadListIds(from notification: Notification) -> Set<String> {
+    if let ids = notification.userInfo?["readListIds"] as? Set<String> {
+      return ids
+    }
+    if let ids = notification.userInfo?["readListIds"] as? [String] {
+      return Set(ids)
+    }
+    if let id = notification.userInfo?["readListId"] as? String {
+      return [id]
+    }
+    return []
   }
 
   private func reloadItem() {
     Task {
       await loadItem()
+    }
+  }
+
+  private func deleteReadList() {
+    Task {
+      do {
+        try await ReadListService.deleteReadList(readListId: readListId)
+        ErrorManager.shared.notify(message: String(localized: "notification.readList.deleted"))
+        await loadItem()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
     }
   }
 

--- a/KMReader/Features/ReadList/Views/ReadListQueryItemView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListQueryItemView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct ReadListQueryItemView: View {
   let readListId: String
   var layout: BrowseLayoutMode = .grid
+  var onItemMissing: (() -> Void)? = nil
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @State private var item: ReadListDisplayItem?
@@ -16,10 +17,12 @@ struct ReadListQueryItemView: View {
 
   init(
     readListId: String,
-    layout: BrowseLayoutMode = .grid
+    layout: BrowseLayoutMode = .grid,
+    onItemMissing: (() -> Void)? = nil
   ) {
     self.readListId = readListId
     self.layout = layout
+    self.onItemMissing = onItemMissing
 
   }
 
@@ -108,9 +111,13 @@ struct ReadListQueryItemView: View {
       item = nil
       return
     }
-    item = try? await database.fetchReadListDisplayItem(
+    let loadedItem = try? await database.fetchReadListDisplayItem(
       readListId: readListId,
       instanceId: current.instanceId
     )
+    item = loadedItem
+    if loadedItem == nil {
+      onItemMissing?()
+    }
   }
 }

--- a/KMReader/Features/ReadList/Views/ReadListRowView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListRowView.swift
@@ -8,9 +8,9 @@ import SwiftUI
 struct ReadListRowView: View {
   let item: ReadListDisplayItem
   var onMutationCompleted: (() -> Void)? = nil
+  let onDeleteRequested: () -> Void
 
   @State private var showEditSheet = false
-  @State private var showDeleteConfirmation = false
 
   var body: some View {
     HStack(spacing: 12) {
@@ -65,7 +65,7 @@ struct ReadListRowView: View {
               offlinePolicyLimit: item.offlinePolicyLimit,
               isPinned: item.isPinned,
               onDeleteRequested: {
-                showDeleteConfirmation = true
+                onDeleteRequested()
               },
               onEditRequested: {
                 showEditSheet = true
@@ -80,28 +80,8 @@ struct ReadListRowView: View {
         }
       }
     }
-    .alert("Delete Read List", isPresented: $showDeleteConfirmation) {
-      Button("Cancel", role: .cancel) {}
-      Button("Delete", role: .destructive) {
-        deleteReadList()
-      }
-    } message: {
-      Text("Are you sure you want to delete this read list? This action cannot be undone.")
-    }
     .sheet(isPresented: $showEditSheet) {
       ReadListEditSheet(readList: item.readList)
-    }
-  }
-
-  private func deleteReadList() {
-    Task {
-      do {
-        try await ReadListService.deleteReadList(readListId: item.readListId)
-        ErrorManager.shared.notify(message: String(localized: "notification.readList.deleted"))
-        onMutationCompleted?()
-      } catch {
-        ErrorManager.shared.alert(error: error)
-      }
     }
   }
 

--- a/KMReader/Features/ReadList/Views/ReadListsBrowseView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListsBrowseView.swift
@@ -54,7 +54,10 @@ struct ReadListsBrowseView: View {
             ForEach(items) { readList in
               ReadListQueryItemView(
                 readListId: readList.id,
-                layout: .grid
+                layout: .grid,
+                onItemMissing: {
+                  removeReadList(id: readList.id)
+                }
               )
               .padding(.bottom)
             }
@@ -65,7 +68,10 @@ struct ReadListsBrowseView: View {
             ForEach(items) { readList in
               ReadListQueryItemView(
                 readListId: readList.id,
-                layout: .list
+                layout: .list,
+                onItemMissing: {
+                  removeReadList(id: readList.id)
+                }
               )
               if items.last != readList {
                 Divider()
@@ -123,6 +129,12 @@ struct ReadListsBrowseView: View {
     guard loadID == currentLoadID else { return }
     withAnimation {
       isLoading = false
+    }
+  }
+
+  private func removeReadList(id: String) {
+    withAnimation {
+      items.removeAll { $0.id == id }
     }
   }
 

--- a/KMReader/Features/Series/ViewModels/SeriesViewModel.swift
+++ b/KMReader/Features/Series/ViewModels/SeriesViewModel.swift
@@ -140,6 +140,12 @@ class SeriesViewModel {
     pagination.advance(moreAvailable: moreAvailable)
   }
 
+  func removeSeries(id: String) {
+    withAnimation {
+      _ = pagination.removeItems(withIDs: [id])
+    }
+  }
+
   private func beginLoad(refresh: Bool) -> UUID? {
     if refresh {
       withAnimation {

--- a/KMReader/Features/Series/Views/SeriesCardView.swift
+++ b/KMReader/Features/Series/Views/SeriesCardView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct SeriesCardView: View {
   let item: SeriesDisplayItem
   var onMutationCompleted: (() -> Void)? = nil
+  var onDeleteRequested: (() -> Void)? = nil
 
   @AppStorage("coverOnlyCards") private var coverOnlyCards: Bool = false
   @AppStorage("cardTextOverlayMode") private var cardTextOverlayMode: Bool = false
@@ -15,7 +16,6 @@ struct SeriesCardView: View {
   @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
 
   @State private var showCollectionPicker = false
-  @State private var showDeleteConfirmation = false
   @State private var showEditSheet = false
 
   var navDestination: NavDestination {
@@ -76,9 +76,7 @@ struct SeriesCardView: View {
           onShowCollectionPicker: {
             showCollectionPicker = true
           },
-          onDeleteRequested: {
-            showDeleteConfirmation = true
-          },
+          onDeleteRequested: onDeleteRequested,
           onEditRequested: {
             showEditSheet = true
           },
@@ -122,14 +120,6 @@ struct SeriesCardView: View {
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .frame(maxHeight: .infinity, alignment: .top)
-    .alert("Delete Series", isPresented: $showDeleteConfirmation) {
-      Button("Cancel", role: .cancel) {}
-      Button("Delete", role: .destructive) {
-        deleteSeries()
-      }
-    } message: {
-      Text("Are you sure you want to delete this series? This action cannot be undone.")
-    }
     .sheet(isPresented: $showCollectionPicker) {
       CollectionPickerSheet(
         seriesId: item.seriesId,
@@ -191,15 +181,4 @@ struct SeriesCardView: View {
     }
   }
 
-  private func deleteSeries() {
-    Task {
-      do {
-        try await SeriesDeletionService.deleteSeries(item)
-        ErrorManager.shared.notify(message: String(localized: "notification.series.deleted"))
-        onMutationCompleted?()
-      } catch {
-        ErrorManager.shared.alert(error: error)
-      }
-    }
-  }
 }

--- a/KMReader/Features/Series/Views/SeriesItemView.swift
+++ b/KMReader/Features/Series/Views/SeriesItemView.swift
@@ -10,18 +10,48 @@ struct SeriesItemView: View {
   let layout: BrowseLayoutMode
   var onMutationCompleted: (() -> Void)? = nil
 
+  @State private var showDeleteConfirmation = false
+
   var body: some View {
-    switch layout {
-    case .grid:
-      SeriesCardView(
-        item: item,
-        onMutationCompleted: onMutationCompleted
-      )
-    case .list:
-      SeriesRowView(
-        item: item,
-        onMutationCompleted: onMutationCompleted
-      )
+    Group {
+      switch layout {
+      case .grid:
+        SeriesCardView(
+          item: item,
+          onMutationCompleted: onMutationCompleted,
+          onDeleteRequested: {
+            showDeleteConfirmation = true
+          }
+        )
+      case .list:
+        SeriesRowView(
+          item: item,
+          onMutationCompleted: onMutationCompleted,
+          onDeleteRequested: {
+            showDeleteConfirmation = true
+          }
+        )
+      }
+    }
+    .alert("Delete Series", isPresented: $showDeleteConfirmation) {
+      Button("Cancel", role: .cancel) {}
+      Button("Delete", role: .destructive) {
+        deleteSeries()
+      }
+    } message: {
+      Text("Are you sure you want to delete this series? This action cannot be undone.")
+    }
+  }
+
+  private func deleteSeries() {
+    Task {
+      do {
+        try await SeriesDeletionService.deleteSeries(item)
+        ErrorManager.shared.notify(message: String(localized: "notification.series.deleted"))
+        onMutationCompleted?()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
     }
   }
 }

--- a/KMReader/Features/Series/Views/SeriesQueryItemView.swift
+++ b/KMReader/Features/Series/Views/SeriesQueryItemView.swift
@@ -12,6 +12,7 @@ struct SeriesQueryItemView: View {
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @State private var item: SeriesDisplayItem?
+  @State private var showDeleteConfirmation = false
 
   init(
     seriesId: String,
@@ -29,12 +30,18 @@ struct SeriesQueryItemView: View {
         case .grid:
           SeriesCardView(
             item: item,
-            onMutationCompleted: reloadItem
+            onMutationCompleted: reloadItem,
+            onDeleteRequested: {
+              showDeleteConfirmation = true
+            }
           )
         case .list:
           SeriesRowView(
             item: item,
-            onMutationCompleted: reloadItem
+            onMutationCompleted: reloadItem,
+            onDeleteRequested: {
+              showDeleteConfirmation = true
+            }
           )
         }
       } else {
@@ -48,6 +55,14 @@ struct SeriesQueryItemView: View {
       notification in
       guard shouldReload(for: notification) else { return }
       reloadItem()
+    }
+    .alert("Delete Series", isPresented: $showDeleteConfirmation) {
+      Button("Cancel", role: .cancel) {}
+      Button("Delete", role: .destructive) {
+        deleteSeries()
+      }
+    } message: {
+      Text("Are you sure you want to delete this series? This action cannot be undone.")
     }
   }
 
@@ -73,6 +88,22 @@ struct SeriesQueryItemView: View {
   private func reloadItem() {
     Task {
       await loadItem()
+    }
+  }
+
+  private func deleteSeries() {
+    Task {
+      do {
+        if let item {
+          try await SeriesDeletionService.deleteSeries(item)
+        } else {
+          try await SeriesDeletionService.deleteSeries(seriesId: seriesId, instanceId: current.instanceId)
+        }
+        ErrorManager.shared.notify(message: String(localized: "notification.series.deleted"))
+        await loadItem()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
     }
   }
 

--- a/KMReader/Features/Series/Views/SeriesQueryItemView.swift
+++ b/KMReader/Features/Series/Views/SeriesQueryItemView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct SeriesQueryItemView: View {
   let seriesId: String
   let layout: BrowseLayoutMode
+  var onItemMissing: (() -> Void)? = nil
 
   @AppStorage("currentAccount") private var current: Current = .init()
   @State private var item: SeriesDisplayItem?
@@ -16,10 +17,12 @@ struct SeriesQueryItemView: View {
 
   init(
     seriesId: String,
-    layout: BrowseLayoutMode
+    layout: BrowseLayoutMode,
+    onItemMissing: (() -> Void)? = nil
   ) {
     self.seriesId = seriesId
     self.layout = layout
+    self.onItemMissing = onItemMissing
 
   }
 
@@ -112,9 +115,13 @@ struct SeriesQueryItemView: View {
       item = nil
       return
     }
-    item = try? await database.fetchSeriesDisplayItem(
+    let loadedItem = try? await database.fetchSeriesDisplayItem(
       seriesId: seriesId,
       instanceId: current.instanceId
     )
+    item = loadedItem
+    if loadedItem == nil {
+      onItemMissing?()
+    }
   }
 }

--- a/KMReader/Features/Series/Views/SeriesQueryView.swift
+++ b/KMReader/Features/Series/Views/SeriesQueryView.swift
@@ -59,7 +59,10 @@ struct SeriesQueryView: View {
           ForEach(viewModel.pagination.items) { series in
             SeriesQueryItemView(
               seriesId: series.id,
-              layout: .grid
+              layout: .grid,
+              onItemMissing: {
+                viewModel.removeSeries(id: series.id)
+              }
             )
             .padding(.bottom)
             .onAppear {
@@ -75,7 +78,10 @@ struct SeriesQueryView: View {
           ForEach(viewModel.pagination.items) { series in
             SeriesQueryItemView(
               seriesId: series.id,
-              layout: .list
+              layout: .list,
+              onItemMissing: {
+                viewModel.removeSeries(id: series.id)
+              }
             )
             .onAppear {
               if viewModel.pagination.shouldLoadMore(after: series) {

--- a/KMReader/Features/Series/Views/SeriesRowView.swift
+++ b/KMReader/Features/Series/Views/SeriesRowView.swift
@@ -8,11 +8,11 @@ import SwiftUI
 struct SeriesRowView: View {
   let item: SeriesDisplayItem
   var onMutationCompleted: (() -> Void)? = nil
+  var onDeleteRequested: (() -> Void)? = nil
 
   @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
 
   @State private var showCollectionPicker = false
-  @State private var showDeleteConfirmation = false
   @State private var showEditSheet = false
 
   var series: Series {
@@ -113,9 +113,7 @@ struct SeriesRowView: View {
               onShowCollectionPicker: {
                 showCollectionPicker = true
               },
-              onDeleteRequested: {
-                showDeleteConfirmation = true
-              },
+              onDeleteRequested: onDeleteRequested,
               onEditRequested: {
                 showEditSheet = true
               },
@@ -125,14 +123,6 @@ struct SeriesRowView: View {
           }
         }
       }
-    }
-    .alert("Delete Series", isPresented: $showDeleteConfirmation) {
-      Button("Cancel", role: .cancel) {}
-      Button("Delete", role: .destructive) {
-        deleteSeries()
-      }
-    } message: {
-      Text("Are you sure you want to delete this series? This action cannot be undone.")
     }
     .sheet(isPresented: $showCollectionPicker) {
       CollectionPickerSheet(
@@ -191,15 +181,4 @@ struct SeriesRowView: View {
     }
   }
 
-  private func deleteSeries() {
-    Task {
-      do {
-        try await SeriesDeletionService.deleteSeries(series, instanceId: item.instanceId)
-        ErrorManager.shared.notify(message: String(localized: "notification.series.deleted"))
-        onMutationCompleted?()
-      } catch {
-        ErrorManager.shared.alert(error: error)
-      }
-    }
-  }
 }

--- a/KMReader/Features/Sync/Services/SyncService.swift
+++ b/KMReader/Features/Sync/Services/SyncService.swift
@@ -61,13 +61,14 @@ nonisolated enum SyncService {
         hasMore = !result.last
         page += 1
       }
-      let deletedCount = await database.deleteCollectionsNotIn(
+      let deletedCollectionIds = await database.deleteCollectionsNotIn(
         remoteCollectionIds,
         instanceId: instanceId
       )
+      await ContentProjectionNotifier.postCollectionsDidChange(collectionIds: deletedCollectionIds)
       await postSidebarProjectionDidChange(instanceId: instanceId)
-      if deletedCount > 0 {
-        logger.info("🧹 Removed \(deletedCount) stale collections")
+      if !deletedCollectionIds.isEmpty {
+        logger.info("🧹 Removed \(deletedCollectionIds.count) stale collections")
       }
       logger.info("📂 Synced collections")
     } catch {
@@ -92,13 +93,14 @@ nonisolated enum SyncService {
         page += 1
       }
       await syncAutomaticReadListBooks(Array(automaticPolicyReadListIds), instanceId: instanceId)
-      let deletedCount = await database.deleteReadListsNotIn(
+      let deletedReadListIds = await database.deleteReadListsNotIn(
         remoteReadListIds,
         instanceId: instanceId
       )
+      await ContentProjectionNotifier.postReadListsDidChange(readListIds: deletedReadListIds)
       await postSidebarProjectionDidChange(instanceId: instanceId)
-      if deletedCount > 0 {
-        logger.info("🧹 Removed \(deletedCount) stale read lists")
+      if !deletedReadListIds.isEmpty {
+        logger.info("🧹 Removed \(deletedReadListIds.count) stale read lists")
       }
       logger.info("📖 Synced readlists")
     } catch {
@@ -158,7 +160,13 @@ nonisolated enum SyncService {
       return series
     } catch APIError.notFound {
       let instanceId = AppConfig.current.instanceId
+      let item = try? await database.fetchSeriesDisplayItem(seriesId: seriesId, instanceId: instanceId)
       await database.deleteSeries(id: seriesId, instanceId: instanceId)
+      await ContentProjectionNotifier.postSeriesDidChange(
+        seriesId: seriesId,
+        libraryId: item?.series.libraryId,
+        refreshDelay: 0
+      )
       throw APIError.notFound(message: "Series not found", url: nil, response: nil, request: nil)
     }
   }
@@ -335,7 +343,15 @@ nonisolated enum SyncService {
       return book
     } catch APIError.notFound {
       let instanceId = AppConfig.current.instanceId
+      let item = try? await database.fetchBookDisplayItem(bookId: bookId, instanceId: instanceId)
       await database.deleteBook(id: bookId, instanceId: instanceId)
+      await ContentProjectionNotifier.postBookAndSeriesDidChange(
+        bookId: bookId,
+        instanceId: instanceId,
+        seriesId: item?.seriesId,
+        libraryId: item?.book.libraryId,
+        refreshDelay: 0
+      )
       throw APIError.notFound(message: "Book not found", url: nil, response: nil, request: nil)
     }
   }
@@ -453,6 +469,7 @@ nonisolated enum SyncService {
     } catch APIError.notFound {
       let instanceId = AppConfig.current.instanceId
       await database.deleteCollection(id: id, instanceId: instanceId)
+      await ContentProjectionNotifier.postCollectionDidChange(collectionId: id, refreshDelay: 0)
       throw APIError.notFound(message: "Collection not found", url: nil, response: nil, request: nil)
     }
   }
@@ -527,6 +544,7 @@ nonisolated enum SyncService {
     } catch APIError.notFound {
       let instanceId = AppConfig.current.instanceId
       await database.deleteReadList(id: id, instanceId: instanceId)
+      await ContentProjectionNotifier.postReadListDidChange(readListId: id, refreshDelay: 0)
       throw APIError.notFound(message: "Read list not found", url: nil, response: nil, request: nil)
     }
   }

--- a/KMReader/Features/Sync/Services/SyncWorker.swift
+++ b/KMReader/Features/Sync/Services/SyncWorker.swift
@@ -251,12 +251,13 @@ actor SyncWorker {
         )
       }
 
-      let deletedCount = await database.deleteCollectionsNotIn(
+      let deletedCollectionIds = await database.deleteCollectionsNotIn(
         remoteCollectionIds,
         instanceId: instanceId
       )
-      if deletedCount > 0 {
-        logger.info("🧹 Removed \(deletedCount) stale collections")
+      await ContentProjectionNotifier.postCollectionsDidChange(collectionIds: deletedCollectionIds)
+      if !deletedCollectionIds.isEmpty {
+        logger.info("🧹 Removed \(deletedCollectionIds.count) stale collections")
       }
       await SyncService.postSidebarProjectionDidChange(instanceId: instanceId)
       logger.info("📂 Synced collections")
@@ -416,12 +417,13 @@ actor SyncWorker {
       }
 
       await SyncService.syncAutomaticReadListBooks(Array(automaticPolicyReadListIds), instanceId: instanceId)
-      let deletedCount = await database.deleteReadListsNotIn(
+      let deletedReadListIds = await database.deleteReadListsNotIn(
         remoteReadListIds,
         instanceId: instanceId
       )
-      if deletedCount > 0 {
-        logger.info("🧹 Removed \(deletedCount) stale read lists")
+      await ContentProjectionNotifier.postReadListsDidChange(readListIds: deletedReadListIds)
+      if !deletedReadListIds.isEmpty {
+        logger.info("🧹 Removed \(deletedReadListIds.count) stale read lists")
       }
       await SyncService.postSidebarProjectionDidChange(instanceId: instanceId)
       logger.info("📖 Synced read lists")

--- a/KMReader/Shared/Foundation/Services/ContentProjectionNotifier.swift
+++ b/KMReader/Shared/Foundation/Services/ContentProjectionNotifier.swift
@@ -109,6 +109,18 @@ nonisolated enum ContentProjectionNotifier {
     }
   }
 
+  static func postCollectionsDidChange(
+    collectionIds: [String],
+    refreshDelay: UInt64 = localRefreshDelay
+  ) async {
+    let ids = Set(collectionIds.filter { !$0.isEmpty })
+    guard !ids.isEmpty else { return }
+
+    await MainActor.run {
+      enqueueCollectionIds(ids, refreshDelay: refreshDelay)
+    }
+  }
+
   static func postReadListDidChange(
     readListId: String,
     refreshDelay: UInt64 = localRefreshDelay
@@ -117,6 +129,18 @@ nonisolated enum ContentProjectionNotifier {
 
     await MainActor.run {
       enqueueReadListIds([readListId], refreshDelay: refreshDelay)
+    }
+  }
+
+  static func postReadListsDidChange(
+    readListIds: [String],
+    refreshDelay: UInt64 = localRefreshDelay
+  ) async {
+    let ids = Set(readListIds.filter { !$0.isEmpty })
+    guard !ids.isEmpty else { return }
+
+    await MainActor.run {
+      enqueueReadListIds(ids, refreshDelay: refreshDelay)
     }
   }
 

--- a/KMReader/Shared/Helpers/PaginationState.swift
+++ b/KMReader/Shared/Helpers/PaginationState.swift
@@ -52,4 +52,11 @@ struct PaginationState<Item: Identifiable & Equatable> {
     return true
   }
 
+  mutating func removeItems(withIDs ids: Set<Item.ID>) -> Bool {
+    guard !ids.isEmpty else { return false }
+    let originalCount = items.count
+    items.removeAll { ids.contains($0.id) }
+    return items.count != originalCount
+  }
+
 }


### PR DESCRIPTION
## Summary

Refs #909.

This stabilizes content deletion flows by moving destructive confirmation ownership out of volatile card and row views into stable query/item wrappers for read lists, collections, books, and series. Physical delete paths now emit targeted projection invalidations so existing item wrappers can fall back to placeholders without restoring browse-level refresh behavior.

The read list and collection detail/child list flows also handle removed parents explicitly, so a deleted parent no longer leaves child queries trying to reload against a missing server resource.

## Validation

- `git diff --check`
- `make build`
