### PR TITLE
fix(storage): use tvOS-safe support directory

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 489;
+				CURRENT_PROJECT_VERSION = 490;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 489;
+				CURRENT_PROJECT_VERSION = 490;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 489;
+				CURRENT_PROJECT_VERSION = 490;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 489;
+				CURRENT_PROJECT_VERSION = 490;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/AppStorageDirectory.swift
+++ b/KMReader/Core/Storage/AppStorageDirectory.swift
@@ -1,0 +1,113 @@
+//
+// AppStorageDirectory.swift
+//
+//
+
+import Foundation
+
+nonisolated enum AppStorageDirectory {
+  #if os(tvOS)
+    private static let tvOSSupportFallbackName = "KMReaderSupport"
+    private static let libraryCachesPath = "Library/Caches"
+  #endif
+
+  static func supportDirectory(fileManager: FileManager = .default) throws -> URL {
+    #if os(tvOS)
+      return try tvOSSupportDirectory(fileManager: fileManager)
+    #else
+      return try standardApplicationSupport(fileManager: fileManager)
+    #endif
+  }
+
+  static func supportDirectoryCandidates(fileManager: FileManager = .default) -> [URL] {
+    var candidates: [URL] = []
+
+    #if os(tvOS)
+      if let support = tvOSSupportDirectoryCandidate(fileManager: fileManager) {
+        candidates.append(support)
+      }
+      if let appContainerSupport = tvOSAppContainerSupportDirectoryCandidate(fileManager: fileManager) {
+        candidates.append(appContainerSupport)
+      }
+      if let sharedCaches = sharedContainerCachesDirectoryCandidate() {
+        candidates.append(sharedCaches)
+      }
+    #endif
+
+    if let applicationSupport = applicationSupportCandidate(fileManager: fileManager) {
+      candidates.append(applicationSupport)
+    }
+
+    return uniquedByPath(candidates)
+  }
+
+  static func ensureDirectoryExists(at url: URL, fileManager: FileManager = .default) throws {
+    var isDirectory: ObjCBool = false
+    if fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+      isDirectory.boolValue
+    {
+      return
+    }
+    try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+  }
+
+  private static func standardApplicationSupport(fileManager: FileManager) throws -> URL {
+    let unavailableError = AppErrorType.storageNotConfigured(message: "Application Support directory is unavailable")
+    guard let applicationSupport = applicationSupportCandidate(fileManager: fileManager) else {
+      throw unavailableError
+    }
+
+    try ensureDirectoryExists(at: applicationSupport, fileManager: fileManager)
+    return applicationSupport
+  }
+
+  private static func applicationSupportCandidate(fileManager: FileManager) -> URL? {
+    fileManager.urls(
+      for: .applicationSupportDirectory,
+      in: .userDomainMask
+    ).first
+  }
+
+  private static func uniquedByPath(_ urls: [URL]) -> [URL] {
+    var seen = Set<String>()
+    var result: [URL] = []
+    for url in urls {
+      let path = url.standardizedFileURL.path
+      guard seen.insert(path).inserted else { continue }
+      result.append(url)
+    }
+    return result
+  }
+
+  #if os(tvOS)
+    private static func tvOSSupportDirectory(fileManager: FileManager) throws -> URL {
+      guard let support = tvOSSupportDirectoryCandidate(fileManager: fileManager) else {
+        throw AppErrorType.storageNotConfigured(message: "tvOS cache directory is unavailable")
+      }
+
+      try ensureDirectoryExists(at: support, fileManager: fileManager)
+      return support
+    }
+
+    private static func tvOSSupportDirectoryCandidate(fileManager: FileManager) -> URL? {
+      tvOSAppContainerSupportDirectoryCandidate(fileManager: fileManager)
+    }
+
+    private static func tvOSAppContainerSupportDirectoryCandidate(fileManager: FileManager) -> URL? {
+      guard
+        let caches = fileManager.urls(
+          for: .cachesDirectory,
+          in: .userDomainMask
+        ).first
+      else {
+        return nil
+      }
+
+      return caches.appendingPathComponent(tvOSSupportFallbackName, isDirectory: true)
+    }
+
+    private static func sharedContainerCachesDirectoryCandidate() -> URL? {
+      WidgetDataStore.sharedContainerURL?.appendingPathComponent(libraryCachesPath, isDirectory: true)
+    }
+  #endif
+}

--- a/KMReader/Core/Storage/GRDB/LocalDatabase.swift
+++ b/KMReader/Core/Storage/GRDB/LocalDatabase.swift
@@ -98,31 +98,12 @@ nonisolated enum LocalDatabase {
   }
 
   static func databaseURL(fileManager: FileManager = .default) throws -> URL {
-    guard
-      let applicationSupport = fileManager.urls(
-        for: .applicationSupportDirectory,
-        in: .userDomainMask
-      ).first
-    else {
-      throw AppErrorType.storageNotConfigured(message: "Application Support directory is unavailable")
-    }
-
-    try fileManager.createDirectory(
-      at: applicationSupport,
-      withIntermediateDirectories: true
-    )
-    return applicationSupport.appendingPathComponent(fileName)
+    let supportDirectory = try AppStorageDirectory.supportDirectory(fileManager: fileManager)
+    return supportDirectory.appendingPathComponent(fileName)
   }
 
   static func legacyStoreCandidates(fileManager: FileManager = .default) -> [URL] {
-    var storeDirectories: [URL] = []
-
-    if let applicationSupport = fileManager.urls(
-      for: .applicationSupportDirectory,
-      in: .userDomainMask
-    ).first {
-      storeDirectories.append(applicationSupport)
-    }
+    var storeDirectories = AppStorageDirectory.supportDirectoryCandidates(fileManager: fileManager)
 
     if let sharedContainer = WidgetDataStore.sharedContainerURL {
       storeDirectories.append(sharedContainer.appendingPathComponent("Library/Application Support", isDirectory: true))

--- a/KMReader/Core/Storage/LocalDataResetService.swift
+++ b/KMReader/Core/Storage/LocalDataResetService.swift
@@ -37,14 +37,7 @@ enum LocalDataResetService {
   }
 
   private static func resetDirectories(fileManager: FileManager) -> [URL] {
-    var directories: [URL] = []
-
-    if let applicationSupport = fileManager.urls(
-      for: .applicationSupportDirectory,
-      in: .userDomainMask
-    ).first {
-      directories.append(applicationSupport)
-    }
+    var directories = AppStorageDirectory.supportDirectoryCandidates(fileManager: fileManager)
 
     if let caches = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first {
       directories.append(caches)
@@ -97,14 +90,7 @@ enum LocalDataResetService {
   }
 
   private static func persistentStoreFileCandidates(fileManager: FileManager) -> [URL] {
-    var storeDirectories: [URL] = []
-
-    if let applicationSupport = fileManager.urls(
-      for: .applicationSupportDirectory,
-      in: .userDomainMask
-    ).first {
-      storeDirectories.append(applicationSupport)
-    }
+    var storeDirectories = AppStorageDirectory.supportDirectoryCandidates(fileManager: fileManager)
 
     if let sharedContainer = WidgetDataStore.sharedContainerURL {
       storeDirectories.append(sharedContainer.appendingPathComponent("Library/Application Support", isDirectory: true))

--- a/KMReader/Core/Storage/LogStore.swift
+++ b/KMReader/Core/Storage/LogStore.swift
@@ -51,17 +51,9 @@ actor LogStore {
   }
 
   nonisolated private static func openDatabaseQueue(fileManager: FileManager = .default) throws -> DatabaseQueue {
-    guard
-      let appSupport = fileManager.urls(
-        for: .applicationSupportDirectory,
-        in: .userDomainMask
-      ).first
-    else {
-      throw AppErrorType.storageNotConfigured(message: "Application Support directory is unavailable")
-    }
-
-    let logsDir = appSupport.appendingPathComponent("Logs", isDirectory: true)
-    try fileManager.createDirectory(at: logsDir, withIntermediateDirectories: true)
+    let supportDirectory = try AppStorageDirectory.supportDirectory(fileManager: fileManager)
+    let logsDir = supportDirectory.appendingPathComponent("Logs", isDirectory: true)
+    try AppStorageDirectory.ensureDirectoryExists(at: logsDir, fileManager: fileManager)
     let url = logsDir.appendingPathComponent(fileName)
 
     let queue = try DatabaseQueue(path: url.path)

--- a/KMReader/Core/Storage/Schema/KMReaderMigrationPlan.swift
+++ b/KMReader/Core/Storage/Schema/KMReaderMigrationPlan.swift
@@ -40,18 +40,15 @@ nonisolated private enum MigrationSnapshotStore {
   private static let rawSeriesPrefix = "raw-series"
 
   private static var directoryURL: URL {
-    let baseURL =
-      FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-      ?? FileManager.default.temporaryDirectory
+    let baseURL = (try? AppStorageDirectory.supportDirectory()) ?? FileManager.default.temporaryDirectory
     return baseURL.appendingPathComponent(directoryName, isDirectory: true)
   }
 
   static func prepare() throws {
     clear()
-    try FileManager.default.createDirectory(
+    try AppStorageDirectory.ensureDirectoryExists(
       at: directoryURL,
-      withIntermediateDirectories: true,
-      attributes: nil
+      fileManager: .default
     )
   }
 

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -191,12 +191,8 @@ actor OfflineManager {
 
   /// Base directory for all offline books.
   private static func baseDirectory() -> URL {
-    let appSupport =
-      FileManager.default.urls(
-        for: .applicationSupportDirectory, in: .userDomainMask
-      ).first ?? FileManager.default.temporaryDirectory
-    ensureDirectoryExists(at: appSupport)
-    let base = appSupport.appendingPathComponent(directoryName, isDirectory: true)
+    let supportDirectory = (try? AppStorageDirectory.supportDirectory()) ?? FileManager.default.temporaryDirectory
+    let base = supportDirectory.appendingPathComponent(directoryName, isDirectory: true)
     migrateLegacyDirectoryIfNeeded(to: base)
     ensureDirectoryExists(at: base)
     excludeFromBackupIfNeeded(at: base)
@@ -2874,13 +2870,7 @@ actor OfflineManager {
   // MARK: - File System Helpers
 
   private static func ensureDirectoryExists(at url: URL) {
-    var isDirectory: ObjCBool = false
-    if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
-      isDirectory.boolValue
-    {
-      return
-    }
-    try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    try? AppStorageDirectory.ensureDirectoryExists(at: url)
   }
 
   private static func excludeFromBackupIfNeeded(at url: URL) {

--- a/KMReader/Features/Reader/Services/FontFileManager.swift
+++ b/KMReader/Features/Reader/Services/FontFileManager.swift
@@ -5,15 +5,12 @@
 
 import Foundation
 
-/// Manages font file storage in Application Support directory
+/// Manages font file storage in the app support directory.
 enum FontFileManager {
   /// Returns the base directory for custom fonts
   static func fontsDirectory() -> URL? {
-    guard let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-    else {
-      return nil
-    }
-    let fontsDir = appSupportURL.appendingPathComponent("CustomFonts", isDirectory: true)
+    guard let supportDirectory = try? AppStorageDirectory.supportDirectory() else { return nil }
+    let fontsDir = supportDirectory.appendingPathComponent("CustomFonts", isDirectory: true)
     ensureDirectoryExists(at: fontsDir)
     return fontsDir
   }
@@ -22,11 +19,8 @@ enum FontFileManager {
   /// - Parameter relativePath: Relative path like "CustomFonts/font.ttf"
   /// - Returns: Absolute file path, or nil if resolution fails
   static func resolvePath(_ relativePath: String) -> String? {
-    guard let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-    else {
-      return nil
-    }
-    return appSupportURL.appendingPathComponent(relativePath).path
+    guard let supportDirectory = try? AppStorageDirectory.supportDirectory() else { return nil }
+    return supportDirectory.appendingPathComponent(relativePath).path
   }
 
   /// Resolves a font file by its stored file name.
@@ -84,13 +78,7 @@ enum FontFileManager {
   // MARK: - Helpers
 
   private static func ensureDirectoryExists(at url: URL) {
-    var isDirectory: ObjCBool = false
-    if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
-      isDirectory.boolValue
-    {
-      return
-    }
-    try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    try? AppStorageDirectory.ensureDirectoryExists(at: url)
   }
 }
 


### PR DESCRIPTION
## What Changed

KMReader now resolves app-owned support storage through a shared helper instead of directly creating `Application Support`. On tvOS, new local databases, logs, offline books, migration snapshots, and custom fonts use an app-container cache-backed support directory so Apple TV launch does not fail when `Application Support` cannot be created on device.

The legacy SwiftData import/reset paths still check the old Application Support locations and the tvOS SwiftData App Group cache default store, so existing data can be found during migration or cleanup.

## Validation

- `git diff --check origin/main...HEAD`
- `make build`
