### PR TITLE
feat(browse): surface search from dashboard

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 491;
+				CURRENT_PROJECT_VERSION = 492;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 491;
+				CURRENT_PROJECT_VERSION = 492;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 491;
+				CURRENT_PROJECT_VERSION = 492;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 491;
+				CURRENT_PROJECT_VERSION = 492;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Browse/Views/BrowseSearchFocusModifier.swift
+++ b/KMReader/Features/Browse/Views/BrowseSearchFocusModifier.swift
@@ -1,0 +1,45 @@
+//
+// BrowseSearchFocusModifier.swift
+//
+//
+
+import SwiftUI
+
+extension View {
+  @ViewBuilder
+  func browseSearchFocus(_ binding: FocusState<Bool>.Binding, when shouldFocus: Bool) -> some View {
+    #if os(iOS) || os(macOS)
+      if #available(iOS 18.0, macOS 15.0, *) {
+        modifier(
+          BrowseSearchFocusModifier(
+            isSearchFocused: binding,
+            focusesSearchOnAppear: shouldFocus
+          )
+        )
+      } else {
+        self
+      }
+    #else
+      self
+    #endif
+  }
+}
+
+#if os(iOS) || os(macOS)
+  @available(iOS 18.0, macOS 15.0, *)
+  private struct BrowseSearchFocusModifier: ViewModifier {
+    let isSearchFocused: FocusState<Bool>.Binding
+    let focusesSearchOnAppear: Bool
+
+    func body(content: Content) -> some View {
+      content
+        .searchFocused(isSearchFocused)
+        .task {
+          if focusesSearchOnAppear {
+            await Task.yield()
+            isSearchFocused.wrappedValue = true
+          }
+        }
+    }
+  }
+#endif

--- a/KMReader/Features/Browse/Views/BrowseView.swift
+++ b/KMReader/Features/Browse/Views/BrowseView.swift
@@ -170,30 +170,28 @@ struct BrowseView: View {
           #endif
         }
 
-        ToolbarItem(placement: .confirmationAction) {
-          HStack {
-            if effectiveContent == .series || effectiveContent == .books {
-              Button {
-                showSavedFilters = true
-              } label: {
-                Image(systemName: "bookmark")
-              }
-            }
-
+        ToolbarItemGroup(placement: .confirmationAction) {
+          if effectiveContent == .series || effectiveContent == .books {
             Button {
-              showFilterSheet = true
+              showSavedFilters = true
             } label: {
-              Image(systemName: "line.3.horizontal.decrease.circle")
+              Image(systemName: "bookmark")
             }
+          }
 
-            Menu {
-              LayoutModePicker(
-                selection: layoutModeBinding,
-                showGridDensity: true
-              )
-            } label: {
-              Image(systemName: "ellipsis")
-            }
+          Button {
+            showFilterSheet = true
+          } label: {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+          }
+
+          Menu {
+            LayoutModePicker(
+              selection: layoutModeBinding,
+              showGridDensity: true
+            )
+          } label: {
+            Image(systemName: "ellipsis")
           }
         }
       }

--- a/KMReader/Features/Browse/Views/BrowseView.swift
+++ b/KMReader/Features/Browse/Views/BrowseView.swift
@@ -9,6 +9,7 @@ struct BrowseView: View {
   let authViewModel: AuthViewModel
   let fixedContent: BrowseContentType?
   let metadataFilter: MetadataFilterConfig?
+  let focusesSearchOnAppear: Bool
 
   @Environment(\.browseLibrarySelection) private var librarySelection
 
@@ -30,6 +31,7 @@ struct BrowseView: View {
   @State private var showLibraryPicker = false
   @State private var showFilterSheet = false
   @State private var showSavedFilters = false
+  @FocusState private var isSearchFocused: Bool
 
   private var effectiveContent: BrowseContentType {
     fixedContent ?? browseContent
@@ -52,11 +54,13 @@ struct BrowseView: View {
   init(
     authViewModel: AuthViewModel,
     fixedContent: BrowseContentType? = nil,
-    metadataFilter: MetadataFilterConfig? = nil
+    metadataFilter: MetadataFilterConfig? = nil,
+    focusesSearchOnAppear: Bool = false
   ) {
     self.authViewModel = authViewModel
     self.fixedContent = fixedContent
     self.metadataFilter = metadataFilter
+    self.focusesSearchOnAppear = focusesSearchOnAppear
   }
 
   var title: String {
@@ -148,6 +152,7 @@ struct BrowseView: View {
     }
     .inlineNavigationBarTitle(title)
     .searchable(text: $searchQuery)
+    .browseSearchFocus($isSearchFocused, when: focusesSearchOnAppear)
     #if os(iOS) || os(macOS)
       .toolbar {
         if librarySelection == nil {

--- a/KMReader/Features/Dashboard/Views/DashboardView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardView.swift
@@ -8,6 +8,11 @@ import SwiftUI
 struct DashboardView: View {
   let authViewModel: AuthViewModel
   let readerPresentation: ReaderPresentationManager
+
+  #if os(iOS)
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+  #endif
+
   @State private var isRefreshing = false
   @State private var showLibraryPicker = false
   @State private var isCheckingConnection = false
@@ -33,6 +38,27 @@ struct DashboardView: View {
 
   private var isQueueingDashboardOffline: Bool {
     !offlineQueueingSections.isEmpty
+  }
+
+  private var showsBrowseSearchButton: Bool {
+    #if os(macOS)
+      return true
+    #elseif os(iOS)
+      return horizontalSizeClass == .regular
+    #else
+      return false
+    #endif
+  }
+
+  @ViewBuilder
+  private var browseSearchButton: some View {
+    if showsBrowseSearchButton {
+      NavigationLink(value: NavDestination.browse) {
+        Image(systemName: "magnifyingglass")
+      }
+      .help(String(localized: "Search"))
+      .accessibilityLabel(String(localized: "Search"))
+    }
   }
 
   @ViewBuilder
@@ -188,7 +214,9 @@ struct DashboardView: View {
           }
         #endif
 
-        ToolbarItem(placement: .confirmationAction) {
+        ToolbarItemGroup(placement: .confirmationAction) {
+          browseSearchButton
+
           if isOffline {
             Button {
               Task {

--- a/KMReader/Features/Dashboard/Views/DashboardView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardView.swift
@@ -9,10 +9,6 @@ struct DashboardView: View {
   let authViewModel: AuthViewModel
   let readerPresentation: ReaderPresentationManager
 
-  #if os(iOS)
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-  #endif
-
   @State private var isRefreshing = false
   @State private var showLibraryPicker = false
   @State private var isCheckingConnection = false
@@ -44,7 +40,7 @@ struct DashboardView: View {
     #if os(macOS)
       return true
     #elseif os(iOS)
-      return horizontalSizeClass == .regular
+      return PlatformHelper.isPad
     #else
       return false
     #endif
@@ -53,7 +49,7 @@ struct DashboardView: View {
   @ViewBuilder
   private var browseSearchButton: some View {
     if showsBrowseSearchButton {
-      NavigationLink(value: NavDestination.browse) {
+      NavigationLink(value: NavDestination.browseSearch) {
         Image(systemName: "magnifyingglass")
       }
       .help(String(localized: "Search"))

--- a/KMReader/Features/Offline/Views/OfflineView.swift
+++ b/KMReader/Features/Offline/Views/OfflineView.swift
@@ -162,28 +162,26 @@ struct OfflineView: View {
           #endif
         }
 
-        ToolbarItem(placement: .confirmationAction) {
-          HStack {
-            Button {
-              showSavedFilters = true
-            } label: {
-              Image(systemName: "bookmark")
-            }
+        ToolbarItemGroup(placement: .confirmationAction) {
+          Button {
+            showSavedFilters = true
+          } label: {
+            Image(systemName: "bookmark")
+          }
 
-            Button {
-              showFilterSheet = true
-            } label: {
-              Image(systemName: "line.3.horizontal.decrease.circle")
-            }
+          Button {
+            showFilterSheet = true
+          } label: {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+          }
 
-            Menu {
-              LayoutModePicker(
-                selection: layoutModeBinding,
-                showGridDensity: true
-              )
-            } label: {
-              Image(systemName: "ellipsis")
-            }
+          Menu {
+            LayoutModePicker(
+              selection: layoutModeBinding,
+              showGridDensity: true
+            )
+          } label: {
+            Image(systemName: "ellipsis")
           }
         }
       }

--- a/KMReader/MainSplitView.swift
+++ b/KMReader/MainSplitView.swift
@@ -78,7 +78,7 @@ import SwiftUI
           detailPath.append(NavDestination.seriesDetail(seriesId: seriesId))
         }
       case .search:
-        nav = .browse
+        nav = .browseSearch
       case .downloads:
         nav = .offline
       }

--- a/KMReader/MainSplitView.swift
+++ b/KMReader/MainSplitView.swift
@@ -78,7 +78,7 @@ import SwiftUI
           detailPath.append(NavDestination.seriesDetail(seriesId: seriesId))
         }
       case .search:
-        nav = .browseSeries
+        nav = .browse
       case .downloads:
         nav = .offline
       }

--- a/KMReader/Shared/Foundation/Models/NavDestination.swift
+++ b/KMReader/Shared/Foundation/Models/NavDestination.swift
@@ -9,6 +9,7 @@ import SwiftUI
 enum NavDestination: Hashable {
   case home
   case browse
+  case browseSearch
   case browseSeries
   case browseBooks
   case browseCollections
@@ -83,6 +84,11 @@ enum NavDestination: Hashable {
       )
     case .browse:
       BrowseView(authViewModel: context.authViewModel)
+    case .browseSearch:
+      BrowseView(
+        authViewModel: context.authViewModel,
+        focusesSearchOnAppear: true
+      )
     case .browseSeries:
       BrowseView(
         authViewModel: context.authViewModel,

--- a/KMReader/Shared/Foundation/Models/NavDestination.swift
+++ b/KMReader/Shared/Foundation/Models/NavDestination.swift
@@ -8,6 +8,7 @@ import SwiftUI
 
 enum NavDestination: Hashable {
   case home
+  case browse
   case browseSeries
   case browseBooks
   case browseCollections
@@ -80,6 +81,8 @@ enum NavDestination: Hashable {
         authViewModel: context.authViewModel,
         readerPresentation: context.readerPresentation
       )
+    case .browse:
+      BrowseView(authViewModel: context.authViewModel)
     case .browseSeries:
       BrowseView(
         authViewModel: context.authViewModel,


### PR DESCRIPTION
## Summary

This adds a visible Browse/Search entry from the Dashboard toolbar on iPad and macOS, so split-view users can reach the same top-level search surface that iPhone already exposes through the Browse tab.

The Dashboard entry is shown for iPad regardless of the current horizontal size class, covering compact-width Split View and Stage Manager layouts where the app still uses `MainSplitView`. Search-specific navigation now opens Browse with a request to focus the search field on platforms where SwiftUI exposes that API.

The existing search deep link also opens this search-focused Browse route instead of jumping straight into series browse. Dashboard, Browse, and Offline toolbar actions use `ToolbarItemGroup` for peer toolbar controls instead of wrapping multiple controls in a single `ToolbarItem` with an `HStack`.

This addresses the search-entry part of #913 without closing the issue, since the other reports still need follow-up details.

## Validation

- `swift-format -i KMReader/Features/Dashboard/Views/DashboardView.swift KMReader/Features/Browse/Views/BrowseView.swift KMReader/Features/Browse/Views/BrowseSearchFocusModifier.swift KMReader/Features/Offline/Views/OfflineView.swift KMReader/Shared/Foundation/Models/NavDestination.swift KMReader/MainSplitView.swift`
- `git diff --check`
- `make build-ios`
- `make build-macos`
- `make build-tvos`
