### PR TITLE
fix(localization): correct list layout labels

### DIFF
--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -10193,7 +10193,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dernier"
+            "value" : "Liste"
           }
         },
         "it" : {
@@ -10205,7 +10205,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最後"
+            "value" : "リスト"
           }
         },
         "ko" : {


### PR DESCRIPTION
## What Changed

Corrects the localized List layout label so Japanese displays リスト instead of 最後.

The same list/last mistranslation also affected French, so this updates that label to Liste as well.

## Validation

- `python3 -m json.tool KMReader/Localizable.xcstrings >/dev/null`
- `./misc/translate.py list`
- `git diff --check`
- `make build`
