### PR TITLE
fix(offline): normalize archive path replacements

### DIFF
--- a/KMReader/Features/Offline/Services/ArchiveExtractionService.swift
+++ b/KMReader/Features/Offline/Services/ArchiveExtractionService.swift
@@ -24,7 +24,11 @@ nonisolated enum ArchiveExtractionService {
       try? FileManager.default.removeItem(at: stagingDirectory)
     }
 
-    try ArchiveReader().extract(archiveFile, to: stagingDirectory, permissionMode: .normalized)
+    try ArchiveReader().extract(
+      archiveFile,
+      to: stagingDirectory,
+      permissionMode: .normalized
+    )
 
     let extractedFiles = try regularFiles(in: stagingDirectory)
     var remainingDestinations = destinationsByArchivePath

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -2474,14 +2474,7 @@ actor OfflineManager {
       )
     }
 
-    var requiredPaths: Set<String> = []
-    for page in pages {
-      guard let normalizedPath = Self.normalizeArchivePath(page.fileName) else {
-        throw AppErrorType.invalidFileURL(url: page.fileName)
-      }
-      requiredPaths.insert(normalizedPath)
-    }
-
+    let requiredPaths = try Self.requiredArchivePaths(for: pages)
     let availablePathsByNormalizedPath = try await archivePathIndex(for: archiveFile)
     let availablePaths = Set(availablePathsByNormalizedPath.keys)
 
@@ -2600,7 +2593,10 @@ actor OfflineManager {
         throw error
       }
 
-      let archivePathIndex = try await archivePathIndex(for: archiveFile, priority: .userInitiated)
+      let archivePathIndex = try await archivePathIndex(
+        for: archiveFile,
+        priority: .userInitiated
+      )
       guard let fallbackEntryPath = archivePathIndex[normalizedPath],
         fallbackEntryPath != page.fileName
       else {
@@ -2641,6 +2637,17 @@ actor OfflineManager {
     )
   }
 
+  private static func requiredArchivePaths(for pages: [BookPage]) throws -> Set<String> {
+    var requiredPaths: Set<String> = []
+    for page in pages {
+      guard let normalizedPath = normalizeArchivePath(page.fileName) else {
+        throw AppErrorType.invalidFileURL(url: page.fileName)
+      }
+      requiredPaths.insert(normalizedPath)
+    }
+    return requiredPaths
+  }
+
   private static func manifestResourcePath(from href: String) -> String? {
     let trimmed = href.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return nil }
@@ -2658,6 +2665,11 @@ actor OfflineManager {
   }
 
   private static func normalizeArchivePath(_ path: String) -> String? {
+    // Komga's archive extractors may decode malformed path bytes as `?`, while
+    // Swift can surface U+FFFD. Normalize that replacement marker before
+    // comparing server page paths with local archive entries.
+    let path = path.replacingOccurrences(of: "\u{FFFD}", with: "?")
+
     // Treat both `/` and `\` as separators. CBR archives created on Windows tooling
     // use backslashes inside entry paths, and Komga returns those verbatim in
     // `BookPage.fileName`. libarchive normalizes RAR `\` to `/` when extracting, so


### PR DESCRIPTION
Refs #913.

## Summary

- Normalize archive path replacement markers before comparing Komga page filenames with local archive entries.
- Reuse the same normalized required-path set for archive validation and page reads.
- Keep archive decoding native instead of adding user-configurable encoding fallbacks.

## Validation

- `make format`
- `make build`
- `make localize`
- `./misc/translate.py list`
- `python3 -m json.tool KMReader/Localizable.xcstrings >/dev/null`
- `git diff --check`
