### PR TITLE
fix(widgets): sync dashboard widget entries from sections

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 494;
+				CURRENT_PROJECT_VERSION = 495;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 494;
+				CURRENT_PROJECT_VERSION = 495;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 494;
+				CURRENT_PROJECT_VERSION = 495;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 494;
+				CURRENT_PROJECT_VERSION = 495;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
@@ -715,6 +715,12 @@ extension DatabaseOperator {
     }) ?? []
   }
 
+  func fetchBooksForWidget(bookIds: [String], instanceId: String) -> [Book] {
+    (try? read { db in
+      try fetchBooksByIds(db: db, ids: bookIds, instanceId: instanceId).map { $0.toBook() }
+    }) ?? []
+  }
+
   func fetchRecentlyAddedBooksForWidget(
     instanceId: String,
     libraryIds: [String],
@@ -752,6 +758,12 @@ extension DatabaseOperator {
       sql += "\nLIMIT ?"
       arguments += StatementArguments([limit])
       return try KomgaSeries.fetchAll(db, sql: sql, arguments: arguments).map { $0.toSeries() }
+    }) ?? []
+  }
+
+  func fetchSeriesForWidget(seriesIds: [String], instanceId: String) -> [Series] {
+    (try? read { db in
+      try fetchSeriesByIds(db: db, ids: seriesIds, instanceId: instanceId).map { $0.toSeries() }
     }) ?? []
   }
 

--- a/KMReader/Core/Storage/WidgetConfigurationService.swift
+++ b/KMReader/Core/Storage/WidgetConfigurationService.swift
@@ -1,0 +1,70 @@
+//
+// WidgetConfigurationService.swift
+//
+//
+
+import Foundation
+
+#if canImport(WidgetKit) && !os(tvOS)
+  import WidgetKit
+#endif
+
+actor WidgetConfigurationService {
+  static let shared = WidgetConfigurationService()
+
+  private let cacheDuration: TimeInterval = 30
+  private var cachedKinds: Set<String>?
+  private var cachedAt: Date?
+  private var loadingTask: Task<Set<String>, Never>?
+
+  func hasConfiguredWidget(kind: String) async -> Bool {
+    await configuredWidgetKinds(matching: [kind]).contains(kind)
+  }
+
+  func configuredWidgetKinds(matching kinds: [String]) async -> Set<String> {
+    let configuredKinds = await currentConfiguredKinds()
+    return Set(kinds).intersection(configuredKinds)
+  }
+
+  private func currentConfiguredKinds() async -> Set<String> {
+    if let cachedKinds, let cachedAt, Date().timeIntervalSince(cachedAt) < cacheDuration {
+      return cachedKinds
+    }
+
+    if let loadingTask {
+      return await loadingTask.value
+    }
+
+    let task = Task {
+      await Self.loadConfiguredKinds()
+    }
+    loadingTask = task
+
+    let kinds = await task.value
+    cachedKinds = kinds
+    cachedAt = Date()
+    loadingTask = nil
+
+    return kinds
+  }
+
+  private static func loadConfiguredKinds() async -> Set<String> {
+    #if canImport(WidgetKit) && !os(tvOS)
+      await withCheckedContinuation { (continuation: CheckedContinuation<Set<String>, Never>) in
+        WidgetCenter.shared.getCurrentConfigurations { result in
+          switch result {
+          case .success(let widgets):
+            continuation.resume(returning: Set(widgets.map(\.kind)))
+          case .failure(let error):
+            AppLogger(.app).error(
+              "Failed to read widget configurations: \(error.localizedDescription)"
+            )
+            continuation.resume(returning: Set(WidgetDataStore.widgetKinds))
+          }
+        }
+      }
+    #else
+      []
+    #endif
+  }
+}

--- a/KMReader/Core/Storage/WidgetDataService.swift
+++ b/KMReader/Core/Storage/WidgetDataService.swift
@@ -19,11 +19,22 @@ enum WidgetDataService {
     let libraryIds = AppConfig.dashboard.libraryIds
 
     Task.detached(priority: .utility) {
-      guard await Self.canWriteWidgetData(instanceId: instanceId) else { return }
+      guard await Self.canWriteWidgetData(instanceId: instanceId, libraryIds: libraryIds) else {
+        return
+      }
       let configuredWidgetKinds = await WidgetConfigurationService.shared.configuredWidgetKinds(
         matching: WidgetDataStore.widgetKinds
       )
-      guard !configuredWidgetKinds.isEmpty else { return }
+      guard Self.isCurrentWidgetContext(instanceId: instanceId, libraryIds: libraryIds) else {
+        return
+      }
+      Self.clearWidgetPayloads(
+        forKinds: Set(WidgetDataStore.widgetKinds).subtracting(configuredWidgetKinds)
+      )
+      guard !configuredWidgetKinds.isEmpty else {
+        Self.copyThumbnails(books: [], series: [], removingStaleFiles: true)
+        return
+      }
 
       var copiedBooks: [Book] = []
       var copiedSeries: [Series] = []
@@ -32,12 +43,16 @@ enum WidgetDataService {
       var recentlyAddedCount = 0
       var recentlyUpdatedSeriesCount = 0
 
-      guard AppConfig.current.instanceId == instanceId else { return }
+      guard Self.isCurrentWidgetContext(instanceId: instanceId, libraryIds: libraryIds) else {
+        return
+      }
       if configuredWidgetKinds.contains(WidgetDataStore.keepReading.kind) {
         let books =
           (try? await DatabaseOperator.database().fetchKeepReadingBooksForWidget(
             instanceId: instanceId, libraryIds: libraryIds, limit: 6)) ?? []
-        guard AppConfig.current.instanceId == instanceId else { return }
+        guard Self.isCurrentWidgetContext(instanceId: instanceId, libraryIds: libraryIds) else {
+          return
+        }
         WidgetDataStore.saveEntries(
           books.map { Self.bookToEntry($0) },
           forKey: WidgetDataStore.keepReading.storageKey
@@ -51,7 +66,9 @@ enum WidgetDataService {
         let books =
           (try? await DatabaseOperator.database().fetchRecentlyAddedBooksForWidget(
             instanceId: instanceId, libraryIds: libraryIds, limit: 6)) ?? []
-        guard AppConfig.current.instanceId == instanceId else { return }
+        guard Self.isCurrentWidgetContext(instanceId: instanceId, libraryIds: libraryIds) else {
+          return
+        }
         WidgetDataStore.saveEntries(
           books.map { Self.bookToEntry($0) },
           forKey: WidgetDataStore.recentlyAdded.storageKey
@@ -65,7 +82,9 @@ enum WidgetDataService {
         let series =
           (try? await DatabaseOperator.database().fetchRecentlyUpdatedSeriesForWidget(
             instanceId: instanceId, libraryIds: libraryIds, limit: 6)) ?? []
-        guard AppConfig.current.instanceId == instanceId else { return }
+        guard Self.isCurrentWidgetContext(instanceId: instanceId, libraryIds: libraryIds) else {
+          return
+        }
         WidgetDataStore.saveSeriesEntries(
           series.map { Self.seriesToEntry($0) },
           forKey: WidgetDataStore.recentlyUpdatedSeries.storageKey
@@ -88,17 +107,23 @@ enum WidgetDataService {
     }
   }
 
-  static func updateKeepReadingBooks(_ books: [Book], instanceId: String) {
+  static func updateKeepReadingBooks(_ books: [Book], instanceId: String, libraryIds: [String]) {
     let books = Array(books.prefix(6))
     Task.detached(priority: .utility) {
-      guard await Self.canWriteWidgetData(instanceId: instanceId) else { return }
-      guard AppConfig.current.instanceId == instanceId else { return }
+      guard await Self.canWriteWidgetData(instanceId: instanceId, libraryIds: libraryIds) else {
+        return
+      }
       guard
         await WidgetConfigurationService.shared.hasConfiguredWidget(
           kind: WidgetDataStore.keepReading.kind
         )
-      else { return }
-      guard AppConfig.current.instanceId == instanceId else { return }
+      else {
+        WidgetDataStore.clearEntries(for: WidgetDataStore.keepReading)
+        return
+      }
+      guard Self.isCurrentWidgetContext(instanceId: instanceId, libraryIds: libraryIds) else {
+        return
+      }
       WidgetDataStore.saveEntries(
         books.map { Self.bookToEntry($0) },
         forKey: WidgetDataStore.keepReading.storageKey
@@ -108,17 +133,23 @@ enum WidgetDataService {
     }
   }
 
-  static func updateRecentlyAddedBooks(_ books: [Book], instanceId: String) {
+  static func updateRecentlyAddedBooks(_ books: [Book], instanceId: String, libraryIds: [String]) {
     let books = Array(books.prefix(6))
     Task.detached(priority: .utility) {
-      guard await Self.canWriteWidgetData(instanceId: instanceId) else { return }
-      guard AppConfig.current.instanceId == instanceId else { return }
+      guard await Self.canWriteWidgetData(instanceId: instanceId, libraryIds: libraryIds) else {
+        return
+      }
       guard
         await WidgetConfigurationService.shared.hasConfiguredWidget(
           kind: WidgetDataStore.recentlyAdded.kind
         )
-      else { return }
-      guard AppConfig.current.instanceId == instanceId else { return }
+      else {
+        WidgetDataStore.clearEntries(for: WidgetDataStore.recentlyAdded)
+        return
+      }
+      guard Self.isCurrentWidgetContext(instanceId: instanceId, libraryIds: libraryIds) else {
+        return
+      }
       WidgetDataStore.saveEntries(
         books.map { Self.bookToEntry($0) },
         forKey: WidgetDataStore.recentlyAdded.storageKey
@@ -128,17 +159,27 @@ enum WidgetDataService {
     }
   }
 
-  static func updateRecentlyUpdatedSeries(_ series: [Series], instanceId: String) {
+  static func updateRecentlyUpdatedSeries(
+    _ series: [Series],
+    instanceId: String,
+    libraryIds: [String]
+  ) {
     let series = Array(series.prefix(6))
     Task.detached(priority: .utility) {
-      guard await Self.canWriteWidgetData(instanceId: instanceId) else { return }
-      guard AppConfig.current.instanceId == instanceId else { return }
+      guard await Self.canWriteWidgetData(instanceId: instanceId, libraryIds: libraryIds) else {
+        return
+      }
       guard
         await WidgetConfigurationService.shared.hasConfiguredWidget(
           kind: WidgetDataStore.recentlyUpdatedSeries.kind
         )
-      else { return }
-      guard AppConfig.current.instanceId == instanceId else { return }
+      else {
+        WidgetDataStore.clearEntries(for: WidgetDataStore.recentlyUpdatedSeries)
+        return
+      }
+      guard Self.isCurrentWidgetContext(instanceId: instanceId, libraryIds: libraryIds) else {
+        return
+      }
       WidgetDataStore.saveSeriesEntries(
         series.map { Self.seriesToEntry($0) },
         forKey: WidgetDataStore.recentlyUpdatedSeries.storageKey
@@ -148,31 +189,46 @@ enum WidgetDataService {
     }
   }
 
-  static func updateKeepReadingBookIds(_ bookIds: [String], instanceId: String) async {
+  static func updateKeepReadingBookIds(
+    _ bookIds: [String],
+    instanceId: String,
+    libraryIds: [String]
+  ) async {
+    guard await canWriteWidgetData(instanceId: instanceId, libraryIds: libraryIds) else { return }
     let books =
       await DatabaseOperator.databaseIfConfigured()?.fetchBooksForWidget(
         bookIds: Array(bookIds.prefix(6)),
         instanceId: instanceId
       ) ?? []
-    updateKeepReadingBooks(books, instanceId: instanceId)
+    updateKeepReadingBooks(books, instanceId: instanceId, libraryIds: libraryIds)
   }
 
-  static func updateRecentlyAddedBookIds(_ bookIds: [String], instanceId: String) async {
+  static func updateRecentlyAddedBookIds(
+    _ bookIds: [String],
+    instanceId: String,
+    libraryIds: [String]
+  ) async {
+    guard await canWriteWidgetData(instanceId: instanceId, libraryIds: libraryIds) else { return }
     let books =
       await DatabaseOperator.databaseIfConfigured()?.fetchBooksForWidget(
         bookIds: Array(bookIds.prefix(6)),
         instanceId: instanceId
       ) ?? []
-    updateRecentlyAddedBooks(books, instanceId: instanceId)
+    updateRecentlyAddedBooks(books, instanceId: instanceId, libraryIds: libraryIds)
   }
 
-  static func updateRecentlyUpdatedSeriesIds(_ seriesIds: [String], instanceId: String) async {
+  static func updateRecentlyUpdatedSeriesIds(
+    _ seriesIds: [String],
+    instanceId: String,
+    libraryIds: [String]
+  ) async {
+    guard await canWriteWidgetData(instanceId: instanceId, libraryIds: libraryIds) else { return }
     let series =
       await DatabaseOperator.databaseIfConfigured()?.fetchSeriesForWidget(
         seriesIds: Array(seriesIds.prefix(6)),
         instanceId: instanceId
       ) ?? []
-    updateRecentlyUpdatedSeries(series, instanceId: instanceId)
+    updateRecentlyUpdatedSeries(series, instanceId: instanceId, libraryIds: libraryIds)
   }
 
   @MainActor
@@ -313,15 +369,35 @@ enum WidgetDataService {
     #endif
   }
 
-  private static nonisolated func canWriteWidgetData(instanceId: String) async -> Bool {
-    guard !instanceId.isEmpty, AppConfig.current.instanceId == instanceId else { return false }
+  private static nonisolated func clearWidgetPayloads(forKinds kinds: Set<String>) {
+    guard !kinds.isEmpty else { return }
+    for widget in WidgetDataStore.widgets where kinds.contains(widget.kind) {
+      WidgetDataStore.clearEntries(for: widget)
+    }
+  }
+
+  private static nonisolated func canWriteWidgetData(
+    instanceId: String,
+    libraryIds: [String]
+  ) async -> Bool {
+    guard isCurrentWidgetContext(instanceId: instanceId, libraryIds: libraryIds) else {
+      return false
+    }
     guard !(await isProtectedInstance(instanceId)) else {
       if AppConfig.current.instanceId == instanceId {
         await clearWidgetData()
       }
       return false
     }
-    return AppConfig.current.instanceId == instanceId
+    return isCurrentWidgetContext(instanceId: instanceId, libraryIds: libraryIds)
+  }
+
+  private static nonisolated func isCurrentWidgetContext(
+    instanceId: String,
+    libraryIds: [String]
+  ) -> Bool {
+    guard !instanceId.isEmpty, AppConfig.current.instanceId == instanceId else { return false }
+    return Set(AppConfig.dashboard.libraryIds) == Set(libraryIds)
   }
 
   private static nonisolated func isProtectedInstance(_ instanceId: String) async -> Bool {

--- a/KMReader/Core/Storage/WidgetDataService.swift
+++ b/KMReader/Core/Storage/WidgetDataService.swift
@@ -19,10 +19,7 @@ enum WidgetDataService {
     let libraryIds = AppConfig.dashboard.libraryIds
 
     Task.detached(priority: .utility) {
-      guard !(await Self.isProtectedInstance(instanceId)) else {
-        await Self.clearWidgetData()
-        return
-      }
+      guard await Self.canWriteWidgetData(instanceId: instanceId) else { return }
 
       let keepReadingBooks =
         (try? await DatabaseOperator.database().fetchKeepReadingBooksForWidget(
@@ -37,12 +34,17 @@ enum WidgetDataService {
       let recentlyAddedEntries = recentlyAddedBooks.map { Self.bookToEntry($0) }
       let recentlyUpdatedSeriesEntries = recentlyUpdatedSeries.map { Self.seriesToEntry($0) }
 
-      WidgetDataStore.saveEntries(keepReadingEntries, forKey: WidgetDataStore.keepReadingKey)
-      WidgetDataStore.saveEntries(recentlyAddedEntries, forKey: WidgetDataStore.recentlyAddedKey)
+      guard AppConfig.current.instanceId == instanceId else { return }
+      WidgetDataStore.saveEntries(keepReadingEntries, forKey: WidgetDataStore.keepReading.storageKey)
+      WidgetDataStore.saveEntries(recentlyAddedEntries, forKey: WidgetDataStore.recentlyAdded.storageKey)
       WidgetDataStore.saveSeriesEntries(
-        recentlyUpdatedSeriesEntries, forKey: WidgetDataStore.recentlyUpdatedSeriesKey)
+        recentlyUpdatedSeriesEntries, forKey: WidgetDataStore.recentlyUpdatedSeries.storageKey)
 
-      Self.copyThumbnails(books: keepReadingBooks + recentlyAddedBooks, series: recentlyUpdatedSeries)
+      Self.copyThumbnails(
+        books: keepReadingBooks + recentlyAddedBooks,
+        series: recentlyUpdatedSeries,
+        removingStaleFiles: true
+      )
 
       #if canImport(WidgetKit)
         WidgetCenter.shared.reloadAllTimelines()
@@ -51,6 +53,75 @@ enum WidgetDataService {
         "Widget data refreshed: keepReading=\(keepReadingEntries.count), recentlyAdded=\(recentlyAddedEntries.count), recentlyUpdatedSeries=\(recentlyUpdatedSeriesEntries.count)"
       )
     }
+  }
+
+  static func updateKeepReadingBooks(_ books: [Book], instanceId: String) {
+    let books = Array(books.prefix(6))
+    Task.detached(priority: .utility) {
+      guard await Self.canWriteWidgetData(instanceId: instanceId) else { return }
+      guard AppConfig.current.instanceId == instanceId else { return }
+      WidgetDataStore.saveEntries(
+        books.map { Self.bookToEntry($0) },
+        forKey: WidgetDataStore.keepReading.storageKey
+      )
+      Self.copyThumbnails(books: books, series: [])
+      Self.reloadWidget(kind: WidgetDataStore.keepReading.kind)
+    }
+  }
+
+  static func updateRecentlyAddedBooks(_ books: [Book], instanceId: String) {
+    let books = Array(books.prefix(6))
+    Task.detached(priority: .utility) {
+      guard await Self.canWriteWidgetData(instanceId: instanceId) else { return }
+      guard AppConfig.current.instanceId == instanceId else { return }
+      WidgetDataStore.saveEntries(
+        books.map { Self.bookToEntry($0) },
+        forKey: WidgetDataStore.recentlyAdded.storageKey
+      )
+      Self.copyThumbnails(books: books, series: [])
+      Self.reloadWidget(kind: WidgetDataStore.recentlyAdded.kind)
+    }
+  }
+
+  static func updateRecentlyUpdatedSeries(_ series: [Series], instanceId: String) {
+    let series = Array(series.prefix(6))
+    Task.detached(priority: .utility) {
+      guard await Self.canWriteWidgetData(instanceId: instanceId) else { return }
+      guard AppConfig.current.instanceId == instanceId else { return }
+      WidgetDataStore.saveSeriesEntries(
+        series.map { Self.seriesToEntry($0) },
+        forKey: WidgetDataStore.recentlyUpdatedSeries.storageKey
+      )
+      Self.copyThumbnails(books: [], series: series)
+      Self.reloadWidget(kind: WidgetDataStore.recentlyUpdatedSeries.kind)
+    }
+  }
+
+  static func updateKeepReadingBookIds(_ bookIds: [String], instanceId: String) async {
+    let books =
+      await DatabaseOperator.databaseIfConfigured()?.fetchBooksForWidget(
+        bookIds: Array(bookIds.prefix(6)),
+        instanceId: instanceId
+      ) ?? []
+    updateKeepReadingBooks(books, instanceId: instanceId)
+  }
+
+  static func updateRecentlyAddedBookIds(_ bookIds: [String], instanceId: String) async {
+    let books =
+      await DatabaseOperator.databaseIfConfigured()?.fetchBooksForWidget(
+        bookIds: Array(bookIds.prefix(6)),
+        instanceId: instanceId
+      ) ?? []
+    updateRecentlyAddedBooks(books, instanceId: instanceId)
+  }
+
+  static func updateRecentlyUpdatedSeriesIds(_ seriesIds: [String], instanceId: String) async {
+    let series =
+      await DatabaseOperator.databaseIfConfigured()?.fetchSeriesForWidget(
+        seriesIds: Array(seriesIds.prefix(6)),
+        instanceId: instanceId
+      ) ?? []
+    updateRecentlyUpdatedSeries(series, instanceId: instanceId)
   }
 
   @MainActor
@@ -98,7 +169,11 @@ enum WidgetDataService {
     )
   }
 
-  private static nonisolated func copyThumbnails(books: [Book], series: [Series]) {
+  private static nonisolated func copyThumbnails(
+    books: [Book],
+    series: [Series],
+    removingStaleFiles: Bool = false
+  ) {
     guard let destDir = WidgetDataStore.thumbnailDirectory else { return }
     let fm = FileManager.default
 
@@ -106,21 +181,23 @@ enum WidgetDataService {
       try? fm.createDirectory(at: destDir, withIntermediateDirectories: true)
     }
 
-    let validFileNames = Set(
-      books.compactMap { book -> String? in
-        let source = ThumbnailCache.getThumbnailFileURL(id: book.id, type: .book)
-        return fm.fileExists(atPath: source.path) ? bookThumbnailFileName(bookId: book.id) : nil
-      }
-        + series.compactMap { series in
-          let source = ThumbnailCache.getThumbnailFileURL(id: series.id, type: .series)
-          return fm.fileExists(atPath: source.path)
-            ? seriesThumbnailFileName(seriesId: series.id) : nil
+    if removingStaleFiles {
+      let validFileNames = Set(
+        books.compactMap { book -> String? in
+          let source = ThumbnailCache.getThumbnailFileURL(id: book.id, type: .book)
+          return fm.fileExists(atPath: source.path) ? bookThumbnailFileName(bookId: book.id) : nil
         }
-    )
+          + series.compactMap { series in
+            let source = ThumbnailCache.getThumbnailFileURL(id: series.id, type: .series)
+            return fm.fileExists(atPath: source.path)
+              ? seriesThumbnailFileName(seriesId: series.id) : nil
+          }
+      )
 
-    if let existing = try? fm.contentsOfDirectory(atPath: destDir.path) {
-      for file in existing where !validFileNames.contains(file) {
-        try? fm.removeItem(at: destDir.appendingPathComponent(file))
+      if let existing = try? fm.contentsOfDirectory(atPath: destDir.path) {
+        for file in existing where !validFileNames.contains(file) {
+          try? fm.removeItem(at: destDir.appendingPathComponent(file))
+        }
       }
     }
 
@@ -169,6 +246,23 @@ enum WidgetDataService {
 
   private static nonisolated func seriesThumbnailFileName(seriesId: String) -> String {
     "series_\(seriesId).jpg"
+  }
+
+  private static nonisolated func reloadWidget(kind: String) {
+    #if canImport(WidgetKit)
+      WidgetCenter.shared.reloadTimelines(ofKind: kind)
+    #endif
+  }
+
+  private static nonisolated func canWriteWidgetData(instanceId: String) async -> Bool {
+    guard !instanceId.isEmpty, AppConfig.current.instanceId == instanceId else { return false }
+    guard !(await isProtectedInstance(instanceId)) else {
+      if AppConfig.current.instanceId == instanceId {
+        await clearWidgetData()
+      }
+      return false
+    }
+    return AppConfig.current.instanceId == instanceId
   }
 
   private static nonisolated func isProtectedInstance(_ instanceId: String) async -> Bool {

--- a/KMReader/Core/Storage/WidgetDataService.swift
+++ b/KMReader/Core/Storage/WidgetDataService.swift
@@ -20,37 +20,70 @@ enum WidgetDataService {
 
     Task.detached(priority: .utility) {
       guard await Self.canWriteWidgetData(instanceId: instanceId) else { return }
+      let configuredWidgetKinds = await WidgetConfigurationService.shared.configuredWidgetKinds(
+        matching: WidgetDataStore.widgetKinds
+      )
+      guard !configuredWidgetKinds.isEmpty else { return }
 
-      let keepReadingBooks =
-        (try? await DatabaseOperator.database().fetchKeepReadingBooksForWidget(
-          instanceId: instanceId, libraryIds: libraryIds, limit: 6)) ?? []
-      let recentlyAddedBooks =
-        (try? await DatabaseOperator.database().fetchRecentlyAddedBooksForWidget(
-          instanceId: instanceId, libraryIds: libraryIds, limit: 6)) ?? []
-      let recentlyUpdatedSeries =
-        (try? await DatabaseOperator.database().fetchRecentlyUpdatedSeriesForWidget(
-          instanceId: instanceId, libraryIds: libraryIds, limit: 6)) ?? []
-      let keepReadingEntries = keepReadingBooks.map { Self.bookToEntry($0) }
-      let recentlyAddedEntries = recentlyAddedBooks.map { Self.bookToEntry($0) }
-      let recentlyUpdatedSeriesEntries = recentlyUpdatedSeries.map { Self.seriesToEntry($0) }
+      var copiedBooks: [Book] = []
+      var copiedSeries: [Series] = []
+      var reloadedKinds: Set<String> = []
+      var keepReadingCount = 0
+      var recentlyAddedCount = 0
+      var recentlyUpdatedSeriesCount = 0
 
       guard AppConfig.current.instanceId == instanceId else { return }
-      WidgetDataStore.saveEntries(keepReadingEntries, forKey: WidgetDataStore.keepReading.storageKey)
-      WidgetDataStore.saveEntries(recentlyAddedEntries, forKey: WidgetDataStore.recentlyAdded.storageKey)
-      WidgetDataStore.saveSeriesEntries(
-        recentlyUpdatedSeriesEntries, forKey: WidgetDataStore.recentlyUpdatedSeries.storageKey)
+      if configuredWidgetKinds.contains(WidgetDataStore.keepReading.kind) {
+        let books =
+          (try? await DatabaseOperator.database().fetchKeepReadingBooksForWidget(
+            instanceId: instanceId, libraryIds: libraryIds, limit: 6)) ?? []
+        guard AppConfig.current.instanceId == instanceId else { return }
+        WidgetDataStore.saveEntries(
+          books.map { Self.bookToEntry($0) },
+          forKey: WidgetDataStore.keepReading.storageKey
+        )
+        copiedBooks += books
+        reloadedKinds.insert(WidgetDataStore.keepReading.kind)
+        keepReadingCount = books.count
+      }
+
+      if configuredWidgetKinds.contains(WidgetDataStore.recentlyAdded.kind) {
+        let books =
+          (try? await DatabaseOperator.database().fetchRecentlyAddedBooksForWidget(
+            instanceId: instanceId, libraryIds: libraryIds, limit: 6)) ?? []
+        guard AppConfig.current.instanceId == instanceId else { return }
+        WidgetDataStore.saveEntries(
+          books.map { Self.bookToEntry($0) },
+          forKey: WidgetDataStore.recentlyAdded.storageKey
+        )
+        copiedBooks += books
+        reloadedKinds.insert(WidgetDataStore.recentlyAdded.kind)
+        recentlyAddedCount = books.count
+      }
+
+      if configuredWidgetKinds.contains(WidgetDataStore.recentlyUpdatedSeries.kind) {
+        let series =
+          (try? await DatabaseOperator.database().fetchRecentlyUpdatedSeriesForWidget(
+            instanceId: instanceId, libraryIds: libraryIds, limit: 6)) ?? []
+        guard AppConfig.current.instanceId == instanceId else { return }
+        WidgetDataStore.saveSeriesEntries(
+          series.map { Self.seriesToEntry($0) },
+          forKey: WidgetDataStore.recentlyUpdatedSeries.storageKey
+        )
+        copiedSeries += series
+        reloadedKinds.insert(WidgetDataStore.recentlyUpdatedSeries.kind)
+        recentlyUpdatedSeriesCount = series.count
+      }
 
       Self.copyThumbnails(
-        books: keepReadingBooks + recentlyAddedBooks,
-        series: recentlyUpdatedSeries,
+        books: copiedBooks,
+        series: copiedSeries,
         removingStaleFiles: true
       )
 
-      #if canImport(WidgetKit)
-        WidgetCenter.shared.reloadAllTimelines()
-      #endif
+      Self.reloadWidgets(kinds: reloadedKinds)
       AppLogger(.app).debug(
-        "Widget data refreshed: keepReading=\(keepReadingEntries.count), recentlyAdded=\(recentlyAddedEntries.count), recentlyUpdatedSeries=\(recentlyUpdatedSeriesEntries.count)"
+        "Widget data refreshed: keepReading=\(keepReadingCount), recentlyAdded=\(recentlyAddedCount), recentlyUpdatedSeries=\(recentlyUpdatedSeriesCount)"
       )
     }
   }
@@ -59,6 +92,12 @@ enum WidgetDataService {
     let books = Array(books.prefix(6))
     Task.detached(priority: .utility) {
       guard await Self.canWriteWidgetData(instanceId: instanceId) else { return }
+      guard AppConfig.current.instanceId == instanceId else { return }
+      guard
+        await WidgetConfigurationService.shared.hasConfiguredWidget(
+          kind: WidgetDataStore.keepReading.kind
+        )
+      else { return }
       guard AppConfig.current.instanceId == instanceId else { return }
       WidgetDataStore.saveEntries(
         books.map { Self.bookToEntry($0) },
@@ -74,6 +113,12 @@ enum WidgetDataService {
     Task.detached(priority: .utility) {
       guard await Self.canWriteWidgetData(instanceId: instanceId) else { return }
       guard AppConfig.current.instanceId == instanceId else { return }
+      guard
+        await WidgetConfigurationService.shared.hasConfiguredWidget(
+          kind: WidgetDataStore.recentlyAdded.kind
+        )
+      else { return }
+      guard AppConfig.current.instanceId == instanceId else { return }
       WidgetDataStore.saveEntries(
         books.map { Self.bookToEntry($0) },
         forKey: WidgetDataStore.recentlyAdded.storageKey
@@ -87,6 +132,12 @@ enum WidgetDataService {
     let series = Array(series.prefix(6))
     Task.detached(priority: .utility) {
       guard await Self.canWriteWidgetData(instanceId: instanceId) else { return }
+      guard AppConfig.current.instanceId == instanceId else { return }
+      guard
+        await WidgetConfigurationService.shared.hasConfiguredWidget(
+          kind: WidgetDataStore.recentlyUpdatedSeries.kind
+        )
+      else { return }
       guard AppConfig.current.instanceId == instanceId else { return }
       WidgetDataStore.saveSeriesEntries(
         series.map { Self.seriesToEntry($0) },
@@ -251,6 +302,14 @@ enum WidgetDataService {
   private static nonisolated func reloadWidget(kind: String) {
     #if canImport(WidgetKit)
       WidgetCenter.shared.reloadTimelines(ofKind: kind)
+    #endif
+  }
+
+  private static nonisolated func reloadWidgets(kinds: Set<String>) {
+    #if canImport(WidgetKit)
+      for kind in kinds {
+        WidgetCenter.shared.reloadTimelines(ofKind: kind)
+      }
     #endif
   }
 

--- a/KMReader/Features/Dashboard/Models/DashboardSection.swift
+++ b/KMReader/Features/Dashboard/Models/DashboardSection.swift
@@ -94,6 +94,19 @@ enum DashboardSection: String, CaseIterable, Identifiable, Codable, Sendable {
     }
   }
 
+  var widgetDataTarget: DashboardWidgetDataTarget? {
+    switch self {
+    case .keepReading:
+      return .keepReading
+    case .recentlyAddedBooks:
+      return .recentlyAdded
+    case .recentlyUpdatedSeries:
+      return .recentlyUpdatedSeries
+    default:
+      return nil
+    }
+  }
+
   static var latestOfflineQueueSections: [DashboardSection] {
     allCases.filter(\.supportsDownloadLatest)
   }

--- a/KMReader/Features/Dashboard/Models/DashboardWidgetDataTarget.swift
+++ b/KMReader/Features/Dashboard/Models/DashboardWidgetDataTarget.swift
@@ -8,34 +8,50 @@ enum DashboardWidgetDataTarget: Sendable {
   case recentlyAdded
   case recentlyUpdatedSeries
 
-  func update(books: [Book], instanceId: String) {
+  func update(books: [Book], instanceId: String, libraryIds: [String]) {
     switch self {
     case .keepReading:
-      WidgetDataService.updateKeepReadingBooks(books, instanceId: instanceId)
+      WidgetDataService.updateKeepReadingBooks(books, instanceId: instanceId, libraryIds: libraryIds)
     case .recentlyAdded:
-      WidgetDataService.updateRecentlyAddedBooks(books, instanceId: instanceId)
+      WidgetDataService.updateRecentlyAddedBooks(books, instanceId: instanceId, libraryIds: libraryIds)
     case .recentlyUpdatedSeries:
       break
     }
   }
 
-  func update(series: [Series], instanceId: String) {
+  func update(series: [Series], instanceId: String, libraryIds: [String]) {
     switch self {
     case .recentlyUpdatedSeries:
-      WidgetDataService.updateRecentlyUpdatedSeries(series, instanceId: instanceId)
+      WidgetDataService.updateRecentlyUpdatedSeries(
+        series,
+        instanceId: instanceId,
+        libraryIds: libraryIds
+      )
     case .keepReading, .recentlyAdded:
       break
     }
   }
 
-  func update(ids: [String], instanceId: String) async {
+  func update(ids: [String], instanceId: String, libraryIds: [String]) async {
     switch self {
     case .keepReading:
-      await WidgetDataService.updateKeepReadingBookIds(ids, instanceId: instanceId)
+      await WidgetDataService.updateKeepReadingBookIds(
+        ids,
+        instanceId: instanceId,
+        libraryIds: libraryIds
+      )
     case .recentlyAdded:
-      await WidgetDataService.updateRecentlyAddedBookIds(ids, instanceId: instanceId)
+      await WidgetDataService.updateRecentlyAddedBookIds(
+        ids,
+        instanceId: instanceId,
+        libraryIds: libraryIds
+      )
     case .recentlyUpdatedSeries:
-      await WidgetDataService.updateRecentlyUpdatedSeriesIds(ids, instanceId: instanceId)
+      await WidgetDataService.updateRecentlyUpdatedSeriesIds(
+        ids,
+        instanceId: instanceId,
+        libraryIds: libraryIds
+      )
     }
   }
 }

--- a/KMReader/Features/Dashboard/Models/DashboardWidgetDataTarget.swift
+++ b/KMReader/Features/Dashboard/Models/DashboardWidgetDataTarget.swift
@@ -1,0 +1,41 @@
+//
+// DashboardWidgetDataTarget.swift
+//
+//
+
+enum DashboardWidgetDataTarget: Sendable {
+  case keepReading
+  case recentlyAdded
+  case recentlyUpdatedSeries
+
+  func update(books: [Book], instanceId: String) {
+    switch self {
+    case .keepReading:
+      WidgetDataService.updateKeepReadingBooks(books, instanceId: instanceId)
+    case .recentlyAdded:
+      WidgetDataService.updateRecentlyAddedBooks(books, instanceId: instanceId)
+    case .recentlyUpdatedSeries:
+      break
+    }
+  }
+
+  func update(series: [Series], instanceId: String) {
+    switch self {
+    case .recentlyUpdatedSeries:
+      WidgetDataService.updateRecentlyUpdatedSeries(series, instanceId: instanceId)
+    case .keepReading, .recentlyAdded:
+      break
+    }
+  }
+
+  func update(ids: [String], instanceId: String) async {
+    switch self {
+    case .keepReading:
+      await WidgetDataService.updateKeepReadingBookIds(ids, instanceId: instanceId)
+    case .recentlyAdded:
+      await WidgetDataService.updateRecentlyAddedBookIds(ids, instanceId: instanceId)
+    case .recentlyUpdatedSeries:
+      await WidgetDataService.updateRecentlyUpdatedSeriesIds(ids, instanceId: instanceId)
+    }
+  }
+}

--- a/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
@@ -260,7 +260,12 @@ struct DashboardSectionDetailView: View {
         ids = []
       }
       applyPage(ids: ids, moreAvailable: ids.count == pagination.pageSize)
-      updateWidgetDataIfNeeded(ids: ids, refresh: refresh, instanceId: instanceId)
+      updateWidgetDataIfNeeded(
+        ids: ids,
+        refresh: refresh,
+        instanceId: instanceId,
+        libraryIds: libraryIds
+      )
     } else {
       do {
         switch section.contentKind {
@@ -273,7 +278,11 @@ struct DashboardSectionDetailView: View {
             let ids = page.content.map { $0.id }
             applyPage(ids: ids, moreAvailable: !page.last)
             if refresh {
-              updateWidgetDataIfNeeded(books: page.content, instanceId: instanceId)
+              updateWidgetDataIfNeeded(
+                books: page.content,
+                instanceId: instanceId,
+                libraryIds: libraryIds
+              )
             }
           }
         case .series:
@@ -285,7 +294,11 @@ struct DashboardSectionDetailView: View {
             let ids = page.content.map { $0.id }
             applyPage(ids: ids, moreAvailable: !page.last)
             if refresh {
-              updateWidgetDataIfNeeded(series: page.content, instanceId: instanceId)
+              updateWidgetDataIfNeeded(
+                series: page.content,
+                instanceId: instanceId,
+                libraryIds: libraryIds
+              )
             }
           }
         case .collections, .readLists:
@@ -317,20 +330,25 @@ struct DashboardSectionDetailView: View {
     }
   }
 
-  private func updateWidgetDataIfNeeded(books: [Book], instanceId: String) {
-    section.widgetDataTarget?.update(books: books, instanceId: instanceId)
+  private func updateWidgetDataIfNeeded(books: [Book], instanceId: String, libraryIds: [String]) {
+    section.widgetDataTarget?.update(books: books, instanceId: instanceId, libraryIds: libraryIds)
   }
 
-  private func updateWidgetDataIfNeeded(series: [Series], instanceId: String) {
-    section.widgetDataTarget?.update(series: series, instanceId: instanceId)
+  private func updateWidgetDataIfNeeded(series: [Series], instanceId: String, libraryIds: [String]) {
+    section.widgetDataTarget?.update(series: series, instanceId: instanceId, libraryIds: libraryIds)
   }
 
-  private func updateWidgetDataIfNeeded(ids: [String], refresh: Bool, instanceId: String) {
+  private func updateWidgetDataIfNeeded(
+    ids: [String],
+    refresh: Bool,
+    instanceId: String,
+    libraryIds: [String]
+  ) {
     guard refresh, let target = section.widgetDataTarget else { return }
     guard !instanceId.isEmpty else { return }
 
     Task {
-      await target.update(ids: ids, instanceId: instanceId)
+      await target.update(ids: ids, instanceId: instanceId, libraryIds: libraryIds)
     }
   }
 

--- a/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionDetailView.swift
@@ -239,6 +239,7 @@ struct DashboardSectionDetailView: View {
     }
 
     let libraryIds = dashboard.libraryIds
+    let instanceId = AppConfig.current.instanceId
 
     if AppConfig.isOffline {
       let ids: [String]
@@ -259,6 +260,7 @@ struct DashboardSectionDetailView: View {
         ids = []
       }
       applyPage(ids: ids, moreAvailable: ids.count == pagination.pageSize)
+      updateWidgetDataIfNeeded(ids: ids, refresh: refresh, instanceId: instanceId)
     } else {
       do {
         switch section.contentKind {
@@ -270,6 +272,9 @@ struct DashboardSectionDetailView: View {
           ) {
             let ids = page.content.map { $0.id }
             applyPage(ids: ids, moreAvailable: !page.last)
+            if refresh {
+              updateWidgetDataIfNeeded(books: page.content, instanceId: instanceId)
+            }
           }
         case .series:
           if let page = try await section.fetchSeries(
@@ -279,6 +284,9 @@ struct DashboardSectionDetailView: View {
           ) {
             let ids = page.content.map { $0.id }
             applyPage(ids: ids, moreAvailable: !page.last)
+            if refresh {
+              updateWidgetDataIfNeeded(series: page.content, instanceId: instanceId)
+            }
           }
         case .collections, .readLists:
           applyPage(ids: [], moreAvailable: false)
@@ -306,6 +314,23 @@ struct DashboardSectionDetailView: View {
   private func removeItem(id: String) {
     withAnimation {
       _ = pagination.removeItems(withIDs: [id])
+    }
+  }
+
+  private func updateWidgetDataIfNeeded(books: [Book], instanceId: String) {
+    section.widgetDataTarget?.update(books: books, instanceId: instanceId)
+  }
+
+  private func updateWidgetDataIfNeeded(series: [Series], instanceId: String) {
+    section.widgetDataTarget?.update(series: series, instanceId: instanceId)
+  }
+
+  private func updateWidgetDataIfNeeded(ids: [String], refresh: Bool, instanceId: String) {
+    guard refresh, let target = section.widgetDataTarget else { return }
+    guard !instanceId.isEmpty else { return }
+
+    Task {
+      await target.update(ids: ids, instanceId: instanceId)
     }
   }
 

--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -182,6 +182,7 @@ struct DashboardSectionView: View {
     }
 
     let libraryIds = dashboard.libraryIds
+    let instanceId = AppConfig.current.instanceId
     let isFirstPage = pagination.currentPage == 0
 
     if !AppConfig.isOffline {
@@ -207,6 +208,7 @@ struct DashboardSectionView: View {
         ids = []
       }
       applyPage(ids: ids, moreAvailable: ids.count == pagination.pageSize)
+      updateWidgetDataIfNeeded(ids: ids, isFirstPage: isFirstPage, instanceId: instanceId)
     } else {
       do {
         switch section.contentKind {
@@ -219,6 +221,7 @@ struct DashboardSectionView: View {
             let ids = page.content.map { $0.id }
             if isFirstPage {
               _ = sectionCacheStore.updateIfChanged(section: section, ids: ids)
+              updateWidgetDataIfNeeded(books: page.content, instanceId: instanceId)
             }
             applyPage(ids: ids, moreAvailable: !page.last)
           }
@@ -231,6 +234,7 @@ struct DashboardSectionView: View {
             let ids = page.content.map { $0.id }
             if isFirstPage {
               _ = sectionCacheStore.updateIfChanged(section: section, ids: ids)
+              updateWidgetDataIfNeeded(series: page.content, instanceId: instanceId)
             }
             applyPage(ids: ids, moreAvailable: !page.last)
           }
@@ -274,6 +278,23 @@ struct DashboardSectionView: View {
     }
 
     pagination.advance(moreAvailable: moreAvailable)
+  }
+
+  private func updateWidgetDataIfNeeded(books: [Book], instanceId: String) {
+    section.widgetDataTarget?.update(books: books, instanceId: instanceId)
+  }
+
+  private func updateWidgetDataIfNeeded(series: [Series], instanceId: String) {
+    section.widgetDataTarget?.update(series: series, instanceId: instanceId)
+  }
+
+  private func updateWidgetDataIfNeeded(ids: [String], isFirstPage: Bool, instanceId: String) {
+    guard isFirstPage, let target = section.widgetDataTarget else { return }
+    guard !instanceId.isEmpty else { return }
+
+    Task {
+      await target.update(ids: ids, instanceId: instanceId)
+    }
   }
 
   private func removeItem(id: String) {

--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -208,7 +208,12 @@ struct DashboardSectionView: View {
         ids = []
       }
       applyPage(ids: ids, moreAvailable: ids.count == pagination.pageSize)
-      updateWidgetDataIfNeeded(ids: ids, isFirstPage: isFirstPage, instanceId: instanceId)
+      updateWidgetDataIfNeeded(
+        ids: ids,
+        isFirstPage: isFirstPage,
+        instanceId: instanceId,
+        libraryIds: libraryIds
+      )
     } else {
       do {
         switch section.contentKind {
@@ -221,7 +226,11 @@ struct DashboardSectionView: View {
             let ids = page.content.map { $0.id }
             if isFirstPage {
               _ = sectionCacheStore.updateIfChanged(section: section, ids: ids)
-              updateWidgetDataIfNeeded(books: page.content, instanceId: instanceId)
+              updateWidgetDataIfNeeded(
+                books: page.content,
+                instanceId: instanceId,
+                libraryIds: libraryIds
+              )
             }
             applyPage(ids: ids, moreAvailable: !page.last)
           }
@@ -234,7 +243,11 @@ struct DashboardSectionView: View {
             let ids = page.content.map { $0.id }
             if isFirstPage {
               _ = sectionCacheStore.updateIfChanged(section: section, ids: ids)
-              updateWidgetDataIfNeeded(series: page.content, instanceId: instanceId)
+              updateWidgetDataIfNeeded(
+                series: page.content,
+                instanceId: instanceId,
+                libraryIds: libraryIds
+              )
             }
             applyPage(ids: ids, moreAvailable: !page.last)
           }
@@ -280,20 +293,25 @@ struct DashboardSectionView: View {
     pagination.advance(moreAvailable: moreAvailable)
   }
 
-  private func updateWidgetDataIfNeeded(books: [Book], instanceId: String) {
-    section.widgetDataTarget?.update(books: books, instanceId: instanceId)
+  private func updateWidgetDataIfNeeded(books: [Book], instanceId: String, libraryIds: [String]) {
+    section.widgetDataTarget?.update(books: books, instanceId: instanceId, libraryIds: libraryIds)
   }
 
-  private func updateWidgetDataIfNeeded(series: [Series], instanceId: String) {
-    section.widgetDataTarget?.update(series: series, instanceId: instanceId)
+  private func updateWidgetDataIfNeeded(series: [Series], instanceId: String, libraryIds: [String]) {
+    section.widgetDataTarget?.update(series: series, instanceId: instanceId, libraryIds: libraryIds)
   }
 
-  private func updateWidgetDataIfNeeded(ids: [String], isFirstPage: Bool, instanceId: String) {
+  private func updateWidgetDataIfNeeded(
+    ids: [String],
+    isFirstPage: Bool,
+    instanceId: String,
+    libraryIds: [String]
+  ) {
     guard isFirstPage, let target = section.widgetDataTarget else { return }
     guard !instanceId.isEmpty else { return }
 
     Task {
-      await target.update(ids: ids, instanceId: instanceId)
+      await target.update(ids: ids, instanceId: instanceId, libraryIds: libraryIds)
     }
   }
 

--- a/KMReaderWidgets/KeepReadingWidget.swift
+++ b/KMReaderWidgets/KeepReadingWidget.swift
@@ -17,12 +17,12 @@ struct KeepReadingProvider: TimelineProvider {
   }
 
   func getSnapshot(in context: Context, completion: @escaping (KeepReadingEntry) -> Void) {
-    let books = WidgetDataStore.loadEntries(forKey: WidgetDataStore.keepReadingKey)
+    let books = WidgetDataStore.loadEntries(forKey: WidgetDataStore.keepReading.storageKey)
     completion(KeepReadingEntry(date: .now, books: books))
   }
 
   func getTimeline(in context: Context, completion: @escaping (Timeline<KeepReadingEntry>) -> Void) {
-    let books = WidgetDataStore.loadEntries(forKey: WidgetDataStore.keepReadingKey)
+    let books = WidgetDataStore.loadEntries(forKey: WidgetDataStore.keepReading.storageKey)
     let entry = KeepReadingEntry(date: .now, books: books)
     let nextUpdate = Calendar.current.date(byAdding: .minute, value: 30, to: .now) ?? .now
     completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
@@ -103,7 +103,7 @@ struct KeepReadingWidgetEntryView: View {
 }
 
 struct KeepReadingWidget: Widget {
-  let kind = "KeepReadingWidget"
+  let kind = WidgetDataStore.keepReading.kind
 
   var body: some WidgetConfiguration {
     StaticConfiguration(kind: kind, provider: KeepReadingProvider()) { entry in

--- a/KMReaderWidgets/RecentlyAddedWidget.swift
+++ b/KMReaderWidgets/RecentlyAddedWidget.swift
@@ -17,14 +17,14 @@ struct RecentlyAddedProvider: TimelineProvider {
   }
 
   func getSnapshot(in context: Context, completion: @escaping (RecentlyAddedEntry) -> Void) {
-    let books = WidgetDataStore.loadEntries(forKey: WidgetDataStore.recentlyAddedKey)
+    let books = WidgetDataStore.loadEntries(forKey: WidgetDataStore.recentlyAdded.storageKey)
     completion(RecentlyAddedEntry(date: .now, books: books))
   }
 
   func getTimeline(
     in context: Context, completion: @escaping (Timeline<RecentlyAddedEntry>) -> Void
   ) {
-    let books = WidgetDataStore.loadEntries(forKey: WidgetDataStore.recentlyAddedKey)
+    let books = WidgetDataStore.loadEntries(forKey: WidgetDataStore.recentlyAdded.storageKey)
     let entry = RecentlyAddedEntry(date: .now, books: books)
     let nextUpdate = Calendar.current.date(byAdding: .minute, value: 30, to: .now) ?? .now
     completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
@@ -105,7 +105,7 @@ struct RecentlyAddedWidgetEntryView: View {
 }
 
 struct RecentlyAddedWidget: Widget {
-  let kind = "RecentlyAddedWidget"
+  let kind = WidgetDataStore.recentlyAdded.kind
 
   var body: some WidgetConfiguration {
     StaticConfiguration(kind: kind, provider: RecentlyAddedProvider()) { entry in

--- a/KMReaderWidgets/RecentlyUpdatedSeriesWidget.swift
+++ b/KMReaderWidgets/RecentlyUpdatedSeriesWidget.swift
@@ -17,14 +17,14 @@ struct RecentlyUpdatedSeriesProvider: TimelineProvider {
   }
 
   func getSnapshot(in context: Context, completion: @escaping (RecentlyUpdatedSeriesEntry) -> Void) {
-    let series = WidgetDataStore.loadSeriesEntries(forKey: WidgetDataStore.recentlyUpdatedSeriesKey)
+    let series = WidgetDataStore.loadSeriesEntries(forKey: WidgetDataStore.recentlyUpdatedSeries.storageKey)
     completion(RecentlyUpdatedSeriesEntry(date: .now, series: series))
   }
 
   func getTimeline(
     in context: Context, completion: @escaping (Timeline<RecentlyUpdatedSeriesEntry>) -> Void
   ) {
-    let series = WidgetDataStore.loadSeriesEntries(forKey: WidgetDataStore.recentlyUpdatedSeriesKey)
+    let series = WidgetDataStore.loadSeriesEntries(forKey: WidgetDataStore.recentlyUpdatedSeries.storageKey)
     let entry = RecentlyUpdatedSeriesEntry(date: .now, series: series)
     let nextUpdate = Calendar.current.date(byAdding: .minute, value: 30, to: .now) ?? .now
     completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
@@ -105,7 +105,7 @@ struct RecentlyUpdatedSeriesWidgetEntryView: View {
 }
 
 struct RecentlyUpdatedSeriesWidget: Widget {
-  let kind = "RecentlyUpdatedSeriesWidget"
+  let kind = WidgetDataStore.recentlyUpdatedSeries.kind
 
   var body: some WidgetConfiguration {
     StaticConfiguration(kind: kind, provider: RecentlyUpdatedSeriesProvider()) { entry in

--- a/Shared/WidgetData.swift
+++ b/Shared/WidgetData.swift
@@ -30,11 +30,6 @@ struct WidgetSeriesEntry: Codable, Sendable {
 }
 
 enum WidgetDataStore: Sendable {
-  struct WidgetDescriptor: Sendable {
-    let kind: String
-    let storageKey: String
-  }
-
   static nonisolated let suiteName = "group.com.everpcpc.Komga"
   static nonisolated let keepReading = WidgetDescriptor(
     kind: "KeepReadingWidget",
@@ -48,8 +43,11 @@ enum WidgetDataStore: Sendable {
     kind: "RecentlyUpdatedSeriesWidget",
     storageKey: "widget.recentlyUpdatedSeries"
   )
+  static nonisolated var widgets: [WidgetDescriptor] {
+    [keepReading, recentlyAdded, recentlyUpdatedSeries]
+  }
   static nonisolated var widgetKinds: [String] {
-    [keepReading.kind, recentlyAdded.kind, recentlyUpdatedSeries.kind]
+    widgets.map(\.kind)
   }
   private static nonisolated let thumbnailDirectoryName = "WidgetThumbnails"
 
@@ -69,6 +67,10 @@ enum WidgetDataStore: Sendable {
     guard let defaults = sharedDefaults else { return }
     guard let data = try? JSONEncoder().encode(entries) else { return }
     defaults.set(data, forKey: key)
+  }
+
+  static nonisolated func clearEntries(for descriptor: WidgetDescriptor) {
+    sharedDefaults?.removeObject(forKey: descriptor.storageKey)
   }
 
   static nonisolated func loadEntries(forKey key: String) -> [WidgetBookEntry] {
@@ -104,9 +106,9 @@ enum WidgetDataStore: Sendable {
   }
 
   static nonisolated func clearAll() {
-    sharedDefaults?.removeObject(forKey: keepReading.storageKey)
-    sharedDefaults?.removeObject(forKey: recentlyAdded.storageKey)
-    sharedDefaults?.removeObject(forKey: recentlyUpdatedSeries.storageKey)
+    for widget in widgets {
+      clearEntries(for: widget)
+    }
     if let dir = thumbnailDirectory {
       try? FileManager.default.removeItem(at: dir)
     }

--- a/Shared/WidgetData.swift
+++ b/Shared/WidgetData.swift
@@ -30,10 +30,24 @@ struct WidgetSeriesEntry: Codable, Sendable {
 }
 
 enum WidgetDataStore: Sendable {
+  struct WidgetDescriptor: Sendable {
+    let kind: String
+    let storageKey: String
+  }
+
   static nonisolated let suiteName = "group.com.everpcpc.Komga"
-  static nonisolated let keepReadingKey = "widget.keepReading"
-  static nonisolated let recentlyAddedKey = "widget.recentlyAdded"
-  static nonisolated let recentlyUpdatedSeriesKey = "widget.recentlyUpdatedSeries"
+  static nonisolated let keepReading = WidgetDescriptor(
+    kind: "KeepReadingWidget",
+    storageKey: "widget.keepReading"
+  )
+  static nonisolated let recentlyAdded = WidgetDescriptor(
+    kind: "RecentlyAddedWidget",
+    storageKey: "widget.recentlyAdded"
+  )
+  static nonisolated let recentlyUpdatedSeries = WidgetDescriptor(
+    kind: "RecentlyUpdatedSeriesWidget",
+    storageKey: "widget.recentlyUpdatedSeries"
+  )
   private static nonisolated let thumbnailDirectoryName = "WidgetThumbnails"
 
   static nonisolated var sharedDefaults: UserDefaults? {
@@ -87,9 +101,9 @@ enum WidgetDataStore: Sendable {
   }
 
   static nonisolated func clearAll() {
-    sharedDefaults?.removeObject(forKey: keepReadingKey)
-    sharedDefaults?.removeObject(forKey: recentlyAddedKey)
-    sharedDefaults?.removeObject(forKey: recentlyUpdatedSeriesKey)
+    sharedDefaults?.removeObject(forKey: keepReading.storageKey)
+    sharedDefaults?.removeObject(forKey: recentlyAdded.storageKey)
+    sharedDefaults?.removeObject(forKey: recentlyUpdatedSeries.storageKey)
     if let dir = thumbnailDirectory {
       try? FileManager.default.removeItem(at: dir)
     }

--- a/Shared/WidgetData.swift
+++ b/Shared/WidgetData.swift
@@ -48,6 +48,9 @@ enum WidgetDataStore: Sendable {
     kind: "RecentlyUpdatedSeriesWidget",
     storageKey: "widget.recentlyUpdatedSeries"
   )
+  static nonisolated var widgetKinds: [String] {
+    [keepReading.kind, recentlyAdded.kind, recentlyUpdatedSeries.kind]
+  }
   private static nonisolated let thumbnailDirectoryName = "WidgetThumbnails"
 
   static nonisolated var sharedDefaults: UserDefaults? {

--- a/Shared/WidgetDescriptor.swift
+++ b/Shared/WidgetDescriptor.swift
@@ -1,0 +1,9 @@
+//
+//  WidgetDescriptor.swift
+//  KMReader
+//
+
+struct WidgetDescriptor: Sendable {
+  let kind: String
+  let storageKey: String
+}


### PR DESCRIPTION
Refs #913.

## Summary

- Update widget snapshots from the Dashboard section content that was just refreshed, so widgets stay aligned with the app-visible first page.
- Scope widget writes to the Dashboard sections that actually back widgets: Keep Reading, Recently Added, and Recently Updated Series.
- Skip widget snapshot writes, thumbnail copies, and timeline reloads when the corresponding widget is not configured by the user.
- Clear skipped widget payloads so newly added widgets do not show stale entries from an old server or library filter context.
- Carry dashboard library filters through async widget writes and recheck them before saving.
- Cache WidgetKit configuration checks briefly and fail open if WidgetKit cannot return configurations.
- Include the generated build-number bump to 495.

## Validation

- `make format`
- `git diff --check`
- `make build`
