### PR TITLE
fix(dashboard): remember library filters per server

### DIFF
--- a/KMReader/ContentView.swift
+++ b/KMReader/ContentView.swift
@@ -107,6 +107,10 @@ struct ContentView: View {
         .task(id: protectedAccessTaskID) {
           guard isLoggedIn else { return }
           guard await unlockProtectedCurrentInstanceForRendering() else { return }
+          await DashboardLibrarySelectionStore.loadSelection(
+            for: current.instanceId,
+            preferCachedIfUnset: true
+          )
 
           if authViewModel.bootstrapState == .requiresValidation {
             let serverReachable = await authViewModel.loadCurrentUser()

--- a/KMReader/Core/Storage/DashboardLibrarySelectionStore.swift
+++ b/KMReader/Core/Storage/DashboardLibrarySelectionStore.swift
@@ -1,0 +1,79 @@
+//
+// DashboardLibrarySelectionStore.swift
+//
+//
+
+import Foundation
+
+enum DashboardLibrarySelectionStore {
+  static func persistSelection(_ libraryIds: [String], instanceId: String) async {
+    guard !instanceId.isEmpty else { return }
+    do {
+      let database = try await DatabaseOperator.database()
+      try await database.updateSelectedLibraryIds(libraryIds, instanceId: instanceId)
+    } catch {
+      AppLogger(.database).error(
+        "Failed to persist dashboard library selection: \(error.localizedDescription)")
+    }
+  }
+
+  @MainActor
+  static func persistCurrentSelection() async {
+    let instanceId = AppConfig.current.instanceId
+    let libraryIds = AppConfig.dashboard.libraryIds
+    await persistSelection(libraryIds, instanceId: instanceId)
+  }
+
+  @MainActor
+  static func loadSelection(for instanceId: String, preferCachedIfUnset: Bool = false) async {
+    guard !instanceId.isEmpty else {
+      applyCachedSelection([])
+      return
+    }
+
+    let cachedLibraryIds = AppConfig.dashboard.libraryIds
+    let storedLibraryIds = await fetchStoredSelection(for: instanceId)
+
+    if let storedLibraryIds {
+      applyCachedSelection(storedLibraryIds)
+      return
+    }
+
+    if preferCachedIfUnset && !cachedLibraryIds.isEmpty {
+      await persistSelection(cachedLibraryIds, instanceId: instanceId)
+      applyCachedSelection(cachedLibraryIds)
+      return
+    }
+
+    applyCachedSelection([])
+  }
+
+  @MainActor
+  static func updateCurrentSelection(_ libraryIds: [String]) {
+    let instanceId = AppConfig.current.instanceId
+    applyCachedSelection(libraryIds)
+    Task {
+      await persistSelection(libraryIds, instanceId: instanceId)
+    }
+  }
+
+  @MainActor
+  private static func applyCachedSelection(_ libraryIds: [String]) {
+    var dashboard = AppConfig.dashboard
+    guard dashboard.libraryIds != libraryIds else { return }
+    dashboard.libraryIds = libraryIds
+    AppConfig.dashboard = dashboard
+    DashboardSectionCacheStore.shared.reset()
+  }
+
+  private static func fetchStoredSelection(for instanceId: String) async -> [String]? {
+    do {
+      let database = try await DatabaseOperator.database()
+      return try await database.fetchSelectedLibraryIds(instanceId: instanceId)
+    } catch {
+      AppLogger(.database).error(
+        "Failed to load dashboard library selection: \(error.localizedDescription)")
+      return nil
+    }
+  }
+}

--- a/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
@@ -370,6 +370,24 @@ extension DatabaseOperator {
     }
   }
 
+  func fetchSelectedLibraryIds(instanceId: String) throws -> [String]? {
+    guard let uuid = UUID(uuidString: instanceId) else { return nil }
+    return try read { db in
+      guard let instance = try KomgaInstance.fetchOne(db, key: uuid) else { return nil }
+      guard instance.selectedLibraryIdsRaw != nil else { return nil }
+      return instance.selectedLibraryIds
+    }
+  }
+
+  func updateSelectedLibraryIds(_ libraryIds: [String], instanceId: String) throws {
+    guard let uuid = UUID(uuidString: instanceId) else { return }
+    try write { db in
+      guard var instance = try KomgaInstance.fetchOne(db, key: uuid) else { return }
+      instance.selectedLibraryIds = libraryIds
+      try save(instance, db: db)
+    }
+  }
+
   func updateServerDisplayItem(
     id: UUID,
     name: String,

--- a/KMReader/Core/Storage/GRDB/GRDBRecords.swift
+++ b/KMReader/Core/Storage/GRDB/GRDBRecords.swift
@@ -22,6 +22,7 @@ nonisolated extension KomgaInstance: FetchableRecord, MutablePersistableRecord {
     case isAdmin = "is_admin"
     case authMethod = "auth_method"
     case protected
+    case selectedLibraryIdsRaw = "selected_library_ids_raw"
     case createdAt = "created_at"
     case lastUsedAt = "last_used_at"
     case seriesLastSyncedAt = "series_last_synced_at"

--- a/KMReader/Core/Storage/GRDB/LocalDatabase.swift
+++ b/KMReader/Core/Storage/GRDB/LocalDatabase.swift
@@ -94,6 +94,12 @@ nonisolated enum LocalDatabase {
       try backfillReadListBookMemberships(db)
     }
 
+    migrator.registerMigration("00005_add_instance_library_selection") { db in
+      try db.alter(table: KomgaInstance.databaseTableName) { table in
+        table.add(column: "selected_library_ids_raw", .text)
+      }
+    }
+
     try migrator.migrate(writer)
   }
 

--- a/KMReader/Features/Auth/Models/KomgaInstance.swift
+++ b/KMReader/Features/Auth/Models/KomgaInstance.swift
@@ -13,6 +13,7 @@ nonisolated struct KomgaInstance: Codable, Equatable, Sendable {
   var isAdmin: Bool
   var authMethod: AuthenticationMethod?
   var protected: Bool
+  var selectedLibraryIdsRaw: String?
   var createdAt: Date
   var lastUsedAt: Date
   var seriesLastSyncedAt: Date
@@ -27,6 +28,7 @@ nonisolated struct KomgaInstance: Codable, Equatable, Sendable {
     isAdmin: Bool,
     authMethod: AuthenticationMethod = .basicAuth,
     protected: Bool = false,
+    selectedLibraryIdsRaw: String? = nil,
     createdAt: Date = Date(),
     lastUsedAt: Date = Date(),
     seriesLastSyncedAt: Date = Date(timeIntervalSince1970: 0),
@@ -40,6 +42,7 @@ nonisolated struct KomgaInstance: Codable, Equatable, Sendable {
     self.isAdmin = isAdmin
     self.authMethod = authMethod
     self.protected = protected
+    self.selectedLibraryIdsRaw = selectedLibraryIdsRaw
     self.createdAt = createdAt
     self.lastUsedAt = lastUsedAt
     self.seriesLastSyncedAt = seriesLastSyncedAt
@@ -54,5 +57,33 @@ nonisolated extension KomgaInstance {
 
   var resolvedAuthMethod: AuthenticationMethod {
     authMethod ?? .basicAuth
+  }
+
+  var selectedLibraryIds: [String] {
+    get {
+      Self.decodeSelectedLibraryIds(selectedLibraryIdsRaw)
+    }
+    set {
+      selectedLibraryIdsRaw = Self.encodeSelectedLibraryIds(newValue)
+    }
+  }
+
+  static func decodeSelectedLibraryIds(_ rawValue: String?) -> [String] {
+    guard let rawValue, let data = rawValue.data(using: .utf8) else { return [] }
+    guard let values = try? JSONSerialization.jsonObject(with: data) as? [String] else { return [] }
+    var seen = Set<String>()
+    return values.filter { !$0.isEmpty && seen.insert($0).inserted }
+  }
+
+  static func encodeSelectedLibraryIds(_ libraryIds: [String]) -> String {
+    var seen = Set<String>()
+    let normalized = libraryIds.filter { !$0.isEmpty && seen.insert($0).inserted }
+    guard
+      let data = try? JSONSerialization.data(withJSONObject: normalized, options: []),
+      let encoded = String(data: data, encoding: .utf8)
+    else {
+      return "[]"
+    }
+    return encoded
   }
 }

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -77,7 +77,10 @@ class AuthViewModel {
 
   func logout(clearCurrent: Bool = false) {
     LocalDeviceAuthenticationService.shared.clearProtectedAccess()
+    let instanceId = AppConfig.current.instanceId
+    let libraryIds = AppConfig.dashboard.libraryIds
     Task {
+      await DashboardLibrarySelectionStore.persistSelection(libraryIds, instanceId: instanceId)
       // Disconnect SSE before logout
       await SSEService.shared.disconnect()
       try? await AuthService.logout(clearCurrent: clearCurrent)
@@ -161,6 +164,7 @@ class AuthViewModel {
     }
 
     // Ensure current session is logged out before switching to a new instance when sharing a single session
+    await DashboardLibrarySelectionStore.persistCurrentSelection()
     try? await AuthService.logout()
 
     // Establish stateful session before switching
@@ -206,8 +210,7 @@ class AuthViewModel {
 
         AppConfig.isLoggedIn = true
 
-        AppConfig.dashboard.libraryIds = []
-        DashboardSectionCacheStore.shared.reset()
+        await DashboardLibrarySelectionStore.loadSelection(for: instance.instanceId)
         AppConfig.serverLastUpdate = nil
 
         // Switch to offline mode
@@ -253,6 +256,7 @@ class AuthViewModel {
     // Update AppConfig only after validation succeeds
     APIClient.shared.setServer(url: serverURL)
     APIClient.shared.setAuthToken(authToken)
+    await DashboardLibrarySelectionStore.persistCurrentSelection()
 
     let finalInstanceId: String
     let finalDisplayName: String
@@ -294,8 +298,7 @@ class AuthViewModel {
       AppConfig.exitOfflineMode()
     }
 
-    AppConfig.dashboard.libraryIds = []
-    DashboardSectionCacheStore.shared.reset()
+    await DashboardLibrarySelectionStore.loadSelection(for: finalInstanceId)
     AppConfig.serverLastUpdate = nil
 
     // Load libraries

--- a/KMReader/Shared/UI/LibraryListContent.swift
+++ b/KMReader/Shared/UI/LibraryListContent.swift
@@ -133,10 +133,16 @@ struct LibraryListContent: View {
         selectedLibraryIds = Array(selectedLibraryIds.prefix(1))
       }
     }
+    .onChange(of: dashboard.libraryIds) { _, newValue in
+      guard selectionEnabled, selectedLibraryIds != newValue else { return }
+      withAnimation {
+        selectedLibraryIds = newValue
+      }
+    }
     .onDisappear {
       if selectionEnabled, dashboard.libraryIds != selectedLibraryIds {
         withAnimation {
-          dashboard.libraryIds = selectedLibraryIds
+          DashboardLibrarySelectionStore.updateCurrentSelection(selectedLibraryIds)
         }
       }
     }


### PR DESCRIPTION
## What Changed

This makes the dashboard library filter persistent per Komga server. The current `dashboard.libraryIds` value still acts as the active UI cache, but the durable value now lives on the selected `komga_instances` row through a new append-only GRDB migration.

The active selection is saved before logout or server switching, restored after online/offline server switches, and migrated from the existing cached value on first launch when the current instance has no stored selection yet.

## User Impact

Switching between saved Komga servers no longer resets the selected/visible libraries. Each server restores its own library filter, while selecting all libraries still maps to an empty selection.

Refs #921

## Validation

- `make format`
- `git diff --check`
- `make build`
