### PR TITLE
fix(epub): stabilize vertical RTL pagination

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 495;
+				CURRENT_PROJECT_VERSION = 496;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 495;
+				CURRENT_PROJECT_VERSION = 496;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 495;
+				CURRENT_PROJECT_VERSION = 496;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 495;
+				CURRENT_PROJECT_VERSION = 496;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView.swift
@@ -178,6 +178,21 @@
         static let animationDuration: TimeInterval = 0.3
       }
 
+      private var paginationLayout: WebPubPaginationLayout {
+        WebPubPaginationLayout.resolve(
+          language: parent.viewModel.publicationLanguage,
+          readingProgression: parent.viewModel.publicationReadingProgression
+        )
+      }
+
+      private var forwardDragSign: CGFloat {
+        paginationLayout.reversesHorizontalGestureDirection ? 1 : -1
+      }
+
+      private var backwardDragSign: CGFloat {
+        -forwardDragSign
+      }
+
       init(_ parent: WebPubPagedCoverView) {
         self.parent = parent
         self.currentChapterIndex = parent.viewModel.currentChapterIndex
@@ -611,7 +626,7 @@
         guard abs(translation.x) > abs(translation.y) + Metrics.directionalDragBias else { return }
         guard abs(translation.x) > Metrics.minimumDragDistance else { return }
 
-        let directionOffset = translation.x < 0 ? 1 : -1
+        let directionOffset = pageTurnDirectionOffset(for: translation.x)
 
         if directionOffset == 1 {
           guard nextController != nil else {
@@ -621,7 +636,11 @@
             return
           }
           transitionDirection = 1
-          dragOffset = translation.x
+          dragOffset = clampedDragOffset(
+            translation.x,
+            sign: forwardDragSign,
+            viewWidth: viewWidth
+          )
         } else {
           guard previousController != nil else {
             dragOffset = translation.x * Metrics.overscrollResistance
@@ -630,11 +649,27 @@
             return
           }
           transitionDirection = -1
-          // translation.x is positive when dragging right; map 0→viewWidth to 0→viewWidth for dragOffset
-          dragOffset = min(translation.x, viewWidth)
+          dragOffset = clampedDragOffset(
+            translation.x,
+            sign: backwardDragSign,
+            viewWidth: viewWidth
+          )
         }
 
         updateDragLayout(viewWidth: viewWidth)
+      }
+
+      private func pageTurnDirectionOffset(for translationX: CGFloat) -> Int {
+        translationX * forwardDragSign > 0 ? 1 : -1
+      }
+
+      private func clampedDragOffset(
+        _ translationX: CGFloat,
+        sign: CGFloat,
+        viewWidth: CGFloat
+      ) -> CGFloat {
+        guard viewWidth > 0 else { return 0 }
+        return sign * min(abs(translationX), viewWidth)
       }
 
       private func handlePanEnded(translation: CGPoint, velocity: CGPoint, viewWidth: CGFloat) {
@@ -680,10 +715,10 @@
 
             previousController?.view.isHidden = true
           } else {
-            // Backward: previous page slides in from left
+            // Backward: previous page slides in from the physical previous edge.
             previousController?.view.isHidden = false
             previousController?.view.layer.zPosition = 1
-            let offset = dragOffset - viewWidth
+            let offset = dragOffset - backwardDragSign * viewWidth
             previousController?.view.frame = container.view.bounds.offsetBy(dx: offset, dy: 0)
             updateShadow(for: previousController?.view, isElevated: true, offset: offset)
 
@@ -736,10 +771,11 @@
             delay: 0,
             options: [.curveEaseOut]
           ) {
-            self.dragOffset = -viewWidth
+            let targetOffset = self.forwardDragSign * viewWidth
+            self.dragOffset = targetOffset
             self.frontController?.view.frame =
-              self.containerViewController?.view.bounds.offsetBy(dx: -viewWidth, dy: 0) ?? .zero
-            self.updateShadow(for: self.frontController?.view, isElevated: true, offset: -viewWidth)
+              self.containerViewController?.view.bounds.offsetBy(dx: targetOffset, dy: 0) ?? .zero
+            self.updateShadow(for: self.frontController?.view, isElevated: true, offset: targetOffset)
           } completion: { _ in
             self.completeForwardTransition()
           }
@@ -749,7 +785,7 @@
             delay: 0,
             options: [.curveEaseOut]
           ) {
-            self.dragOffset = viewWidth
+            self.dragOffset = self.backwardDragSign * viewWidth
             self.previousController?.view.frame = self.containerViewController?.view.bounds ?? .zero
             self.updateShadow(for: self.previousController?.view, isElevated: true, offset: 0)
           } completion: { _ in
@@ -916,9 +952,10 @@
             delay: 0,
             options: [.curveEaseOut]
           ) {
+            let targetOffset = self.forwardDragSign * viewWidth
             self.frontController?.view.frame =
-              container.view.bounds.offsetBy(dx: -viewWidth, dy: 0)
-            self.updateShadow(for: self.frontController?.view, isElevated: true, offset: -viewWidth)
+              container.view.bounds.offsetBy(dx: targetOffset, dy: 0)
+            self.updateShadow(for: self.frontController?.view, isElevated: true, offset: targetOffset)
           } completion: { _ in
             self.finalizeJump(
               to: targetVC,
@@ -927,9 +964,9 @@
             )
           }
         } else {
-          // Target slides in from left
+          // Target slides in from the physical previous edge.
           targetVC.view.layer.zPosition = 1
-          targetVC.view.frame = container.view.bounds.offsetBy(dx: -viewWidth, dy: 0)
+          targetVC.view.frame = container.view.bounds.offsetBy(dx: -backwardDragSign * viewWidth, dy: 0)
           targetVC.view.isHidden = false
           frontController?.view.layer.zPosition = 0
 
@@ -991,9 +1028,15 @@
               options: [.curveEaseOut]
             ) {
               self.previousController?.view.frame =
-                self.containerViewController?.view.bounds.offsetBy(dx: -viewWidth, dy: 0) ?? .zero
+                self.containerViewController?.view.bounds.offsetBy(
+                  dx: -self.backwardDragSign * viewWidth,
+                  dy: 0
+                ) ?? .zero
               self.updateShadow(
-                for: self.previousController?.view, isElevated: true, offset: -viewWidth)
+                for: self.previousController?.view,
+                isElevated: true,
+                offset: -self.backwardDragSign * viewWidth
+              )
             } completion: { _ in
               self.resetDragState()
             }

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCoverView_macOS.swift
@@ -123,6 +123,13 @@
     private var snapshotRequestID: Int = 0
     private var horizontalAnimationOffset: CGFloat = 0
 
+    private var paginationLayout: WebPubPaginationLayout {
+      WebPubPaginationLayout.resolve(
+        language: publicationLanguage,
+        readingProgression: publicationReadingProgression
+      )
+    }
+
     init(parent: WebPubPagedCoverView) {
       self.parent = parent
       super.init()
@@ -570,7 +577,7 @@
     }
 
     private func coverEdgeOffset(distance: CGFloat) -> CGFloat {
-      publicationReadingProgression == .rtl ? distance : -distance
+      paginationLayout.reversesHorizontalGestureDirection ? distance : -distance
     }
 
     private func updateProgressDisplay(for pageIndex: Int) {
@@ -625,24 +632,11 @@
 
     private func scrollToPage(_ pageIndex: Int, animated: Bool) {
       guard let webView else { return }
-      let pageWidth = webView.bounds.width
-      guard pageWidth > 0 else { return }
-      let contentWidth = max(pageWidth, CGFloat(totalPagesInChapter) * pageWidth)
-      let maxOffset = max(0, contentWidth - pageWidth)
-      let targetOffset = min(pageWidth * CGFloat(pageIndex), maxOffset)
-      let js = """
-          (function() {
-            var left = \(Double(targetOffset));
-            if (\(animated ? "true" : "false")) {
-              window.scrollTo({ left: left, top: 0, behavior: 'smooth' });
-            } else {
-              window.scrollTo(left, 0);
-            }
-            if (document.documentElement) { document.documentElement.scrollLeft = left; }
-            if (document.body) { document.body.scrollLeft = left; }
-            return true;
-          })();
-        """
+      let js = WebPubPagedJavaScriptBuilder.makeScrollToPageScript(
+        pageIndex: pageIndex,
+        animated: animated,
+        paginationLayout: paginationLayout
+      )
       webView.evaluateJavaScript(js, completionHandler: nil)
     }
 
@@ -723,7 +717,8 @@
       let js = WebPubPagedJavaScriptBuilder.makePaginationScript(
         targetPageIndex: targetPageIndex,
         preferLastPage: preferLastPage,
-        waitForLoadEvents: true
+        waitForLoadEvents: true,
+        paginationLayout: paginationLayout
       )
       webView.evaluateJavaScript(js, completionHandler: nil)
     }

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedCurlView.swift
@@ -24,7 +24,7 @@
     }
 
     func makeUIViewController(context: Context) -> UIPageViewController {
-      let spineLocation: UIPageViewController.SpineLocation = .min
+      let spineLocation = pageCurlSpineLocation
       let options: [UIPageViewController.OptionsKey: Any] = [.spineLocation: NSNumber(value: spineLocation.rawValue)]
 
       let pageVC = UIPageViewController(
@@ -32,7 +32,10 @@
         navigationOrientation: .horizontal,
         options: options
       )
-      PageCurlControllerPlanner.configure(pageViewController: pageVC)
+      PageCurlControllerPlanner.configure(
+        pageViewController: pageVC,
+        semanticContentAttribute: pageCurlSemanticContentAttribute
+      )
       pageVC.dataSource = context.coordinator
       pageVC.delegate = context.coordinator
       PageCurlBacksideViewController.applyStyle(pageCurlBacksideStyle(), to: pageVC)
@@ -116,7 +119,10 @@
     func updateUIViewController(_ uiViewController: UIPageViewController, context: Context) {
       context.coordinator.parent = self
       defer { context.coordinator.hasCompletedInitialUpdate = true }
-      PageCurlControllerPlanner.configure(pageViewController: uiViewController)
+      PageCurlControllerPlanner.configure(
+        pageViewController: uiViewController,
+        semanticContentAttribute: pageCurlSemanticContentAttribute
+      )
       PageCurlBacksideViewController.applyStyle(pageCurlBacksideStyle(), to: uiViewController)
 
       let initialChapterIndex = viewModel.currentChapterIndex
@@ -198,7 +204,7 @@
           targetChapterIndex > context.coordinator.currentChapterIndex
           || (targetChapterIndex == context.coordinator.currentChapterIndex
             && normalizedPageIndex > context.coordinator.currentPageIndex)
-        let direction: UIPageViewController.NavigationDirection = isForward ? .forward : .reverse
+        let direction = pageCurlNavigationDirection(forward: isForward)
 
         context.coordinator.isAnimating = true
         let shouldAnimateTransition = context.coordinator.hasCompletedInitialUpdate && animateTapTurns
@@ -308,6 +314,28 @@
       )
     }
 
+    private var paginationLayout: WebPubPaginationLayout {
+      WebPubPaginationLayout.resolve(
+        language: viewModel.publicationLanguage,
+        readingProgression: viewModel.publicationReadingProgression
+      )
+    }
+
+    private var pageCurlSpineLocation: UIPageViewController.SpineLocation {
+      paginationLayout.reversesHorizontalGestureDirection ? .max : .min
+    }
+
+    private var pageCurlSemanticContentAttribute: UISemanticContentAttribute {
+      paginationLayout.reversesHorizontalGestureDirection ? .forceRightToLeft : .forceLeftToRight
+    }
+
+    private func pageCurlNavigationDirection(forward: Bool) -> UIPageViewController.NavigationDirection {
+      if paginationLayout.reversesHorizontalGestureDirection {
+        return forward ? .reverse : .forward
+      }
+      return forward ? .forward : .reverse
+    }
+
     private func pageCurlBacksideToken(chapterIndex: Int, subPageIndex: Int) -> String {
       "\(chapterIndex):\(subPageIndex)"
     }
@@ -381,6 +409,12 @@
         self.parent = parent
         self.currentChapterIndex = parent.viewModel.currentChapterIndex
         self.currentPageIndex = parent.viewModel.currentPageIndex
+      }
+
+      private typealias PageTarget = (chapterIndex: Int, subPageIndex: Int)
+
+      private var paginationLayout: WebPubPaginationLayout {
+        parent.paginationLayout
       }
 
       private func cacheKey(chapterIndex: Int, pageIndex: Int) -> String {
@@ -629,18 +663,7 @@
         }
 
         guard let current = viewController as? EpubPageViewController else { return nil }
-
-        let target: (chapterIndex: Int, subPageIndex: Int)?
-        if current.chapterIndex == 0 && current.currentSubPageIndex <= 0 {
-          target = nil
-        } else if current.currentSubPageIndex > 0 {
-          target = (current.chapterIndex, current.currentSubPageIndex - 1)
-        } else {
-          let previousChapter = current.chapterIndex - 1
-          guard previousChapter >= 0 else { return nil }
-          let previousCount = parent.viewModel.chapterPageCount(at: previousChapter) ?? 1
-          target = (previousChapter, max(0, previousCount - 1))
-        }
+        let target = pageViewControllerBeforeTarget(from: current)
 
         guard let target else { return nil }
         let mirroredSnapshot = mirroredSnapshotForBackside(
@@ -675,20 +698,7 @@
         }
 
         guard let current = viewController as? EpubPageViewController else { return nil }
-
-        let target: (chapterIndex: Int, subPageIndex: Int)?
-        let storedCount = parent.viewModel.chapterPageCount(at: current.chapterIndex) ?? 1
-        let chapterPageCount = max(storedCount, current.totalPagesInChapter)
-        if current.currentSubPageIndex < chapterPageCount - 1 {
-          target = (current.chapterIndex, current.currentSubPageIndex + 1)
-        } else {
-          let nextChapter = current.chapterIndex + 1
-          if nextChapter < parent.viewModel.chapterCount {
-            target = (nextChapter, 0)
-          } else {
-            target = nil
-          }
-        }
+        let target = pageViewControllerAfterTarget(from: current)
 
         guard let target else { return nil }
         let mirroredSnapshot = mirroredSnapshotForBackside(
@@ -704,6 +714,46 @@
             mirroredSnapshot: mirroredSnapshot
           )
         )
+      }
+
+      private func pageViewControllerBeforeTarget(from current: EpubPageViewController) -> PageTarget? {
+        if paginationLayout.reversesHorizontalGestureDirection {
+          return nextLogicalTarget(from: current)
+        }
+        return previousLogicalTarget(from: current)
+      }
+
+      private func pageViewControllerAfterTarget(from current: EpubPageViewController) -> PageTarget? {
+        if paginationLayout.reversesHorizontalGestureDirection {
+          return previousLogicalTarget(from: current)
+        }
+        return nextLogicalTarget(from: current)
+      }
+
+      private func previousLogicalTarget(from current: EpubPageViewController) -> PageTarget? {
+        if current.chapterIndex == 0 && current.currentSubPageIndex <= 0 {
+          return nil
+        }
+        if current.currentSubPageIndex > 0 {
+          return (current.chapterIndex, current.currentSubPageIndex - 1)
+        }
+        let previousChapter = current.chapterIndex - 1
+        guard previousChapter >= 0 else { return nil }
+        let previousCount = parent.viewModel.chapterPageCount(at: previousChapter) ?? 1
+        return (previousChapter, max(0, previousCount - 1))
+      }
+
+      private func nextLogicalTarget(from current: EpubPageViewController) -> PageTarget? {
+        let storedCount = parent.viewModel.chapterPageCount(at: current.chapterIndex) ?? 1
+        let chapterPageCount = max(storedCount, current.totalPagesInChapter)
+        if current.currentSubPageIndex < chapterPageCount - 1 {
+          return (current.chapterIndex, current.currentSubPageIndex + 1)
+        }
+        let nextChapter = current.chapterIndex + 1
+        if nextChapter < parent.viewModel.chapterCount {
+          return (nextChapter, 0)
+        }
+        return nil
       }
 
       func pageViewController(
@@ -796,7 +846,7 @@
         _ pageViewController: UIPageViewController,
         spineLocationFor orientation: UIInterfaceOrientation
       ) -> UIPageViewController.SpineLocation {
-        .min
+        parent.pageCurlSpineLocation
       }
 
       @objc func handleTap(_ recognizer: UITapGestureRecognizer) {
@@ -1058,40 +1108,63 @@
           let viewWidth = pageVC.view.bounds.width
           let tapZoneWidth = viewWidth * 0.3
 
-          // Block left tap at first page
-          if isAtFirstPage && location.x < tapZoneWidth {
+          let isPreviousTap =
+            paginationLayout.reversesHorizontalGestureDirection
+            ? location.x > viewWidth - tapZoneWidth
+            : location.x < tapZoneWidth
+          let isNextTap =
+            paginationLayout.reversesHorizontalGestureDirection
+            ? location.x < tapZoneWidth
+            : location.x > viewWidth - tapZoneWidth
+
+          if isAtFirstPage && isPreviousTap {
             return false
           }
 
-          // Block right tap at last page
-          if isAtLastPage && location.x > viewWidth - tapZoneWidth {
+          if isAtLastPage && isNextTap {
             parent.onEndReached()
             return false
           }
-        }
-        // For pan gestures, check the translation direction
-        else if let panGesture = gestureRecognizer as? UIPanGestureRecognizer {
+        } else if let panGesture = gestureRecognizer as? UIPanGestureRecognizer {
           let translation = panGesture.translation(in: pageVC.view)
+          let velocity = panGesture.velocity(in: pageVC.view)
+          let directionSignal = horizontalGestureDirectionSignal(
+            translationX: translation.x,
+            velocityX: velocity.x
+          )
 
-          // Block backward swipe (left to right, positive translation) at first page
-          if isAtFirstPage && translation.x > 0 {
-            return false
-          }
-
-          // Block forward swipe (right to left, negative translation) at last page
-          if isAtLastPage && translation.x < 0 {
-            parent.onEndReached()
-            return false
-          }
-
-          // Ambiguous initial pan direction (often ~0 at begin):
-          // avoid starting boundary curls that may request non-existent neighbors.
-          if abs(translation.x) < 1 {
+          if directionSignal == 0 {
             return !isAtFirstPage && !isAtLastPage
+          }
+
+          if horizontalGestureSignalIsForward(directionSignal) {
+            if isAtLastPage {
+              parent.onEndReached()
+              return false
+            }
+          } else if isAtFirstPage {
+            return false
           }
         }
 
         return true
+      }
+
+      private func horizontalGestureDirectionSignal(
+        translationX: CGFloat,
+        velocityX: CGFloat
+      ) -> CGFloat {
+        if abs(translationX) >= 1 {
+          return translationX
+        }
+        if abs(velocityX) >= 60 {
+          return velocityX
+        }
+        return 0
+      }
+
+      private func horizontalGestureSignalIsForward(_ signal: CGFloat) -> Bool {
+        paginationLayout.reversesHorizontalGestureDirection ? signal > 0 : signal < 0
       }
 
       func gestureRecognizer(
@@ -1145,6 +1218,13 @@
     private var labelTopOffset: CGFloat
     private var labelBottomOffset: CGFloat
     private var useSafeArea: Bool
+
+    private var paginationLayout: WebPubPaginationLayout {
+      WebPubPaginationLayout.resolve(
+        language: publicationLanguage,
+        readingProgression: publicationReadingProgression
+      )
+    }
 
     private let epubResourceSchemeHandler = EpubResourceSchemeHandler()
 
@@ -1639,199 +1719,22 @@
     }
 
     private func injectPaginationJS(targetPageIndex: Int, preferLastPage: Bool) {
-      let js = """
-          (function() {
-            var target = \(targetPageIndex);
-            var preferLast = \(preferLastPage ? "true" : "false");
-            var lastReportedPageCount = 0;
-            var resizeDebounceTimer = null;
-            var hasFinalized = false;
-
-            var finalize = function() {
-              if (hasFinalized) return;
-              hasFinalized = true;
-
-              var root = document.documentElement;
-              var pageWidth = root.clientWidth || window.innerWidth;
-              if (!pageWidth || pageWidth <= 0) { pageWidth = 1; }
-
-              var currentWidth = root.scrollWidth || document.body.scrollWidth;
-              var total = Math.max(1, Math.ceil(currentWidth / pageWidth));
-              var maxScroll = Math.max(0, currentWidth - pageWidth);
-
-              // Recalculate target to ensure we land on the actual last page if requested.
-              var finalTarget = preferLast ? (total - 1) : target;
-              var offset = Math.min(pageWidth * finalTarget, maxScroll);
-
-              // Apply scroll position immediately.
-              window.scrollTo(offset, 0);
-              if (document.documentElement) { document.documentElement.scrollLeft = offset; }
-              if (document.body) { document.body.scrollLeft = offset; }
-
-              // Store initial page count for ResizeObserver comparison
-              lastReportedPageCount = total;
-
-              // Small delay to ensure WebKit commits the paint before signaling readiness.
-              setTimeout(function() {
-                if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.readerBridge) {
-                  window.webkit.messageHandlers.readerBridge.postMessage({
-                    type: 'ready',
-                    totalPages: total,
-                    currentPage: finalTarget
-                  });
-                }
-              }, 60);
-            };
-
-            var startLayoutCheck = function() {
-              var root = document.documentElement;
-              var lastW = root.scrollWidth || document.body.scrollWidth;
-              var stableCount = 0;
-              var attempt = 0;
-
-              var check = function() {
-                if (hasFinalized) return;
-
-                attempt++;
-                var currentW = root.scrollWidth || document.body.scrollWidth;
-                var pageWidth = root.clientWidth || window.innerWidth;
-                if (!pageWidth || pageWidth <= 0) { pageWidth = 1; }
-
-                // Readium-style stability check:
-                // Wait for the multi-column layout to expand beyond 1 page if we expect more.
-                if (currentW === lastW && currentW > 0) {
-                  stableCount++;
-                } else {
-                  stableCount = 0;
-                  lastW = currentW;
-                }
-
-                // If jumping to a deep page (preferLast or target > 0),
-                // we must wait for the width to actually represent multiple pages.
-                var isProbablyReady = (stableCount >= 4);
-                if ((preferLast || target > 0) && currentW <= pageWidth && attempt < 40) {
-                  isProbablyReady = false;
-                }
-
-                if (isProbablyReady || attempt >= 60) {
-                  finalize();
-                } else {
-                  window.requestAnimationFrame(check);
-                }
-              };
-              window.requestAnimationFrame(check);
-            };
-
-            // Global timeout: force finalize after 10 seconds regardless of load state
-            var globalTimeout = setTimeout(function() {
-              finalize();
-            }, 10000);
-
-            // Use the 'load' event to ensure all resources are fetched before calculating layout.
-            // But also start on DOMContentLoaded as a fallback if load takes too long
-            var loadStarted = false;
-            var startOnce = function() {
-              if (loadStarted) return;
-              loadStarted = true;
-              clearTimeout(globalTimeout);
-              startLayoutCheck();
-            };
-
-            if (document.readyState === 'complete') {
-              startOnce();
-            } else {
-              // Start on DOMContentLoaded (DOM ready, images may still be loading)
-              if (document.readyState === 'interactive' || document.readyState === 'loading') {
-                document.addEventListener('DOMContentLoaded', function() {
-                  // Give images a brief moment to start loading
-                  setTimeout(startOnce, 500);
-                });
-              }
-              // Also listen for full load (all resources including images)
-              window.addEventListener('load', function() {
-                startOnce();
-              });
-            }
-
-            // Continuous monitoring for late-loading resources (like gaiji or large images).
-            // Only enable during initial load phase, then lock the page count once stable.
-            if (window.ResizeObserver) {
-              var stableScrollWidth = 0;
-              var stableCheckCount = 0;
-              var isPageCountLocked = false;
-              var resizeDebounceTimer = null;
-
-              var ro = new ResizeObserver(function() {
-                // Once locked, stop monitoring
-                if (isPageCountLocked) {
-                  return;
-                }
-
-                // Debounce: wait for 1000ms of stability before checking
-                if (resizeDebounceTimer) {
-                  clearTimeout(resizeDebounceTimer);
-                }
-
-                resizeDebounceTimer = setTimeout(function() {
-                  var w = document.documentElement.scrollWidth || document.body.scrollWidth;
-                  var pageWidth = document.documentElement.clientWidth || window.innerWidth;
-                  if (!pageWidth || pageWidth <= 0) { pageWidth = 1; }
-
-                  if (pageWidth > 0 && w > 0) {
-                    // Check if scrollWidth has stabilized
-                    if (w === stableScrollWidth) {
-                      stableCheckCount++;
-                      // After 3 consecutive stable checks (3 seconds total), lock the page count
-                      if (stableCheckCount >= 3) {
-                        isPageCountLocked = true;
-                        ro.disconnect();
-                        return;
-                      }
-                    } else {
-                      // ScrollWidth changed, reset stability counter
-                      stableCheckCount = 0;
-                      stableScrollWidth = w;
-
-                      var t = Math.max(1, Math.ceil(w / pageWidth));
-                      // Only report if page count changed significantly (more than 1 page difference)
-                      if (Math.abs(t - lastReportedPageCount) > 1) {
-                        lastReportedPageCount = t;
-                        window.webkit.messageHandlers.readerBridge.postMessage({
-                          type: 'pageCountUpdate',
-                          totalPages: t
-                        });
-                      }
-                    }
-                  }
-                }, 1000);
-              });
-
-              // Start observing after a delay to let initial layout settle
-              setTimeout(function() {
-                stableScrollWidth = document.documentElement.scrollWidth || document.body.scrollWidth;
-                ro.observe(document.documentElement);
-              }, 1500);
-            }
-          })();
-        """
-
+      let js = WebPubPagedJavaScriptBuilder.makePaginationScript(
+        targetPageIndex: targetPageIndex,
+        preferLastPage: preferLastPage,
+        waitForLoadEvents: true,
+        paginationLayout: paginationLayout
+      )
       webView.evaluateJavaScript(js, completionHandler: nil)
     }
 
     private func scrollToPage(_ pageIndex: Int) {
       guard isContentLoaded else { return }
-      let js = """
-          (function() {
-            var root = document.documentElement;
-            var pageWidth = root.clientWidth || window.innerWidth;
-            if (!pageWidth || pageWidth <= 0) { pageWidth = 1; }
-            var maxScroll = Math.max(0, (root.scrollWidth || document.body.scrollWidth) - pageWidth);
-            var offset = Math.min(pageWidth * \(pageIndex), maxScroll);
-            window.scrollTo(offset, 0);
-            if (document.documentElement) { document.documentElement.scrollLeft = offset; }
-            if (document.body) { document.body.scrollLeft = offset; }
-          })();
-        """
+      let js = WebPubPagedJavaScriptBuilder.makeScrollToPageScript(
+        pageIndex: pageIndex,
+        animated: false,
+        paginationLayout: paginationLayout
+      )
       webView.evaluateJavaScript(js, completionHandler: nil)
     }
 

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedJavaScriptBuilder.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedJavaScriptBuilder.swift
@@ -17,10 +17,14 @@
         language: language,
         readingProgression: readingProgression
       )
-      let shouldSetDir = readiumVariant == "rtl"
+      let paginationLayout = WebPubPaginationLayout.resolve(
+        language: language,
+        readingProgression: readingProgression
+      )
+      let shouldSetDir = readiumVariant == "rtl" || (readingProgression == .rtl && readiumVariant != "cjk-vertical")
       let requestedView = readiumProperties["--USER__view"] ?? nil
       let usesTransformPagination =
-        (readiumVariant == "rtl" || readiumVariant == "cjk-vertical")
+        paginationLayout.usesReverseScrollLeft
         && requestedView != "readium-scroll-on"
       let pagedCompatibilityCSS = Data(
         pagedCompatibilityCSS(

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedJavaScriptBuilder.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedJavaScriptBuilder.swift
@@ -103,14 +103,47 @@
             + atob('\(pagedCompatibilityCSS)');
           style.textContent = css;
           var transformPagination = \(usesTransformPagination ? "true" : "false");
-          var wrapper = document.getElementById('kmreader-pagination-strip');
-          if (document.body && !transformPagination && wrapper) {
+          var restorePageElementTransforms = function() {
+            if (!document.body) { return; }
+            Array.prototype.forEach.call(document.body.children, function(element) {
+              if (!element.hasAttribute('data-kmreader-transform-saved')) { return; }
+              var originalTransform = element.getAttribute('data-kmreader-original-transform') || '';
+              var originalTransition = element.getAttribute('data-kmreader-original-transition') || '';
+              if (originalTransform) {
+                element.style.transform = originalTransform;
+              } else {
+                element.style.removeProperty('transform');
+              }
+              if (originalTransition) {
+                element.style.transition = originalTransition;
+              } else {
+                element.style.removeProperty('transition');
+              }
+              element.removeAttribute('data-kmreader-transform-saved');
+              element.removeAttribute('data-kmreader-original-transform');
+              element.removeAttribute('data-kmreader-original-transition');
+            });
+          };
+          var unwrapLegacyPaginationStrip = function() {
+            if (!document.body) { return; }
+            var wrapper = document.getElementById('kmreader-pagination-strip');
+            if (!wrapper) { return; }
             wrapper.style.transition = '';
             wrapper.style.transform = '';
             while (wrapper.firstChild) {
               document.body.insertBefore(wrapper.firstChild, wrapper);
             }
             wrapper.remove();
+          };
+          if (document.body) {
+            unwrapLegacyPaginationStrip();
+            if (transformPagination) {
+              document.body.classList.add('kmreader-transform-pagination');
+            } else {
+              document.body.classList.remove('kmreader-transform-pagination');
+              document.body.removeAttribute('data-kmreader-logical-offset');
+              restorePageElementTransforms();
+            }
           }
           if (document.body && !transformPagination) {
             document.body.style.transition = '';
@@ -327,34 +360,95 @@
     private static func paginationRuntimeScript(paginationLayout: WebPubPaginationLayout) -> String {
       """
       var reverseScrollLeft = \(paginationLayout.usesReverseScrollLeft ? "true" : "false");
-      var ensurePaginationStrip = function() {
+      var activeLogicalOffset = 0;
+      var unwrapLegacyPaginationStrip = function() {
         var body = document.body;
-        if (!reverseScrollLeft || !body) { return null; }
+        if (!body) { return; }
         var wrapper = document.getElementById('kmreader-pagination-strip');
-        if (wrapper) { return wrapper; }
-        wrapper = document.createElement('div');
-        wrapper.id = 'kmreader-pagination-strip';
-        while (body.firstChild) {
-          wrapper.appendChild(body.firstChild);
+        if (!wrapper) { return; }
+        wrapper.style.transition = '';
+        wrapper.style.transform = '';
+        while (wrapper.firstChild) {
+          body.insertBefore(wrapper.firstChild, wrapper);
         }
-        body.appendChild(wrapper);
-        return wrapper;
+        wrapper.remove();
+      };
+      var paginatedBodyChildren = function() {
+        var body = document.body;
+        if (!body) { return []; }
+        return Array.prototype.filter.call(body.children, function(element) {
+          return element.id !== 'kmreader-pagination-strip';
+        });
+      };
+      var restorePageElementTransforms = function() {
+        paginatedBodyChildren().forEach(function(element) {
+          if (!element.hasAttribute('data-kmreader-transform-saved')) { return; }
+          var originalTransform = element.getAttribute('data-kmreader-original-transform') || '';
+          var originalTransition = element.getAttribute('data-kmreader-original-transition') || '';
+          if (originalTransform) {
+            element.style.transform = originalTransform;
+          } else {
+            element.style.removeProperty('transform');
+          }
+          if (originalTransition) {
+            element.style.transition = originalTransition;
+          } else {
+            element.style.removeProperty('transition');
+          }
+          element.removeAttribute('data-kmreader-transform-saved');
+          element.removeAttribute('data-kmreader-original-transform');
+          element.removeAttribute('data-kmreader-original-transition');
+        });
+      };
+      var applyPageElementTransforms = function(offset, animated) {
+        var body = document.body;
+        if (!body) { return; }
+        unwrapLegacyPaginationStrip();
+        if (offset <= 0) {
+          activeLogicalOffset = 0;
+          restorePageElementTransforms();
+          body.classList.remove('kmreader-transform-pagination');
+          body.removeAttribute('data-kmreader-logical-offset');
+          return;
+        }
+        activeLogicalOffset = offset;
+        body.classList.add('kmreader-transform-pagination');
+        body.setAttribute('data-kmreader-logical-offset', String(offset));
+        paginatedBodyChildren().forEach(function(element) {
+          if (!element.hasAttribute('data-kmreader-transform-saved')) {
+            element.setAttribute('data-kmreader-transform-saved', 'true');
+            element.setAttribute('data-kmreader-original-transform', element.style.transform || '');
+            element.setAttribute('data-kmreader-original-transition', element.style.transition || '');
+          }
+          var originalTransform = element.getAttribute('data-kmreader-original-transform') || '';
+          var paginationTransform = 'translate3d(' + offset + 'px, 0, 0)';
+          element.style.transition = animated ? 'transform 250ms ease' : 'none';
+          element.style.transform = originalTransform
+            ? (paginationTransform + ' ' + originalTransform)
+            : paginationTransform;
+        });
       };
       var measurePagination = function() {
         var root = document.documentElement;
         var body = document.body;
-        var wrapper = ensurePaginationStrip();
+        var previousOffset = activeLogicalOffset;
+        if (body && body.hasAttribute('data-kmreader-logical-offset')) {
+          previousOffset = parseFloat(body.getAttribute('data-kmreader-logical-offset') || '0') || previousOffset;
+        }
+        if (reverseScrollLeft) {
+          unwrapLegacyPaginationStrip();
+          restorePageElementTransforms();
+        }
         var pageWidth = (root && root.clientWidth) || window.innerWidth;
         if (!pageWidth || pageWidth <= 0) { pageWidth = 1; }
-        var currentWidth = wrapper ? Math.max(
-          wrapper.scrollWidth || 0,
-          wrapper.offsetWidth || 0,
-          pageWidth
-        ) : Math.max(
+        var currentWidth = Math.max(
           root ? (root.scrollWidth || 0) : 0,
           body ? (body.scrollWidth || 0) : 0,
           pageWidth
         );
+        if (reverseScrollLeft && previousOffset > 0) {
+          applyPageElementTransforms(previousOffset, false);
+        }
         return {
           pageWidth: pageWidth,
           currentWidth: currentWidth,
@@ -367,10 +461,7 @@
         var root = document.documentElement;
         var body = document.body;
         if (reverseScrollLeft && body) {
-          var wrapper = ensurePaginationStrip();
-          if (!wrapper) { return; }
-          wrapper.style.transition = animated ? 'transform 250ms ease' : 'none';
-          wrapper.style.transform = 'translate3d(' + offset + 'px, 0, 0)';
+          applyPageElementTransforms(offset, animated);
           window.scrollTo(0, 0);
           if (root) {
             root.scrollLeft = 0;
@@ -410,7 +501,7 @@
           transform-origin: top right !important;
         }
 
-        #kmreader-pagination-strip {
+        body.kmreader-transform-pagination > :not(#kmreader-pagination-strip) {
           transform-origin: top right !important;
           will-change: transform;
         }

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedJavaScriptBuilder.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedJavaScriptBuilder.swift
@@ -18,6 +18,16 @@
         readingProgression: readingProgression
       )
       let shouldSetDir = readiumVariant == "rtl"
+      let requestedView = readiumProperties["--USER__view"] ?? nil
+      let usesTransformPagination =
+        (readiumVariant == "rtl" || readiumVariant == "cjk-vertical")
+        && requestedView != "readium-scroll-on"
+      let pagedCompatibilityCSS = Data(
+        pagedCompatibilityCSS(
+          for: readiumVariant,
+          usesTransformPagination: usesTransformPagination
+        ).utf8
+      ).base64EncodedString()
 
       let readiumBefore = Data(readiumAssets.before.utf8).base64EncodedString()
       let readiumDefault = Data(readiumAssets.defaultCSS.utf8).base64EncodedString()
@@ -85,8 +95,23 @@
           var css = atob('\(readiumBefore)') + "\\n"
             + (hasStyles ? "" : atob('\(readiumDefault)') + "\\n")
             + atob('\(readiumAfter)') + "\\n"
-            + atob('\(customCSS)');
+            + atob('\(customCSS)') + "\\n"
+            + atob('\(pagedCompatibilityCSS)');
           style.textContent = css;
+          var transformPagination = \(usesTransformPagination ? "true" : "false");
+          var wrapper = document.getElementById('kmreader-pagination-strip');
+          if (document.body && !transformPagination && wrapper) {
+            wrapper.style.transition = '';
+            wrapper.style.transform = '';
+            while (wrapper.firstChild) {
+              document.body.insertBefore(wrapper.firstChild, wrapper);
+            }
+            wrapper.remove();
+          }
+          if (document.body && !transformPagination) {
+            document.body.style.transition = '';
+            document.body.style.transform = '';
+          }
 
           return true;
         })();
@@ -96,12 +121,14 @@
     static func makePaginationScript(
       targetPageIndex: Int,
       preferLastPage: Bool,
-      waitForLoadEvents: Bool
+      waitForLoadEvents: Bool,
+      paginationLayout: WebPubPaginationLayout
     ) -> String {
       """
       (function() {
         var target = \(targetPageIndex);
         var preferLast = \(preferLastPage ? "true" : "false");
+        \(paginationRuntimeScript(paginationLayout: paginationLayout))
         var lastReportedPageCount = 0;
         var hasFinalized = false;
 
@@ -109,23 +136,13 @@
           if (hasFinalized) return;
           hasFinalized = true;
 
-          var root = document.documentElement;
-          var pageWidth = root.clientWidth || window.innerWidth;
-          if (!pageWidth || pageWidth <= 0) { pageWidth = 1; }
-
-          var currentWidth = Math.max(
-            root.scrollWidth || 0,
-            document.body ? (document.body.scrollWidth || 0) : 0,
-            pageWidth
-          );
+          var metrics = measurePagination();
+          var pageWidth = metrics.pageWidth;
+          var currentWidth = metrics.currentWidth;
           var total = Math.max(1, Math.ceil(currentWidth / pageWidth));
-          var maxScroll = Math.max(0, currentWidth - pageWidth);
           var finalTarget = preferLast ? (total - 1) : Math.max(0, Math.min(total - 1, target));
-          var offset = Math.min(pageWidth * finalTarget, maxScroll);
 
-          window.scrollTo(offset, 0);
-          if (document.documentElement) { document.documentElement.scrollLeft = offset; }
-          if (document.body) { document.body.scrollLeft = offset; }
+          scrollToLogicalOffset(pageWidth * finalTarget, false);
 
           lastReportedPageCount = total;
 
@@ -141,8 +158,7 @@
         };
 
         var startLayoutCheck = function() {
-          var root = document.documentElement;
-          var lastW = root.scrollWidth || document.body.scrollWidth;
+          var lastW = measurePagination().currentWidth;
           var stableCount = 0;
           var attempt = 0;
 
@@ -150,9 +166,9 @@
             if (hasFinalized) return;
 
             attempt++;
-            var currentW = root.scrollWidth || document.body.scrollWidth;
-            var pageWidth = root.clientWidth || window.innerWidth;
-            if (!pageWidth || pageWidth <= 0) { pageWidth = 1; }
+            var metrics = measurePagination();
+            var currentW = metrics.currentWidth;
+            var pageWidth = metrics.pageWidth;
 
             if (currentW === lastW && currentW > 0) {
               stableCount++;
@@ -204,8 +220,198 @@
             startOnce();
           });
         }
+
+        if (window.ResizeObserver) {
+          var stableScrollWidth = 0;
+          var stableCheckCount = 0;
+          var isPageCountLocked = false;
+          var resizeDebounceTimer = null;
+
+          var ro = new ResizeObserver(function() {
+            if (isPageCountLocked) {
+              return;
+            }
+
+            if (resizeDebounceTimer) {
+              clearTimeout(resizeDebounceTimer);
+            }
+
+            resizeDebounceTimer = setTimeout(function() {
+              var metrics = measurePagination();
+              var w = metrics.currentWidth;
+              var pageWidth = metrics.pageWidth;
+
+              if (pageWidth > 0 && w > 0) {
+                if (w === stableScrollWidth) {
+                  stableCheckCount++;
+                  if (stableCheckCount >= 3) {
+                    isPageCountLocked = true;
+                    ro.disconnect();
+                    return;
+                  }
+                } else {
+                  stableCheckCount = 0;
+                  stableScrollWidth = w;
+
+                  var total = Math.max(1, Math.ceil(w / pageWidth));
+                  if (Math.abs(total - lastReportedPageCount) > 1) {
+                    lastReportedPageCount = total;
+                    if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.readerBridge) {
+                      window.webkit.messageHandlers.readerBridge.postMessage({
+                        type: 'pageCountUpdate',
+                        totalPages: total
+                      });
+                    }
+                  }
+                }
+              }
+            }, 1000);
+          });
+
+          setTimeout(function() {
+            stableScrollWidth = measurePagination().currentWidth;
+            ro.observe(document.documentElement);
+          }, 1500);
+        }
       })();
       """
+    }
+
+    static func makeScrollToPageScript(
+      pageIndex: Int,
+      animated: Bool,
+      paginationLayout: WebPubPaginationLayout
+    ) -> String {
+      makeScrollToLogicalOffsetScript(
+        logicalOffset: "pageWidth * \(pageIndex)",
+        animated: animated,
+        paginationLayout: paginationLayout
+      )
+    }
+
+    static func makeScrollToLogicalOffsetScript(
+      logicalOffset: Double,
+      animated: Bool,
+      paginationLayout: WebPubPaginationLayout
+    ) -> String {
+      makeScrollToLogicalOffsetScript(
+        logicalOffset: String(
+          format: "%.4f",
+          locale: Locale(identifier: "en_US_POSIX"),
+          logicalOffset
+        ),
+        animated: animated,
+        paginationLayout: paginationLayout
+      )
+    }
+
+    private static func makeScrollToLogicalOffsetScript(
+      logicalOffset: String,
+      animated: Bool,
+      paginationLayout: WebPubPaginationLayout
+    ) -> String {
+      """
+      (function() {
+        \(paginationRuntimeScript(paginationLayout: paginationLayout))
+        var pageWidth = measurePagination().pageWidth;
+        scrollToLogicalOffset(\(logicalOffset), \(animated ? "true" : "false"));
+        return true;
+      })();
+      """
+    }
+
+    private static func paginationRuntimeScript(paginationLayout: WebPubPaginationLayout) -> String {
+      """
+      var reverseScrollLeft = \(paginationLayout.usesReverseScrollLeft ? "true" : "false");
+      var ensurePaginationStrip = function() {
+        var body = document.body;
+        if (!reverseScrollLeft || !body) { return null; }
+        var wrapper = document.getElementById('kmreader-pagination-strip');
+        if (wrapper) { return wrapper; }
+        wrapper = document.createElement('div');
+        wrapper.id = 'kmreader-pagination-strip';
+        while (body.firstChild) {
+          wrapper.appendChild(body.firstChild);
+        }
+        body.appendChild(wrapper);
+        return wrapper;
+      };
+      var measurePagination = function() {
+        var root = document.documentElement;
+        var body = document.body;
+        var wrapper = ensurePaginationStrip();
+        var pageWidth = (root && root.clientWidth) || window.innerWidth;
+        if (!pageWidth || pageWidth <= 0) { pageWidth = 1; }
+        var currentWidth = wrapper ? Math.max(
+          wrapper.scrollWidth || 0,
+          wrapper.offsetWidth || 0,
+          pageWidth
+        ) : Math.max(
+          root ? (root.scrollWidth || 0) : 0,
+          body ? (body.scrollWidth || 0) : 0,
+          pageWidth
+        );
+        return {
+          pageWidth: pageWidth,
+          currentWidth: currentWidth,
+          maxScroll: Math.max(0, currentWidth - pageWidth)
+        };
+      };
+      var scrollToLogicalOffset = function(logicalOffset, animated) {
+        var metrics = measurePagination();
+        var offset = Math.max(0, Math.min(logicalOffset, metrics.maxScroll));
+        var root = document.documentElement;
+        var body = document.body;
+        if (reverseScrollLeft && body) {
+          var wrapper = ensurePaginationStrip();
+          if (!wrapper) { return; }
+          wrapper.style.transition = animated ? 'transform 250ms ease' : 'none';
+          wrapper.style.transform = 'translate3d(' + offset + 'px, 0, 0)';
+          window.scrollTo(0, 0);
+          if (root) {
+            root.scrollLeft = 0;
+            root.scrollTop = 0;
+          }
+          body.scrollLeft = 0;
+          body.scrollTop = 0;
+          return;
+        }
+        var left = reverseScrollLeft ? -offset : offset;
+        if (animated) {
+          window.scrollTo({ left: left, top: 0, behavior: 'smooth' });
+        } else {
+          window.scrollTo(left, 0);
+        }
+        if (root) {
+          root.scrollLeft = left;
+          root.scrollTop = 0;
+        }
+        if (body) {
+          body.scrollLeft = left;
+          body.scrollTop = 0;
+        }
+      };
+      """
+    }
+
+    private static func pagedCompatibilityCSS(
+      for readiumVariant: String?,
+      usesTransformPagination: Bool
+    ) -> String {
+      guard usesTransformPagination, readiumVariant == "cjk-vertical" else { return "" }
+      return """
+        body {
+          min-height: 0 !important;
+          max-height: var(--RS__defaultLineLength) !important;
+          transform-origin: top right !important;
+        }
+
+        #kmreader-pagination-strip {
+          transform-origin: top right !important;
+          will-change: transform;
+        }
+
+        """
     }
   }
 #endif

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedJavaScriptBuilder.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedJavaScriptBuilder.swift
@@ -122,6 +122,7 @@
               element.removeAttribute('data-kmreader-transform-saved');
               element.removeAttribute('data-kmreader-original-transform');
               element.removeAttribute('data-kmreader-original-transition');
+              element.removeAttribute('data-kmreader-author-transform');
             });
           };
           var unwrapLegacyPaginationStrip = function() {
@@ -398,6 +399,7 @@
           element.removeAttribute('data-kmreader-transform-saved');
           element.removeAttribute('data-kmreader-original-transform');
           element.removeAttribute('data-kmreader-original-transition');
+          element.removeAttribute('data-kmreader-author-transform');
         });
       };
       var applyPageElementTransforms = function(offset, animated) {
@@ -419,12 +421,17 @@
             element.setAttribute('data-kmreader-transform-saved', 'true');
             element.setAttribute('data-kmreader-original-transform', element.style.transform || '');
             element.setAttribute('data-kmreader-original-transition', element.style.transition || '');
+            var computedTransform = window.getComputedStyle ? window.getComputedStyle(element).transform : '';
+            if (!computedTransform || computedTransform === 'none') {
+              computedTransform = '';
+            }
+            element.setAttribute('data-kmreader-author-transform', computedTransform);
           }
-          var originalTransform = element.getAttribute('data-kmreader-original-transform') || '';
+          var authorTransform = element.getAttribute('data-kmreader-author-transform') || '';
           var paginationTransform = 'translate3d(' + offset + 'px, 0, 0)';
           element.style.transition = animated ? 'transform 250ms ease' : 'none';
-          element.style.transform = originalTransform
-            ? (paginationTransform + ' ' + originalTransform)
+          element.style.transform = authorTransform
+            ? (paginationTransform + ' ' + authorTransform)
             : paginationTransform;
         });
       };

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView.swift
@@ -277,6 +277,13 @@
     var currentChapterIndex: Int { chapterIndex }
     var currentPageIndex: Int { currentSubPageIndex }
 
+    private var paginationLayout: WebPubPaginationLayout {
+      WebPubPaginationLayout.resolve(
+        language: publicationLanguage,
+        readingProgression: publicationReadingProgression
+      )
+    }
+
     private let epubResourceSchemeHandler = EpubResourceSchemeHandler()
 
     private var containerView: UIView?
@@ -538,22 +545,33 @@
 
       switch gesture.state {
       case .began:
-        interactivePanStartOffsetX = webView.scrollView.contentOffset.x
-        webView.scrollView.setContentOffset(
-          CGPoint(x: interactivePanStartOffsetX, y: 0),
-          animated: false
-        )
+        interactivePanStartOffsetX =
+          paginationLayout.usesReverseScrollLeft
+          ? CGFloat(currentSubPageIndex) * pageWidth
+          : webView.scrollView.contentOffset.x
+        if paginationLayout.usesReverseScrollLeft {
+          scrollToLogicalOffset(interactivePanStartOffsetX, animated: false)
+        } else {
+          webView.scrollView.setContentOffset(
+            CGPoint(x: interactivePanStartOffsetX, y: 0),
+            animated: false
+          )
+        }
       case .changed:
-        let translationX = gesture.translation(in: view).x
+        let translationX = logicalTranslationX(from: gesture)
         let rawOffset = interactivePanStartOffsetX - translationX
         let adjustedOffset = adjustedHorizontalOffset(
           rawOffset,
           maxOffset: maxOffset
         )
-        webView.scrollView.setContentOffset(
-          CGPoint(x: adjustedOffset, y: 0),
-          animated: false
-        )
+        if paginationLayout.usesReverseScrollLeft {
+          scrollToLogicalOffset(adjustedOffset, animated: false)
+        } else {
+          webView.scrollView.setContentOffset(
+            CGPoint(x: adjustedOffset, y: 0),
+            animated: false
+          )
+        }
       case .ended:
         finishInteractivePan(
           gesture: gesture,
@@ -565,6 +583,16 @@
       default:
         break
       }
+    }
+
+    private func logicalTranslationX(from gesture: UIPanGestureRecognizer) -> CGFloat {
+      let translationX = gesture.translation(in: view).x
+      return paginationLayout.reversesHorizontalGestureDirection ? -translationX : translationX
+    }
+
+    private func logicalVelocityX(from gesture: UIPanGestureRecognizer) -> CGFloat {
+      let velocityX = gesture.velocity(in: view).x
+      return paginationLayout.reversesHorizontalGestureDirection ? -velocityX : velocityX
     }
 
     private func adjustedHorizontalOffset(_ rawOffset: CGFloat, maxOffset: CGFloat) -> CGFloat {
@@ -584,8 +612,8 @@
       pageWidth: CGFloat,
       maxOffset: CGFloat
     ) {
-      let translationX = gesture.translation(in: view).x
-      let velocityX = gesture.velocity(in: view).x
+      let translationX = logicalTranslationX(from: gesture)
+      let velocityX = logicalVelocityX(from: gesture)
       let rawOffset = interactivePanStartOffsetX - translationX
 
       if rawOffset < -chapterOverscrollThreshold {
@@ -875,6 +903,12 @@
       let pageWidth = webView.bounds.width
       guard pageWidth > 0 else { return }
 
+      if paginationLayout.usesReverseScrollLeft {
+        let logicalOffset = pageWidth * CGFloat(max(0, pageIndex))
+        scrollToLogicalOffset(logicalOffset, animated: animated)
+        return
+      }
+
       let contentWidth = webView.scrollView.contentSize.width
       let maxOffset = max(0, contentWidth - webView.bounds.width)
       let targetOffset = min(pageWidth * CGFloat(pageIndex), maxOffset)
@@ -882,11 +916,22 @@
       webView.scrollView.setContentOffset(CGPoint(x: targetOffset, y: 0), animated: animated)
     }
 
+    private func scrollToLogicalOffset(_ offset: CGFloat, animated: Bool) {
+      guard isContentLoaded else { return }
+      let js = WebPubPagedJavaScriptBuilder.makeScrollToLogicalOffsetScript(
+        logicalOffset: Double(offset),
+        animated: animated,
+        paginationLayout: paginationLayout
+      )
+      webView.evaluateJavaScript(js, completionHandler: nil)
+    }
+
     private func injectPaginationJS(targetPageIndex: Int, preferLastPage: Bool) {
       let js = WebPubPagedJavaScriptBuilder.makePaginationScript(
         targetPageIndex: targetPageIndex,
         preferLastPage: preferLastPage,
-        waitForLoadEvents: true
+        waitForLoadEvents: true,
+        paginationLayout: paginationLayout
       )
       webView.evaluateJavaScript(js, completionHandler: nil)
     }
@@ -968,6 +1013,7 @@
       targetContentOffset: UnsafeMutablePointer<CGPoint>
     ) {
       guard isContentLoaded else { return }
+      guard !paginationLayout.usesReverseScrollLeft else { return }
       let pageWidth = webView.bounds.width
       guard pageWidth > 0 else { return }
 
@@ -1008,6 +1054,7 @@
 
     private func updateCurrentPageFromScroll() {
       guard isContentLoaded else { return }
+      guard !paginationLayout.usesReverseScrollLeft else { return }
       let pageWidth = webView.bounds.width
       guard pageWidth > 0 else { return }
 

--- a/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPagedScrollView_macOS.swift
@@ -82,6 +82,13 @@
     private var isAwaitingPaginationReady = false
     private var animatePageTransitions = true
 
+    private var paginationLayout: WebPubPaginationLayout {
+      WebPubPaginationLayout.resolve(
+        language: publicationLanguage,
+        readingProgression: publicationReadingProgression
+      )
+    }
+
     init(parent: WebPubPagedScrollView) {
       self.parent = parent
       super.init()
@@ -276,24 +283,11 @@
 
     private func scrollToPage(_ pageIndex: Int, animated: Bool) {
       guard let webView else { return }
-      let pageWidth = webView.bounds.width
-      guard pageWidth > 0 else { return }
-      let contentWidth = max(pageWidth, CGFloat(totalPagesInChapter) * pageWidth)
-      let maxOffset = max(0, contentWidth - pageWidth)
-      let targetOffset = min(pageWidth * CGFloat(pageIndex), maxOffset)
-      let js = """
-          (function() {
-            var left = \(Double(targetOffset));
-            if (\(animated ? "true" : "false")) {
-              window.scrollTo({ left: left, top: 0, behavior: 'smooth' });
-            } else {
-              window.scrollTo(left, 0);
-            }
-            if (document.documentElement) { document.documentElement.scrollLeft = left; }
-            if (document.body) { document.body.scrollLeft = left; }
-            return true;
-          })();
-        """
+      let js = WebPubPagedJavaScriptBuilder.makeScrollToPageScript(
+        pageIndex: pageIndex,
+        animated: animated,
+        paginationLayout: paginationLayout
+      )
       webView.evaluateJavaScript(js, completionHandler: nil)
     }
 
@@ -367,7 +361,8 @@
       let js = WebPubPagedJavaScriptBuilder.makePaginationScript(
         targetPageIndex: targetPageIndex,
         preferLastPage: preferLastPage,
-        waitForLoadEvents: true
+        waitForLoadEvents: true,
+        paginationLayout: paginationLayout
       )
       webView.evaluateJavaScript(js, completionHandler: nil)
     }

--- a/KMReader/Features/Reader/Views/Epub/WebPubPaginationLayout.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPaginationLayout.swift
@@ -9,6 +9,10 @@
       language: String?,
       readingProgression: WebPubReadingProgression?
     ) -> WebPubPaginationLayout {
+      if readingProgression == .rtl {
+        return .reverseHorizontal
+      }
+
       switch ReadiumCSSLoader.resolveVariantSubdirectory(
         language: language,
         readingProgression: readingProgression

--- a/KMReader/Features/Reader/Views/Epub/WebPubPaginationLayout.swift
+++ b/KMReader/Features/Reader/Views/Epub/WebPubPaginationLayout.swift
@@ -1,0 +1,31 @@
+#if os(iOS) || os(macOS)
+  import Foundation
+
+  enum WebPubPaginationLayout: String, Sendable {
+    case horizontal
+    case reverseHorizontal
+
+    static func resolve(
+      language: String?,
+      readingProgression: WebPubReadingProgression?
+    ) -> WebPubPaginationLayout {
+      switch ReadiumCSSLoader.resolveVariantSubdirectory(
+        language: language,
+        readingProgression: readingProgression
+      ) {
+      case "rtl", "cjk-vertical":
+        return .reverseHorizontal
+      default:
+        return .horizontal
+      }
+    }
+
+    var usesReverseScrollLeft: Bool {
+      self == .reverseHorizontal
+    }
+
+    var reversesHorizontalGestureDirection: Bool {
+      self == .reverseHorizontal
+    }
+  }
+#endif


### PR DESCRIPTION
## Summary

This improves paged EPUB rendering for right-to-left and vertical CJK books. Reverse paged layouts now use a shared pagination layout resolver, stable wrapper-based measurements, and transform-based logical scrolling so later pages render instead of drifting into blank space.

Scroll, cover, and page curl modes now agree on page count, page movement, and gesture direction for vertical Japanese RTL content. The same layout resolver is used on iOS and macOS so cover/pagecurl animations and programmatic page jumps follow the same reading flow.

This PR also includes the build-version bump to 496.

## Validation

- `make format`
- `git diff --check origin/main...HEAD`
- `make build-ios`
- `make build-macos`
