### PR TITLE
fix(reader): separate content and controls viewports

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 496;
+				CURRENT_PROJECT_VERSION = 497;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 496;
+				CURRENT_PROJECT_VERSION = 497;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 496;
+				CURRENT_PROJECT_VERSION = 497;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 496;
+				CURRENT_PROJECT_VERSION = 497;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -361,6 +361,17 @@ struct DivinaReaderView: View {
     return "\(Int(screenSize.width))x\(Int(screenSize.height))"
   }
 
+  private func readerViewportSize(containerSize: CGSize, safeAreaInsets: EdgeInsets) -> CGSize {
+    CGSize(
+      width: max(0, containerSize.width + safeAreaInsets.leading + safeAreaInsets.trailing),
+      height: max(0, containerSize.height + safeAreaInsets.top + safeAreaInsets.bottom)
+    )
+  }
+
+  private func readerViewportOffset(safeAreaInsets: EdgeInsets) -> CGSize {
+    CGSize(width: -safeAreaInsets.leading, height: -safeAreaInsets.top)
+  }
+
   private func readerPresentationKey(useDualPage: Bool) -> String {
     [
       readingDirection.rawValue,
@@ -519,35 +530,35 @@ struct DivinaReaderView: View {
 
   var body: some View {
     GeometryReader { geometry in
-      let screenSize = geometry.size
+      let containerSize = geometry.size
+      let safeAreaInsets = geometry.safeAreaInsets
+      let screenSize = readerViewportSize(containerSize: containerSize, safeAreaInsets: safeAreaInsets)
+      let screenOffset = readerViewportOffset(safeAreaInsets: safeAreaInsets)
       let screenKey = screenKey(screenSize: screenSize)
       let useDualPage = shouldUseDualPage(screenSize: screenSize)
 
-      ZStack {
-        readerBackground.color.readerIgnoresSafeArea()
-
-        readerContent(
+      ZStack(alignment: .topLeading) {
+        readerSurface(
           useDualPage: useDualPage,
-          screenSize: screenSize
+          screenSize: screenSize,
+          screenKey: screenKey
         )
-
-        #if os(tvOS)
-          tvRemoteCommandOverlay
-        #endif
-
-        helperOverlay(screenKey: screenKey)
+        .frame(width: screenSize.width, height: screenSize.height, alignment: .topLeading)
+        .offset(x: screenOffset.width, y: screenOffset.height)
 
         controlsOverlay(useDualPage: useDualPage)
+          .frame(width: containerSize.width, height: containerSize.height, alignment: .topLeading)
 
         keyboardHelpOverlay
       }
+      .frame(width: containerSize.width, height: containerSize.height, alignment: .topLeading)
       .onGeometryChange(for: CGFloat.self) {
         $0.safeAreaInsets.top
       } action: {
         readerSafeAreaTop = $0
       }
       .onGeometryChange(for: CGFloat.self) {
-        $0.size.height
+        $0.size.height + $0.safeAreaInsets.top + $0.safeAreaInsets.bottom
       } action: {
         readerViewHeight = $0
       }
@@ -722,6 +733,30 @@ struct DivinaReaderView: View {
     #if os(iOS)
       .readerDismissGesture(readingDirection: readingDirection)
     #endif
+  }
+
+  private func readerSurface(
+    useDualPage: Bool,
+    screenSize: CGSize,
+    screenKey: String
+  ) -> some View {
+    ZStack(alignment: .topLeading) {
+      readerBackground.color
+
+      readerContent(
+        useDualPage: useDualPage,
+        screenSize: screenSize
+      )
+
+      #if os(tvOS)
+        tvRemoteCommandOverlay
+      #endif
+
+      helperOverlay(screenKey: screenKey)
+        .frame(width: screenSize.width, height: screenSize.height)
+        .clipped()
+    }
+    .frame(width: screenSize.width, height: screenSize.height, alignment: .topLeading)
   }
 
   @ViewBuilder

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -362,14 +362,22 @@ struct DivinaReaderView: View {
   }
 
   private func readerViewportSize(containerSize: CGSize, safeAreaInsets: EdgeInsets) -> CGSize {
-    CGSize(
-      width: max(0, containerSize.width + safeAreaInsets.leading + safeAreaInsets.trailing),
-      height: max(0, containerSize.height + safeAreaInsets.top + safeAreaInsets.bottom)
-    )
+    #if os(iOS) || os(tvOS)
+      CGSize(
+        width: max(0, containerSize.width + safeAreaInsets.leading + safeAreaInsets.trailing),
+        height: max(0, containerSize.height + safeAreaInsets.top + safeAreaInsets.bottom)
+      )
+    #else
+      containerSize
+    #endif
   }
 
   private func readerViewportOffset(safeAreaInsets: EdgeInsets) -> CGSize {
-    CGSize(width: -safeAreaInsets.leading, height: -safeAreaInsets.top)
+    #if os(iOS) || os(tvOS)
+      CGSize(width: -safeAreaInsets.leading, height: -safeAreaInsets.top)
+    #else
+      .zero
+    #endif
   }
 
   private func readerPresentationKey(useDualPage: Bool) -> String {
@@ -558,7 +566,11 @@ struct DivinaReaderView: View {
         readerSafeAreaTop = $0
       }
       .onGeometryChange(for: CGFloat.self) {
-        $0.size.height + $0.safeAreaInsets.top + $0.safeAreaInsets.bottom
+        #if os(iOS) || os(tvOS)
+          $0.size.height + $0.safeAreaInsets.top + $0.safeAreaInsets.bottom
+        #else
+          $0.size.height
+        #endif
       } action: {
         readerViewHeight = $0
       }

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -759,6 +759,7 @@ struct DivinaReaderView: View {
         useDualPage: useDualPage,
         screenSize: screenSize
       )
+      .frame(width: screenSize.width, height: screenSize.height)
 
       #if os(tvOS)
         tvRemoteCommandOverlay


### PR DESCRIPTION
## Summary

- Separate the DIVINA reader content viewport from the controls viewport.
- Let iOS and tvOS paged reader content use the full safe-area-expanded screen while keeping controls constrained to the SwiftUI safe-area container.
- Keep macOS reader content inside the safe-area container so it does not render under window chrome.
- Bump the build version to 497 for delivery.

## Related Issue

- Fixes #924

## Validation

- `make build-ios`
- `make build-macos`
