### PR TITLE
fix(ui): keep selection rows visible while projections load

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 497;
+				CURRENT_PROJECT_VERSION = 498;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 497;
+				CURRENT_PROJECT_VERSION = 498;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 497;
+				CURRENT_PROJECT_VERSION = 498;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 497;
+				CURRENT_PROJECT_VERSION = 498;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Views/BookSelectionItemView.swift
+++ b/KMReader/Features/Book/Views/BookSelectionItemView.swift
@@ -36,46 +36,77 @@ struct BookSelectionItemView: View {
   }
 
   var body: some View {
-    Group {
-      if let item {
-        Group {
-          switch layout {
-          case .grid:
-            BookCardView(
-              item: item,
-              onReadBook: { _ in },
-              showSeriesTitle: showSeriesTitle
-            )
-          case .list:
-            BookRowView(
-              item: item,
-              onReadBook: { _ in },
-              showSeriesTitle: showSeriesTitle
-            )
-          }
+    selectionContent
+      .allowsHitTesting(false)
+      .scaleEffect(isSelected ? 0.96 : 1.0)
+      .overlay {
+        if isSelected {
+          RoundedRectangle(cornerRadius: 12)
+            .stroke(Color.accentColor, lineWidth: 2)
         }
-        .allowsHitTesting(false)
-        .scaleEffect(isSelected ? 0.96 : 1.0)
-        .overlay {
+      }
+      .animation(.default, value: isSelected)
+      .contentShape(Rectangle())
+      .highPriorityGesture(
+        TapGesture().onEnded {
           if isSelected {
-            RoundedRectangle(cornerRadius: 12)
-              .stroke(Color.accentColor, lineWidth: 2)
+            selectedBookIds.remove(bookId)
+          } else {
+            selectedBookIds.insert(bookId)
           }
         }
-        .animation(.default, value: isSelected)
-        .contentShape(Rectangle())
-        .highPriorityGesture(
-          TapGesture().onEnded {
-            if isSelected {
-              selectedBookIds.remove(bookId)
-            } else {
-              selectedBookIds.insert(bookId)
-            }
-          }
+      )
+      .task(id: "\(current.instanceId)|\(bookId)") {
+        await loadItem()
+      }
+      .onReceive(NotificationCenter.default.publisher(for: .bookProjectionDidChange)) {
+        notification in
+        guard shouldReload(for: notification) else { return }
+        reloadItem()
+      }
+  }
+
+  @ViewBuilder
+  private var selectionContent: some View {
+    if let item {
+      switch layout {
+      case .grid:
+        BookCardView(
+          item: item,
+          onReadBook: { _ in },
+          showSeriesTitle: showSeriesTitle
+        )
+      case .list:
+        BookRowView(
+          item: item,
+          onReadBook: { _ in },
+          showSeriesTitle: showSeriesTitle
         )
       }
+    } else {
+      CardPlaceholder(
+        layout: layout,
+        kind: .book,
+        showBookSeriesTitle: showSeriesTitle
+      )
     }
-    .task(id: "\(current.instanceId)|\(bookId)") {
+  }
+
+  private func shouldReload(for notification: Notification) -> Bool {
+    if notification.userInfo?["bookId"] as? String == bookId {
+      return true
+    }
+    if let bookIds = notification.userInfo?["bookIds"] as? Set<String> {
+      return bookIds.contains(bookId)
+    }
+    if let bookIds = notification.userInfo?["bookIds"] as? [String] {
+      return bookIds.contains(bookId)
+    }
+    return false
+  }
+
+  private func reloadItem() {
+    Task {
       await loadItem()
     }
   }

--- a/KMReader/Features/Series/Views/SeriesSelectionItemView.swift
+++ b/KMReader/Features/Series/Views/SeriesSelectionItemView.swift
@@ -30,42 +30,75 @@ struct SeriesSelectionItemView: View {
   }
 
   var body: some View {
-    Group {
-      if let item {
-        Group {
-          switch layout {
-          case .grid:
-            SeriesCardView(
-              item: item
-            )
-          case .list:
-            SeriesRowView(
-              item: item
-            )
-          }
+    selectionContent
+      .allowsHitTesting(false)
+      .scaleEffect(isSelected ? 0.96 : 1.0)
+      .overlay {
+        if isSelected {
+          RoundedRectangle(cornerRadius: 12)
+            .stroke(Color.accentColor, lineWidth: 2)
         }
-        .allowsHitTesting(false)
-        .scaleEffect(isSelected ? 0.96 : 1.0)
-        .overlay {
+      }
+      .animation(.default, value: isSelected)
+      .contentShape(Rectangle())
+      .highPriorityGesture(
+        TapGesture().onEnded {
           if isSelected {
-            RoundedRectangle(cornerRadius: 12)
-              .stroke(Color.accentColor, lineWidth: 2)
+            selectedSeriesIds.remove(seriesId)
+          } else {
+            selectedSeriesIds.insert(seriesId)
           }
         }
-        .animation(.default, value: isSelected)
-        .contentShape(Rectangle())
-        .highPriorityGesture(
-          TapGesture().onEnded {
-            if isSelected {
-              selectedSeriesIds.remove(seriesId)
-            } else {
-              selectedSeriesIds.insert(seriesId)
-            }
-          }
+      )
+      .task(id: "\(current.instanceId)|\(seriesId)") {
+        await loadItem()
+      }
+      .onReceive(NotificationCenter.default.publisher(for: .seriesProjectionDidChange)) {
+        notification in
+        guard shouldReload(for: notification) else { return }
+        reloadItem()
+      }
+  }
+
+  @ViewBuilder
+  private var selectionContent: some View {
+    if let item {
+      switch layout {
+      case .grid:
+        SeriesCardView(
+          item: item
+        )
+      case .list:
+        SeriesRowView(
+          item: item
         )
       }
+    } else {
+      CardPlaceholder(layout: layout, kind: .series)
     }
-    .task(id: "\(current.instanceId)|\(seriesId)") {
+  }
+
+  private func shouldReload(for notification: Notification) -> Bool {
+    let changedIds = changedSeriesIds(from: notification)
+    guard !changedIds.isEmpty else { return true }
+    return changedIds.contains(seriesId)
+  }
+
+  private func changedSeriesIds(from notification: Notification) -> Set<String> {
+    if let ids = notification.userInfo?["seriesIds"] as? Set<String> {
+      return ids
+    }
+    if let ids = notification.userInfo?["seriesIds"] as? [String] {
+      return Set(ids)
+    }
+    if let id = notification.userInfo?["seriesId"] as? String {
+      return [id]
+    }
+    return []
+  }
+
+  private func reloadItem() {
+    Task {
       await loadItem()
     }
   }


### PR DESCRIPTION
## What changed

Read list and collection selection rows now keep their normal placeholder footprint while the local book or series projection is unavailable, instead of rendering an empty zero-height row.

The selection rows also reload when their book or series projection changes, so placeholders are replaced as soon as the display item is available.

## Validation

- `make format`
- `make build`
