### PR TITLE
docs: refresh 5.2 store copy

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,16 +1,17 @@
 New
-- Protect saved Komga servers with device authentication, so private libraries stay hidden until you unlock them.
-- Add offline download policies for read lists, matching the existing series policy workflow.
-- Add a floating reading action bar on series pages that shows the exact book and progress target before opening the reader.
+- Add a dashboard search shortcut on iPad and Mac, so Browse search is easier to reach from split-view dashboards.
+- Add a cancellable offline cover sync task for downloaded books, series, read lists, and collections.
 
 Improvements
-- Offline downloaded sections now show clearer book counts alongside storage usage.
-- Offline pages can be refreshed with pull to refresh on iOS and macOS.
-- Downloaded PDFs open faster in DIVINA mode by preparing lightweight metadata first and rendering page images as needed.
-- Dashboard sections now better match Komga web UI behavior and stay current after local reading, deletion, and offline changes.
-- Reader overlays and tap handling are smoother, with fewer abrupt transitions during loading, keyboard help, zoom, and long-press interactions.
+- Library filters now stay tied to each saved Komga server across startup, online switching, and offline switching.
+- Dashboard widgets now stay aligned with the same refreshed Keep Reading, Recently Added, and Recently Updated content shown in the app.
+- Online Browse search now follows Komga relevance ordering, while offline search keeps your saved local sort.
+- Downloaded archives with unusual filename encoding now open more reliably in offline mode.
+- Cover thumbnails now keep tap and context-menu areas bounded to the visible cover.
 
 Fixes
-- Fixed end-page selection after offline preloading, especially for Webtoon reading.
-- Fixed unavailable book and series indicators after deleting local files.
-- Fixed stale dashboard and progress projections after reader close or server events.
+- Fixed paged manga fitting in iPhone landscape so pages and reader controls are not clipped.
+- Fixed vertical RTL EPUB page turns, blank pages, and unstable page counts.
+- Fixed tvOS DIVINA cover-mode navigation near page transitions and end pages.
+- Fixed localized list layout labels in Japanese and French.
+- Fixed read list and collection edit rows while local book or series data is still loading.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -10,10 +10,11 @@ Rotate individual pages, crop empty page borders in DIVINA, tune preloading for 
 
 - Browse and discover
 Use Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/read lists, reading history, saved filters, advanced metadata filters with all/any matching, optional unread-cover blur, Spotlight indexing, widgets, and Home Screen quick actions.
-KMReader keeps a local database for responsive browsing, dashboards, logs, and downloaded-library workflows, including large libraries.
+KMReader keeps a local database for responsive browsing, dashboards, logs, and downloaded-library workflows, including large libraries. Dashboard library scopes stay tied to each saved server, and widgets mirror refreshed dashboard content.
 
 - Offline and sync
 Download books for offline reading, set per-series and per-read-list download policies, browse downloaded items with count and storage summaries, queue dashboard sections, keep reading with iOS background downloads and Live Activities, prepare local pages on demand with offline-first reading, and sync progress when you reconnect.
+Sync missing covers for downloaded books, series, read lists, and collections so offline browsing stays visual.
 
 - Multi-server and admin tools
 Save multiple Komga servers, protect private servers with device authentication, and switch instantly.

--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@
 ### Browse and Discovery
 
 - Dashboard sections for Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists, with quick offline actions for current or full book sections where supported.
-- Browse Series, Books, Collections, and Read Lists with metadata filters, all/any matching, saved filters, reading history, and optional unread-cover blur.
+- Browse Series, Books, Collections, and Read Lists with metadata filters, all/any matching, saved filters, reading history, dashboard search access on larger layouts, and optional unread-cover blur.
 - Local database storage keeps large libraries, dashboards, logs, downloaded content, and offline browsing responsive.
-- Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
+- Server-specific dashboard library scopes, refreshed widget payloads, Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
 
 ### Offline and Sync
 
 - Download books for offline reading across DIVINA, EPUB, and PDF workflows, with optional offline-first reading that prepares local content before opening the reader.
 - Per-series and per-read-list policies support manual, unread-only, unread + cleanup, and all-books downloads.
-- Downloaded library sections show book counts alongside storage usage, with pull-to-refresh support on iOS and macOS.
+- Downloaded library sections show book counts alongside storage usage, sync missing covers for offline data, and support pull to refresh on iOS and macOS.
 - Large downloads stream to disk, while CBZ, CBR, PDF, and supported EPUB offline flows keep source files available and prepare pages on demand.
 - Progress and offline changes sync when reconnecting, with stale progress protection and automatic recovery from server outages when offline mode was entered automatically. Cache controls cover pages and thumbnails.
 - iOS background downloads and Live Activities show reader progress, incognito status, download progress, and processing state.

--- a/static/index.html
+++ b/static/index.html
@@ -29,8 +29,9 @@
                     Read, download, browse, and manage your Komga library with
                     native DIVINA, EPUB, and PDF readers, Webtoon and spread
                     layouts, reader image processing, reliable local storage,
-                    offline-first reading, dashboard download actions, protected
-                    servers, advanced filtering, multi-server support, and Apple-platform integrations
+                    offline-first reading, offline cover sync, server-scoped
+                    dashboard filters, advanced search, protected servers,
+                    multi-server support, and Apple-platform integrations
                     on iPhone, iPad, Mac, and Apple TV.
                 </p>
                 <div class="cta">
@@ -101,9 +102,10 @@
                             Updated, pinned collections/read lists, reading
                             history, metadata filters with all/any matching,
                             saved filters, optional unread-cover blur,
-                            dashboard download actions, local database storage,
-                            widgets, quick actions, and Spotlight indexing keep
-                            the useful parts of your library close.
+                            dashboard download and search actions,
+                            server-scoped library filters, local database
+                            storage, widgets, quick actions, and Spotlight
+                            indexing keep the useful parts of your library close.
                         </p>
                     </article>
                     <article class="card">
@@ -113,9 +115,10 @@
                             Download books for offline reading, set per-series
                             and per-read-list download policies, prepare local
                             content before the reader opens, prepare pages on
-                            demand, browse downloaded items with count and
-                            storage summaries, use iOS background downloads and
-                            Live Activities, and sync progress when you reconnect.
+                            demand, sync missing covers for offline data, browse
+                            downloaded items with count and storage summaries,
+                            use iOS background downloads and Live Activities,
+                            and sync progress when you reconnect.
                         </p>
                     </article>
                     <article class="card">


### PR DESCRIPTION
## Problem
The public documentation and App Store release copy need to match the 5.2 release.

## Approach
Refresh README, App Store description, landing page copy, and App Store changelog from the current user-visible product changes.

## Validation
- [x] Reviewed latest-tag-to-HEAD commits
- [x] Ran git diff --check
