### PR TITLE
fix(offline): default cover sync scope to dashboard libraries

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 500;
+				CURRENT_PROJECT_VERSION = 501;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 500;
+				CURRENT_PROJECT_VERSION = 501;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 500;
+				CURRENT_PROJECT_VERSION = 501;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 500;
+				CURRENT_PROJECT_VERSION = 501;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/Cache/ThumbnailCache.swift
+++ b/KMReader/Core/Storage/Cache/ThumbnailCache.swift
@@ -12,7 +12,7 @@ extension Notification.Name {
   static let thumbnailDidRefresh = Notification.Name("thumbnailDidRefresh")
 }
 
-nonisolated enum ThumbnailType: String, CaseIterable, Sendable {
+nonisolated enum ThumbnailType: String, CaseIterable, Hashable, Sendable {
   case book
   case series
   case collection
@@ -296,6 +296,54 @@ actor ThumbnailCache {
     } catch is DiskCacheLimitReachedError {
       return .cacheLimitReached
     }
+  }
+
+  /// Returns cached cover thumbnail ids matching the requested ids.
+  func cachedCoverThumbnailIds(matching requestedIdsByType: [ThumbnailType: Set<String>]) async
+    -> [ThumbnailType: Set<String>]
+  {
+    let requestedIdsByType = requestedIdsByType.filter { type, ids in
+      type != .page && !ids.isEmpty
+    }
+    guard !requestedIdsByType.isEmpty else { return [:] }
+
+    let diskCacheURL = CacheNamespace.directory(for: "KomgaThumbnailCache")
+
+    return await Task.detached(priority: .utility) {
+      var cachedIdsByType: [ThumbnailType: Set<String>] = [:]
+      let fileManager = FileManager.default
+
+      for (type, requestedIds) in requestedIdsByType {
+        let typeDirectory = diskCacheURL.appendingPathComponent(type.rawValue, isDirectory: true)
+        guard
+          let fileURLs = try? fileManager.contentsOfDirectory(
+            at: typeDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+          )
+        else {
+          continue
+        }
+
+        var cachedIds = Set<String>()
+        for fileURL in fileURLs where fileURL.pathExtension.lowercased() == "jpg" {
+          let isRegularFile =
+            (try? fileURL.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
+          guard isRegularFile else { continue }
+
+          let id = fileURL.deletingPathExtension().lastPathComponent
+          if requestedIds.contains(id) {
+            cachedIds.insert(id)
+          }
+        }
+
+        if !cachedIds.isEmpty {
+          cachedIdsByType[type] = cachedIds
+        }
+      }
+
+      return cachedIdsByType
+    }.value
   }
 
   private static nonisolated func taskCacheKey(

--- a/KMReader/Features/Offline/Services/OfflineCoverSyncService.swift
+++ b/KMReader/Features/Offline/Services/OfflineCoverSyncService.swift
@@ -11,6 +11,7 @@ actor OfflineCoverSyncService {
   static let shared = OfflineCoverSyncService()
 
   private let logger = AppLogger(.offline)
+  private let cachedProgressReportStride = 25
   private var isRunning = false
 
   private init() {}
@@ -33,6 +34,9 @@ actor OfflineCoverSyncService {
       instanceId: instanceId,
       libraryIds: libraryIds
     )
+    var cachedThumbnailIds = await ThumbnailCache.shared.cachedCoverThumbnailIds(
+      matching: targetIdsByType(targets)
+    )
     var summary = OfflineCoverSyncSummary()
     summary.totalCount = targets.count
     await reportProgress(summary: summary, onProgress: onProgress)
@@ -40,6 +44,13 @@ actor OfflineCoverSyncService {
     for target in targets {
       if shouldStopSync(instanceId: instanceId) {
         return await stopSync(summary: summary, onProgress: onProgress)
+      }
+
+      if cachedThumbnailIds[target.type]?.contains(target.thumbnailId) == true {
+        summary.existingCount += 1
+        summary.checkedCount += 1
+        await reportCachedProgressIfNeeded(summary: summary, onProgress: onProgress)
+        continue
       }
 
       do {
@@ -50,16 +61,21 @@ actor OfflineCoverSyncService {
 
         switch result {
         case .cached:
+          cachedThumbnailIds[target.type, default: []].insert(target.thumbnailId)
           summary.existingCount += 1
+          summary.checkedCount += 1
+          await reportCachedProgressIfNeeded(summary: summary, onProgress: onProgress)
         case .stored:
+          cachedThumbnailIds[target.type, default: []].insert(target.thumbnailId)
           summary.storedCount += 1
+          summary.checkedCount += 1
+          await reportProgress(summary: summary, onProgress: onProgress)
         case .cacheLimitReached:
           summary.stoppedAtCacheLimit = true
           logger.info("⏸️ Stopped offline cover sync because cover cache reached its maximum size")
           await reportProgress(summary: summary, onProgress: onProgress)
           return summary
         }
-        summary.checkedCount += 1
       } catch is CancellationError {
         return await stopSync(summary: summary, onProgress: onProgress)
       } catch APIError.offline {
@@ -80,10 +96,11 @@ actor OfflineCoverSyncService {
         logger.warning(
           "⚠️ Failed to sync offline cover for \(target.type.rawValue) \(target.thumbnailId): \(error.localizedDescription)"
         )
+        await reportProgress(summary: summary, onProgress: onProgress)
       }
-      await reportProgress(summary: summary, onProgress: onProgress)
     }
 
+    await reportProgress(summary: summary, onProgress: onProgress)
     logger.info(
       "✅ Offline cover sync finished: checked=\(summary.checkedCount), existing=\(summary.existingCount), stored=\(summary.storedCount), failed=\(summary.failedCount)"
     )
@@ -100,6 +117,25 @@ actor OfflineCoverSyncService {
       return true
     default:
       return false
+    }
+  }
+
+  private func targetIdsByType(_ targets: [OfflineCoverSyncTarget]) -> [ThumbnailType: Set<String>] {
+    var idsByType: [ThumbnailType: Set<String>] = [:]
+    for target in targets {
+      idsByType[target.type, default: []].insert(target.thumbnailId)
+    }
+    return idsByType
+  }
+
+  private func reportCachedProgressIfNeeded(
+    summary: OfflineCoverSyncSummary,
+    onProgress: OfflineCoverSyncProgressHandler?
+  ) async {
+    if summary.checkedCount == summary.totalCount
+      || summary.checkedCount.isMultiple(of: cachedProgressReportStride)
+    {
+      await reportProgress(summary: summary, onProgress: onProgress)
     }
   }
 

--- a/KMReader/Features/Offline/Services/OfflineCoverSyncService.swift
+++ b/KMReader/Features/Offline/Services/OfflineCoverSyncService.swift
@@ -11,7 +11,7 @@ actor OfflineCoverSyncService {
   static let shared = OfflineCoverSyncService()
 
   private let logger = AppLogger(.offline)
-  private let cachedProgressReportStride = 25
+  private let cachedProgressReportInterval: TimeInterval = 0.15
   private var isRunning = false
 
   private init() {}
@@ -40,6 +40,7 @@ actor OfflineCoverSyncService {
     var summary = OfflineCoverSyncSummary()
     summary.totalCount = targets.count
     await reportProgress(summary: summary, onProgress: onProgress)
+    var lastCachedProgressReportAt = Date()
 
     for target in targets {
       if shouldStopSync(instanceId: instanceId) {
@@ -49,7 +50,11 @@ actor OfflineCoverSyncService {
       if cachedThumbnailIds[target.type]?.contains(target.thumbnailId) == true {
         summary.existingCount += 1
         summary.checkedCount += 1
-        await reportCachedProgressIfNeeded(summary: summary, onProgress: onProgress)
+        await reportCachedProgressIfNeeded(
+          summary: summary,
+          lastReportAt: &lastCachedProgressReportAt,
+          onProgress: onProgress
+        )
         continue
       }
 
@@ -64,7 +69,11 @@ actor OfflineCoverSyncService {
           cachedThumbnailIds[target.type, default: []].insert(target.thumbnailId)
           summary.existingCount += 1
           summary.checkedCount += 1
-          await reportCachedProgressIfNeeded(summary: summary, onProgress: onProgress)
+          await reportCachedProgressIfNeeded(
+            summary: summary,
+            lastReportAt: &lastCachedProgressReportAt,
+            onProgress: onProgress
+          )
         case .stored:
           cachedThumbnailIds[target.type, default: []].insert(target.thumbnailId)
           summary.storedCount += 1
@@ -130,13 +139,17 @@ actor OfflineCoverSyncService {
 
   private func reportCachedProgressIfNeeded(
     summary: OfflineCoverSyncSummary,
+    lastReportAt: inout Date,
     onProgress: OfflineCoverSyncProgressHandler?
   ) async {
-    if summary.checkedCount == summary.totalCount
-      || summary.checkedCount.isMultiple(of: cachedProgressReportStride)
-    {
-      await reportProgress(summary: summary, onProgress: onProgress)
-    }
+    let now = Date()
+    guard
+      summary.checkedCount == summary.totalCount
+        || now.timeIntervalSince(lastReportAt) >= cachedProgressReportInterval
+    else { return }
+
+    lastReportAt = now
+    await reportProgress(summary: summary, onProgress: onProgress)
   }
 
   private func stopSync(

--- a/KMReader/Features/Offline/ViewModels/OfflineCoverSyncViewModel.swift
+++ b/KMReader/Features/Offline/ViewModels/OfflineCoverSyncViewModel.swift
@@ -15,10 +15,8 @@ final class OfflineCoverSyncViewModel {
   private(set) var progress: OfflineCoverSyncProgress?
   private(set) var libraries: [LibraryInfo] = []
   private(set) var selectedLibraryIds: Set<String> = []
-  private(set) var loadedLibraryScopeTaskID: [String] = []
   @ObservationIgnored private var syncTask: Task<Void, Never>?
   @ObservationIgnored private var libraryScopeInstanceId: String?
-  @ObservationIgnored private var pendingLibraryScopeTaskID: [String] = []
   @ObservationIgnored private var hasManualLibrarySelection = false
 
   private init() {}
@@ -28,12 +26,6 @@ final class OfflineCoverSyncViewModel {
   }
 
   func loadLibraryScopeOptions(instanceId: String, defaultLibraryIds: [String]) async {
-    let taskID = Self.libraryScopeTaskID(
-      instanceId: instanceId,
-      defaultLibraryIds: defaultLibraryIds
-    )
-    pendingLibraryScopeTaskID = taskID
-
     guard !instanceId.isEmpty else {
       clearLibraryScope()
       return
@@ -48,7 +40,7 @@ final class OfflineCoverSyncViewModel {
 
     let loadedLibraries = await database.fetchLibraries(instanceId: instanceId)
       .filter { $0.id != KomgaLibrary.allLibrariesId }
-    guard !Task.isCancelled, pendingLibraryScopeTaskID == taskID else { return }
+    guard !Task.isCancelled else { return }
 
     let isNewInstanceScope = libraryScopeInstanceId != instanceId
     libraryScopeInstanceId = instanceId
@@ -65,20 +57,11 @@ final class OfflineCoverSyncViewModel {
       selectedLibraryIds = Set(defaultLibraryIds)
     }
     normalizeSelectedLibraryIds()
-    loadedLibraryScopeTaskID = taskID
   }
 
-  func selectedLibraryIdsForSync(instanceId: String) -> [String] {
-    guard libraryScopeInstanceId == instanceId else { return [] }
+  func selectedLibraryIdsForSync(instanceId: String, defaultLibraryIds: [String]) -> [String] {
+    guard libraryScopeInstanceId == instanceId else { return defaultLibraryIds.sorted() }
     return selectedLibraryIds.sorted()
-  }
-
-  func hasLoadedLibraryScope(instanceId: String, defaultLibraryIds: [String]) -> Bool {
-    loadedLibraryScopeTaskID
-      == Self.libraryScopeTaskID(
-        instanceId: instanceId,
-        defaultLibraryIds: defaultLibraryIds
-      )
   }
 
   func selectLibraries(_ libraryIds: Set<String>) {
@@ -183,8 +166,6 @@ final class OfflineCoverSyncViewModel {
     libraryScopeInstanceId = nil
     libraries = []
     selectedLibraryIds = []
-    loadedLibraryScopeTaskID = []
-    pendingLibraryScopeTaskID = []
     hasManualLibrarySelection = false
   }
 
@@ -205,10 +186,4 @@ final class OfflineCoverSyncViewModel {
     return selectedLibraryIds
   }
 
-  private static func libraryScopeTaskID(
-    instanceId: String,
-    defaultLibraryIds: [String]
-  ) -> [String] {
-    [instanceId] + defaultLibraryIds.sorted()
-  }
 }

--- a/KMReader/Features/Offline/ViewModels/OfflineCoverSyncViewModel.swift
+++ b/KMReader/Features/Offline/ViewModels/OfflineCoverSyncViewModel.swift
@@ -24,7 +24,7 @@ final class OfflineCoverSyncViewModel {
     selectedLibraryIds.isEmpty
   }
 
-  func loadLibraryScopeOptions(instanceId: String) async {
+  func loadLibraryScopeOptions(instanceId: String, defaultLibraryIds: [String]) async {
     guard !instanceId.isEmpty else {
       clearLibraryScope()
       return
@@ -38,15 +38,13 @@ final class OfflineCoverSyncViewModel {
     let loadedLibraries = await database.fetchLibraries(instanceId: instanceId)
       .filter { $0.id != KomgaLibrary.allLibrariesId }
 
-    if libraryScopeInstanceId != instanceId {
-      libraryScopeInstanceId = instanceId
-      selectedLibraryIds = []
-    }
+    libraryScopeInstanceId = instanceId
 
     if libraries != loadedLibraries {
       libraries = loadedLibraries
     }
 
+    selectedLibraryIds = Set(defaultLibraryIds)
     normalizeSelectedLibraryIds()
   }
 

--- a/KMReader/Features/Offline/ViewModels/OfflineCoverSyncViewModel.swift
+++ b/KMReader/Features/Offline/ViewModels/OfflineCoverSyncViewModel.swift
@@ -15,8 +15,10 @@ final class OfflineCoverSyncViewModel {
   private(set) var progress: OfflineCoverSyncProgress?
   private(set) var libraries: [LibraryInfo] = []
   private(set) var selectedLibraryIds: Set<String> = []
+  private(set) var loadedLibraryScopeTaskID: [String] = []
   @ObservationIgnored private var syncTask: Task<Void, Never>?
   @ObservationIgnored private var libraryScopeInstanceId: String?
+  @ObservationIgnored private var pendingLibraryScopeTaskID: [String] = []
   @ObservationIgnored private var hasManualLibrarySelection = false
 
   private init() {}
@@ -26,18 +28,27 @@ final class OfflineCoverSyncViewModel {
   }
 
   func loadLibraryScopeOptions(instanceId: String, defaultLibraryIds: [String]) async {
+    let taskID = Self.libraryScopeTaskID(
+      instanceId: instanceId,
+      defaultLibraryIds: defaultLibraryIds
+    )
+    pendingLibraryScopeTaskID = taskID
+
     guard !instanceId.isEmpty else {
       clearLibraryScope()
       return
     }
 
+    guard !Task.isCancelled else { return }
     guard let database = try? await DatabaseOperator.database() else {
+      guard !Task.isCancelled else { return }
       clearLibraryScope()
       return
     }
 
     let loadedLibraries = await database.fetchLibraries(instanceId: instanceId)
       .filter { $0.id != KomgaLibrary.allLibrariesId }
+    guard !Task.isCancelled, pendingLibraryScopeTaskID == taskID else { return }
 
     let isNewInstanceScope = libraryScopeInstanceId != instanceId
     libraryScopeInstanceId = instanceId
@@ -54,6 +65,7 @@ final class OfflineCoverSyncViewModel {
       selectedLibraryIds = Set(defaultLibraryIds)
     }
     normalizeSelectedLibraryIds()
+    loadedLibraryScopeTaskID = taskID
   }
 
   func selectedLibraryIdsForSync(instanceId: String) -> [String] {
@@ -61,10 +73,19 @@ final class OfflineCoverSyncViewModel {
     return selectedLibraryIds.sorted()
   }
 
+  func hasLoadedLibraryScope(instanceId: String, defaultLibraryIds: [String]) -> Bool {
+    loadedLibraryScopeTaskID
+      == Self.libraryScopeTaskID(
+        instanceId: instanceId,
+        defaultLibraryIds: defaultLibraryIds
+      )
+  }
+
   func selectLibraries(_ libraryIds: Set<String>) {
+    let libraryIds = normalizedLibrarySelection(libraryIds)
+    guard selectedLibraryIds != libraryIds else { return }
     hasManualLibrarySelection = true
     selectedLibraryIds = libraryIds
-    normalizeSelectedLibraryIds()
   }
 
   func startSyncMissingCovers(instanceId: String, libraryIds: [String]) {
@@ -162,19 +183,32 @@ final class OfflineCoverSyncViewModel {
     libraryScopeInstanceId = nil
     libraries = []
     selectedLibraryIds = []
+    loadedLibraryScopeTaskID = []
+    pendingLibraryScopeTaskID = []
     hasManualLibrarySelection = false
   }
 
   private func normalizeSelectedLibraryIds() {
+    selectedLibraryIds = normalizedLibrarySelection(selectedLibraryIds)
+  }
+
+  private func normalizedLibrarySelection(_ libraryIds: Set<String>) -> Set<String> {
     guard !libraries.isEmpty else {
-      selectedLibraryIds = []
-      return
+      return []
     }
 
     let validLibraryIds = Set(libraries.map(\.id))
-    selectedLibraryIds = selectedLibraryIds.intersection(validLibraryIds)
+    let selectedLibraryIds = libraryIds.intersection(validLibraryIds)
     if selectedLibraryIds.count == validLibraryIds.count {
-      selectedLibraryIds = []
+      return []
     }
+    return selectedLibraryIds
+  }
+
+  private static func libraryScopeTaskID(
+    instanceId: String,
+    defaultLibraryIds: [String]
+  ) -> [String] {
+    [instanceId] + defaultLibraryIds.sorted()
   }
 }

--- a/KMReader/Features/Offline/ViewModels/OfflineCoverSyncViewModel.swift
+++ b/KMReader/Features/Offline/ViewModels/OfflineCoverSyncViewModel.swift
@@ -17,6 +17,7 @@ final class OfflineCoverSyncViewModel {
   private(set) var selectedLibraryIds: Set<String> = []
   @ObservationIgnored private var syncTask: Task<Void, Never>?
   @ObservationIgnored private var libraryScopeInstanceId: String?
+  @ObservationIgnored private var hasManualLibrarySelection = false
 
   private init() {}
 
@@ -38,13 +39,20 @@ final class OfflineCoverSyncViewModel {
     let loadedLibraries = await database.fetchLibraries(instanceId: instanceId)
       .filter { $0.id != KomgaLibrary.allLibrariesId }
 
+    let isNewInstanceScope = libraryScopeInstanceId != instanceId
     libraryScopeInstanceId = instanceId
 
     if libraries != loadedLibraries {
       libraries = loadedLibraries
     }
 
-    selectedLibraryIds = Set(defaultLibraryIds)
+    if isNewInstanceScope {
+      hasManualLibrarySelection = false
+    }
+
+    if isNewInstanceScope || !hasManualLibrarySelection {
+      selectedLibraryIds = Set(defaultLibraryIds)
+    }
     normalizeSelectedLibraryIds()
   }
 
@@ -54,6 +62,7 @@ final class OfflineCoverSyncViewModel {
   }
 
   func selectLibraries(_ libraryIds: Set<String>) {
+    hasManualLibrarySelection = true
     selectedLibraryIds = libraryIds
     normalizeSelectedLibraryIds()
   }
@@ -153,6 +162,7 @@ final class OfflineCoverSyncViewModel {
     libraryScopeInstanceId = nil
     libraries = []
     selectedLibraryIds = []
+    hasManualLibrarySelection = false
   }
 
   private func normalizeSelectedLibraryIds() {

--- a/KMReader/Features/Offline/Views/OfflineCoverSyncSection.swift
+++ b/KMReader/Features/Offline/Views/OfflineCoverSyncSection.swift
@@ -20,6 +20,10 @@ struct OfflineCoverSyncSection: View {
     viewModel.isSyncing || isOffline || instanceId.isEmpty
   }
 
+  private var libraryScopeTaskID: [String] {
+    [instanceId] + defaultLibraryIds.sorted()
+  }
+
   var body: some View {
     Section {
       VStack(alignment: .leading, spacing: 6) {
@@ -77,7 +81,7 @@ struct OfflineCoverSyncSection: View {
         viewModel.selectLibraries(libraryIds)
       }
     }
-    .task(id: instanceId) {
+    .task(id: libraryScopeTaskID) {
       await viewModel.loadLibraryScopeOptions(
         instanceId: instanceId,
         defaultLibraryIds: defaultLibraryIds

--- a/KMReader/Features/Offline/Views/OfflineCoverSyncSection.swift
+++ b/KMReader/Features/Offline/Views/OfflineCoverSyncSection.swift
@@ -13,11 +13,15 @@ struct OfflineCoverSyncSection: View {
   @State private var isPickerPresented = false
 
   private var isStartDisabled: Bool {
-    !viewModel.isSyncing && (isOffline || instanceId.isEmpty)
+    !viewModel.isSyncing && (isOffline || instanceId.isEmpty || !hasLoadedLibraryScope)
   }
 
   private var isPickerDisabled: Bool {
     viewModel.isSyncing || isOffline || instanceId.isEmpty
+  }
+
+  private var hasLoadedLibraryScope: Bool {
+    viewModel.hasLoadedLibraryScope(instanceId: instanceId, defaultLibraryIds: defaultLibraryIds)
   }
 
   private var libraryScopeTaskID: [String] {

--- a/KMReader/Features/Offline/Views/OfflineCoverSyncSection.swift
+++ b/KMReader/Features/Offline/Views/OfflineCoverSyncSection.swift
@@ -13,15 +13,11 @@ struct OfflineCoverSyncSection: View {
   @State private var isPickerPresented = false
 
   private var isStartDisabled: Bool {
-    !viewModel.isSyncing && (isOffline || instanceId.isEmpty || !hasLoadedLibraryScope)
+    !viewModel.isSyncing && (isOffline || instanceId.isEmpty)
   }
 
   private var isPickerDisabled: Bool {
     viewModel.isSyncing || isOffline || instanceId.isEmpty
-  }
-
-  private var hasLoadedLibraryScope: Bool {
-    viewModel.hasLoadedLibraryScope(instanceId: instanceId, defaultLibraryIds: defaultLibraryIds)
   }
 
   private var libraryScopeTaskID: [String] {
@@ -169,7 +165,10 @@ struct OfflineCoverSyncSection: View {
       return
     }
 
-    let libraryIds = viewModel.selectedLibraryIdsForSync(instanceId: instanceId)
+    let libraryIds = viewModel.selectedLibraryIdsForSync(
+      instanceId: instanceId,
+      defaultLibraryIds: defaultLibraryIds
+    )
     viewModel.startSyncMissingCovers(instanceId: instanceId, libraryIds: libraryIds)
   }
 }

--- a/KMReader/Features/Offline/Views/OfflineCoverSyncSection.swift
+++ b/KMReader/Features/Offline/Views/OfflineCoverSyncSection.swift
@@ -9,6 +9,7 @@ struct OfflineCoverSyncSection: View {
   let viewModel: OfflineCoverSyncViewModel
   let instanceId: String
   let isOffline: Bool
+  let defaultLibraryIds: [String]
   @State private var isPickerPresented = false
 
   private var isStartDisabled: Bool {
@@ -77,7 +78,10 @@ struct OfflineCoverSyncSection: View {
       }
     }
     .task(id: instanceId) {
-      await viewModel.loadLibraryScopeOptions(instanceId: instanceId)
+      await viewModel.loadLibraryScopeOptions(
+        instanceId: instanceId,
+        defaultLibraryIds: defaultLibraryIds
+      )
     }
     .onChange(of: instanceId) { _, newValue in
       viewModel.cancelSyncIfContextChanged(instanceId: newValue, isOffline: isOffline)

--- a/KMReader/Features/Offline/Views/OfflineTasksView.swift
+++ b/KMReader/Features/Offline/Views/OfflineTasksView.swift
@@ -9,6 +9,7 @@ struct OfflineTasksView: View {
   @AppStorage("currentAccount") private var current: Current = .init()
   private var instanceId: String { current.instanceId }
   @AppStorage("isOffline") private var isOffline: Bool = false
+  @AppStorage("dashboard") private var dashboard: DashboardConfiguration = DashboardConfiguration()
   @AppStorage("offlinePaused") private var isPaused: Bool = false
   @AppStorage("offlineAutoDeleteRead") private var autoDeleteRead: Bool = false
   @AppStorage("offlineFirstReading") private var offlineFirstReading: Bool = false
@@ -119,7 +120,8 @@ struct OfflineTasksView: View {
       OfflineCoverSyncSection(
         viewModel: coverSyncViewModel,
         instanceId: instanceId,
-        isOffline: isOffline
+        isOffline: isOffline,
+        defaultLibraryIds: dashboard.libraryIds
       )
 
       if !downloadingTasks.isEmpty {


### PR DESCRIPTION
## Summary

- Default the Offline Tasks missing-cover sync scope to the current dashboard library selection without clobbering manual picker changes.
- Refresh the cover sync default scope when dashboard library defaults arrive late after server switching.
- Snapshot cached cover thumbnails before the sync loop so already-cached covers do not require one filesystem existence check per target, and throttle cached progress updates.
- Bump the build number to 501 with `make bump`.

## Validation

- `make format`
- `git diff --check`
- `make build-macos`
- `git diff --check origin/main...HEAD`
