### PR TITLE
fix(reader): keep completed loading progress full

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 502;
+				CURRENT_PROJECT_VERSION = 503;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 502;
+				CURRENT_PROJECT_VERSION = 503;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 502;
+				CURRENT_PROJECT_VERSION = 503;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 502;
+				CURRENT_PROJECT_VERSION = 503;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/ViewModels/ReaderLoadingProgress.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderLoadingProgress.swift
@@ -1,4 +1,6 @@
 enum ReaderLoadingProgress {
+  static let complete = 1.0
+
   static func displayValue(for progress: Double) -> Double {
     let normalized = min(max(progress, 0), 1)
     guard normalized > 0, normalized < 1 else { return normalized }

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -830,7 +830,7 @@ class ReaderViewModel {
     let status = await OfflineManager.shared.getDownloadStatus(bookId: book.id)
     if case .downloaded = status {
       if updatesLoadingState {
-        clearLoadingProgress()
+        updateLoadingProgress(ReaderLoadingProgress.complete)
         updateLoadingDetail(String(localized: "Using downloaded book files"))
       }
       return
@@ -853,7 +853,7 @@ class ReaderViewModel {
         info: downloadInfo
       )
     case .downloaded:
-      clearLoadingProgress()
+      updateLoadingProgress(ReaderLoadingProgress.complete)
       updateLoadingDetail(String(localized: "Using downloaded book files"))
       return
     }
@@ -867,7 +867,7 @@ class ReaderViewModel {
       switch currentStatus {
       case .downloaded:
         if updatesLoadingState {
-          clearLoadingProgress()
+          updateLoadingProgress(ReaderLoadingProgress.complete)
           updateLoadingDetail(String(localized: "Using downloaded book files"))
         }
         return
@@ -882,7 +882,7 @@ class ReaderViewModel {
           let progress = DownloadProgressTracker.shared.progress[book.id]
         {
           if progress >= 1 {
-            clearLoadingProgress()
+            updateLoadingProgress(ReaderLoadingProgress.complete)
             let status = offlinePostDownloadStatus(for: downloadInfo.kind)
             updateLoadingTitle(status.title)
             updateLoadingDetail(status.detail)

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -690,12 +690,18 @@
     }
 
     private var loadingProgress: Double? {
-      guard viewModel.loadingStage == .downloading else { return nil }
-      if let expectedBytes = viewModel.downloadBytesExpected, expectedBytes > 0 {
-        return viewModel.downloadProgress
-      }
+      switch viewModel.loadingStage {
+      case .downloading:
+        if let expectedBytes = viewModel.downloadBytesExpected, expectedBytes > 0 {
+          return viewModel.downloadProgress
+        }
 
-      return viewModel.downloadProgress > 0 ? viewModel.downloadProgress : nil
+        return viewModel.downloadProgress > 0 ? viewModel.downloadProgress : nil
+      case .finalizingOfflineDownload, .preparingOfflineResources, .preparingReader, .paginating:
+        return ReaderLoadingProgress.complete
+      case .fetchingMetadata, .idle:
+        return nil
+      }
     }
 
     private var loadingDetail: String {

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -444,12 +444,18 @@
     }
 
     private var loadingProgress: Double? {
-      guard viewModel.loadingStage == .downloading else { return nil }
-      if let expectedBytes = viewModel.downloadBytesExpected, expectedBytes > 0 {
-        return viewModel.downloadProgress
-      }
+      switch viewModel.loadingStage {
+      case .downloading:
+        if let expectedBytes = viewModel.downloadBytesExpected, expectedBytes > 0 {
+          return viewModel.downloadProgress
+        }
 
-      return viewModel.downloadProgress > 0 ? viewModel.downloadProgress : nil
+        return viewModel.downloadProgress > 0 ? viewModel.downloadProgress : nil
+      case .finalizingOfflineDownload, .preparingReader:
+        return ReaderLoadingProgress.complete
+      case .fetchingMetadata, .idle:
+        return nil
+      }
     }
 
     private var loadingDetail: String {


### PR DESCRIPTION
## Summary

This keeps the reader loading progress ring filled once an offline download has completed and the loader is finalizing or preparing reader resources. Unknown download progress and metadata fetches still use the spinner, while active downloads continue to show partial progress when available.

The branch also includes the requested build version bump to 503 as a separate commit.

## Validation

- `make format`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `make build`
