### PR TITLE
fix(reader): resolve missing page dimensions

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -692,7 +692,7 @@
 			repositoryURL = "https://github.com/everpcpc/libarchive-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.9;
+				minimumVersion = 0.1.11;
 			};
 		};
 		19F0B1002F10000000B10000 /* XCRemoteSwiftPackageReference "GRDB.swift" */ = {

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 503;
+				CURRENT_PROJECT_VERSION = 504;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 503;
+				CURRENT_PROJECT_VERSION = 504;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 503;
+				CURRENT_PROJECT_VERSION = 504;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 503;
+				CURRENT_PROJECT_VERSION = 504;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Models/BookPage.swift
+++ b/KMReader/Features/Book/Models/BookPage.swift
@@ -20,6 +20,11 @@ struct BookPage: Codable, Identifiable, Sendable {
 }
 
 extension BookPage {
+  nonisolated var hasValidDimensions: Bool {
+    guard let width, let height else { return false }
+    return width > 0 && height > 0
+  }
+
   nonisolated var isAnimatedImageCandidate: Bool {
     let fileExtension = (fileName as NSString).pathExtension.lowercased()
     if fileExtension == "gif" || fileExtension == "webp" {
@@ -60,6 +65,19 @@ extension BookPage {
       sizeBytes: sizeBytes,
       size: size,
       downloadURL: url
+    )
+  }
+
+  nonisolated func withDimensions(width: Int, height: Int) -> BookPage {
+    BookPage(
+      number: number,
+      fileName: fileName,
+      mediaType: mediaType,
+      width: self.width.flatMap { $0 > 0 ? $0 : nil } ?? width,
+      height: self.height.flatMap { $0 > 0 ? $0 : nil } ?? height,
+      sizeBytes: sizeBytes,
+      size: size,
+      downloadURL: downloadURL
     )
   }
 }

--- a/KMReader/Features/Offline/Services/ArchiveExtractionService.swift
+++ b/KMReader/Features/Offline/Services/ArchiveExtractionService.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import ImageIO
 import LibArchive
 
 nonisolated enum ArchiveExtractionService {
@@ -74,11 +75,121 @@ nonisolated enum ArchiveExtractionService {
     return try ArchiveReader().data(forEntryPath: entryPath, in: archiveFile)
   }
 
+  static func imagePixelSize(at fileURL: URL) -> CGSize? {
+    let options = [kCGImageSourceShouldCache: false] as CFDictionary
+    guard let source = CGImageSourceCreateWithURL(fileURL as CFURL, options) else {
+      return nil
+    }
+    return imagePixelSize(from: source)
+  }
+
+  static func imagePixelSizes(
+    from archiveFile: URL,
+    entryPaths: Set<String>,
+    normalizePath: @Sendable (String) -> String?
+  ) throws -> [String: CGSize] {
+    var pendingPathsByNormalizedPath: [String: [String]] = [:]
+    for entryPath in entryPaths {
+      guard let normalizedPath = normalizePath(entryPath) else { continue }
+      pendingPathsByNormalizedPath[normalizedPath, default: []].append(entryPath)
+    }
+    guard !pendingPathsByNormalizedPath.isEmpty else { return [:] }
+
+    var pixelSizes: [String: CGSize] = [:]
+    var currentNormalizedPath: String?
+    var currentEntryPaths: [String] = []
+    var currentData = Data()
+    var currentSource: CGImageSource?
+
+    func captureCurrentPixelSize(isFinal: Bool) {
+      guard let currentSource else { return }
+      CGImageSourceUpdateData(currentSource, currentData as CFData, isFinal)
+      guard let pixelSize = imagePixelSize(from: currentSource) else { return }
+
+      for entryPath in currentEntryPaths {
+        pixelSizes[entryPath] = pixelSize
+      }
+      if let currentNormalizedPath {
+        pendingPathsByNormalizedPath.removeValue(forKey: currentNormalizedPath)
+      }
+    }
+
+    try ArchiveReader().readDataBlocks(
+      in: archiveFile,
+      selecting: { entry in
+        guard !pendingPathsByNormalizedPath.isEmpty else { return .stop }
+        guard entry.fileType == .regular,
+          let normalizedPath = normalizePath(entry.path),
+          let requestedPaths = pendingPathsByNormalizedPath[normalizedPath]
+        else {
+          return .skip
+        }
+
+        currentNormalizedPath = normalizedPath
+        currentEntryPaths = requestedPaths
+        currentData.removeAll(keepingCapacity: true)
+        currentSource = CGImageSourceCreateIncremental(nil)
+        return .read
+      },
+      didFinishEntry: { _, consumedToEOF in
+        if consumedToEOF {
+          captureCurrentPixelSize(isFinal: true)
+        }
+        currentNormalizedPath = nil
+        currentEntryPaths.removeAll(keepingCapacity: true)
+        currentData.removeAll(keepingCapacity: true)
+        currentSource = nil
+      },
+      { _, block in
+        guard merge(block: block, into: &currentData) else {
+          return .finishEntry
+        }
+        captureCurrentPixelSize(isFinal: false)
+        guard let currentNormalizedPath else { return .finishEntry }
+        return pendingPathsByNormalizedPath[currentNormalizedPath] == nil
+          ? .finishEntry : .continueReading
+      }
+    )
+
+    return pixelSizes
+  }
+
   private static func makeStagingDirectory() throws -> URL {
     let directory = FileManager.default.temporaryDirectory
       .appendingPathComponent("KMReaderArchiveExtraction-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     return directory
+  }
+
+  private static func imagePixelSize(from source: CGImageSource) -> CGSize? {
+    guard
+      let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil)
+        as? [CFString: Any],
+      let width = (properties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
+      let height = (properties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue,
+      width > 0,
+      height > 0
+    else {
+      return nil
+    }
+
+    return CGSize(width: width, height: height)
+  }
+
+  private static func merge(block: ArchiveDataBlock, into data: inout Data) -> Bool {
+    guard block.offset >= 0, block.offset <= Int64(Int.max) else { return false }
+    let offset = Int(block.offset)
+    guard block.data.count <= Int.max - offset else { return false }
+    let endOffset = offset + block.data.count
+
+    if data.count < offset {
+      data.append(Data(repeating: 0, count: offset - data.count))
+    }
+    if data.count < endOffset {
+      data.append(Data(repeating: 0, count: endOffset - data.count))
+    }
+    data.replaceSubrange(offset..<endOffset, with: block.data)
+    return true
   }
 
   private static func regularFiles(in directory: URL) throws -> [URL] {

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -1439,6 +1439,105 @@ actor OfflineManager {
     }
   }
 
+  func fillMissingPageDimensions(
+    instanceId: String,
+    bookId: String,
+    pages: [BookPage]
+  ) async -> [BookPage] {
+    let pagesMissingDimensions = pages.filter { !$0.hasValidDimensions }
+    guard !pagesMissingDimensions.isEmpty else { return pages }
+
+    let bookDir = bookDirectory(instanceId: instanceId, bookId: bookId)
+    let cache = pageImageCache(for: instanceId)
+    var localFileURLsByEntryPath: [String: URL] = [:]
+
+    for page in pagesMissingDimensions {
+      let candidateURLs =
+        offlinePageImageFileURLs(bookDir: bookDir, page: page) + [
+          cache.imageFileURL(bookId: bookId, page: page)
+        ]
+      if let fileURL = candidateURLs.first(where: {
+        FileManager.default.fileExists(atPath: $0.path)
+      }) {
+        localFileURLsByEntryPath[page.fileName] = fileURL
+      }
+    }
+
+    var pixelSizesByEntryPath = await Task.detached(priority: .userInitiated) {
+      localFileURLsByEntryPath.reduce(into: [String: CGSize]()) { result, item in
+        if let pixelSize = ArchiveExtractionService.imagePixelSize(at: item.value) {
+          result[item.key] = pixelSize
+        }
+      }
+    }.value
+
+    let unresolvedEntryPaths = Set(
+      pagesMissingDimensions.lazy
+        .map(\.fileName)
+        .filter { pixelSizesByEntryPath[$0] == nil }
+    )
+
+    if !unresolvedEntryPaths.isEmpty,
+      let archiveFile = existingArchivedPageSourceURL(in: bookDir)
+    {
+      do {
+        let archivePixelSizes = try await Task.detached(priority: .userInitiated) {
+          try ArchiveExtractionService.imagePixelSizes(
+            from: archiveFile,
+            entryPaths: unresolvedEntryPaths,
+            normalizePath: Self.normalizeArchivePath
+          )
+        }.value
+        pixelSizesByEntryPath.merge(archivePixelSizes) { current, _ in current }
+      } catch {
+        logger.warning(
+          "⚠️ Failed to read missing page dimensions from archive for book \(bookId): \(error)"
+        )
+      }
+    }
+
+    guard !pixelSizesByEntryPath.isEmpty else { return pages }
+
+    var resolvedCount = 0
+    let resolvedPages = pages.map { page in
+      guard !page.hasValidDimensions,
+        let pixelSize = pixelSizesByEntryPath[page.fileName]
+      else {
+        return page
+      }
+
+      resolvedCount += 1
+      return page.withDimensions(
+        width: Int(pixelSize.width),
+        height: Int(pixelSize.height)
+      )
+    }
+    guard resolvedCount > 0 else { return pages }
+
+    if let database = await DatabaseOperator.databaseIfConfigured() {
+      await database.updateBookPages(
+        bookId: bookId,
+        instanceId: instanceId,
+        pages: resolvedPages
+      )
+    }
+
+    if existingArchivedPageSourceURL(in: bookDir) != nil {
+      do {
+        try Self.writeArchivePagesSidecar(resolvedPages, to: bookDir)
+      } catch {
+        logger.warning(
+          "⚠️ Failed to persist resolved page dimensions sidecar for book \(bookId): \(error)"
+        )
+      }
+    }
+
+    logger.info(
+      "✅ Filled missing page dimensions for book \(bookId): resolved=\(resolvedCount), missing=\(pagesMissingDimensions.count - resolvedCount)"
+    )
+    return resolvedPages
+  }
+
   func storeOfflinePageImage(
     instanceId: String,
     bookId: String,

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -14,6 +14,7 @@ class ReaderViewModel {
   var isolatePages: [Int] = []
   private var isolatePagesByBookId: [String: Set<Int>] = [:]
   private var pageRotationsByBookId: [String: [Int: Int]] = [:]
+  private(set) var bookIdsWithMissingPageDimensions: Set<String> = []
   private var currentPageID: ReaderPageID?
   private var currentViewItemID: ReaderViewItem?
   var navigationTarget: ReaderViewItem?
@@ -123,6 +124,10 @@ class ReaderViewModel {
   func pageRotationDegrees(for pageID: ReaderPageID) -> Int {
     guard let position = isolatePosition(for: pageID) else { return 0 }
     return pageRotationsByBookId[position.bookId]?[position.localIndex] ?? 0
+  }
+
+  func hasMissingPageDimensions(forBookId bookId: String) -> Bool {
+    bookIdsWithMissingPageDimensions.contains(bookId)
   }
 
   var currentPageRotationDegrees: Int {
@@ -590,6 +595,7 @@ class ReaderViewModel {
   private func fetchSegmentPages(for book: Book, purpose: SegmentFetchPurpose) async -> [BookPage]? {
     let database = await DatabaseOperator.databaseIfConfigured()
     let fetchedPages: [BookPage]
+    let shouldRefreshCachedPages: Bool
 
     if AppConfig.offlineFirstReading, purpose.shouldEnsureOfflineReady {
       do {
@@ -603,8 +609,10 @@ class ReaderViewModel {
         return nil
       }
       fetchedPages = localPages
+      shouldRefreshCachedPages = false
     } else if let cachedPages = await database?.fetchPages(id: book.id) {
       fetchedPages = cachedPages
+      shouldRefreshCachedPages = !AppConfig.offlineFirstReading && !AppConfig.isOffline
     } else {
       guard !AppConfig.isOffline else {
         return nil
@@ -613,35 +621,87 @@ class ReaderViewModel {
       do {
         fetchedPages = try await BookService.getBookPages(id: book.id)
         await database?.updateBookPages(bookId: book.id, pages: fetchedPages)
+        shouldRefreshCachedPages = false
       } catch {
         logger.error("❌ Failed to preload segment pages for book \(book.id): \(error)")
         return nil
       }
     }
 
-    return await fillMissingPageDimensions(bookId: book.id, pages: fetchedPages)
-  }
-
-  private func fillMissingPageDimensions(bookId: String, pages: [BookPage]) async -> [BookPage] {
-    guard pages.contains(where: { !$0.hasValidDimensions }) else { return pages }
-    return await OfflineManager.shared.fillMissingPageDimensions(
-      instanceId: AppConfig.current.instanceId,
-      bookId: bookId,
-      pages: pages
+    return await resolvePageDimensions(
+      bookId: book.id,
+      pages: fetchedPages,
+      shouldRefreshCachedPages: shouldRefreshCachedPages
     )
   }
 
-  private func alertForMissingPageDimensionsIfNeeded(pages: [BookPage]) {
-    guard !AppConfig.offlineFirstReading, !AppConfig.isOffline else { return }
-    guard pages.contains(where: { !$0.hasValidDimensions }) else { return }
+  private func resolvePageDimensions(
+    bookId: String,
+    pages: [BookPage],
+    shouldRefreshCachedPages: Bool
+  ) async -> [BookPage] {
+    var resolvedPages = pages
 
-    ErrorManager.shared.alert(
-      message: String(
-        localized: "reader.missingPageDimensions.alert",
-        defaultValue:
-          "Some pages do not include image dimensions. Enable “Analyze pages dimensions” in this library's options in Komga and rescan the library, or enable Offline-first Reading in KMReader. Auto Page Layout and Split Wide Pages may not work correctly until dimensions are available."
+    if shouldRefreshCachedPages,
+      resolvedPages.contains(where: { !$0.hasValidDimensions })
+    {
+      do {
+        let refreshedPages = try await BookService.getBookPages(id: bookId)
+        resolvedPages = preservingKnownDimensions(
+          in: refreshedPages,
+          from: resolvedPages
+        )
+        if let database = await DatabaseOperator.databaseIfConfigured() {
+          await database.updateBookPages(bookId: bookId, pages: resolvedPages)
+        }
+      } catch {
+        logger.warning(
+          "⚠️ Failed to refresh page dimensions from server for book \(bookId): \(error)"
+        )
+      }
+    }
+
+    if resolvedPages.contains(where: { !$0.hasValidDimensions }) {
+      resolvedPages = await OfflineManager.shared.fillMissingPageDimensions(
+        instanceId: AppConfig.current.instanceId,
+        bookId: bookId,
+        pages: resolvedPages
       )
-    )
+    }
+
+    updateMissingPageDimensionsState(bookId: bookId, pages: resolvedPages)
+    return resolvedPages
+  }
+
+  private func preservingKnownDimensions(
+    in refreshedPages: [BookPage],
+    from cachedPages: [BookPage]
+  ) -> [BookPage] {
+    let cachedDimensionsByFileName = cachedPages.reduce(into: [String: (width: Int, height: Int)]()) {
+      result, page in
+      guard page.hasValidDimensions, let width = page.width, let height = page.height else { return }
+      result[page.fileName] = (width, height)
+    }
+
+    return refreshedPages.map { page in
+      guard !page.hasValidDimensions,
+        let dimensions = cachedDimensionsByFileName[page.fileName]
+      else {
+        return page
+      }
+      return page.withDimensions(width: dimensions.width, height: dimensions.height)
+    }
+  }
+
+  private func updateMissingPageDimensionsState(bookId: String, pages: [BookPage]) {
+    let hasMissingDimensions = pages.contains(where: { !$0.hasValidDimensions })
+    if hasMissingDimensions {
+      guard !bookIdsWithMissingPageDimensions.contains(bookId) else { return }
+      bookIdsWithMissingPageDimensions.insert(bookId)
+    } else {
+      guard bookIdsWithMissingPageDimensions.contains(bookId) else { return }
+      bookIdsWithMissingPageDimensions.remove(bookId)
+    }
   }
 
   private func hydrateIsolatePages(for bookId: String) async {
@@ -684,6 +744,7 @@ class ReaderViewModel {
     isolatePages.removeAll()
     isolatePagesByBookId.removeAll()
     pageRotationsByBookId.removeAll()
+    bookIdsWithMissingPageDimensions.removeAll()
     tableOfContents.removeAll()
     tableOfContentsByBookId.removeAll()
     tableOfContentsBookId = nil
@@ -810,19 +871,22 @@ class ReaderViewModel {
       let database = await DatabaseOperator.databaseIfConfigured()
 
       let storedPages: [BookPage]
+      let shouldRefreshCachedPages: Bool
       if let localPages = await database?.fetchPages(id: book.id) {
         storedPages = localPages
+        shouldRefreshCachedPages = !AppConfig.offlineFirstReading && !AppConfig.isOffline
       } else if !AppConfig.isOffline {
         storedPages = try await BookService.getBookPages(id: book.id)
         await database?.updateBookPages(bookId: book.id, pages: storedPages)
+        shouldRefreshCachedPages = false
       } else {
         throw APIError.offline
       }
-      let fetchedPages = await fillMissingPageDimensions(
+      let fetchedPages = await resolvePageDimensions(
         bookId: book.id,
-        pages: storedPages
+        pages: storedPages,
+        shouldRefreshCachedPages: shouldRefreshCachedPages
       )
-      alertForMissingPageDimensionsIfNeeded(pages: fetchedPages)
 
       let localIsolatePages = await database?.fetchIsolatePages(id: book.id) ?? []
       isolatePagesByBookId[book.id] = Set(localIsolatePages)

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -589,6 +589,7 @@ class ReaderViewModel {
 
   private func fetchSegmentPages(for book: Book, purpose: SegmentFetchPurpose) async -> [BookPage]? {
     let database = await DatabaseOperator.databaseIfConfigured()
+    let fetchedPages: [BookPage]
 
     if AppConfig.offlineFirstReading, purpose.shouldEnsureOfflineReady {
       do {
@@ -598,25 +599,49 @@ class ReaderViewModel {
         return nil
       }
 
-      return await database?.fetchPages(id: book.id)
+      guard let localPages = await database?.fetchPages(id: book.id) else {
+        return nil
+      }
+      fetchedPages = localPages
+    } else if let cachedPages = await database?.fetchPages(id: book.id) {
+      fetchedPages = cachedPages
+    } else {
+      guard !AppConfig.isOffline else {
+        return nil
+      }
+
+      do {
+        fetchedPages = try await BookService.getBookPages(id: book.id)
+        await database?.updateBookPages(bookId: book.id, pages: fetchedPages)
+      } catch {
+        logger.error("❌ Failed to preload segment pages for book \(book.id): \(error)")
+        return nil
+      }
     }
 
-    if let cachedPages = await database?.fetchPages(id: book.id) {
-      return cachedPages
-    }
+    return await fillMissingPageDimensions(bookId: book.id, pages: fetchedPages)
+  }
 
-    guard !AppConfig.isOffline else {
-      return nil
-    }
+  private func fillMissingPageDimensions(bookId: String, pages: [BookPage]) async -> [BookPage] {
+    guard pages.contains(where: { !$0.hasValidDimensions }) else { return pages }
+    return await OfflineManager.shared.fillMissingPageDimensions(
+      instanceId: AppConfig.current.instanceId,
+      bookId: bookId,
+      pages: pages
+    )
+  }
 
-    do {
-      let fetchedPages = try await BookService.getBookPages(id: book.id)
-      await database?.updateBookPages(bookId: book.id, pages: fetchedPages)
-      return fetchedPages
-    } catch {
-      logger.error("❌ Failed to preload segment pages for book \(book.id): \(error)")
-      return nil
-    }
+  private func alertForMissingPageDimensionsIfNeeded(pages: [BookPage]) {
+    guard !AppConfig.offlineFirstReading, !AppConfig.isOffline else { return }
+    guard pages.contains(where: { !$0.hasValidDimensions }) else { return }
+
+    ErrorManager.shared.alert(
+      message: String(
+        localized: "reader.missingPageDimensions.alert",
+        defaultValue:
+          "Some pages do not include image dimensions. Enable “Analyze pages dimensions” in this library's options in Komga and rescan the library, or enable Offline-first Reading in KMReader. Auto Page Layout and Split Wide Pages may not work correctly until dimensions are available."
+      )
+    )
   }
 
   private func hydrateIsolatePages(for bookId: String) async {
@@ -784,15 +809,20 @@ class ReaderViewModel {
       await ensureOfflinePDFMetadataForDivina(book: book)
       let database = await DatabaseOperator.databaseIfConfigured()
 
-      let fetchedPages: [BookPage]
+      let storedPages: [BookPage]
       if let localPages = await database?.fetchPages(id: book.id) {
-        fetchedPages = localPages
+        storedPages = localPages
       } else if !AppConfig.isOffline {
-        fetchedPages = try await BookService.getBookPages(id: book.id)
-        await database?.updateBookPages(bookId: book.id, pages: fetchedPages)
+        storedPages = try await BookService.getBookPages(id: book.id)
+        await database?.updateBookPages(bookId: book.id, pages: storedPages)
       } else {
         throw APIError.offline
       }
+      let fetchedPages = await fillMissingPageDimensions(
+        bookId: book.id,
+        pages: storedPages
+      )
+      alertForMissingPageDimensionsIfNeeded(pages: fetchedPages)
 
       let localIsolatePages = await database?.fetchIsolatePages(id: book.id) ?? []
       isolatePagesByBookId[book.id] = Set(localIsolatePages)

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -29,13 +29,16 @@ struct DivinaControlsOverlayView: View {
   let showingControls: Bool
   let showGradientBackground: Bool
   let showProgressBarWhileReading: Bool
+  let showPageDimensionWarning: Bool
 
   @Namespace private var progressBarNamespace
+  @State private var showingPageDimensionWarning = false
 
   #if os(tvOS)
     private enum ControlFocus: Hashable {
       case close
       case title
+      case pageDimensionWarning
       case settings
       case pageNumber
     }
@@ -156,6 +159,14 @@ struct DivinaControlsOverlayView: View {
     .animation(animation, value: controlsVisible)
     .animation(animation, value: showProgressBarWhileReading)
     .allowsHitTesting(controlsVisible)
+    .alert(
+      "reader.pageDimensions.warning.title",
+      isPresented: $showingPageDimensionWarning
+    ) {
+      Button("OK") {}
+    } message: {
+      Text("reader.missingPageDimensions.alert")
+    }
     #if os(iOS)
       .tint(.primary)
     #endif
@@ -268,6 +279,23 @@ struct DivinaControlsOverlayView: View {
         #if os(tvOS)
           .focused($focusedControl, equals: .title)
           .id("titleLabel")
+        #endif
+      }
+
+      if showPageDimensionWarning {
+        Button {
+          showingPageDimensionWarning = true
+        } label: {
+          Image(systemName: "exclamationmark.triangle.fill")
+            .foregroundStyle(.yellow)
+            .contentShape(Circle())
+        }
+        .accessibilityLabel(Text("reader.pageDimensions.warning.title"))
+        .buttonBorderShape(.circle)
+        .controlSize(.large)
+        .readerControlButtonStyle()
+        #if os(tvOS)
+          .focused($focusedControl, equals: .pageDimensionWarning)
         #endif
       }
 

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -45,6 +45,8 @@ struct DivinaReaderView: View {
   @AppStorage("doubleTapZoomMode") private var doubleTapZoomMode: DoubleTapZoomMode = .enabled
   @AppStorage("shakeToOpenLiveText") private var shakeToOpenLiveText: Bool = false
   @AppStorage("divinaPreloadProfile") private var divinaPreloadProfile: ReaderPreloadProfile = .balanced
+  @AppStorage("isOffline") private var isOffline: Bool = false
+  @AppStorage("offlineFirstReading") private var offlineFirstReading: Bool = false
 
   @State private var readingDirection: ReadingDirection
   @State private var pageLayout: PageLayout
@@ -188,6 +190,12 @@ struct DivinaReaderView: View {
 
   private var currentSegmentPreviousBook: Book? {
     currentSegmentContext.previousBook
+  }
+
+  private var showPageDimensionWarning: Bool {
+    guard !isOffline, !offlineFirstReading else { return false }
+    guard pageLayout.supportsDualPageOptions || splitWidePageMode.isEnabled else { return false }
+    return viewModel.hasMissingPageDimensions(forBookId: currentSegmentBookId)
   }
 
   private var handoffBookId: String {
@@ -998,7 +1006,8 @@ struct DivinaReaderView: View {
       controlsVisible: shouldShowControls,
       showingControls: showingControls,
       showGradientBackground: showControlsGradientBackground,
-      showProgressBarWhileReading: showProgressBarWhileReading
+      showProgressBarWhileReading: showProgressBarWhileReading,
+      showPageDimensionWarning: showPageDimensionWarning
     )
   }
 

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -57287,6 +57287,70 @@
         }
       }
     },
+    "reader.pageDimensions.warning.title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seitenabmessungen nicht verfügbar"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page dimensions unavailable"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dimensiones de página no disponibles"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dimensions des pages indisponibles"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dimensioni delle pagine non disponibili"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページ寸法を利用できません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 크기를 사용할 수 없음"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Размеры страниц недоступны"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "页面尺寸不可用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁面尺寸不可用"
+          }
+        }
+      }
+    },
     "reader.pageLayout.auto" : {
       "localizations" : {
         "de" : {

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -153,6 +153,17 @@
       },
       "shouldTranslate" : false
     },
+    "%@\n%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@\n%2$@"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
     "%@ " : {
       "localizations" : {
         "fr" : {
@@ -56696,6 +56707,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "白色"
+          }
+        }
+      }
+    },
+    "reader.missingPageDimensions.alert" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einigen Seiten fehlen die Bildabmessungen. Aktiviere „Analysiere Seitenformat“ in den Optionen dieser Bibliothek in Komga und scanne die Bibliothek erneut, oder aktiviere „Offline zuerst lesen“ in KMReader. „Automatisch“ und „Breite Seiten teilen“ funktionieren möglicherweise erst korrekt, wenn die Abmessungen verfügbar sind."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Some pages do not include image dimensions. Enable “Analyze pages dimensions” in this library's options in Komga and rescan the library, or enable Offline-first Reading in KMReader. Auto Page Layout and Split Wide Pages may not work correctly until dimensions are available."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A algunas páginas les faltan las dimensiones de imagen. Activa «Analizar la dimensión de las páginas» en las opciones de esta biblioteca en Komga y vuelve a escanearla, o activa «Lectura primero sin conexión» en KMReader. «Automático» y «Dividir páginas anchas» podrían no funcionar correctamente hasta que las dimensiones estén disponibles."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Certaines pages ne contiennent pas les dimensions de l’image. Activez « Analyser les dimensions des pages » dans les options de cette bibliothèque dans Komga et relancez son analyse, ou activez « Lecture hors ligne d’abord » dans KMReader. « Automatique » et « Diviser les pages larges » risquent de ne pas fonctionner correctement tant que les dimensions ne sont pas disponibles."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alcune pagine non includono le dimensioni dell'immagine. Abilita «Analizza le dimensioni delle pagine» nelle opzioni di questa libreria in Komga e riesegui la scansione, oppure abilita «Lettura prima offline» in KMReader. «Automatico» e «Dividi pagine larghe» potrebbero non funzionare correttamente finché le dimensioni non sono disponibili."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一部のページに画像の寸法情報がありません。Komga のこのライブラリのオプションで「ページ寸法の分析」を有効にしてライブラリを再スキャンするか、KMReader で「オフライン優先読書」を有効にしてください。寸法情報が利用可能になるまで、「自動」ページレイアウトと「ワイドページを分割」が正しく動作しない場合があります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일부 페이지에 이미지 크기 정보가 없습니다. Komga의 해당 라이브러리 옵션에서 ‘페이지 크기 분석’을 활성화하고 라이브러리를 다시 스캔하거나 KMReader에서 ‘오프라인 우선 읽기’를 활성화하세요. 크기 정보를 사용할 수 있을 때까지 ‘자동’ 페이지 레이아웃과 ‘넓은 페이지 분할’이 올바르게 작동하지 않을 수 있습니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Для некоторых страниц отсутствуют размеры изображения. Включите «Анализировать размеры страниц» в параметрах этой библиотеки в Komga и повторно просканируйте библиотеку либо включите «Чтение сначала офлайн» в KMReader. Пока размеры недоступны, «Авто» и «Разделять широкие страницы» могут работать некорректно."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分页面缺少图片尺寸信息。请在 Komga 的此书库选项中开启“分析页面尺寸”并重新扫描书库，或在 KMReader 中开启“优先离线阅读”。在尺寸信息可用前，“自动”页面布局和“分割宽页”可能无法正常工作。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分頁面缺少圖片尺寸資訊。請在 Komga 的此書庫選項中開啟「分析頁面尺寸」並重新掃描書庫，或在 KMReader 中開啟「優先離線閱讀」。在尺寸資訊可用前，「自動」頁面佈局和「分割寬頁」可能無法正常運作。"
           }
         }
       }


### PR DESCRIPTION
## What changed

- Fill missing DIVINA page dimensions from existing local page files or the image cache before reader layout is generated.
- Use libarchive-swift 0.1.11 to inspect multiple selected archive entries in one traversal and stop reading each entry as soon as ImageIO resolves its pixel size.
- Refresh cached `/pages` metadata online before local fallback, while preserving dimensions that were already recovered locally.
- Persist recovered dimensions to GRDB and the offline archive metadata sidecar.
- Track unresolved dimensions per book so adjacent preloaded segments surface the warning only when they become active.
- Show a non-blocking warning icon in reader controls when the active layout depends on dimensions; opening it explains how to enable **Analyze pages dimensions** in Komga or use **Offline-first Reading** in KMReader.
- Increment the build number to 504.

## User impact

Auto Page Layout and Split Wide Pages can correctly identify portrait and landscape pages when Komga's `/pages` response omitted dimensions but local content is available. When recovery is unavailable, reading is not interrupted: the active segment exposes contextual configuration guidance from the controls overlay.

## Validation

- `make format`
- `make build` (iOS, macOS, and tvOS)
- `./misc/translate.py list`
- `git diff --check`
