### PR TITLE
docs: refresh 6.0 store copy

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,17 +1,8 @@
 New
-- Add a dashboard search shortcut on iPad and Mac, so Browse search is easier to reach from split-view dashboards.
-- Add a cancellable offline cover sync task for downloaded books, series, read lists, and collections.
+- See your recent reading at a glance with a 90-day pages-read heatmap.
+- Export or clear stored logs from the same logs menu.
 
 Improvements
-- Library filters now stay tied to each saved Komga server across startup, online switching, and offline switching.
-- Dashboard widgets now stay aligned with the same refreshed Keep Reading, Recently Added, and Recently Updated content shown in the app.
-- Online Browse search now follows Komga relevance ordering, while offline search keeps your saved local sort.
-- Downloaded archives with unusual filename encoding now open more reliably in offline mode.
-- Cover thumbnails now keep tap and context-menu areas bounded to the visible cover.
-
-Fixes
-- Fixed paged manga fitting in iPhone landscape so pages and reader controls are not clipped.
-- Fixed vertical RTL EPUB page turns, blank pages, and unstable page counts.
-- Fixed tvOS DIVINA cover-mode navigation near page transitions and end pages.
-- Fixed localized list layout labels in Japanese and French.
-- Fixed read list and collection edit rows while local book or series data is still loading.
+- Offline cover sync now stays scoped to your selected dashboard libraries, preserves manual choices, and handles large libraries more efficiently.
+- DIVINA can recover missing page dimensions from cached, downloaded, or streamed content so Auto Page Layout and Split Wide Pages remain accurate.
+- Completed offline downloads now keep the loading indicator full while the reader finishes preparing EPUB, PDF, or page resources.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -9,7 +9,7 @@ Read comics and books with DIVINA on iOS, macOS, and tvOS, plus EPUB and PDF on 
 Rotate individual pages, crop empty page borders in DIVINA, tune preloading for memory or smoother page turns, keep lightweight progress visible while reading, and choose native PDF presentation modes that adapt cleanly between portrait and landscape.
 
 - Browse and discover
-Use Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/read lists, reading history, saved filters, advanced metadata filters with all/any matching, optional unread-cover blur, Spotlight indexing, widgets, and Home Screen quick actions.
+Use Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/read lists, reading history, a 90-day pages-read heatmap, saved filters, advanced metadata filters with all/any matching, optional unread-cover blur, Spotlight indexing, widgets, and Home Screen quick actions.
 KMReader keeps a local database for responsive browsing, dashboards, logs, and downloaded-library workflows, including large libraries. Dashboard library scopes stay tied to each saved server, and widgets mirror refreshed dashboard content.
 
 - Offline and sync
@@ -19,7 +19,7 @@ Sync missing covers for downloaded books, series, read lists, and collections so
 - Multi-server and admin tools
 Save multiple Komga servers, protect private servers with device authentication, and switch instantly.
 Sign in with password or API key, and manage API keys in the app.
-Edit metadata, manage libraries and media, find missing posters or duplicates, monitor tasks, and browse paginated logs.
+Edit metadata, manage libraries and media, find missing posters or duplicates, monitor tasks, and browse, export, or clear paginated logs.
 
 KMReader targets Komga 1.19.0+ and supports API v1/v2.
 KMReader UI is localized in English, German, French, Japanese, Korean, Simplified Chinese, Traditional Chinese, Italian, Russian, and Spanish.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ### Browse and Discovery
 
 - Dashboard sections for Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists, with quick offline actions for current or full book sections where supported.
-- Browse Series, Books, Collections, and Read Lists with metadata filters, all/any matching, saved filters, reading history, dashboard search access on larger layouts, and optional unread-cover blur.
+- Browse Series, Books, Collections, and Read Lists with metadata filters, all/any matching, saved filters, reading history, a 90-day pages-read heatmap, dashboard search access on larger layouts, and optional unread-cover blur.
 - Local database storage keeps large libraries, dashboards, logs, downloaded content, and offline browsing responsive.
 - Server-specific dashboard library scopes, refreshed widget payloads, Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
 
@@ -47,7 +47,7 @@
 
 - Save multiple Komga servers, protect private servers with device authentication, and switch instantly.
 - Sign in with username/password or API key, and manage Komga API keys inside the app.
-- Admin tools cover metadata editing, library management, media analysis, missing posters, duplicate files/pages, task monitoring, and paginated log viewing/export.
+- Admin tools cover metadata editing, library management, media analysis, missing posters, duplicate files/pages, task monitoring, and paginated log viewing, export, and clearing.
 
 ### Platform Highlights
 

--- a/static/index.html
+++ b/static/index.html
@@ -100,8 +100,9 @@
                         <p>
                             Keep Reading, On Deck, Recently Added, Recently
                             Updated, pinned collections/read lists, reading
-                            history, metadata filters with all/any matching,
-                            saved filters, optional unread-cover blur,
+                            history, a 90-day pages-read heatmap, metadata
+                            filters with all/any matching, saved filters,
+                            optional unread-cover blur,
                             dashboard download and search actions,
                             server-scoped library filters, local database
                             storage, widgets, quick actions, and Spotlight
@@ -147,8 +148,8 @@
                         <h3>Manage your server in-app</h3>
                         <p>
                             Edit metadata, manage libraries and media, monitor
-                            tasks, browse paginated logs, and find missing
-                            posters or duplicate files/pages.
+                            tasks, browse, export, or clear paginated logs, and
+                            find missing posters or duplicate files/pages.
                         </p>
                     </article>
                 </div>
@@ -232,7 +233,8 @@
                         <h4>Can admins manage library data in-app?</h4>
                         <p>
                             Yes. KMReader includes metadata editing, library
-                            and media management, task monitoring, and paginated logs.
+                            and media management, task monitoring, and paginated
+                            log viewing, export, and clearing.
                         </p>
                     </article>
                     <article class="faq-item">


### PR DESCRIPTION
## Problem
The public documentation and App Store release copy need to match the 6.0 release.

## Approach
Refresh README, App Store description, landing page copy, and App Store changelog from the current user-visible product changes.

## Validation
- [x] Reviewed latest-tag-to-HEAD commits
- [x] Ran git diff --check
