### PR TITLE
fix(auth): normalize server URL to strip trailing slashes

### DIFF
--- a/KMReader/Core/Network/APIClient.swift
+++ b/KMReader/Core/Network/APIClient.swift
@@ -67,7 +67,9 @@ nonisolated final class APIClient: Sendable {
   }
 
   func setServer(url: String) {
-    AppConfig.current.serverURL = url
+    // Uphold Current.serverURL's no-trailing-slash invariant: this is the
+    // only post-init write path (Current's inits normalize their own).
+    AppConfig.current.serverURL = Current.normalizeServerURL(url)
   }
 
   func setAuthToken(_ token: String?) {

--- a/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
@@ -288,10 +288,23 @@ extension DatabaseOperator {
     displayName: String? = nil,
     instanceId: UUID? = nil
   ) throws -> InstanceSummary {
-    try write { db in
+    // Self-sufficient normalization (callers normalize too, but this must
+    // hold regardless of caller): both the stored row's URL and the incoming
+    // URL are compared in normalized form, so a legacy row persisted with a
+    // trailing slash still matches a re-login for the same account instead
+    // of spawning a duplicate instance — which would orphan everything keyed
+    // to the old instance ID (protected flag, library selection, offline
+    // downloads, last-used state).
+    let serverURL = Current.normalizeServerURL(serverURL)
+    return try write { db in
       let trimmedDisplayName = displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
       let instances = try KomgaInstance.fetchAll(db)
-      if var existing = instances.first(where: { $0.serverURL == serverURL && $0.username == username }) {
+      if var existing = instances.first(where: {
+        Current.normalizeServerURL($0.serverURL) == serverURL && $0.username == username
+      }) {
+        // Heal legacy rows on touch: rewrite the stored URL in normalized
+        // form so the row converges to the invariant without a migration.
+        existing.serverURL = serverURL
         existing.authToken = authToken
         existing.isAdmin = isAdmin
         existing.authMethod = authMethod

--- a/KMReader/Features/Auth/Models/Current.swift
+++ b/KMReader/Features/Auth/Models/Current.swift
@@ -6,6 +6,14 @@
 import Foundation
 
 struct Current: Equatable, Sendable {
+  /// Invariant: always stored without trailing slashes (see
+  /// `normalizeServerURL`). Consumers build request URLs via naive
+  /// concatenation (`serverURL + "/api/..."`); a trailing slash here
+  /// produces `//api/...`, which Komga (Spring Boot) rejects with an
+  /// opaque 400 via Spring Security's StrictHttpFirewall. Both inits
+  /// normalize on assignment; `APIClient.setServer` normalizes the only
+  /// post-init write. New write paths must go through
+  /// `normalizeServerURL` as well.
   var serverURL: String = ""
   var serverDisplayName: String = ""
   var authToken: String = ""
@@ -31,7 +39,7 @@ struct Current: Equatable, Sendable {
     instanceId: String = "",
     sessionToken: String = ""
   ) {
-    self.serverURL = serverURL
+    self.serverURL = Self.normalizeServerURL(serverURL)
     self.serverDisplayName = serverDisplayName
     self.authToken = authToken
     self.authMethod = authMethod
@@ -65,6 +73,19 @@ struct Current: Equatable, Sendable {
     self = Current()
     self.serverURL = savedURL
   }
+
+  /// Canonical server-URL normalization: strip stray whitespace and ALL
+  /// trailing slashes (`while`, not `if`, so `host///` also collapses).
+  /// Reverse-proxy subpaths are preserved: `https://host/komga/` becomes
+  /// `https://host/komga`, and every consumer-supplied path starts with
+  /// `/`, so concatenation stays correct for both root and subpath setups.
+  nonisolated static func normalizeServerURL(_ url: String) -> String {
+    var normalized = url.trimmingCharacters(in: .whitespacesAndNewlines)
+    while normalized.hasSuffix("/") {
+      normalized.removeLast()
+    }
+    return normalized
+  }
 }
 
 extension Current: RawRepresentable {
@@ -77,7 +98,10 @@ extension Current: RawRepresentable {
       return nil
     }
 
-    self.serverURL = dict["serverURL"] as? String ?? ""
+    // Normalizing here self-heals installs that persisted a slashed URL
+    // before normalization existed: `AppConfig.current` re-decodes through
+    // this init on every read, so no migration or re-login is needed.
+    self.serverURL = Self.normalizeServerURL(dict["serverURL"] as? String ?? "")
     self.serverDisplayName = dict["serverDisplayName"] as? String ?? ""
     self.authToken = dict["authToken"] as? String ?? ""
     if let methodRaw = dict["authMethod"] as? String {

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -253,6 +253,14 @@ class AuthViewModel {
     protected: Bool = false,
     successMessage: String
   ) async throws {
+    // Normalize before persisting anywhere (AppConfig AND the instance
+    // row). Login validation succeeds even with a trailing slash because
+    // `buildLoginRequest` normalizes its URL seam locally — without this,
+    // the raw slashed URL would be persisted and every subsequent
+    // naively-concatenated request URL (`serverURL + "/api/..."`) would
+    // 400 against Komga's strict path firewall.
+    let serverURL = Current.normalizeServerURL(serverURL)
+
     // Update AppConfig only after validation succeeds
     APIClient.shared.setServer(url: serverURL)
     APIClient.shared.setAuthToken(authToken)

--- a/KMReader/Features/Server/ServerEditView.swift
+++ b/KMReader/Features/Server/ServerEditView.swift
@@ -211,7 +211,11 @@ struct ServerEditView: View {
   }
 
   private var trimmedServerURL: String {
-    serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    // Full normalization (not just whitespace): a trailing slash saved to
+    // the instance row would resurface as `//api/...` request URLs when
+    // this server is switched to. Also makes editing a legacy slashed row
+    // register as a change, so saving it heals the persisted value.
+    Current.normalizeServerURL(serverURL)
   }
 
   private var trimmedUsername: String {

--- a/KMReader/Shared/Helpers/KomgaWebLinkBuilder.swift
+++ b/KMReader/Shared/Helpers/KomgaWebLinkBuilder.swift
@@ -49,20 +49,12 @@ enum KomgaWebLinkBuilder {
     path: String,
     queryItems: [URLQueryItem]? = nil
   ) -> URL? {
-    let normalizedBase = normalizedServerURL(serverURL)
+    let normalizedBase = Current.normalizeServerURL(serverURL)
     guard !normalizedBase.isEmpty else { return nil }
     guard var components = URLComponents(string: normalizedBase + path) else { return nil }
     if let queryItems, !queryItems.isEmpty {
       components.queryItems = queryItems
     }
     return components.url
-  }
-
-  private static func normalizedServerURL(_ serverURL: String) -> String {
-    var value = serverURL.trimmingCharacters(in: .whitespacesAndNewlines)
-    while value.hasSuffix("/") {
-      value.removeLast()
-    }
-    return value
   }
 }


### PR DESCRIPTION
Closes #940

## Problem

A server URL entered with a trailing slash (`https://komga.example.com/` — typical when pasting from a browser address bar) passes login validation but breaks the entire session afterwards. `buildLoginRequest` normalizes its URL seam locally, so validation and login succeed and the raw slashed URL gets persisted — but `buildRequest`, `SSEService`, and `OfflineManager` all build URLs via naive concatenation (`serverURL + "/api/..."`), producing `//api/...` paths. Komga (Spring Boot) rejects non-normalized paths containing `//` via Spring Security's `StrictHttpFirewall` with an opaque `400 "No message available"` before any controller runs. Result: empty dashboard, every action errors, SSE down — while the same account works fine in the web UI (browser-relative URLs, no concatenation).

Full analysis in #940.

## Approach

Make **"no trailing slashes" an invariant of `Current.serverURL`**, enforced at every write path through one canonical helper, rather than defensively fixing each of the 6+ concatenation sites (any future site would silently reintroduce the bug):

- **`Current.normalizeServerURL`** — trim whitespace, strip ALL trailing slashes (`while`, not `if`, so `host///` also collapses). Reverse-proxy subpaths are preserved: `https://host/komga/` → `https://host/komga`; all consumer paths supply their own leading `/`, so both root and subpath setups stay correct.
- **Memberwise init + `RawRepresentable` init** normalize on assignment. The rawValue path is the **self-heal**: `AppConfig.current` re-decodes from UserDefaults through this init on every read, so installs that already persisted a slashed URL are fixed by the update alone — no migration, no re-login.
- **`APIClient.setServer`** normalizes the only post-init write (used by login and server switching).
- **`AuthViewModel.applyLoginConfiguration`** normalizes before persisting, so new logins also store a clean instance row in the database.
- **`ServerEditView.trimmedServerURL`** uses the canonical helper, so manual edits can't reintroduce a slashed URL — and editing a legacy slashed row registers as a change, so saving heals the stored value.
- **`KomgaWebLinkBuilder`** drops its private duplicate of the same idiom and uses the canonical helper. (That private helper is evidence this bug was hit before in the "open in web" path and fixed locally without propagating — centralizing the invariant prevents a third variant.)

No `didSet` observer on the property: `Current` is used from `nonisolated` contexts (`AppConfig.current`, `rawValue`), and an observer would pick up default actor isolation. Explicit normalization at the (four) write paths keeps the stored property plain and the isolation story simple; the invariant is documented on the property.

## Why not normalize in `buildRequest` instead?

`buildLoginRequest` already shows where per-request-builder normalization leads: two builders in the same file with different URL-seam behavior, which is exactly how this bug shipped. Normalizing once at the source of truth makes every consumer — current and future — correct by construction.

## Validation

- Root cause confirmed against a live repro: user hit this on a freshly added account, log showed `//api/...` 400s everywhere; editing the server URL to remove the trailing slash immediately fixed the session.
- ⚠️ Not build-tested locally (no Xcode environment) — relying on CI. All call sites of the new helper are statically checked for target membership (`KomgaWebLinkBuilder` and `Current` are both app-target-only) and isolation (`nonisolated static`, callable from every calling context).

Suggested manual test plan:
1. Add a server with URL ending in `/` → login → dashboard loads, no 400s in log, SSE connects
2. Simulate a legacy install (persisted slashed URL in `currentAccount` UserDefaults) → update → app works immediately without re-login
3. Reverse-proxy subpath (`https://host/komga/`) → normalized to `https://host/komga`, all requests correct
4. Server edit: paste a slashed URL → saved without slash; open an existing slashed row → Save offered → row healed
5. URL without trailing slash → behavior unchanged
