### PR TITLE
fix(reader): stabilize end page metadata layout

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 505;
+				CURRENT_PROJECT_VERSION = 506;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 505;
+				CURRENT_PROJECT_VERSION = 506;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 505;
+				CURRENT_PROJECT_VERSION = 506;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 505;
+				CURRENT_PROJECT_VERSION = 506;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/NativeEndPageContentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeEndPageContentView_iOS.swift
@@ -60,6 +60,8 @@
     private var contentTopConstraint: NSLayoutConstraint?
     private var contentBottomConstraint: NSLayoutConstraint?
     private var contentMaxWidthConstraint: NSLayoutConstraint?
+    private var previousMetadataWidthConstraint: NSLayoutConstraint?
+    private var nextMetadataWidthConstraint: NSLayoutConstraint?
     private var horizontalDividerWidthConstraint: NSLayoutConstraint?
     private var previousCoverWidthConstraint: NSLayoutConstraint?
     private var previousCoverHeightConstraint: NSLayoutConstraint?
@@ -280,6 +282,10 @@
       previousCoverHeightConstraint = previousCoverView.heightAnchor.constraint(equalToConstant: 160)
       nextCoverWidthConstraint = nextCoverView.widthAnchor.constraint(equalToConstant: 120)
       nextCoverHeightConstraint = nextCoverView.heightAnchor.constraint(equalToConstant: 160)
+      previousMetadataWidthConstraint = previousMetadataStack.widthAnchor.constraint(equalToConstant: 420)
+      nextMetadataWidthConstraint = nextMetadataStack.widthAnchor.constraint(equalToConstant: 420)
+      previousMetadataWidthConstraint?.priority = UILayoutPriority(999)
+      nextMetadataWidthConstraint?.priority = UILayoutPriority(999)
       previousCoverHeightConstraint?.priority = NativeEndPageLayoutMetrics.coverHeightConstraintPriority
       nextCoverHeightConstraint?.priority = NativeEndPageLayoutMetrics.coverHeightConstraintPriority
 
@@ -296,13 +302,15 @@
         previousStack.trailingAnchor.constraint(equalTo: previousContainer.trailingAnchor),
         previousStack.topAnchor.constraint(equalTo: previousContainer.topAnchor),
         previousStack.bottomAnchor.constraint(equalTo: previousContainer.bottomAnchor),
-        previousMetadataStack.widthAnchor.constraint(equalTo: previousStack.widthAnchor),
+        previousMetadataStack.widthAnchor.constraint(lessThanOrEqualTo: previousStack.widthAnchor),
+        previousMetadataWidthConstraint!,
 
         nextStack.leadingAnchor.constraint(equalTo: nextContainer.leadingAnchor),
         nextStack.trailingAnchor.constraint(equalTo: nextContainer.trailingAnchor),
         nextStack.topAnchor.constraint(equalTo: nextContainer.topAnchor),
         nextStack.bottomAnchor.constraint(equalTo: nextContainer.bottomAnchor),
-        nextMetadataStack.widthAnchor.constraint(equalTo: nextStack.widthAnchor),
+        nextMetadataStack.widthAnchor.constraint(lessThanOrEqualTo: nextStack.widthAnchor),
+        nextMetadataWidthConstraint!,
 
         closeButton.centerXAnchor.constraint(equalTo: buttonContainer.centerXAnchor),
         closeButton.topAnchor.constraint(equalTo: buttonContainer.topAnchor),
@@ -543,6 +551,8 @@
       contentTopConstraint?.constant = metrics.outerPadding
       contentBottomConstraint?.constant = -metrics.outerPadding
       contentMaxWidthConstraint?.constant = -metrics.outerPadding * 2
+      previousMetadataWidthConstraint?.constant = metrics.sectionContentMaxWidth
+      nextMetadataWidthConstraint?.constant = metrics.sectionContentMaxWidth
       horizontalDividerWidthConstraint?.constant = metrics.horizontalDividerWidth
       previousCoverWidthConstraint?.constant = metrics.coverWidth
       previousCoverHeightConstraint?.constant = metrics.coverHeight

--- a/KMReader/Features/Reader/Views/NativeEndPageContentView_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativeEndPageContentView_macOS.swift
@@ -58,6 +58,8 @@
     private var contentTopConstraint: NSLayoutConstraint?
     private var contentBottomConstraint: NSLayoutConstraint?
     private var contentMaxWidthConstraint: NSLayoutConstraint?
+    private var previousMetadataWidthConstraint: NSLayoutConstraint?
+    private var nextMetadataWidthConstraint: NSLayoutConstraint?
     private var horizontalDividerWidthConstraint: NSLayoutConstraint?
     private var previousCoverWidthConstraint: NSLayoutConstraint?
     private var previousCoverHeightConstraint: NSLayoutConstraint?
@@ -125,6 +127,7 @@
 
       previousBadgeLabel.alignment = .center
       previousBadgeLabel.maximumNumberOfLines = 1
+      previousBadgeLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
       previousStack.addArrangedSubview(previousBadgeLabel)
 
       previousCoverView.translatesAutoresizingMaskIntoConstraints = false
@@ -138,11 +141,13 @@
       previousTitleLabel.alignment = .center
       previousTitleLabel.maximumNumberOfLines = 2
       previousTitleLabel.lineBreakMode = .byTruncatingTail
+      previousTitleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
       previousMetadataStack.addArrangedSubview(previousTitleLabel)
 
       previousDetailLabel.alignment = .center
       previousDetailLabel.maximumNumberOfLines = 1
       previousDetailLabel.lineBreakMode = .byTruncatingTail
+      previousDetailLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
       previousMetadataStack.addArrangedSubview(previousDetailLabel)
 
       nextContainer.translatesAutoresizingMaskIntoConstraints = false
@@ -154,6 +159,7 @@
 
       nextBadgeLabel.alignment = .center
       nextBadgeLabel.maximumNumberOfLines = 1
+      nextBadgeLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
       nextStack.addArrangedSubview(nextBadgeLabel)
 
       nextCoverView.translatesAutoresizingMaskIntoConstraints = false
@@ -167,11 +173,13 @@
       nextTitleLabel.alignment = .center
       nextTitleLabel.maximumNumberOfLines = 2
       nextTitleLabel.lineBreakMode = .byTruncatingTail
+      nextTitleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
       nextMetadataStack.addArrangedSubview(nextTitleLabel)
 
       nextDetailLabel.alignment = .center
       nextDetailLabel.maximumNumberOfLines = 1
       nextDetailLabel.lineBreakMode = .byTruncatingTail
+      nextDetailLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
       nextMetadataStack.addArrangedSubview(nextDetailLabel)
 
       caughtUpStack.orientation = .horizontal
@@ -184,6 +192,7 @@
 
       caughtUpLabel.alignment = .center
       caughtUpLabel.maximumNumberOfLines = 2
+      caughtUpLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
       caughtUpStack.addArrangedSubview(caughtUpLabel)
 
       horizontalDividerStack.orientation = .horizontal
@@ -203,6 +212,7 @@
 
       dividerTitleLabel.alignment = .center
       dividerTitleLabel.maximumNumberOfLines = 1
+      dividerTitleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
       dividerTitleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
       dividerTitleLabel.setContentHuggingPriority(.required, for: .vertical)
       horizontalDividerStack.addArrangedSubview(dividerTitleLabel)
@@ -255,6 +265,10 @@
       previousCoverHeightConstraint = previousCoverView.heightAnchor.constraint(equalToConstant: 160)
       nextCoverWidthConstraint = nextCoverView.widthAnchor.constraint(equalToConstant: 120)
       nextCoverHeightConstraint = nextCoverView.heightAnchor.constraint(equalToConstant: 160)
+      previousMetadataWidthConstraint = previousMetadataStack.widthAnchor.constraint(equalToConstant: 420)
+      nextMetadataWidthConstraint = nextMetadataStack.widthAnchor.constraint(equalToConstant: 420)
+      previousMetadataWidthConstraint?.priority = NSLayoutConstraint.Priority(999)
+      nextMetadataWidthConstraint?.priority = NSLayoutConstraint.Priority(999)
 
       NSLayoutConstraint.activate([
         contentLeading,
@@ -269,13 +283,19 @@
         previousStack.trailingAnchor.constraint(equalTo: previousContainer.trailingAnchor),
         previousStack.topAnchor.constraint(equalTo: previousContainer.topAnchor),
         previousStack.bottomAnchor.constraint(equalTo: previousContainer.bottomAnchor),
-        previousMetadataStack.widthAnchor.constraint(equalTo: previousStack.widthAnchor),
+        previousMetadataStack.widthAnchor.constraint(lessThanOrEqualTo: previousStack.widthAnchor),
+        previousMetadataWidthConstraint!,
+        previousTitleLabel.widthAnchor.constraint(equalTo: previousMetadataStack.widthAnchor),
+        previousDetailLabel.widthAnchor.constraint(equalTo: previousMetadataStack.widthAnchor),
 
         nextStack.leadingAnchor.constraint(equalTo: nextContainer.leadingAnchor),
         nextStack.trailingAnchor.constraint(equalTo: nextContainer.trailingAnchor),
         nextStack.topAnchor.constraint(equalTo: nextContainer.topAnchor),
         nextStack.bottomAnchor.constraint(equalTo: nextContainer.bottomAnchor),
-        nextMetadataStack.widthAnchor.constraint(equalTo: nextStack.widthAnchor),
+        nextMetadataStack.widthAnchor.constraint(lessThanOrEqualTo: nextStack.widthAnchor),
+        nextMetadataWidthConstraint!,
+        nextTitleLabel.widthAnchor.constraint(equalTo: nextMetadataStack.widthAnchor),
+        nextDetailLabel.widthAnchor.constraint(equalTo: nextMetadataStack.widthAnchor),
 
         previousCoverWidthConstraint!,
         previousCoverHeightConstraint!,
@@ -470,6 +490,8 @@
       contentTopConstraint?.constant = metrics.outerPadding
       contentBottomConstraint?.constant = -metrics.outerPadding
       contentMaxWidthConstraint?.constant = -metrics.outerPadding * 2
+      previousMetadataWidthConstraint?.constant = metrics.sectionContentMaxWidth
+      nextMetadataWidthConstraint?.constant = metrics.sectionContentMaxWidth
       horizontalDividerWidthConstraint?.constant = metrics.horizontalDividerWidth
       previousCoverWidthConstraint?.constant = metrics.coverWidth
       previousCoverHeightConstraint?.constant = metrics.coverHeight

--- a/KMReader/Features/Reader/Views/NativeEndPageLayoutMetrics.swift
+++ b/KMReader/Features/Reader/Views/NativeEndPageLayoutMetrics.swift
@@ -13,6 +13,7 @@ struct NativeEndPageLayoutMetrics {
   let innerPadding: CGFloat
   let stackSpacing: CGFloat
   let portraitSectionSpacing: CGFloat
+  let sectionContentMaxWidth: CGFloat
   let horizontalDividerWidth: CGFloat
   let coverWidth: CGFloat
   let coverHeight: CGFloat
@@ -35,6 +36,7 @@ struct NativeEndPageLayoutMetrics {
       innerPadding: innerPadding,
       stackSpacing: stackSpacing,
       portraitSectionSpacing: stackSpacing + clamped(stackSpacing * 0.5, lower: 6, upper: 12),
+      sectionContentMaxWidth: PlatformDefaults.sectionContentMaxWidth(minDimension: minDimension),
       horizontalDividerWidth: clamped(bounds.width * 0.78, lower: 260, upper: 680),
       coverWidth: coverWidth,
       coverHeight: coverWidth / CoverAspectRatio.widthToHeight,
@@ -124,6 +126,14 @@ struct NativeEndPageLayoutMetrics {
         clamped(minDimension * 0.022, lower: 10, upper: 16)
       #else
         clamped(minDimension * 0.034, lower: 12, upper: 22)
+      #endif
+    }
+
+    static func sectionContentMaxWidth(minDimension: CGFloat) -> CGFloat {
+      #if os(tvOS)
+        clamped(minDimension * 0.48, lower: 420, upper: 560)
+      #else
+        clamped(minDimension * 0.72, lower: 280, upper: 420)
       #endif
     }
 


### PR DESCRIPTION
## What changed

Keep end-page chapter metadata within a centered, platform-aware readable width across iOS, macOS, and tvOS. On macOS, flexible text compression now prevents long titles from expanding the stack beyond the viewport, while title and detail rows use the same centered width.

This PR also increments the build version to 506.

## UX impact

Long chapter titles retain useful content without spanning the full page or shifting cover artwork off center. The pages and size detail row remains centered and no longer collapses the title width.

## Validation

- `make format`
- `git diff --check`
- `make build-ios`
- `make build-macos`
- `make build-tvos`
