### PR TITLE
perf(macos): reduce dashboard scroll hitching

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 506;
+				CURRENT_PROJECT_VERSION = 507;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 506;
+				CURRENT_PROJECT_VERSION = 507;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 506;
+				CURRENT_PROJECT_VERSION = 507;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 506;
+				CURRENT_PROJECT_VERSION = 507;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Shared/UI/HorizontalScrollButtons.swift
+++ b/KMReader/Shared/UI/HorizontalScrollButtons.swift
@@ -25,13 +25,17 @@ import SwiftUI
 
     var body: some View {
       ZStack {
-        scrollButton(direction: .left)
-          .frame(maxWidth: .infinity, alignment: .leading)
+        if isVisible {
+          scrollButton(direction: .left)
+            .transition(.opacity)
+            .frame(maxWidth: .infinity, alignment: .leading)
 
-        scrollButton(direction: .right)
-          .frame(maxWidth: .infinity, alignment: .trailing)
+          scrollButton(direction: .right)
+            .transition(.opacity)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+        }
       }
-      .opacity(isVisible ? 1 : 0)
+      .animation(.easeOut(duration: 0.15), value: isVisible)
       .allowsHitTesting(isVisible)
     }
 

--- a/KMReader/Shared/UI/HorizontalScrollButtonsOverlayModifier.swift
+++ b/KMReader/Shared/UI/HorizontalScrollButtonsOverlayModifier.swift
@@ -20,7 +20,6 @@ import SwiftUI
             itemIds: itemIds,
             isVisible: areButtonsVisible
           )
-          .animation(.easeOut(duration: 0.15), value: areButtonsVisible)
         }
         .onHover { hovering in
           guard areButtonsVisible != hovering else { return }


### PR DESCRIPTION
## What changed

Keep the macOS dashboard arrow controller mounted while conditionally inserting its two material-backed buttons. The buttons still fade in and out on hover, but their material and shadow leave the render tree once hidden.

This also bumps the build number to 507.

## UX impact

Vertical dashboard scrolling remains responsive while retaining the existing Apple Books-style hover affordance and horizontal navigation behavior.

## Validation

- `make format`
- `git diff --check`
- `make build-macos`
- Controlled warm-scroll Instruments comparison: hitch frequency decreased by about 25%, GPU time by about 41%, and frame wait by about 21%
