### PR TITLE
refactor(reader): make rotation session-scoped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,11 @@ This file provides guidance to coding agents working with code in this repositor
 - **Per-Book Preferences**: Save reading direction, page layout, and theme settings per book.
 - **Incognito Mode**: Read without saving progress to server.
 
+### Reader State and Settings Boundaries
+
+- `ReaderSettingsSheet` is reserved for persisted reader preferences. Session-only reader options belong in the reader controls menu or the platform command menu.
+- Page rotation is session-only, applies only to paged DIVINA modes, and must not be exposed or applied in Webtoon mode.
+
 ### Offline & Downloads
 
 - **Background Downloads**: URLSession-based downloads with Live Activities on iOS.
@@ -369,6 +374,7 @@ KMReader/
 17. **Strongly avoid patch-style fixes for structural problems**: When the current abstraction or ownership boundary is wrong, do not preserve it by stacking flags, delays, version counters, bridge layers, or special cases just to keep the diff small. Prefer the larger refactor that moves the code toward the final stable architecture.
 18. **Prioritize end-state quality over local diff size**: Stability, simplicity, clarity of ownership, and long-term maintainability are more important than minimizing code churn. Do not be afraid to rewrite or replace a local subsystem when that is the cleaner and more reliable design.
 19. **If a temporary compatibility layer is unavoidable, mark it explicitly**: State why it exists, what the intended final design is, and what should be removed later. Temporary layers should be rare and treated as debt, not as the default implementation style.
+20. **Keep boundary documentation current**: When a change introduces or changes a lifetime, ownership, persistence, navigation, platform, reader-mode, or UI-placement boundary, update `AGENTS.md` in the same change so the boundary remains explicit and enforceable.
 
 Additional patterns:
 

--- a/KMReader/Core/Storage/DatabaseOperator+Books.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Books.swift
@@ -621,18 +621,6 @@ extension DatabaseOperator {
     }
   }
 
-  func fetchPageRotations(id: String) -> [Int: Int]? {
-    try? read { db in
-      try fetchBookRecord(db: db, id: id)?.pageRotations
-    }
-  }
-
-  func updatePageRotations(bookId: String, rotations: [Int: Int]) {
-    updateBookRecord(bookId: bookId) { book in
-      book.pageRotations = rotations
-    }
-  }
-
   func fetchBookEpubThemePreferences(bookId: String) -> EpubThemePreferences? {
     try? read { db in
       guard let raw = try fetchBookRecord(db: db, id: bookId)?.epubPreferencesRaw else {

--- a/KMReader/Core/Storage/GRDB/GRDBRecords.swift
+++ b/KMReader/Core/Storage/GRDB/GRDBRecords.swift
@@ -162,7 +162,6 @@ nonisolated extension KomgaBook: FetchableRecord, MutablePersistableRecord {
     case downloadedSize = "downloaded_size"
     case readListIdsRaw = "read_list_ids_raw"
     case isolatePagesRaw = "isolate_pages_raw"
-    case pageRotationsRaw = "page_rotations_raw"
     case epubPreferencesRaw = "epub_preferences_raw"
   }
 }

--- a/KMReader/Core/Storage/GRDB/LocalDatabase.swift
+++ b/KMReader/Core/Storage/GRDB/LocalDatabase.swift
@@ -67,6 +67,12 @@ nonisolated enum LocalDatabase {
       try db.execute(sql: "DROP TABLE IF EXISTS local_migration_markers")
     }
 
+    migrator.registerMigration("00007_drop_page_rotations") { db in
+      try db.alter(table: KomgaBook.databaseTableName) { table in
+        table.drop(column: "page_rotations_raw")
+      }
+    }
+
     try migrator.migrate(writer)
   }
 

--- a/KMReader/Features/Book/Models/KomgaBook.swift
+++ b/KMReader/Features/Book/Models/KomgaBook.swift
@@ -44,7 +44,6 @@ nonisolated struct KomgaBook: Codable, Equatable, Sendable {
   var downloadedSize: Int64
   var readListIdsRaw: Data?
   var isolatePagesRaw: Data?
-  var pageRotationsRaw: Data?
   var epubPreferencesRaw: String?
 
   init(
@@ -107,7 +106,6 @@ nonisolated struct KomgaBook: Codable, Equatable, Sendable {
     self.downloadedSize = downloadedSize
     self.readListIdsRaw = try? JSONEncoder().encode([] as [String])
     self.isolatePagesRaw = try? JSONEncoder().encode([] as [Int])
-    self.pageRotationsRaw = nil
     self.epubPreferencesRaw = nil
   }
 }
@@ -128,12 +126,6 @@ nonisolated extension KomgaBook {
   var isolatePages: [Int] {
     get { isolatePagesRaw.flatMap { try? JSONDecoder().decode([Int].self, from: $0) } ?? [] }
     set { isolatePagesRaw = try? JSONEncoder().encode(newValue) }
-  }
-
-  /// Page rotations stored as [pageIndex: degrees]
-  var pageRotations: [Int: Int] {
-    get { pageRotationsRaw.flatMap { try? JSONDecoder().decode([Int: Int].self, from: $0) } ?? [:] }
-    set { pageRotationsRaw = try? JSONEncoder().encode(newValue) }
   }
 
   var epubThemePreferences: EpubThemePreferences? {

--- a/KMReader/Features/Reader/Models/ReaderRotation.swift
+++ b/KMReader/Features/Reader/Models/ReaderRotation.swift
@@ -1,0 +1,30 @@
+//
+// ReaderRotation.swift
+//
+
+import CoreGraphics
+import Foundation
+
+enum ReaderRotation: Int, CaseIterable, Hashable, Sendable {
+  case none = 0
+  case degrees90 = 90
+  case degrees180 = 180
+  case degrees270 = 270
+
+  var degrees: Int {
+    rawValue
+  }
+
+  var displayName: String {
+    "\(degrees)°"
+  }
+
+  var swapsDimensions: Bool {
+    self == .degrees90 || self == .degrees270
+  }
+
+  func rotatedSize(_ size: CGSize) -> CGSize {
+    guard swapsDimensions else { return size }
+    return CGSize(width: size.height, height: size.width)
+  }
+}

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -13,7 +13,7 @@ class ReaderViewModel {
   private(set) var segments: [ReaderSegment] = []
   var isolatePages: [Int] = []
   private var isolatePagesByBookId: [String: Set<Int>] = [:]
-  private var pageRotationsByBookId: [String: [Int: Int]] = [:]
+  private(set) var rotation: ReaderRotation
   private(set) var bookIdsWithMissingPageDimensions: Set<String> = []
   private var currentPageID: ReaderPageID?
   private var currentViewItemID: ReaderViewItem?
@@ -121,29 +121,27 @@ class ReaderViewModel {
     return isolatePagesByBookId[isolatePosition.bookId]?.contains(isolatePosition.localIndex) == true
   }
 
-  func pageRotationDegrees(for pageID: ReaderPageID) -> Int {
-    guard let position = isolatePosition(for: pageID) else { return 0 }
-    return pageRotationsByBookId[position.bookId]?[position.localIndex] ?? 0
-  }
-
   func hasMissingPageDimensions(forBookId bookId: String) -> Bool {
     bookIdsWithMissingPageDimensions.contains(bookId)
   }
 
-  var currentPageRotationDegrees: Int {
-    guard let currentReaderPage else { return 0 }
-    return pageRotationDegrees(for: currentReaderPage.id)
+  func isPageEffectivelyPortrait(_ pageID: ReaderPageID) -> Bool {
+    guard let page = readerPage(for: pageID)?.page,
+      let width = page.width,
+      let height = page.height
+    else {
+      return false
+    }
+    let size = rotation.rotatedSize(
+      CGSize(width: CGFloat(width), height: CGFloat(height))
+    )
+    return size.height > size.width
   }
 
   /// Whether the current page is a wide (non-portrait) image, which cannot be isolated.
   var isCurrentPageWide: Bool {
     guard let currentReaderPage else { return false }
-    let rotation = pageRotationDegrees(for: currentReaderPage.id)
-    let normalized = ((rotation % 360) + 360) % 360
-    if normalized == 90 || normalized == 270 {
-      return currentReaderPage.page.isPortrait
-    }
-    return !currentReaderPage.page.isPortrait
+    return !isPageEffectivelyPortrait(currentReaderPage.id)
   }
 
   convenience init() {
@@ -152,6 +150,7 @@ class ReaderViewModel {
       pageLayout: AppConfig.pageLayout,
       splitWidePageMode: AppConfig.splitWidePageMode,
       pageTransitionStyle: AppConfig.pageTransitionStyle,
+      rotation: .none,
       preloadWindow: AppConfig.divinaPreloadProfile.window,
       incognitoMode: false
     )
@@ -162,6 +161,7 @@ class ReaderViewModel {
     pageLayout: PageLayout,
     splitWidePageMode: SplitWidePageMode = .none,
     pageTransitionStyle: PageTransitionStyle = AppConfig.pageTransitionStyle,
+    rotation: ReaderRotation = .none,
     preloadWindow: ReaderPreloadWindow = ReaderPreloadWindow.balanced,
     incognitoMode: Bool = false
   ) {
@@ -170,6 +170,7 @@ class ReaderViewModel {
     self.forceDualPagePairs = pageLayout == .dual
     self.splitWidePageMode = splitWidePageMode
     self.pageTransitionStyle = pageTransitionStyle
+    self.rotation = rotation
     self.incognitoMode = incognitoMode
     pageLoadScheduler.setPresentationInvalidationHandler { [weak self] invalidation in
       self?.notifyPagePresentationInvalidation(invalidation)
@@ -710,25 +711,6 @@ class ReaderViewModel {
     isolatePagesByBookId[bookId] = Set(isolatePagesForBook)
   }
 
-  private func hydratePageRotations(for bookId: String) async {
-    let database = await DatabaseOperator.databaseIfConfigured()
-    let rotations = await database?.fetchPageRotations(id: bookId) ?? [:]
-    pageRotationsByBookId[bookId] = rotations
-  }
-
-  private func persistPageRotations(_ rotations: [Int: Int], for bookId: String) {
-    Task {
-      if let database = await DatabaseOperator.databaseIfConfigured() {
-        await database.updatePageRotations(bookId: bookId, rotations: rotations)
-      }
-    }
-  }
-
-  private func normalizedPageRotation(_ degrees: Int) -> Int {
-    let normalized = degrees % 360
-    return normalized >= 0 ? normalized : normalized + 360
-  }
-
   private func restoreCurrentPosition(using currentViewItem: ReaderViewItem?) {
     guard let currentViewItem else { return }
     guard navigationTarget == nil else { return }
@@ -743,7 +725,6 @@ class ReaderViewModel {
     pageLoadScheduler.resetForBookLoad()
     isolatePages.removeAll()
     isolatePagesByBookId.removeAll()
-    pageRotationsByBookId.removeAll()
     bookIdsWithMissingPageDimensions.removeAll()
     tableOfContents.removeAll()
     tableOfContentsByBookId.removeAll()
@@ -791,7 +772,6 @@ class ReaderViewModel {
     }
 
     await hydrateIsolatePages(for: nextBook.id)
-    await hydratePageRotations(for: nextBook.id)
     let currentViewItem = currentViewItem()
 
     appendSegment(
@@ -836,7 +816,6 @@ class ReaderViewModel {
     }
 
     await hydrateIsolatePages(for: previousBook.id)
-    await hydratePageRotations(for: previousBook.id)
     let currentViewItem = currentViewItem()
 
     prependSegment(
@@ -890,7 +869,6 @@ class ReaderViewModel {
 
       let localIsolatePages = await database?.fetchIsolatePages(id: book.id) ?? []
       isolatePagesByBookId[book.id] = Set(localIsolatePages)
-      await hydratePageRotations(for: book.id)
       currentPageID = initialPageNumber.flatMap { pageNumber in
         fetchedPages.first(where: { $0.number == pageNumber }).map {
           ReaderPageID(bookId: book.id, pageNumber: $0.number)
@@ -1346,6 +1324,14 @@ class ReaderViewModel {
     }
   }
 
+  func updateRotation(_ rotation: ReaderRotation) {
+    guard self.rotation != rotation else { return }
+    regenerateViewStatePreservingCurrentPage {
+      self.rotation = rotation
+    }
+    notifyPagePresentationInvalidation(.all)
+  }
+
   func updateDualPagePresentationMode(_ isUsingDualPageMode: Bool) {
     guard isActuallyUsingDualPageMode != isUsingDualPageMode else { return }
 
@@ -1354,43 +1340,9 @@ class ReaderViewModel {
     }
   }
 
-  func setPageRotation(_ degrees: Int, for pageID: ReaderPageID) {
-    guard let position = isolatePosition(for: pageID) else { return }
-    let normalized = normalizedPageRotation(degrees)
-    guard pageRotationDegrees(for: pageID) != normalized else { return }
-    var rotations = pageRotationsByBookId[position.bookId] ?? [:]
-    if normalized == 0 {
-      rotations.removeValue(forKey: position.localIndex)
-    } else {
-      rotations[position.localIndex] = normalized
-    }
-    pageRotationsByBookId[position.bookId] = rotations
-    persistPageRotations(rotations, for: position.bookId)
-    regenerateViewStatePreservingCurrentPage {
-      // rotation state already updated above
-    }
-    notifyPagePresentationInvalidation(.pages([pageID]))
-  }
-
-  func rotatePage(_ pageID: ReaderPageID, by degrees: Int) {
-    let current = pageRotationDegrees(for: pageID)
-    setPageRotation(current + degrees, for: pageID)
-  }
-
   func toggleIsolatePage(_ pageID: ReaderPageID) {
     guard let isolatePosition = isolatePosition(for: pageID) else { return }
-    // Wide pages (considering rotation) always fill both slots and cannot be isolated
-    let rotation = pageRotationDegrees(for: pageID)
-    let normalized = ((rotation % 360) + 360) % 360
-    if let page = readerPage(for: pageID)?.page {
-      let effectivelyPortrait: Bool
-      if normalized == 90 || normalized == 270 {
-        effectivelyPortrait = (page.width ?? 0) > (page.height ?? 0)
-      } else {
-        effectivelyPortrait = page.isPortrait
-      }
-      if !effectivelyPortrait { return }
-    }
+    guard isPageEffectivelyPortrait(pageID) else { return }
     toggleIsolatePage(at: isolatePosition)
   }
 
@@ -1441,8 +1393,7 @@ class ReaderViewModel {
       splitWidePages: effectiveSplitWidePages,
       pageCurl: pageTransitionStyle == .pageCurl,
       isolatePages: Set(isolatePages),
-      pageRotationsByBookId: pageRotationsByBookId,
-      segmentPageRangeByBookId: segmentPageRangeByBookId
+      rotation: rotation
     )
     viewItemIndexByPage = generateViewItemIndexMap(items: viewItems)
     currentViewItemID = resolvedViewItem(
@@ -1593,8 +1544,7 @@ private func generateViewItems(
   splitWidePages: Bool,
   pageCurl: Bool,
   isolatePages: Set<Int> = [],
-  pageRotationsByBookId: [String: [Int: Int]] = [:],
-  segmentPageRangeByBookId: [String: Range<Int>] = [:]
+  rotation: ReaderRotation = .none
 ) -> [ReaderViewItem] {
   guard !segments.isEmpty, !readerPages.isEmpty else { return [] }
 
@@ -1614,19 +1564,11 @@ private func generateViewItems(
 
   func effectiveOrientation(at index: Int) -> PageOrientation {
     let page = readerPages[index].page
-    let bookId = readerPages[index].bookId
-    if let range = segmentPageRangeByBookId[bookId] {
-      let localIndex = index - range.lowerBound
-      let rotation = pageRotationsByBookId[bookId]?[localIndex] ?? 0
-      let normalized = ((rotation % 360) + 360) % 360
-      if normalized == 90 || normalized == 270 {
-        guard let width = page.width, let height = page.height else { return .unknown }
-        return width > height ? .portrait : .landscape
-      }
-    }
-
     guard let width = page.width, let height = page.height else { return .unknown }
-    return height > width ? .portrait : .landscape
+    let size = rotation.rotatedSize(
+      CGSize(width: CGFloat(width), height: CGFloat(height))
+    )
+    return size.height > size.width ? .portrait : .landscape
   }
 
   var items: [ReaderViewItem] = []

--- a/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
+++ b/KMReader/Features/Reader/Views/DivinaControlsOverlayView.swift
@@ -10,6 +10,7 @@ struct DivinaControlsOverlayView: View {
   @Binding var pageLayout: PageLayout
   @Binding var isolateCoverPage: Bool
   @Binding var splitWidePageMode: SplitWidePageMode
+  @Binding var rotation: ReaderRotation
 
   @Binding var showingPageJumpSheet: Bool
   @Binding var showingTOCSheet: Bool
@@ -437,6 +438,15 @@ struct DivinaControlsOverlayView: View {
           Label(String(localized: "Split Wide Pages"), systemImage: splitWidePageMode.icon)
         }
         .pickerStyle(.menu)
+
+        Picker(selection: $rotation) {
+          ForEach(ReaderRotation.allCases, id: \.self) { rotation in
+            Text(verbatim: rotation.displayName).tag(rotation)
+          }
+        } label: {
+          Label(String(localized: "Page Rotation"), systemImage: "rotate.right")
+        }
+        .pickerStyle(.menu)
       }
     } header: {
       Text(String(localized: "Current Reading Options"))
@@ -553,7 +563,6 @@ struct DivinaControlsOverlayView: View {
     @ViewBuilder
     private func pageActionsMenu(for pageID: ReaderPageID) -> some View {
       let displayedPageNumber = displayPageNumber(for: pageID)
-      let currentRotation = viewModel.pageRotationDegrees(for: pageID)
       Menu {
         Button {
           sharePage(id: pageID)
@@ -567,12 +576,6 @@ struct DivinaControlsOverlayView: View {
           } label: {
             Label(pageIsolationMenuTitle(for: isolationAction), systemImage: isolationAction.systemImage)
           }
-        }
-
-        Menu {
-          pageRotationActions(for: pageID, currentRotation: currentRotation)
-        } label: {
-          Label("Rotate: \(currentRotation)°", systemImage: "rotate.right")
         }
       } label: {
         Label(
@@ -591,21 +594,6 @@ struct DivinaControlsOverlayView: View {
         return action.title
       }
       return String(localized: "Isolate")
-    }
-
-    @ViewBuilder
-    private func pageRotationActions(for pageID: ReaderPageID, currentRotation: Int) -> some View {
-      ForEach([0, 90, 180, 270], id: \.self) { degrees in
-        Button {
-          viewModel.setPageRotation(degrees, for: pageID)
-        } label: {
-          if currentRotation == degrees {
-            Label("\(degrees)°", systemImage: "checkmark")
-          } else {
-            Text("\(degrees)°")
-          }
-        }
-      }
     }
   #endif
 }

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -52,6 +52,7 @@ struct DivinaReaderView: View {
   @State private var pageLayout: PageLayout
   @State private var isolateCoverPage: Bool
   @State private var splitWidePageMode: SplitWidePageMode
+  @State private var rotation: ReaderRotation
 
   private let logger = AppLogger(.reader)
 
@@ -123,12 +124,14 @@ struct DivinaReaderView: View {
     self._pageLayout = State(initialValue: AppConfig.pageLayout)
     self._isolateCoverPage = State(initialValue: AppConfig.isolateCoverPage)
     self._splitWidePageMode = State(initialValue: AppConfig.splitWidePageMode)
+    self._rotation = State(initialValue: .none)
     self._viewModel = State(
       initialValue: ReaderViewModel(
         isolateCoverPage: AppConfig.isolateCoverPage,
         pageLayout: AppConfig.pageLayout,
         splitWidePageMode: AppConfig.splitWidePageMode,
         pageTransitionStyle: AppConfig.pageTransitionStyle,
+        rotation: .none,
         preloadWindow: AppConfig.divinaPreloadProfile.window,
         incognitoMode: incognito
       )
@@ -635,7 +638,7 @@ struct DivinaReaderView: View {
       )
     }
     .sheet(isPresented: $showingReaderSettingsSheet) {
-      ReaderSettingsSheet(readingDirection: $readingDirection)
+      ReaderSettingsSheet(readingDirection: readingDirection)
     }
     .readerDetailSheet(
       isPresented: $showingDetailSheet,
@@ -660,6 +663,9 @@ struct DivinaReaderView: View {
     }
     .onChange(of: pageTransitionStyle) { _, newValue in
       viewModel.updatePageTransitionStyle(newValue)
+    }
+    .onChange(of: rotation) { _, newValue in
+      viewModel.updateRotation(newValue)
     }
     .onChange(of: divinaPreloadProfile) { _, newValue in
       viewModel.updatePreloadWindow(newValue.window)
@@ -990,6 +996,7 @@ struct DivinaReaderView: View {
       pageLayout: $pageLayout,
       isolateCoverPage: $isolateCoverPage,
       splitWidePageMode: $splitWidePageMode,
+      rotation: $rotation,
       showingPageJumpSheet: $showingPageJumpSheet,
       showingTOCSheet: $showingTOCSheet,
       showingReaderSettingsSheet: $showingReaderSettingsSheet,
@@ -1696,13 +1703,6 @@ struct DivinaReaderView: View {
         })
     }
 
-    private var macPageRotationsByID: [ReaderPageID: Int] {
-      Dictionary(
-        uniqueKeysWithValues: macCommandPageIDs.map { pageID in
-          (pageID, viewModel.pageRotationDegrees(for: pageID))
-        })
-    }
-
     private func sharePageFromCommand(_ pageID: ReaderPageID) {
       guard let image = viewModel.preloadedImage(for: pageID) else { return }
       let fileName = viewModel.page(for: pageID)?.fileName
@@ -1735,12 +1735,13 @@ struct DivinaReaderView: View {
         pageIsolationActions: macPageIsolationActions,
         commandPageIDs: macCommandPageIDs,
         displayPageNumbersByID: macDisplayPageNumbersByID,
-        pageRotationsByID: macPageRotationsByID,
+        rotation: rotation,
         splitWidePageMode: splitWidePageMode,
         supportsSearch: false,
         canSearch: false,
         supportsReadingDirectionSelection: true,
         supportsPageLayoutSelection: true,
+        supportsRotationSelection: readingDirection != .webtoon,
         supportsDualPageOptions: supportsDualPageOptions,
         supportsSplitWidePageMode: supportsSplitWidePageMode
       )
@@ -1794,8 +1795,8 @@ struct DivinaReaderView: View {
           sharePage: { pageID in
             sharePageFromCommand(pageID)
           },
-          setPageRotation: { pageID, degrees in
-            viewModel.setPageRotation(degrees, for: pageID)
+          setRotation: { newRotation in
+            rotation = newRotation
           },
           setSplitWidePageMode: { mode in
             splitWidePageMode = mode
@@ -2016,6 +2017,7 @@ struct DivinaReaderView: View {
       isolateCoverPage: isolateCoverPage,
       pageLayout: pageLayout,
       splitWidePageMode: splitWidePageMode,
+      rotation: rotation,
       preloadWindow: divinaPreloadProfile.window,
       incognitoMode: incognito
     )
@@ -2038,6 +2040,7 @@ struct DivinaReaderView: View {
       isolateCoverPage: isolateCoverPage,
       pageLayout: pageLayout,
       splitWidePageMode: splitWidePageMode,
+      rotation: rotation,
       preloadWindow: divinaPreloadProfile.window,
       incognitoMode: incognito
     )

--- a/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
+++ b/KMReader/Features/Reader/Views/Epub/EpubReaderView.swift
@@ -1064,7 +1064,7 @@
             toggleIsolateCoverPage: {},
             toggleIsolatePage: { _ in },
             sharePage: { _ in },
-            setPageRotation: { _, _ in },
+            setRotation: { _ in },
             setSplitWidePageMode: { _ in },
             toggleContinuousScroll: {}
           )

--- a/KMReader/Features/Reader/Views/Models/NativePageData.swift
+++ b/KMReader/Features/Reader/Views/Models/NativePageData.swift
@@ -6,7 +6,7 @@
 import SwiftUI
 
 /// Split mode for wide pages
-enum PageSplitMode {
+enum PageSplitMode: Hashable {
   case none
   case leftHalf
   case rightHalf
@@ -19,7 +19,7 @@ struct NativePageData {
   let error: String?
   let alignment: HorizontalAlignment
   let splitMode: PageSplitMode
-  let rotationDegrees: Int
+  let rotation: ReaderRotation
   let animatedSourceFileURL: URL?
 
   init(
@@ -28,7 +28,7 @@ struct NativePageData {
     error: String?,
     alignment: HorizontalAlignment,
     splitMode: PageSplitMode = .none,
-    rotationDegrees: Int = 0,
+    rotation: ReaderRotation = .none,
     animatedSourceFileURL: URL? = nil
   ) {
     self.pageID = pageID
@@ -36,7 +36,7 @@ struct NativePageData {
     self.error = error
     self.alignment = alignment
     self.splitMode = splitMode
-    self.rotationDegrees = rotationDegrees
+    self.rotation = rotation
     self.animatedSourceFileURL = animatedSourceFileURL
   }
 }

--- a/KMReader/Features/Reader/Views/NativeImagePageViewController.swift
+++ b/KMReader/Features/Reader/Views/NativeImagePageViewController.swift
@@ -165,7 +165,8 @@
         isLoading: isLoading,
         error: loadError,
         alignment: alignment,
-        splitMode: splitMode
+        splitMode: splitMode,
+        rotation: viewModel.rotation
       )
 
       pageItem.update(
@@ -264,6 +265,7 @@
     }
 
     private func isCurrentAnimatedInlineTarget(viewModel: ReaderViewModel) -> Bool {
+      guard viewModel.rotation == .none else { return false }
       guard let currentViewItem = viewModel.currentViewItem() else {
         return false
       }

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_iOS.swift
@@ -11,6 +11,7 @@
     private let sepiaOverlayView = UIView()
     private let animatedInlineContainer = UIView()
     private let animatedImageController = AnimatedImagePlayerController()
+    private let preparedImageCache = PreparedReaderPageImageCache()
     private let pageNumberLabel = UILabel()
     private let loadingIndicator = UIActivityIndicatorView(style: .medium)
     private let errorLabel = UILabel()
@@ -68,6 +69,7 @@
       updateAnimatedPlayback(sourceFileURL: nil)
       imageView.isHidden = false
       imageView.image = nil
+      preparedImageCache.clear()
       animatedInlineContainer.layer.contents = nil
       updateSepiaOverlay()
     }
@@ -81,7 +83,7 @@
           let pageSourceImage = preparedImage(
             from: viewModel?.preloadedImage(for: data.pageID),
             splitMode: data.splitMode,
-            rotationDegrees: data.rotationDegrees
+            rotation: data.rotation
           )
           #if os(iOS) || os(macOS)
             analysisSourceImage = pageSourceImage
@@ -185,7 +187,7 @@
       let pageSourceImage = preparedImage(
         from: image,
         splitMode: data.splitMode,
-        rotationDegrees: data.rotationDegrees
+        rotation: data.rotation
       )
 
       #if os(iOS) || os(macOS)
@@ -256,43 +258,27 @@
       }
     }
 
-    private func preparedImage(from image: UIImage?, splitMode: PageSplitMode, rotationDegrees: Int) -> UIImage? {
+    private func preparedImage(from image: UIImage?, splitMode: PageSplitMode, rotation: ReaderRotation) -> UIImage? {
       guard let image else { return nil }
-      let rotatedImage = rotateImage(image, degrees: rotationDegrees)
-      let splitImage =
-        splitMode == .none ? rotatedImage : cropImageForSplitMode(image: rotatedImage, splitMode: splitMode)
-      return cropBordersIfNeeded(splitImage)
+      let borderCropMode = AppConfig.divinaPageBorderCropMode
+      return preparedImageCache.resolve(
+        sourceImage: image,
+        rotation: rotation,
+        splitMode: splitMode,
+        borderCropMode: borderCropMode
+      ) {
+        let rotatedImage = image.rotated(for: rotation)
+        let splitImage =
+          splitMode == .none ? rotatedImage : cropImageForSplitMode(image: rotatedImage, splitMode: splitMode)
+        return cropBordersIfNeeded(splitImage, mode: borderCropMode)
+      }
     }
 
-    private func cropBordersIfNeeded(_ image: UIImage?) -> UIImage? {
+    private func cropBordersIfNeeded(_ image: UIImage?, mode: ReaderPageBorderCropMode) -> UIImage? {
       guard let image else { return nil }
-      let mode = AppConfig.divinaPageBorderCropMode
       guard mode != .disabled, let cgImage = image.cgImage else { return image }
       guard let cropped = ReaderPageBorderCropper.crop(cgImage, mode: mode) else { return image }
       return UIImage(cgImage: cropped, scale: image.scale, orientation: image.imageOrientation)
-    }
-
-    private func rotateImage(_ image: UIImage, degrees: Int) -> UIImage {
-      let normalized = ((degrees % 360) + 360) % 360
-      guard normalized != 0 else { return image }
-
-      let radians = CGFloat(normalized) * .pi / 180
-      var rotatedRect = CGRect(origin: .zero, size: image.size)
-        .applying(CGAffineTransform(rotationAngle: radians))
-      rotatedRect.origin = .zero
-
-      let renderer = UIGraphicsImageRenderer(size: rotatedRect.size)
-      return renderer.image { context in
-        context.cgContext.translateBy(x: rotatedRect.size.width / 2, y: rotatedRect.size.height / 2)
-        context.cgContext.rotate(by: radians)
-        image.draw(
-          in: CGRect(
-            x: -image.size.width / 2,
-            y: -image.size.height / 2,
-            width: image.size.width,
-            height: image.size.height
-          ))
-      }
     }
 
     private func cropImageForSplitMode(image: UIImage, splitMode: PageSplitMode) -> UIImage? {
@@ -580,7 +566,6 @@
         if let isolateAction = makePageIsolationAction(for: currentData.pageID) {
           sections.append(UIMenu(options: .displayInline, children: [isolateAction]))
         }
-        sections.append(makePageRotationMenu(for: currentData.pageID))
 
         return UIMenu(children: sections)
       }
@@ -594,17 +579,7 @@
 
       private func makePageIsolationAction(for pageID: ReaderPageID) -> UIAction? {
         guard supportsPageIsolationActions, let viewModel else { return nil }
-        guard let readerPage = viewModel.readerPage(for: pageID) else { return nil }
-        // Check effective portrait considering rotation
-        let rotation = viewModel.pageRotationDegrees(for: pageID)
-        let normalized = ((rotation % 360) + 360) % 360
-        let effectivelyPortrait: Bool
-        if normalized == 90 || normalized == 270 {
-          effectivelyPortrait = (readerPage.page.width ?? 0) > (readerPage.page.height ?? 0)
-        } else {
-          effectivelyPortrait = readerPage.page.isPortrait
-        }
-        guard effectivelyPortrait else { return nil }
+        guard viewModel.isPageEffectivelyPortrait(pageID) else { return nil }
 
         if viewModel.isPageIsolated(pageID) {
           return UIAction(
@@ -622,23 +597,6 @@
         ) { [weak self] _ in
           self?.viewModel?.toggleIsolatePage(pageID)
         }
-      }
-
-      private func makePageRotationMenu(for pageID: ReaderPageID) -> UIMenu {
-        let currentRotation = viewModel?.pageRotationDegrees(for: pageID) ?? 0
-        let actions = [0, 90, 180, 270].map { degrees in
-          UIAction(
-            title: "\(degrees)°",
-            image: currentRotation == degrees ? UIImage(systemName: "checkmark") : nil
-          ) { [weak self] _ in
-            self?.viewModel?.setPageRotation(degrees, for: pageID)
-          }
-        }
-        return UIMenu(
-          title: "\(String(localized: "Rotate")): \(currentRotation)°",
-          image: UIImage(systemName: "rotate.right"),
-          children: actions
-        )
       }
 
       private func shareCurrentImage(for pageID: ReaderPageID) {

--- a/KMReader/Features/Reader/Views/PageImage/NativePageItem_macOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/NativePageItem_macOS.swift
@@ -8,6 +8,7 @@
     private let sepiaOverlayView = NSView()
     private let animatedInlineContainer = NSView()
     private let animatedImageController = AnimatedImagePlayerController()
+    private let preparedImageCache = PreparedReaderPageImageCache()
     private let pageNumberContainer = NSView()
     private let pageNumberLabel = NSTextField()
     private let progressIndicator = NSProgressIndicator()
@@ -56,6 +57,7 @@
       updateAnimatedPlayback(sourceFileURL: nil)
       imageView.isHidden = false
       imageView.image = nil
+      preparedImageCache.clear()
       animatedInlineContainer.layer?.contents = nil
       analyzedImage = nil
       analysisSourceImage = nil
@@ -71,7 +73,7 @@
           let pageSourceImage = preparedImage(
             from: readerViewModel?.preloadedImage(for: data.pageID),
             splitMode: data.splitMode,
-            rotationDegrees: data.rotationDegrees
+            rotation: data.rotation
           )
           analysisSourceImage = pageSourceImage
           imageView.image = pageSourceImage
@@ -222,7 +224,7 @@
       let pageSourceImage = preparedImage(
         from: image,
         splitMode: data.splitMode,
-        rotationDegrees: data.rotationDegrees
+        rotation: data.rotation
       )
 
       let hasDisplayableImage = pageSourceImage != nil
@@ -277,17 +279,24 @@
       }
     }
 
-    private func preparedImage(from image: NSImage?, splitMode: PageSplitMode, rotationDegrees: Int) -> NSImage? {
+    private func preparedImage(from image: NSImage?, splitMode: PageSplitMode, rotation: ReaderRotation) -> NSImage? {
       guard let image else { return nil }
-      let rotatedImage = rotateImage(image, degrees: rotationDegrees)
-      let splitImage =
-        splitMode == .none ? rotatedImage : cropImageForSplitMode(image: rotatedImage, splitMode: splitMode)
-      return cropBordersIfNeeded(splitImage)
+      let borderCropMode = AppConfig.divinaPageBorderCropMode
+      return preparedImageCache.resolve(
+        sourceImage: image,
+        rotation: rotation,
+        splitMode: splitMode,
+        borderCropMode: borderCropMode
+      ) {
+        let rotatedImage = image.rotated(for: rotation)
+        let splitImage =
+          splitMode == .none ? rotatedImage : cropImageForSplitMode(image: rotatedImage, splitMode: splitMode)
+        return cropBordersIfNeeded(splitImage, mode: borderCropMode)
+      }
     }
 
-    private func cropBordersIfNeeded(_ image: NSImage?) -> NSImage? {
+    private func cropBordersIfNeeded(_ image: NSImage?, mode: ReaderPageBorderCropMode) -> NSImage? {
       guard let image else { return nil }
-      let mode = AppConfig.divinaPageBorderCropMode
       guard mode != .disabled,
         let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil),
         let cropped = ReaderPageBorderCropper.crop(cgImage, mode: mode)
@@ -295,34 +304,6 @@
         return image
       }
       return NSImage(cgImage: cropped, size: NSSize(width: cropped.width, height: cropped.height))
-    }
-
-    private func rotateImage(_ image: NSImage, degrees: Int) -> NSImage {
-      let normalized = ((degrees % 360) + 360) % 360
-      guard normalized != 0 else { return image }
-      guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return image }
-
-      let sourceSize = CGSize(width: cgImage.width, height: cgImage.height)
-      let radians = CGFloat(normalized) * .pi / 180
-      var rotatedRect = CGRect(origin: .zero, size: sourceSize)
-        .applying(CGAffineTransform(rotationAngle: radians))
-      rotatedRect.origin = .zero
-
-      let rotatedImage = NSImage(size: rotatedRect.size)
-      rotatedImage.lockFocus()
-      guard let context = NSGraphicsContext.current?.cgContext else {
-        rotatedImage.unlockFocus()
-        return image
-      }
-      context.translateBy(x: rotatedRect.size.width / 2, y: rotatedRect.size.height / 2)
-      context.rotate(by: radians)
-      context.draw(
-        cgImage,
-        in: CGRect(
-          x: -sourceSize.width / 2, y: -sourceSize.height / 2, width: sourceSize.width, height: sourceSize.height)
-      )
-      rotatedImage.unlockFocus()
-      return rotatedImage
     }
 
     private func cropImageForSplitMode(image: NSImage, splitMode: PageSplitMode) -> NSImage? {
@@ -589,14 +570,11 @@
 
       let menu = NSMenu()
       menu.addItem(makeShareMenuItem(for: currentData.pageID))
-      menu.addItem(.separator())
 
       if let isolationItem = makePageIsolationMenuItem(for: currentData.pageID) {
-        menu.addItem(isolationItem)
         menu.addItem(.separator())
+        menu.addItem(isolationItem)
       }
-
-      menu.addItem(makePageRotationMenuItem(for: currentData.pageID))
 
       return menu.items.isEmpty ? nil : menu
     }
@@ -610,17 +588,7 @@
 
     private func makePageIsolationMenuItem(for pageID: ReaderPageID) -> NSMenuItem? {
       guard supportsPageIsolationActions, let readerViewModel else { return nil }
-      guard let readerPage = readerViewModel.readerPage(for: pageID) else { return nil }
-      // Check effective portrait considering rotation
-      let rotation = readerViewModel.pageRotationDegrees(for: pageID)
-      let normalized = ((rotation % 360) + 360) % 360
-      let effectivelyPortrait: Bool
-      if normalized == 90 || normalized == 270 {
-        effectivelyPortrait = (readerPage.page.width ?? 0) > (readerPage.page.height ?? 0)
-      } else {
-        effectivelyPortrait = readerPage.page.isPortrait
-      }
-      guard effectivelyPortrait else { return nil }
+      guard readerViewModel.isPageEffectivelyPortrait(pageID) else { return nil }
 
       if readerViewModel.isPageIsolated(pageID) {
         let item = NSMenuItem(
@@ -642,35 +610,6 @@
       return item
     }
 
-    private func makePageRotationMenuItem(for pageID: ReaderPageID) -> NSMenuItem {
-      let currentRotation = readerViewModel?.pageRotationDegrees(for: pageID) ?? 0
-      let item = NSMenuItem(
-        title: "\(String(localized: "Rotate")): \(currentRotation)°", action: nil, keyEquivalent: "")
-      item.image = NSImage(systemSymbolName: "rotate.right", accessibilityDescription: nil)
-      item.submenu = makePageRotationSubmenu(for: pageID, currentRotation: currentRotation)
-      return item
-    }
-
-    private func makePageRotationSubmenu(for pageID: ReaderPageID, currentRotation: Int) -> NSMenu {
-      let submenu = NSMenu()
-      for degrees in [0, 90, 180, 270] {
-        let item = NSMenuItem(
-          title: "\(degrees)°",
-          action: #selector(handleSetRotationContextMenuAction),
-          keyEquivalent: ""
-        )
-        item.image =
-          currentRotation == degrees
-          ? NSImage(systemSymbolName: "checkmark", accessibilityDescription: nil)
-          : nil
-        item.target = self
-        item.representedObject = PageRotationMenuAction(pageID: pageID, degrees: degrees)
-        item.state = currentRotation == degrees ? .on : .off
-        submenu.addItem(item)
-      }
-      return submenu
-    }
-
     @objc private func handleShareContextMenuAction() {
       guard let pageID = currentData?.pageID, let image = imageView.image else { return }
       let fileName = readerViewModel?.page(for: pageID)?.fileName
@@ -683,15 +622,5 @@
       updateContextMenu()
     }
 
-    @objc private func handleSetRotationContextMenuAction(_ sender: NSMenuItem) {
-      guard let action = sender.representedObject as? PageRotationMenuAction else { return }
-      readerViewModel?.setPageRotation(action.degrees, for: action.pageID)
-      updateContextMenu()
-    }
-
-    private struct PageRotationMenuAction {
-      let pageID: ReaderPageID
-      let degrees: Int
-    }
   }
 #endif

--- a/KMReader/Features/Reader/Views/PageImage/PageScrollView_iOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/PageScrollView_iOS.swift
@@ -276,7 +276,7 @@
         guard width > 0 else { return parent.screenSize.height }
 
         if let image = image {
-          let imageSize = rotatedSize(image.size, degrees: data.rotationDegrees)
+          let imageSize = data.rotation.rotatedSize(image.size)
           if imageSize.width > 0, imageSize.height > 0 {
             let height = width * imageSize.height / imageSize.width
             if height.isFinite && height > 0 {
@@ -291,21 +291,16 @@
           pageWidth > 0,
           pageHeight > 0
         {
-          let height = width * CGFloat(pageHeight) / CGFloat(pageWidth)
+          let sourceSize = data.rotation.rotatedSize(
+            CGSize(width: CGFloat(pageWidth), height: CGFloat(pageHeight))
+          )
+          let height = width * sourceSize.height / sourceSize.width
           if height.isFinite && height > 0 {
             return height
           }
         }
 
         return parent.screenSize.height
-      }
-
-      private func rotatedSize(_ size: CGSize, degrees: Int) -> CGSize {
-        let normalized = ((degrees % 360) + 360) % 360
-        if normalized == 90 || normalized == 270 {
-          return CGSize(width: size.height, height: size.width)
-        }
-        return size
       }
 
       @objc func handleDoubleTap(_ gesture: UITapGestureRecognizer) {

--- a/KMReader/Features/Reader/Views/PageImage/PageScrollView_macOS.swift
+++ b/KMReader/Features/Reader/Views/PageImage/PageScrollView_macOS.swift
@@ -275,7 +275,7 @@
         guard width > 0 else { return parent.screenSize.height }
 
         if let image = image {
-          let imageSize = rotatedSize(image.size, degrees: data.rotationDegrees)
+          let imageSize = data.rotation.rotatedSize(image.size)
           if imageSize.width > 0, imageSize.height > 0 {
             let height = width * imageSize.height / imageSize.width
             if height.isFinite && height > 0 {
@@ -290,21 +290,16 @@
           pageWidth > 0,
           pageHeight > 0
         {
-          let height = width * CGFloat(pageHeight) / CGFloat(pageWidth)
+          let sourceSize = data.rotation.rotatedSize(
+            CGSize(width: CGFloat(pageWidth), height: CGFloat(pageHeight))
+          )
+          let height = width * sourceSize.height / sourceSize.width
           if height.isFinite && height > 0 {
             return height
           }
         }
 
         return parent.screenSize.height
-      }
-
-      private func rotatedSize(_ size: CGSize, degrees: Int) -> CGSize {
-        let normalized = ((degrees % 360) + 360) % 360
-        if normalized == 90 || normalized == 270 {
-          return CGSize(width: size.height, height: size.width)
-        }
-        return size
       }
 
       @objc func handleScrollEnded(_ notification: Notification) {

--- a/KMReader/Features/Reader/Views/PageImage/PlatformImage+ReaderRotation.swift
+++ b/KMReader/Features/Reader/Views/PageImage/PlatformImage+ReaderRotation.swift
@@ -1,0 +1,65 @@
+//
+// PlatformImage+ReaderRotation.swift
+//
+
+import CoreGraphics
+
+#if os(iOS) || os(tvOS)
+  import UIKit
+
+  extension UIImage {
+    func rotated(for rotation: ReaderRotation) -> UIImage {
+      guard rotation != .none else { return self }
+
+      let radians = CGFloat(rotation.degrees) * .pi / 180
+      let rotatedSize = rotation.rotatedSize(size)
+
+      let format = UIGraphicsImageRendererFormat()
+      format.scale = scale
+      let renderer = UIGraphicsImageRenderer(size: rotatedSize, format: format)
+      return renderer.image { context in
+        context.cgContext.translateBy(x: rotatedSize.width / 2, y: rotatedSize.height / 2)
+        context.cgContext.rotate(by: radians)
+        draw(
+          in: CGRect(
+            x: -size.width / 2,
+            y: -size.height / 2,
+            width: size.width,
+            height: size.height
+          ))
+      }
+    }
+  }
+#elseif os(macOS)
+  import AppKit
+
+  extension NSImage {
+    func rotated(for rotation: ReaderRotation) -> NSImage {
+      guard rotation != .none else { return self }
+      guard let cgImage = cgImage(forProposedRect: nil, context: nil, hints: nil) else { return self }
+
+      let sourceSize = CGSize(width: cgImage.width, height: cgImage.height)
+      let radians = CGFloat(rotation.degrees) * .pi / 180
+      let rotatedSize = rotation.rotatedSize(sourceSize)
+
+      let rotatedImage = NSImage(size: rotatedSize)
+      rotatedImage.lockFocus()
+      guard let context = NSGraphicsContext.current?.cgContext else {
+        rotatedImage.unlockFocus()
+        return self
+      }
+      context.translateBy(x: rotatedSize.width / 2, y: rotatedSize.height / 2)
+      context.rotate(by: radians)
+      context.draw(
+        cgImage,
+        in: CGRect(
+          x: -sourceSize.width / 2,
+          y: -sourceSize.height / 2,
+          width: sourceSize.width,
+          height: sourceSize.height
+        ))
+      rotatedImage.unlockFocus()
+      return rotatedImage
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Views/PageImage/PreparedReaderPageImageCache.swift
+++ b/KMReader/Features/Reader/Views/PageImage/PreparedReaderPageImageCache.swift
@@ -1,0 +1,43 @@
+//
+// PreparedReaderPageImageCache.swift
+//
+
+import Foundation
+
+@MainActor
+final class PreparedReaderPageImageCache {
+  private var sourceImage: PlatformImage?
+  private var rotation: ReaderRotation = .none
+  private var splitMode: PageSplitMode = .none
+  private var borderCropMode: ReaderPageBorderCropMode = .disabled
+  private var preparedImage: PlatformImage?
+
+  func resolve(
+    sourceImage: PlatformImage,
+    rotation: ReaderRotation,
+    splitMode: PageSplitMode,
+    borderCropMode: ReaderPageBorderCropMode,
+    prepare: () -> PlatformImage?
+  ) -> PlatformImage? {
+    if self.sourceImage === sourceImage,
+      self.rotation == rotation,
+      self.splitMode == splitMode,
+      self.borderCropMode == borderCropMode
+    {
+      return preparedImage
+    }
+
+    let preparedImage = prepare()
+    self.sourceImage = sourceImage
+    self.rotation = rotation
+    self.splitMode = splitMode
+    self.borderCropMode = borderCropMode
+    self.preparedImage = preparedImage
+    return preparedImage
+  }
+
+  func clear() {
+    sourceImage = nil
+    preparedImage = nil
+  }
+}

--- a/KMReader/Features/Reader/Views/PageImage/ReaderViewModel+NativePageData.swift
+++ b/KMReader/Features/Reader/Views/PageImage/ReaderViewModel+NativePageData.swift
@@ -107,8 +107,10 @@ extension ReaderViewModel {
       error: nil,
       alignment: alignment,
       splitMode: splitMode,
-      rotationDegrees: pageRotationDegrees(for: pageID),
-      animatedSourceFileURL: isPlaybackActive ? animatedSourceFileURL(for: pageID) : nil
+      rotation: rotation,
+      animatedSourceFileURL:
+        isPlaybackActive && rotation == .none
+        ? animatedSourceFileURL(for: pageID) : nil
     )
   }
 }

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -737,7 +737,7 @@
             },
             toggleIsolatePage: { _ in },
             sharePage: { _ in },
-            setPageRotation: { _, _ in },
+            setRotation: { _ in },
             setSplitWidePageMode: { _ in },
             toggleContinuousScroll: {}
           )

--- a/KMReader/Features/Reader/Views/ReaderCommandHandlers.swift
+++ b/KMReader/Features/Reader/Views/ReaderCommandHandlers.swift
@@ -15,7 +15,7 @@ struct ReaderCommandHandlers {
   let toggleIsolateCoverPage: () -> Void
   let toggleIsolatePage: (ReaderPageID) -> Void
   let sharePage: (ReaderPageID) -> Void
-  let setPageRotation: (ReaderPageID, Int) -> Void
+  let setRotation: (ReaderRotation) -> Void
   let setSplitWidePageMode: (SplitWidePageMode) -> Void
   let toggleContinuousScroll: () -> Void
 }

--- a/KMReader/Features/Reader/Views/ReaderCommandState.swift
+++ b/KMReader/Features/Reader/Views/ReaderCommandState.swift
@@ -17,13 +17,14 @@ struct ReaderCommandState: Equatable {
   var pageIsolationActions: [ReaderPageIsolationActions.Action] = []
   var commandPageIDs: [ReaderPageID] = []
   var displayPageNumbersByID: [ReaderPageID: Int] = [:]
-  var pageRotationsByID: [ReaderPageID: Int] = [:]
+  var rotation: ReaderRotation = .none
   var splitWidePageMode: SplitWidePageMode = .none
   var continuousScroll: Bool = false
   var supportsSearch: Bool = false
   var canSearch: Bool = false
   var supportsReadingDirectionSelection: Bool = false
   var supportsPageLayoutSelection: Bool = false
+  var supportsRotationSelection: Bool = false
   var supportsDualPageOptions: Bool = false
   var supportsSplitWidePageMode: Bool = false
   var supportsContinuousScrollToggle: Bool = false

--- a/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
+++ b/KMReader/Features/Reader/Views/ReaderPresentationManager.swift
@@ -303,8 +303,8 @@ final class ReaderPresentationManager {
       readerCommandHandlers?.sharePage(pageID)
     }
 
-    func setPageRotationFromCommand(_ pageID: ReaderPageID, degrees: Int) {
-      readerCommandHandlers?.setPageRotation(pageID, degrees)
+    func setRotationFromCommand(_ rotation: ReaderRotation) {
+      readerCommandHandlers?.setRotation(rotation)
     }
 
     func setSplitWidePageModeFromCommand(_ mode: SplitWidePageMode) {

--- a/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
+++ b/KMReader/Features/Reader/Views/Sheets/ReaderSettingsSheet.swift
@@ -6,8 +6,7 @@
 import SwiftUI
 
 struct ReaderSettingsSheet: View {
-  // Session-specific bindings (not persisted until reader closes)
-  @Binding var readingDirection: ReadingDirection
+  let readingDirection: ReadingDirection
 
   // Persisted settings (via @AppStorage)
   @AppStorage("readerBackground") private var readerBackground: ReaderBackground = .system

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -1520,9 +1520,6 @@
         }
       }
     },
-    "%lld°" : {
-      "shouldTranslate" : false
-    },
     "%lld+" : {
       "localizations" : {
         "de" : {
@@ -52679,6 +52676,70 @@
         }
       }
     },
+    "Page Rotation" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seitendrehung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Rotation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotación de páginas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotation des pages"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotazione delle pagine"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ページの回転"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "페이지 회전"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поворот страниц"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "页面旋转"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "頁面旋轉"
+          }
+        }
+      }
+    },
     "Page Transition Style" : {
       "localizations" : {
         "de" : {
@@ -61635,134 +61696,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "角色"
-          }
-        }
-      }
-    },
-    "Rotate" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Drehen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rotate"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Girar"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pivoter"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruota"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "回転"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "회전"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Повернуть"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "旋转"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "旋轉"
-          }
-        }
-      }
-    },
-    "Rotate: %lld°" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Drehen: %lld°"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rotate: %lld°"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Girar: %lld°"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pivoter : %lld°"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruota: %lld°"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "回転：%lld°"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "회전: %lld°"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поворот: %lld°"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "旋转：%lld°"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "旋轉：%lld°"
           }
         }
       }

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -223,7 +223,10 @@ struct MainApp: App {
           .disabled(!state.isActive || !state.canSearch)
         }
 
-        if state.supportsReadingDirectionSelection || state.supportsPageLayoutSelection {
+        if state.supportsReadingDirectionSelection
+          || state.supportsPageLayoutSelection
+          || state.supportsRotationSelection
+        {
           Divider()
         }
 
@@ -254,6 +257,23 @@ struct MainApp: App {
                   Label(layout.displayName, systemImage: "checkmark")
                 } else {
                   Text(layout.displayName)
+                }
+              }
+            }
+          }
+          .disabled(!state.isActive)
+        }
+
+        if state.supportsRotationSelection {
+          Menu("Page Rotation") {
+            ForEach(ReaderRotation.allCases, id: \.self) { rotation in
+              Button {
+                readerPresentation.setRotationFromCommand(rotation)
+              } label: {
+                if state.rotation == rotation {
+                  Label(rotation.displayName, systemImage: "checkmark")
+                } else {
+                  Text(rotation.displayName)
                 }
               }
             }
@@ -334,7 +354,6 @@ struct MainApp: App {
 
           ForEach(state.commandPageIDs, id: \.self) { pageID in
             let displayPageNumber = state.displayPageNumbersByID[pageID] ?? pageID.pageNumber + 1
-            let currentRotation = state.pageRotationsByID[pageID] ?? 0
             Menu("Page \(displayPageNumber)") {
               Button("Share") {
                 readerPresentation.sharePageFromCommand(pageID)
@@ -347,22 +366,6 @@ struct MainApp: App {
                   readerPresentation.toggleIsolatePageFromCommand(isolationAction.pageID)
                 }
                 .disabled(!state.isActive)
-              }
-
-              Divider()
-              Menu("Rotate: \(currentRotation)°") {
-                ForEach([0, 90, 180, 270], id: \.self) { degrees in
-                  Button {
-                    readerPresentation.setPageRotationFromCommand(pageID, degrees: degrees)
-                  } label: {
-                    if currentRotation == degrees {
-                      Label("\(degrees)°", systemImage: "checkmark")
-                    } else {
-                      Text("\(degrees)°")
-                    }
-                  }
-                  .disabled(!state.isActive)
-                }
               }
             }
             .disabled(!state.isActive)

--- a/KMReader/Shared/UI/ReaderOverlay.swift
+++ b/KMReader/Shared/UI/ReaderOverlay.swift
@@ -48,6 +48,7 @@ import SwiftUI
             readerPresentation: readerPresentation,
             onClose: { readerPresentation.closeReader() }
           )
+          .id(session.id)
         } else {
           ReaderPlaceholderView {
             readerPresentation.closeReader()


### PR DESCRIPTION
## Summary

- replace persisted per-page rotation with one reading-session rotation option for paged DIVINA modes
- expose rotation in the in-reader options menu on iOS/tvOS and the Reader menu on macOS, while keeping Webtoon unchanged
- remove legacy page-rotation storage with a forward GRDB migration and document the reader-state boundary

## Validation

- `make format`
- `make build`
- `make localize`
- `./misc/translate.py list`
- `git diff --check`
- `python3 -m json.tool KMReader/Localizable.xcstrings`

Closes #946
