### PR TITLE
fix(reader): preserve position across page curl rebuilds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ This file provides guidance to coding agents working with code in this repositor
 
 - `ReaderSettingsSheet` is reserved for persisted reader preferences. Session-only reader options belong in the reader controls menu or the platform command menu.
 - Page rotation is session-only, applies only to paged DIVINA modes, and must not be exposed or applied in Webtoon mode.
+- `ReaderViewModel` owns the committed semantic reader position and navigation commands as a full `ReaderViewItem` plus its focused `ReaderPageID`. Page Curl adapters must not publish a position while mounting or dismantling; restoration may fall back to the first item, but command resolution must be strict and discard invalid targets.
+- Page Curl indices are local to one coordinator-owned immutable snapshot. UIKit controllers and asynchronous completions must cross update, preload, rotation, and teardown boundaries using stable reader-item identities rather than array indices or view tags.
+- During seamless DIVINA cross-book navigation, `currentReaderPage` is the committed position, `currentBook` and `ReaderSession.book` follow its segment, and `currentBookId` remains the explicit whole-book load anchor.
 
 ### Offline & Downloads
 

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 507;
+				CURRENT_PROJECT_VERSION = 508;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 507;
+				CURRENT_PROJECT_VERSION = 508;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 507;
+				CURRENT_PROJECT_VERSION = 508;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 507;
+				CURRENT_PROJECT_VERSION = 508;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Models/ReaderPageProgressSnapshot.swift
+++ b/KMReader/Features/Reader/Models/ReaderPageProgressSnapshot.swift
@@ -1,0 +1,11 @@
+//
+// ReaderPageProgressSnapshot.swift
+//
+
+import Foundation
+
+struct ReaderPageProgressSnapshot: Equatable, Sendable {
+  let bookId: String
+  let page: Int
+  let completed: Bool
+}

--- a/KMReader/Features/Reader/Models/ReaderPositionAnchor.swift
+++ b/KMReader/Features/Reader/Models/ReaderPositionAnchor.swift
@@ -1,0 +1,10 @@
+//
+// ReaderPositionAnchor.swift
+//
+
+import Foundation
+
+struct ReaderPositionAnchor: Equatable {
+  let item: ReaderViewItem?
+  let focusedPageID: ReaderPageID?
+}

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -17,7 +17,7 @@ class ReaderViewModel {
   private(set) var bookIdsWithMissingPageDimensions: Set<String> = []
   private var currentPageID: ReaderPageID?
   private var currentViewItemID: ReaderViewItem?
-  var navigationTarget: ReaderViewItem?
+  var navigationTarget: ReaderPositionAnchor?
   var isLoading = true
   var loadingTitle = String(localized: "Loading book...")
   var loadingDetail = String(localized: "Resolving page metadata")
@@ -41,6 +41,8 @@ class ReaderViewModel {
   private var pagePresentationInvalidationHandlers: [UUID: PagePresentationInvalidationHandler] = [:]
   @ObservationIgnored
   private var pdfPreparationTasks: [String: Task<Void, Never>] = [:]
+  @ObservationIgnored
+  private var progressDispatchTail: Task<Void, Never>?
 
   private enum SegmentFetchPurpose {
     case nextPreload
@@ -237,7 +239,7 @@ class ReaderViewModel {
     return isolatePosition(forGlobalPageIndex: pageIndex)
   }
 
-  private func resolvedViewItem(
+  private func matchingViewItem(
     preferredItem: ReaderViewItem? = nil,
     preferredPageID: ReaderPageID? = nil
   ) -> ReaderViewItem? {
@@ -252,14 +254,17 @@ class ReaderViewModel {
     {
       return resolvedItem
     }
-    return viewItems.first
+    return nil
   }
 
-  func resolvedViewItem(for item: ReaderViewItem?) -> ReaderViewItem? {
-    resolvedViewItem(
-      preferredItem: item,
-      preferredPageID: item?.pageID
-    )
+  private func resolvedViewItem(
+    preferredItem: ReaderViewItem? = nil,
+    preferredPageID: ReaderPageID? = nil
+  ) -> ReaderViewItem? {
+    matchingViewItem(
+      preferredItem: preferredItem,
+      preferredPageID: preferredPageID
+    ) ?? viewItems.first
   }
 
   func updatePreloadWindow(_ preloadWindow: ReaderPreloadWindow) {
@@ -711,12 +716,6 @@ class ReaderViewModel {
     isolatePagesByBookId[bookId] = Set(isolatePagesForBook)
   }
 
-  private func restoreCurrentPosition(using currentViewItem: ReaderViewItem?) {
-    guard let currentViewItem else { return }
-    guard navigationTarget == nil else { return }
-    updateCurrentPosition(viewItem: currentViewItem)
-  }
-
   private func syncPageLoadSchedulerCurrentPage() {
     pageLoadScheduler.updateCurrentPageID(resolvedCurrentPageID)
   }
@@ -772,7 +771,7 @@ class ReaderViewModel {
     }
 
     await hydrateIsolatePages(for: nextBook.id)
-    let currentViewItem = currentViewItem()
+    let positionAnchor = captureCurrentPositionAnchor()
 
     appendSegment(
       currentBook: nextBook,
@@ -780,8 +779,7 @@ class ReaderViewModel {
       nextBook: nil,
       pages: fetchedPages
     )
-    regenerateViewState()
-    restoreCurrentPosition(using: currentViewItem)
+    regenerateViewState(preserving: positionAnchor)
   }
 
   func preloadPreviousSegmentIfNeeded(
@@ -816,7 +814,7 @@ class ReaderViewModel {
     }
 
     await hydrateIsolatePages(for: previousBook.id)
-    let currentViewItem = currentViewItem()
+    let positionAnchor = captureCurrentPositionAnchor()
 
     prependSegment(
       currentBook: previousBook,
@@ -824,8 +822,7 @@ class ReaderViewModel {
       nextBook: currentBook,
       pages: fetchedPages
     )
-    regenerateViewState()
-    restoreCurrentPosition(using: currentViewItem)
+    regenerateViewState(preserving: positionAnchor)
   }
 
   func loadPages(
@@ -1175,7 +1172,7 @@ class ReaderViewModel {
     guard let segmentIndex = segmentIndex(forSegmentBookId: bookId) else { return }
 
     let segment = segments[segmentIndex]
-    let currentItem = currentViewItem()
+    let positionAnchor = captureCurrentPositionAnchor()
     segments[segmentIndex] = ReaderSegment(
       previousBook: segment.previousBook,
       currentBook: segment.currentBook,
@@ -1183,8 +1180,7 @@ class ReaderViewModel {
       pages: pages
     )
     rebuildReaderPages()
-    regenerateViewState()
-    restoreCurrentPosition(using: currentItem)
+    regenerateViewState(preserving: positionAnchor)
     notifyPagePresentationInvalidation(.all)
   }
 
@@ -1232,30 +1228,56 @@ class ReaderViewModel {
     pageLoadScheduler.clearPreloadedImages()
   }
 
-  /// Update reading progress on the server
-  /// Uses API page number (1-based) instead of array index (0-based)
-  /// Skip update if incognito mode is enabled
-  func updateProgress() async {
-    // Skip progress updates in incognito mode
-    guard !incognitoMode else {
-      logger.debug("⏭️ [Progress/Page] Skip capture: incognito mode enabled")
-      return
-    }
-    guard let currentReaderPage else {
-      logger.debug("⏭️ [Progress/Page] Skip capture: current page unavailable")
-      return
-    }
-    let currentBookId = currentReaderPage.bookId
-
-    let completed = isBookCompleted(for: currentReaderPage)
-    logger.debug(
-      "📝 [Progress/Page] Captured from reader state: book=\(currentBookId), page=\(currentReaderPage.pageNumber), completed=\(completed)"
+  func captureProgressSnapshot(for pageID: ReaderPageID?) -> ReaderPageProgressSnapshot? {
+    guard let pageID, let readerPage = readerPage(for: pageID) else { return nil }
+    return ReaderPageProgressSnapshot(
+      bookId: readerPage.bookId,
+      page: readerPage.pageNumber,
+      completed: isBookCompleted(for: readerPage)
     )
+  }
 
+  func enqueueProgressChange(
+    from previousSnapshot: ReaderPageProgressSnapshot?,
+    to currentSnapshot: ReaderPageProgressSnapshot?
+  ) {
+    guard !incognitoMode else {
+      logger.debug("⏭️ [Progress/Page] Skip enqueue: incognito mode enabled")
+      return
+    }
+
+    let precedingDispatch = progressDispatchTail
+    progressDispatchTail = Task(priority: .userInitiated) {
+      await precedingDispatch?.value
+      await self.dispatchProgressChange(from: previousSnapshot, to: currentSnapshot)
+    }
+  }
+
+  private func dispatchProgressChange(
+    from previousSnapshot: ReaderPageProgressSnapshot?,
+    to currentSnapshot: ReaderPageProgressSnapshot?
+  ) async {
+    if let previousSnapshot,
+      previousSnapshot.bookId != currentSnapshot?.bookId
+    {
+      logger.debug(
+        "🚿 [Progress/Page] Flush committed book boundary: book=\(previousSnapshot.bookId), page=\(previousSnapshot.page), completed=\(previousSnapshot.completed)"
+      )
+      await ReaderProgressDispatchService.shared.flushPageProgress(
+        bookId: previousSnapshot.bookId,
+        snapshotPage: previousSnapshot.page,
+        snapshotCompleted: previousSnapshot.completed
+      )
+    }
+
+    guard let currentSnapshot else { return }
+    logger.debug(
+      "📝 [Progress/Page] Dispatch committed snapshot: book=\(currentSnapshot.bookId), page=\(currentSnapshot.page), completed=\(currentSnapshot.completed)"
+    )
     await ReaderProgressDispatchService.shared.submitPageProgress(
-      bookId: currentBookId,
-      page: currentReaderPage.pageNumber,
-      completed: completed
+      bookId: currentSnapshot.bookId,
+      page: currentSnapshot.page,
+      completed: currentSnapshot.completed
     )
   }
 
@@ -1265,25 +1287,12 @@ class ReaderViewModel {
       return
     }
 
-    let snapshotBookId = currentReaderPage?.bookId
-    let snapshotPage = currentReaderPage?.pageNumber
-    let snapshotCompleted = currentReaderPage.map { isBookCompleted(for: $0) }
+    let snapshot = captureProgressSnapshot(for: currentReaderPage?.id)
 
     logger.debug(
-      "🚿 [Progress/Page] Flush requested from reader: book=\(snapshotBookId ?? "unknown"), hasCurrentPage=\(snapshotPage != nil)"
+      "🚿 [Progress/Page] Flush requested from reader: book=\(snapshot?.bookId ?? "unknown"), hasCurrentPage=\(snapshot != nil)"
     )
-
-    Task {
-      guard let flushBookId = snapshotBookId else {
-        logger.debug("⏭️ [Progress/Page] Skip flush: no active book ID")
-        return
-      }
-      await ReaderProgressDispatchService.shared.flushPageProgress(
-        bookId: flushBookId,
-        snapshotPage: snapshotPage,
-        snapshotCompleted: snapshotCompleted
-      )
-    }
+    enqueueProgressChange(from: snapshot, to: nil)
   }
 
   private func isBookCompleted(for readerPage: ReaderPage) -> Bool {
@@ -1297,7 +1306,7 @@ class ReaderViewModel {
   func updateDualPageSettings(noCover: Bool) {
     let newIsolateCover = !noCover
     guard isolateCoverPageEnabled != newIsolateCover else { return }
-    regenerateViewStatePreservingCurrentPage {
+    regenerateViewStatePreservingCurrentPosition {
       isolateCoverPageEnabled = newIsolateCover
     }
   }
@@ -1305,28 +1314,28 @@ class ReaderViewModel {
   func updatePageLayout(_ layout: PageLayout) {
     let shouldForceDualPage = layout == .dual
     guard forceDualPagePairs != shouldForceDualPage else { return }
-    regenerateViewStatePreservingCurrentPage {
+    regenerateViewStatePreservingCurrentPosition {
       forceDualPagePairs = shouldForceDualPage
     }
   }
 
   func updateSplitWidePageMode(_ mode: SplitWidePageMode) {
     guard splitWidePageMode != mode else { return }
-    regenerateViewStatePreservingCurrentPage {
+    regenerateViewStatePreservingCurrentPosition {
       splitWidePageMode = mode
     }
   }
 
   func updatePageTransitionStyle(_ style: PageTransitionStyle) {
     guard pageTransitionStyle != style else { return }
-    regenerateViewStatePreservingCurrentPage {
+    regenerateViewStatePreservingCurrentPosition {
       pageTransitionStyle = style
     }
   }
 
   func updateRotation(_ rotation: ReaderRotation) {
     guard self.rotation != rotation else { return }
-    regenerateViewStatePreservingCurrentPage {
+    regenerateViewStatePreservingCurrentPosition {
       self.rotation = rotation
     }
     notifyPagePresentationInvalidation(.all)
@@ -1335,7 +1344,7 @@ class ReaderViewModel {
   func updateDualPagePresentationMode(_ isUsingDualPageMode: Bool) {
     guard isActuallyUsingDualPageMode != isUsingDualPageMode else { return }
 
-    regenerateViewStatePreservingCurrentPage {
+    regenerateViewStatePreservingCurrentPosition {
       isActuallyUsingDualPageMode = isUsingDualPageMode
     }
   }
@@ -1369,13 +1378,11 @@ class ReaderViewModel {
     }
   }
 
-  func preserveCurrentPageForPresentationRebuild() {
-    requestNavigation(toPageID: resolvedCurrentPageID)
+  private func regenerateViewState() {
+    regenerateViewState(preserving: captureCurrentPositionAnchor())
   }
 
-  private func regenerateViewState() {
-    let preservedCurrentItem = currentViewItemID
-    let preservedCurrentPageID = resolvedCurrentPageID
+  private func regenerateViewState(preserving positionAnchor: ReaderPositionAnchor) {
 
     // Apply the split-wide preference consistently in single and dual presentations.
     let effectiveSplitWidePages = splitWidePageMode.isEnabled
@@ -1396,22 +1403,22 @@ class ReaderViewModel {
       rotation: rotation
     )
     viewItemIndexByPage = generateViewItemIndexMap(items: viewItems)
-    currentViewItemID = resolvedViewItem(
-      preferredItem: preservedCurrentItem,
-      preferredPageID: preservedCurrentPageID
-    )
-    currentPageID = resolvedCurrentPageID(
-      for: currentViewItemID,
-      preferredPageID: preservedCurrentPageID
-    )
-    syncPageLoadSchedulerCurrentPage()
+    restoreCurrentPosition(anchor: positionAnchor)
   }
 
-  private func regenerateViewStatePreservingCurrentPage(_ mutation: () -> Void) {
-    let currentPageID = resolvedCurrentPageID
+  private func regenerateViewStatePreservingCurrentPosition(_ mutation: () -> Void) {
+    let positionAnchor = captureCurrentPositionAnchor()
+    let pendingNavigationTarget = navigationTarget
     mutation()
-    regenerateViewState()
-    requestNavigation(toPageID: currentPageID)
+    regenerateViewState(preserving: positionAnchor)
+    if let pendingNavigationTarget,
+      let remappedTarget = matchingPositionAnchor(for: pendingNavigationTarget)
+    {
+      navigationTarget = remappedTarget
+    } else {
+      let restoredAnchor = captureCurrentPositionAnchor()
+      navigationTarget = restoredAnchor.item == nil ? nil : restoredAnchor
+    }
   }
 
   func viewItem(at index: Int) -> ReaderViewItem? {
@@ -1433,12 +1440,16 @@ class ReaderViewModel {
       navigationTarget = nil
       return
     }
-    navigationTarget = resolvedViewItem(preferredPageID: pageID)
+    guard let item = matchingViewItem(preferredPageID: pageID) else {
+      navigationTarget = nil
+      return
+    }
+    navigationTarget = ReaderPositionAnchor(item: item, focusedPageID: pageID)
   }
 
   func requestNavigation(toViewItem viewItem: ReaderViewItem?) {
     guard
-      let viewItem = resolvedViewItem(
+      let viewItem = matchingViewItem(
         preferredItem: viewItem,
         preferredPageID: viewItem?.pageID
       )
@@ -1446,18 +1457,32 @@ class ReaderViewModel {
       navigationTarget = nil
       return
     }
-    navigationTarget = viewItem
+    let currentFocusedPageID = resolvedCurrentPageID
+    let focusedPageID: ReaderPageID
+    if let currentFocusedPageID,
+      viewItem.pageIDs.contains(currentFocusedPageID) || viewItem.pageID == currentFocusedPageID
+    {
+      focusedPageID = currentFocusedPageID
+    } else {
+      focusedPageID = viewItem.pageID
+    }
+    navigationTarget = ReaderPositionAnchor(item: viewItem, focusedPageID: focusedPageID)
   }
 
   func clearNavigationTarget() {
     navigationTarget = nil
   }
 
+  func clearNavigationTarget(matching target: ReaderPositionAnchor) {
+    guard navigationTarget == target else { return }
+    navigationTarget = nil
+  }
+
   func adjacentViewItem(from item: ReaderViewItem? = nil, offset: Int) -> ReaderViewItem? {
     guard offset != 0 else {
-      return item ?? navigationTarget ?? currentViewItem()
+      return item ?? navigationTarget?.item ?? currentViewItem()
     }
-    let anchorItem = item ?? navigationTarget ?? currentViewItem()
+    let anchorItem = item ?? navigationTarget?.item ?? currentViewItem()
     guard let anchorItem, let anchorIndex = viewItemIndex(for: anchorItem) else {
       return nil
     }
@@ -1471,11 +1496,9 @@ class ReaderViewModel {
       syncPageLoadSchedulerCurrentPage()
       return
     }
-    currentPageID = pageID
-    currentViewItemID = resolvedViewItem(
-      preferredPageID: pageID
+    updateCurrentPosition(
+      anchor: ReaderPositionAnchor(item: nil, focusedPageID: pageID)
     )
-    syncPageLoadSchedulerCurrentPage()
   }
 
   private func resolvedCurrentPageID(
@@ -1496,15 +1519,65 @@ class ReaderViewModel {
       syncPageLoadSchedulerCurrentPage()
       return
     }
-    let preferredPageID = currentPageID
-    currentViewItemID = resolvedViewItem(
-      preferredItem: viewItem,
-      preferredPageID: preferredPageID ?? viewItem.pageID
+    updateCurrentPosition(
+      anchor: ReaderPositionAnchor(
+        item: viewItem,
+        focusedPageID: currentPageID ?? viewItem.pageID
+      )
     )
-    currentPageID = resolvedCurrentPageID(
-      for: currentViewItemID,
-      preferredPageID: preferredPageID
+  }
+
+  func captureCurrentPositionAnchor() -> ReaderPositionAnchor {
+    ReaderPositionAnchor(
+      item: currentViewItem(),
+      focusedPageID: resolvedCurrentPageID
     )
+  }
+
+  func resolvedPositionAnchor(for anchor: ReaderPositionAnchor) -> ReaderPositionAnchor? {
+    if let matchingAnchor = matchingPositionAnchor(for: anchor) {
+      return matchingAnchor
+    }
+    guard let firstItem = viewItems.first else { return nil }
+    return ReaderPositionAnchor(item: firstItem, focusedPageID: firstItem.pageID)
+  }
+
+  func matchingPositionAnchor(for anchor: ReaderPositionAnchor) -> ReaderPositionAnchor? {
+    guard
+      let resolvedItem = matchingViewItem(
+        preferredItem: anchor.item,
+        preferredPageID: anchor.focusedPageID
+      )
+    else {
+      return nil
+    }
+    return ReaderPositionAnchor(
+      item: resolvedItem,
+      focusedPageID: resolvedCurrentPageID(
+        for: resolvedItem,
+        preferredPageID: anchor.focusedPageID
+      )
+    )
+  }
+
+  func updateCurrentPosition(anchor: ReaderPositionAnchor) {
+    guard let resolvedAnchor = matchingPositionAnchor(for: anchor) else { return }
+    assignCurrentPosition(resolvedAnchor)
+  }
+
+  private func restoreCurrentPosition(anchor: ReaderPositionAnchor) {
+    guard let resolvedAnchor = resolvedPositionAnchor(for: anchor) else {
+      currentViewItemID = nil
+      currentPageID = nil
+      syncPageLoadSchedulerCurrentPage()
+      return
+    }
+    assignCurrentPosition(resolvedAnchor)
+  }
+
+  private func assignCurrentPosition(_ anchor: ReaderPositionAnchor) {
+    currentViewItemID = anchor.item
+    currentPageID = anchor.focusedPageID
     syncPageLoadSchedulerCurrentPage()
   }
 

--- a/KMReader/Features/Reader/Views/CurlDualPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlDualPageView.swift
@@ -3,6 +3,7 @@
 //
 
 #if os(iOS)
+  import Foundation
   import SwiftUI
   import UIKit
 
@@ -27,8 +28,6 @@
       case end(segmentBookId: String)
       case placeholder
     }
-
-    private let slotViewIdentifier = "curlDualSlot"
 
     func makeCoordinator() -> Coordinator {
       Coordinator(self)
@@ -60,12 +59,7 @@
         semanticContentAttribute: mode.isRTL ? .forceRightToLeft : .forceLeftToRight
       )
 
-      let initialSpreadIndex = viewModel.currentViewItem().flatMap { viewModel.viewItemIndex(for: $0) } ?? 0
-      context.coordinator.currentItem = viewModel.viewItem(at: initialSpreadIndex)
-      context.coordinator.updateViewItemsSnapshot(viewModel.viewItems)
-      Task { @MainActor in
-        viewModel.updateCurrentPosition(viewItem: viewModel.viewItem(at: initialSpreadIndex))
-      }
+      let initialSpreadIndex = context.coordinator.currentResolvedSpreadIndex() ?? 0
 
       if let initialPair = context.coordinator.pageControllerPair(for: initialSpreadIndex) {
         PageCurlControllerPlanner.safeSetViewControllers(
@@ -89,6 +83,13 @@
       return pageVC
     }
 
+    static func dismantleUIViewController(
+      _ pageViewController: UIPageViewController,
+      coordinator: Coordinator
+    ) {
+      coordinator.teardown(pageViewController: pageViewController)
+    }
+
     func updateUIViewController(_ pageVC: UIPageViewController, context: Context) {
       context.coordinator.parent = self
       context.coordinator.pageViewController = pageVC
@@ -101,100 +102,20 @@
       )
 
       context.coordinator.syncCurrentItemWithVisibleController()
-      let didViewItemsChange = context.coordinator.updateViewItemsSnapshot(viewModel.viewItems)
-      context.coordinator.refreshVisibleControllerConfiguration()
-
-      let targetSpreadIndex: Int? = {
-        if let explicitTarget = viewModel.navigationTarget.flatMap({ viewModel.resolvedViewItem(for: $0) }) {
-          return viewModel.viewItemIndex(for: explicitTarget)
-        }
-        if didViewItemsChange, let currentItem = viewModel.currentViewItem() {
-          return viewModel.viewItemIndex(for: currentItem)
-        }
-        return nil
-      }()
-
-      guard let targetSpreadIndex else { return }
-      let currentSpreadIndex = context.coordinator.currentResolvedSpreadIndex() ?? targetSpreadIndex
-
-      let clearTargets: () -> Void = {
-        _ = Task { @MainActor in
-          viewModel.clearNavigationTarget()
-        }
-      }
-
-      guard targetSpreadIndex != currentSpreadIndex else {
-        clearTargets()
-        return
-      }
-
-      guard let targetPair = context.coordinator.pageControllerPair(for: targetSpreadIndex) else {
-        clearTargets()
-        return
-      }
-
+      let didViewItemsChange = context.coordinator.updateViewItemsSnapshot(
+        PageCurlViewItemsSnapshot(items: viewModel.viewItems),
+        preferredAnchor: viewModel.captureCurrentPositionAnchor()
+      )
       guard !context.coordinator.isTransitioning else { return }
-
-      let direction: UIPageViewController.NavigationDirection
-      if mode.isRTL {
-        direction = targetSpreadIndex > currentSpreadIndex ? .reverse : .forward
-      } else {
-        direction = targetSpreadIndex > currentSpreadIndex ? .forward : .reverse
-      }
-
-      context.coordinator.isTransitioning = true
-      let shouldAnimateTransition = context.coordinator.hasCompletedInitialUpdate && animateTapTurns
-      PageCurlControllerPlanner.safeSetViewControllers(
-        targetPair,
+      context.coordinator.refreshVisibleControllerConfiguration()
+      context.coordinator.processNavigationTarget(
         on: pageVC,
-        direction: direction,
-        animated: shouldAnimateTransition
-      ) { completed in
-        Task { @MainActor in
-          context.coordinator.isTransitioning = false
-          if completed || !shouldAnimateTransition {
-            if let committedPair = context.coordinator.pageControllerPair(for: targetSpreadIndex) {
-              PageCurlControllerPlanner.safeSetViewControllers(
-                committedPair,
-                on: pageVC,
-                direction: direction,
-                animated: false
-              )
-            }
-            context.coordinator.currentItem = viewModel.viewItem(at: targetSpreadIndex)
-            viewModel.updateCurrentPosition(viewItem: context.coordinator.currentItem)
-          }
-          viewModel.clearNavigationTarget()
-        }
-      }
+        restoreModelPosition: didViewItemsChange
+      )
     }
 
-    private func encodedTag(for spreadIndex: Int, slot: SpreadSlot) -> Int {
-      spreadIndex * 2 + slot.rawValue + 1
-    }
-
-    private func decodedMetadata(
-      for controller: UIViewController
-    ) -> (spreadIndex: Int, slot: SpreadSlot)? {
-      guard controller.view.accessibilityIdentifier == slotViewIdentifier else { return nil }
-      let rawTag = controller.view.tag - 1
-      guard rawTag >= 0 else { return nil }
-      let slotRaw = rawTag % 2
-      guard let slot = SpreadSlot(rawValue: slotRaw) else { return nil }
-      let spreadIndex = rawTag / 2
-      return (spreadIndex: spreadIndex, slot: slot)
-    }
-
-    private func applyMetadata(
-      to controller: UIViewController,
-      spreadIndex: Int,
-      slot: SpreadSlot
-    ) {
-      controller.view.tag = encodedTag(for: spreadIndex, slot: slot)
-      controller.view.accessibilityIdentifier = slotViewIdentifier
-    }
-
-    class Coordinator: NSObject, UIPageViewControllerDataSource, UIPageViewControllerDelegate,
+    @MainActor
+    final class Coordinator: NSObject, UIPageViewControllerDataSource, UIPageViewControllerDelegate,
       UIGestureRecognizerDelegate
     {
       var parent: CurlDualPageView
@@ -202,15 +123,25 @@
       weak var pageViewController: UIPageViewController?
       var isTransitioning = false
       var hasCompletedInitialUpdate = false
+      private var isActive = true
       private weak var doubleTapRecognizer: UITapGestureRecognizer?
+      private var installedTapRecognizers: [UIGestureRecognizer] = []
       private var transitionTargetItem: ReaderViewItem?
-      private var lastViewItemsCount: Int = 0
-      private var lastFirstViewItem: ReaderViewItem?
-      private var lastLastViewItem: ReaderViewItem?
+      private var viewItemsSnapshot: PageCurlViewItemsSnapshot
+      private var pendingViewItemsSnapshot: PageCurlViewItemsSnapshot?
+      private let controllerIdentities =
+        NSMapTable<UIViewController, PageCurlControllerIdentity>.weakToStrongObjects()
+      private var transitionToken = 0
+      private var preloadTask: Task<Void, Never>?
+      private var navigationContinuationTask: Task<Void, Never>?
+      private var consumedNavigationTarget: ReaderPositionAnchor?
+      private var retriedNavigationTarget: ReaderPositionAnchor?
 
       init(_ parent: CurlDualPageView) {
         self.parent = parent
-        self.currentItem = parent.viewModel.currentViewItem()
+        let snapshot = PageCurlViewItemsSnapshot(items: parent.viewModel.viewItems)
+        self.viewItemsSnapshot = snapshot
+        self.currentItem = snapshot.resolvedItem(for: parent.viewModel.captureCurrentPositionAnchor())
       }
 
       func installTapRecognizers(on view: UIView) {
@@ -233,6 +164,7 @@
         longPress.delegate = self
         singleTap.require(toFail: longPress)
         view.addGestureRecognizer(longPress)
+        installedTapRecognizers = [singleTap, doubleTap, longPress]
         applyDoubleTapRecognizerState()
       }
 
@@ -241,22 +173,317 @@
       }
 
       private var totalSpreads: Int {
-        parent.viewModel.viewItems.count
+        viewItemsSnapshot.count
       }
 
       @discardableResult
-      func updateViewItemsSnapshot(_ items: [ReaderViewItem]) -> Bool {
-        let firstItem = items.first
-        let lastItem = items.last
-        let didChange =
-          items.count != lastViewItemsCount
-          || firstItem != lastFirstViewItem
-          || lastItem != lastLastViewItem
+      func updateViewItemsSnapshot(
+        _ snapshot: PageCurlViewItemsSnapshot,
+        preferredAnchor: ReaderPositionAnchor
+      ) -> Bool {
+        guard snapshot != viewItemsSnapshot else {
+          pendingViewItemsSnapshot = nil
+          return false
+        }
+        guard !isTransitioning else {
+          pendingViewItemsSnapshot = snapshot
+          return false
+        }
+        return applyViewItemsSnapshot(snapshot, preferredAnchor: preferredAnchor)
+      }
 
-        lastViewItemsCount = items.count
-        lastFirstViewItem = firstItem
-        lastLastViewItem = lastItem
-        return didChange
+      private func applyViewItemsSnapshot(
+        _ snapshot: PageCurlViewItemsSnapshot,
+        preferredAnchor: ReaderPositionAnchor
+      ) -> Bool {
+        guard snapshot != viewItemsSnapshot else { return false }
+        viewItemsSnapshot = snapshot
+        currentItem = snapshot.resolvedItem(for: preferredAnchor)
+        return true
+      }
+
+      @discardableResult
+      private func applyPendingViewItemsSnapshot(preferredAnchor: ReaderPositionAnchor) -> Bool {
+        guard let pendingViewItemsSnapshot else { return false }
+        self.pendingViewItemsSnapshot = nil
+        return applyViewItemsSnapshot(
+          pendingViewItemsSnapshot,
+          preferredAnchor: preferredAnchor
+        )
+      }
+
+      func resolvedItem(for anchor: ReaderPositionAnchor) -> ReaderViewItem? {
+        viewItemsSnapshot.resolvedItem(for: anchor)
+      }
+
+      func spreadIndex(for item: ReaderViewItem) -> Int? {
+        viewItemsSnapshot.index(for: item)
+      }
+
+      func beginTransition() -> Int {
+        preloadTask?.cancel()
+        preloadTask = nil
+        transitionToken += 1
+        isTransitioning = true
+        return transitionToken
+      }
+
+      func processNavigationTarget(
+        on pageViewController: UIPageViewController,
+        restoreModelPosition: Bool = false
+      ) {
+        guard isActive, self.pageViewController === pageViewController, !isTransitioning else {
+          return
+        }
+
+        let explicitTarget = parent.viewModel.navigationTarget
+        let target: (anchor: ReaderPositionAnchor, item: ReaderViewItem)?
+        if let explicitTarget,
+          let item = viewItemsSnapshot.matchingItem(for: explicitTarget)
+        {
+          target = (explicitTarget, item)
+        } else if explicitTarget == nil, restoreModelPosition {
+          let modelAnchor = parent.viewModel.captureCurrentPositionAnchor()
+          target = resolvedItem(for: modelAnchor).map { (modelAnchor, $0) }
+        } else {
+          target = nil
+        }
+
+        guard let target, let targetSpreadIndex = spreadIndex(for: target.item) else {
+          if let explicitTarget {
+            let modelSnapshot = PageCurlViewItemsSnapshot(items: parent.viewModel.viewItems)
+            if viewItemsSnapshot == modelSnapshot {
+              retriedNavigationTarget = nil
+              scheduleNavigationContinuation(
+                consuming: explicitTarget,
+                on: pageViewController
+              )
+            }
+          }
+          return
+        }
+        let currentSpreadIndex = currentResolvedSpreadIndex() ?? targetSpreadIndex
+
+        guard targetSpreadIndex != currentSpreadIndex else {
+          currentItem = target.item
+          if let explicitTarget {
+            retriedNavigationTarget = nil
+            commitCurrentItem(target.item, preserving: explicitTarget)
+            scheduleNavigationContinuation(
+              consuming: explicitTarget,
+              on: pageViewController
+            )
+          }
+          return
+        }
+
+        guard let targetPair = pageControllerPair(for: targetSpreadIndex) else {
+          if let explicitTarget {
+            retriedNavigationTarget = nil
+            scheduleNavigationContinuation(
+              consuming: explicitTarget,
+              on: pageViewController
+            )
+          }
+          return
+        }
+
+        let direction: UIPageViewController.NavigationDirection
+        if parent.mode.isRTL {
+          direction = targetSpreadIndex > currentSpreadIndex ? .reverse : .forward
+        } else {
+          direction = targetSpreadIndex > currentSpreadIndex ? .forward : .reverse
+        }
+
+        let token = beginTransition()
+        let shouldAnimateTransition = hasCompletedInitialUpdate && parent.animateTapTurns
+        PageCurlControllerPlanner.safeSetViewControllers(
+          targetPair,
+          on: pageViewController,
+          direction: direction,
+          animated: shouldAnimateTransition
+        ) { [weak self, weak pageViewController] completed in
+          guard let self, let pageViewController else { return }
+          self.finishProgrammaticTransition(
+            token: token,
+            completed: completed || !shouldAnimateTransition,
+            targetItem: target.item,
+            targetAnchor: target.anchor,
+            consumedNavigationTarget: explicitTarget,
+            pageViewController: pageViewController,
+            direction: direction
+          )
+        }
+      }
+
+      func finishProgrammaticTransition(
+        token: Int,
+        completed: Bool,
+        targetItem: ReaderViewItem,
+        targetAnchor: ReaderPositionAnchor,
+        consumedNavigationTarget: ReaderPositionAnchor?,
+        pageViewController: UIPageViewController,
+        direction: UIPageViewController.NavigationDirection
+      ) {
+        guard isActive,
+          token == transitionToken,
+          self.pageViewController === pageViewController
+        else { return }
+        isTransitioning = false
+        transitionTargetItem = nil
+
+        if completed {
+          retriedNavigationTarget = nil
+          let anchor = localAnchor(for: targetItem, preserving: targetAnchor)
+          let pendingAnchor: ReaderPositionAnchor
+          if consumedNavigationTarget != nil,
+            let pendingViewItemsSnapshot,
+            pendingViewItemsSnapshot.matchingItem(for: anchor) == nil
+          {
+            pendingAnchor = parent.viewModel.captureCurrentPositionAnchor()
+          } else {
+            pendingAnchor = anchor
+          }
+          applyPendingViewItemsSnapshot(preferredAnchor: pendingAnchor)
+
+          let committedItem =
+            consumedNavigationTarget == nil
+            ? viewItemsSnapshot.resolvedItem(for: anchor)
+            : viewItemsSnapshot.matchingItem(for: anchor)
+          if let committedItem,
+            let committedSpreadIndex = viewItemsSnapshot.index(for: committedItem)
+          {
+            if let committedPair = pageControllerPair(for: committedSpreadIndex) {
+              PageCurlControllerPlanner.safeSetViewControllers(
+                committedPair,
+                on: pageViewController,
+                direction: direction,
+                animated: false
+              )
+            }
+            commitCurrentItem(committedItem, preserving: anchor)
+          } else {
+            refreshVisibleControllerConfiguration()
+          }
+          scheduleNavigationContinuation(
+            consuming: consumedNavigationTarget,
+            on: pageViewController
+          )
+        } else {
+          syncCurrentItemWithVisibleController()
+          let anchor = currentPositionAnchor()
+          applyPendingViewItemsSnapshot(preferredAnchor: anchor)
+          refreshVisibleControllerConfiguration()
+          if let consumedNavigationTarget,
+            retriedNavigationTarget != consumedNavigationTarget
+          {
+            retriedNavigationTarget = consumedNavigationTarget
+            scheduleNavigationContinuation(consuming: nil, on: pageViewController)
+          }
+        }
+      }
+
+      func scheduleNavigationContinuation(
+        consuming target: ReaderPositionAnchor?,
+        on pageViewController: UIPageViewController
+      ) {
+        if let target {
+          consumedNavigationTarget = target
+        }
+        guard navigationContinuationTask == nil else { return }
+
+        navigationContinuationTask = Task { @MainActor [weak self, weak pageViewController] in
+          await Task.yield()
+          guard !Task.isCancelled,
+            let self,
+            let pageViewController,
+            self.isActive,
+            self.pageViewController === pageViewController
+          else { return }
+
+          let consumedTarget = self.consumedNavigationTarget
+          self.consumedNavigationTarget = nil
+          self.navigationContinuationTask = nil
+          if let consumedTarget {
+            self.parent.viewModel.clearNavigationTarget(matching: consumedTarget)
+          }
+          self.processNavigationTarget(on: pageViewController)
+        }
+      }
+
+      private func localAnchor(
+        for item: ReaderViewItem,
+        preserving anchor: ReaderPositionAnchor?
+      ) -> ReaderPositionAnchor {
+        let focusedPageID: ReaderPageID?
+        if let preferredPageID = anchor?.focusedPageID,
+          item.pageIDs.contains(preferredPageID) || item.pageID == preferredPageID
+        {
+          focusedPageID = preferredPageID
+        } else {
+          focusedPageID = item.pageID
+        }
+        return ReaderPositionAnchor(item: item, focusedPageID: focusedPageID)
+      }
+
+      private func currentPositionAnchor() -> ReaderPositionAnchor {
+        let focusedPageID = parent.viewModel.captureCurrentPositionAnchor().focusedPageID
+        return ReaderPositionAnchor(item: currentItem, focusedPageID: focusedPageID)
+      }
+
+      private func commitCurrentItem(
+        _ item: ReaderViewItem,
+        preserving preferredAnchor: ReaderPositionAnchor?
+      ) {
+        guard isActive else { return }
+        currentItem = item
+        let anchor = localAnchor(for: item, preserving: preferredAnchor)
+        parent.viewModel.updateCurrentPosition(anchor: anchor)
+
+        preloadTask?.cancel()
+        let token = transitionToken
+        let viewModel = parent.viewModel
+        preloadTask = Task(priority: .utility) { @MainActor [weak self, weak viewModel] in
+          guard !Task.isCancelled,
+            let self,
+            self.isActive,
+            token == self.transitionToken,
+            self.currentItem == item,
+            let viewModel
+          else { return }
+          await viewModel.preloadPages()
+        }
+      }
+
+      func teardown(pageViewController: UIPageViewController) {
+        guard isActive else { return }
+        isActive = false
+        transitionToken += 1
+        isTransitioning = false
+        hasCompletedInitialUpdate = false
+        transitionTargetItem = nil
+        pendingViewItemsSnapshot = nil
+
+        preloadTask?.cancel()
+        preloadTask = nil
+        navigationContinuationTask?.cancel()
+        navigationContinuationTask = nil
+        consumedNavigationTarget = nil
+        retriedNavigationTarget = nil
+
+        pageViewController.dataSource = nil
+        pageViewController.delegate = nil
+        for recognizer in pageViewController.gestureRecognizers where recognizer.delegate === self {
+          recognizer.delegate = nil
+        }
+        for recognizer in installedTapRecognizers {
+          recognizer.view?.removeGestureRecognizer(recognizer)
+        }
+        installedTapRecognizers.removeAll()
+        doubleTapRecognizer = nil
+        controllerIdentities.removeAllObjects()
+        currentItem = nil
+        self.pageViewController = nil
       }
 
       private func beforeSpreadIndex(from spreadIndex: Int) -> Int {
@@ -274,7 +501,7 @@
       private func isFirstSpreadInSegment(_ spreadIndex: Int) -> Bool {
         guard spreadIndex >= 0 else { return false }
         if spreadIndex == 0 { return true }
-        guard let previousItem = parent.viewModel.viewItem(at: spreadIndex - 1) else { return false }
+        guard let previousItem = viewItemsSnapshot.item(at: spreadIndex - 1) else { return false }
         if case .end = previousItem {
           return true
         }
@@ -284,7 +511,7 @@
       private func isLastSpreadInSegment(_ spreadIndex: Int) -> Bool {
         guard spreadIndex >= 0 else { return false }
         if spreadIndex >= totalSpreads - 1 { return true }
-        guard let nextItem = parent.viewModel.viewItem(at: spreadIndex + 1) else { return false }
+        guard let nextItem = viewItemsSnapshot.item(at: spreadIndex + 1) else { return false }
         if case .end = nextItem {
           return true
         }
@@ -319,7 +546,7 @@
 
       private func slotContent(for spreadIndex: Int, slot: SpreadSlot) -> SlotContent? {
         guard isValidSpreadIndex(spreadIndex) else { return nil }
-        guard let item = parent.viewModel.viewItem(at: spreadIndex) else { return nil }
+        guard let item = viewItemsSnapshot.item(at: spreadIndex) else { return nil }
 
         switch item {
         case .dual(let firstID, let secondID):
@@ -379,6 +606,31 @@
         let placeholder = UIViewController()
         placeholder.view.backgroundColor = UIColor(parent.renderConfig.readerBackground.color)
         return placeholder
+      }
+
+      private func registerIdentity(
+        for controller: UIViewController,
+        item: ReaderViewItem,
+        role: PageCurlControllerIdentity.Role,
+        slot: SpreadSlot
+      ) {
+        controllerIdentities.setObject(
+          PageCurlControllerIdentity(item: item, role: role, slot: slot.rawValue),
+          forKey: controller
+        )
+      }
+
+      private func controllerMetadata(
+        for controller: UIViewController
+      ) -> (item: ReaderViewItem, slot: SpreadSlot, role: PageCurlControllerIdentity.Role)? {
+        guard let identity = controllerIdentities.object(forKey: controller),
+          let item = identity.item,
+          let slotRawValue = identity.slot,
+          let slot = SpreadSlot(rawValue: slotRawValue)
+        else {
+          return nil
+        }
+        return (item: item, slot: slot, role: identity.role)
       }
 
       private func configureImageController(
@@ -441,16 +693,21 @@
           configureEndController(endController, segmentBookId: segmentBookId, slot: slot)
           return true
         case .placeholder:
+          guard !(controller is NativeImagePageViewController),
+            !(controller is NativeEndPageViewController)
+          else { return false }
           controller.view.backgroundColor = UIColor(parent.renderConfig.readerBackground.color)
           return true
         }
       }
 
       private func pageController(for spreadIndex: Int, slot: SpreadSlot) -> UIViewController? {
-        guard parent.viewModel.hasPages else { return nil }
+        guard !viewItemsSnapshot.isEmpty else { return nil }
+        guard let item = viewItemsSnapshot.item(at: spreadIndex) else { return nil }
         guard let content = slotContent(for: spreadIndex, slot: slot) else { return nil }
 
         let controller: UIViewController
+        let role: PageCurlControllerIdentity.Role
         switch content {
         case .page(let pageID, let splitMode):
           let imageController = NativeImagePageViewController()
@@ -461,15 +718,18 @@
             alignment: spineAlignment(for: slot)
           )
           controller = imageController
+          role = .content
         case .end(let segmentBookId):
           let endController = NativeEndPageViewController()
           configureEndController(endController, segmentBookId: segmentBookId, slot: slot)
           controller = endController
+          role = .content
         case .placeholder:
           controller = makePlaceholderController()
+          role = .placeholder
         }
 
-        parent.applyMetadata(to: controller, spreadIndex: spreadIndex, slot: slot)
+        registerIdentity(for: controller, item: item, role: role, slot: slot)
         return controller
       }
 
@@ -482,44 +742,54 @@
         return [first, second]
       }
 
-      private func spreadIndices(
+      private func spreadItems(
         from controllers: [UIViewController]
-      ) -> [Int] {
-        controllers.compactMap { parent.decodedMetadata(for: $0)?.spreadIndex }
+      ) -> [ReaderViewItem] {
+        var seenItems: Set<ReaderViewItem> = []
+        return controllers.compactMap { controller in
+          guard let item = controllerMetadata(for: controller)?.item,
+            seenItems.insert(item).inserted
+          else { return nil }
+          return item
+        }
       }
 
-      private func resolvedSpreadIndex(for item: ReaderViewItem?) -> Int? {
-        guard let item = parent.viewModel.resolvedViewItem(for: item) else { return nil }
-        return parent.viewModel.viewItemIndex(for: item)
+      private func exactSpreadIndex(for item: ReaderViewItem?) -> Int? {
+        guard let item else { return nil }
+        return viewItemsSnapshot.index(for: item)
       }
 
       func currentResolvedSpreadIndex() -> Int? {
-        resolvedSpreadIndex(for: currentItem)
+        guard let currentItem else { return nil }
+        let focusedPageID = parent.viewModel.captureCurrentPositionAnchor().focusedPageID
+        return viewItemsSnapshot.index(
+          for: ReaderPositionAnchor(item: currentItem, focusedPageID: focusedPageID)
+        )
       }
 
       private func resolvedVisibleSpreadIndex() -> Int? {
         guard let visibleControllers = pageViewController?.viewControllers else { return nil }
-        let uniqueIndices = Array(Set(spreadIndices(from: visibleControllers))).sorted()
-        guard !uniqueIndices.isEmpty else { return nil }
-        if uniqueIndices.count == 1 {
-          return uniqueIndices[0]
+        let uniqueItems = spreadItems(from: visibleControllers)
+        guard !uniqueItems.isEmpty else { return nil }
+        if uniqueItems.count == 1 {
+          return exactSpreadIndex(for: uniqueItems[0])
         }
-        if let transitionTargetSpreadIndex = resolvedSpreadIndex(for: transitionTargetItem),
-          uniqueIndices.contains(transitionTargetSpreadIndex)
+        if let transitionTargetSpreadIndex = exactSpreadIndex(for: transitionTargetItem),
+          uniqueItems.contains(where: { exactSpreadIndex(for: $0) == transitionTargetSpreadIndex })
         {
           return transitionTargetSpreadIndex
         }
         if let currentSpreadIndex = currentResolvedSpreadIndex(),
-          uniqueIndices.contains(currentSpreadIndex)
+          uniqueItems.contains(where: { exactSpreadIndex(for: $0) == currentSpreadIndex })
         {
           return currentSpreadIndex
         }
-        return uniqueIndices[0]
+        return uniqueItems.compactMap { exactSpreadIndex(for: $0) }.first
       }
 
       func syncCurrentItemWithVisibleController() {
         if let visibleSpreadIndex = resolvedVisibleSpreadIndex() {
-          currentItem = parent.viewModel.viewItem(at: visibleSpreadIndex)
+          currentItem = viewItemsSnapshot.item(at: visibleSpreadIndex)
         }
       }
 
@@ -527,15 +797,17 @@
         guard !isTransitioning else { return }
         guard let pageViewController else { return }
         guard let visibleControllers = pageViewController.viewControllers else { return }
-        guard let spreadIndex = resolvedVisibleSpreadIndex() else { return }
+        guard let spreadIndex = resolvedVisibleSpreadIndex() ?? currentResolvedSpreadIndex() else { return }
 
         var needsReplacement = false
         for controller in visibleControllers {
-          guard let metadata = parent.decodedMetadata(for: controller) else {
+          guard let metadata = controllerMetadata(for: controller) else {
             needsReplacement = true
             break
           }
-          if metadata.spreadIndex != spreadIndex {
+          guard let expectedItem = viewItemsSnapshot.item(at: spreadIndex),
+            metadata.item == expectedItem
+          else {
             needsReplacement = true
             break
           }
@@ -561,16 +833,18 @@
         _ pageViewController: UIPageViewController,
         viewControllerBefore viewController: UIViewController
       ) -> UIViewController? {
-        guard let metadata = parent.decodedMetadata(for: viewController) else { return nil }
+        guard let metadata = controllerMetadata(for: viewController),
+          let spreadIndex = viewItemsSnapshot.index(for: metadata.item)
+        else { return nil }
 
         switch metadata.slot {
         case .first:
-          let targetSpreadIndex = beforeSpreadIndex(from: metadata.spreadIndex)
+          let targetSpreadIndex = beforeSpreadIndex(from: spreadIndex)
           guard isValidSpreadIndex(targetSpreadIndex) else { return nil }
           return pageController(for: targetSpreadIndex, slot: .second)
         case .second:
-          guard isValidSpreadIndex(metadata.spreadIndex) else { return nil }
-          return pageController(for: metadata.spreadIndex, slot: .first)
+          guard isValidSpreadIndex(spreadIndex) else { return nil }
+          return pageController(for: spreadIndex, slot: .first)
         }
       }
 
@@ -578,14 +852,16 @@
         _ pageViewController: UIPageViewController,
         viewControllerAfter viewController: UIViewController
       ) -> UIViewController? {
-        guard let metadata = parent.decodedMetadata(for: viewController) else { return nil }
+        guard let metadata = controllerMetadata(for: viewController),
+          let spreadIndex = viewItemsSnapshot.index(for: metadata.item)
+        else { return nil }
 
         switch metadata.slot {
         case .first:
-          guard isValidSpreadIndex(metadata.spreadIndex) else { return nil }
-          return pageController(for: metadata.spreadIndex, slot: .second)
+          guard isValidSpreadIndex(spreadIndex) else { return nil }
+          return pageController(for: spreadIndex, slot: .second)
         case .second:
-          let targetSpreadIndex = afterSpreadIndex(from: metadata.spreadIndex)
+          let targetSpreadIndex = afterSpreadIndex(from: spreadIndex)
           guard isValidSpreadIndex(targetSpreadIndex) else { return nil }
           return pageController(for: targetSpreadIndex, slot: .first)
         }
@@ -597,13 +873,13 @@
         _ pageViewController: UIPageViewController,
         willTransitionTo pendingViewControllers: [UIViewController]
       ) {
-        isTransitioning = true
-        let pendingIndices = Array(Set(spreadIndices(from: pendingViewControllers))).sorted()
-        let currentSpreadIndex = currentResolvedSpreadIndex()
-        if let explicitTarget = pendingIndices.first(where: { $0 != currentSpreadIndex }) {
-          transitionTargetItem = parent.viewModel.viewItem(at: explicitTarget)
+        guard isActive, self.pageViewController === pageViewController else { return }
+        _ = beginTransition()
+        let pendingItems = spreadItems(from: pendingViewControllers)
+        if let explicitTarget = pendingItems.first(where: { $0 != currentItem }) {
+          transitionTargetItem = explicitTarget
         } else {
-          transitionTargetItem = pendingIndices.first.flatMap { parent.viewModel.viewItem(at: $0) }
+          transitionTargetItem = pendingItems.first
         }
       }
 
@@ -613,25 +889,47 @@
         previousViewControllers: [UIViewController],
         transitionCompleted completed: Bool
       ) {
+        guard isActive, self.pageViewController === pageViewController else { return }
         isTransitioning = false
         syncCurrentItemWithVisibleController()
 
         guard completed else {
           transitionTargetItem = nil
+          let anchor = currentPositionAnchor()
+          applyPendingViewItemsSnapshot(preferredAnchor: anchor)
+          refreshVisibleControllerConfiguration()
+          scheduleNavigationContinuation(consuming: nil, on: pageViewController)
           return
         }
 
-        guard
-          let committedSpreadIndex =
-            resolvedSpreadIndex(for: transitionTargetItem)
-            ?? resolvedVisibleSpreadIndex()
-            ?? currentResolvedSpreadIndex()
-        else {
-          transitionTargetItem = nil
+        let committedCandidate = transitionTargetItem ?? currentItem
+        transitionTargetItem = nil
+        guard let committedCandidate else {
+          let anchor = parent.viewModel.captureCurrentPositionAnchor()
+          applyPendingViewItemsSnapshot(preferredAnchor: anchor)
+          refreshVisibleControllerConfiguration()
+          scheduleNavigationContinuation(consuming: nil, on: pageViewController)
           return
         }
-        transitionTargetItem = nil
-        guard isValidSpreadIndex(committedSpreadIndex) else { return }
+
+        let anchor = localAnchor(
+          for: committedCandidate,
+          preserving: currentPositionAnchor()
+        )
+        applyPendingViewItemsSnapshot(preferredAnchor: anchor)
+        let committedItem =
+          viewItemsSnapshot.matchingItem(for: anchor)
+          ?? viewItemsSnapshot.resolvedItem(
+            for: parent.viewModel.captureCurrentPositionAnchor()
+          )
+        guard let committedItem,
+          let committedSpreadIndex = viewItemsSnapshot.index(for: committedItem),
+          isValidSpreadIndex(committedSpreadIndex)
+        else {
+          refreshVisibleControllerConfiguration()
+          scheduleNavigationContinuation(consuming: nil, on: pageViewController)
+          return
+        }
 
         if let committedPair = pageControllerPair(for: committedSpreadIndex) {
           PageCurlControllerPlanner.safeSetViewControllers(
@@ -642,14 +940,8 @@
           )
         }
 
-        currentItem = parent.viewModel.viewItem(at: committedSpreadIndex)
-        let viewModel = parent.viewModel
-        Task { @MainActor in
-          viewModel.updateCurrentPosition(viewItem: currentItem)
-        }
-        Task(priority: .utility) { @MainActor in
-          await viewModel.preloadPages()
-        }
+        commitCurrentItem(committedItem, preserving: anchor)
+        scheduleNavigationContinuation(consuming: nil, on: pageViewController)
       }
 
       func pageViewController(

--- a/KMReader/Features/Reader/Views/CurlPageView.swift
+++ b/KMReader/Features/Reader/Views/CurlPageView.swift
@@ -3,6 +3,7 @@
 //
 
 #if os(iOS)
+  import Foundation
   import SwiftUI
   import UIKit
 
@@ -23,17 +24,16 @@
 
     func makeUIViewController(context: Context) -> UIPageViewController {
       let spineLocation: UIPageViewController.SpineLocation = mode.isRTL ? .max : .min
-      let pageVC = UIPageViewController(
+      let pageViewController = UIPageViewController(
         transitionStyle: .pageCurl,
         navigationOrientation: mode.isVertical ? .vertical : .horizontal,
         options: [.spineLocation: NSNumber(value: spineLocation.rawValue)]
       )
-      context.coordinator.pageViewController = pageVC
-      pageVC.dataSource = context.coordinator
-      pageVC.delegate = context.coordinator
-      context.coordinator.installTapRecognizers(on: pageVC.view)
 
-      for recognizer in pageVC.gestureRecognizers {
+      context.coordinator.attach(to: pageViewController)
+      context.coordinator.installTapRecognizers(on: pageViewController.view)
+
+      for recognizer in pageViewController.gestureRecognizers {
         recognizer.delegate = context.coordinator
         if recognizer is UITapGestureRecognizer {
           recognizer.isEnabled = false
@@ -41,135 +41,24 @@
       }
 
       PageCurlControllerPlanner.configure(
-        pageViewController: pageVC,
+        pageViewController: pageViewController,
         semanticContentAttribute: mode.isRTL ? .forceRightToLeft : .forceLeftToRight
       )
-      PageCurlBacksideViewController.applyStyle(pageCurlBacksideStyle(), to: pageVC)
+      PageCurlBacksideViewController.applyStyle(pageCurlBacksideStyle(), to: pageViewController)
+      context.coordinator.installInitialControllers(on: pageViewController)
 
-      let initialIndex = viewModel.currentViewItem().flatMap { viewModel.viewItemIndex(for: $0) } ?? 0
-      context.coordinator.currentItem = viewModel.viewItem(at: initialIndex)
-      context.coordinator.updateViewItemsSnapshot(viewModel.viewItems)
-      Task { @MainActor in
-        viewModel.updateCurrentPosition(viewItem: viewModel.viewItem(at: initialIndex))
-      }
-
-      if let initialVC = context.coordinator.pageViewController(for: initialIndex) {
-        let controllers = pageCurlControllers(
-          primary: initialVC,
-          targetIndex: initialIndex,
-          animated: false,
-          in: pageVC
-        )
-        PageCurlControllerPlanner.safeSetViewControllers(
-          controllers,
-          on: pageVC,
-          direction: .forward,
-          animated: false
-        )
-      } else {
-        PageCurlControllerPlanner.safeSetViewControllers(
-          PageCurlControllerPlanner.placeholderControllers(
-            in: pageVC,
-            backgroundColor: UIColor(renderConfig.readerBackground.color)
-          ),
-          on: pageVC,
-          direction: .forward,
-          animated: false
-        )
-      }
-
-      return pageVC
+      return pageViewController
     }
 
-    func updateUIViewController(_ pageVC: UIPageViewController, context: Context) {
-      context.coordinator.parent = self
-      context.coordinator.pageViewController = pageVC
-      context.coordinator.applyDoubleTapRecognizerState()
-      defer { context.coordinator.hasCompletedInitialUpdate = true }
-      PageCurlControllerPlanner.configure(
-        pageViewController: pageVC,
-        semanticContentAttribute: mode.isRTL ? .forceRightToLeft : .forceLeftToRight
-      )
-      PageCurlBacksideViewController.applyStyle(pageCurlBacksideStyle(), to: pageVC)
-      context.coordinator.syncCurrentItemWithVisibleController()
-      let didViewItemsChange = context.coordinator.updateViewItemsSnapshot(viewModel.viewItems)
-      context.coordinator.refreshVisibleControllerConfiguration()
+    func updateUIViewController(_ pageViewController: UIPageViewController, context: Context) {
+      context.coordinator.update(parent: self, pageViewController: pageViewController)
+    }
 
-      let targetViewItemIndex: Int? = {
-        if let explicitTarget = viewModel.navigationTarget.flatMap({ viewModel.resolvedViewItem(for: $0) }) {
-          return viewModel.viewItemIndex(for: explicitTarget)
-        }
-        if didViewItemsChange, let currentItem = viewModel.currentViewItem() {
-          return viewModel.viewItemIndex(for: currentItem)
-        }
-        return nil
-      }()
-
-      guard let targetViewItemIndex else { return }
-      let currentPageIndex = context.coordinator.currentResolvedIndex() ?? targetViewItemIndex
-
-      let clearTargets: () -> Void = {
-        _ = Task { @MainActor in
-          viewModel.clearNavigationTarget()
-        }
-      }
-
-      guard targetViewItemIndex != currentPageIndex else {
-        clearTargets()
-        return
-      }
-
-      guard let targetVC = context.coordinator.pageViewController(for: targetViewItemIndex) else {
-        clearTargets()
-        return
-      }
-
-      guard !context.coordinator.isTransitioning else { return }
-
-      let direction: UIPageViewController.NavigationDirection
-      if mode.isRTL {
-        direction = targetViewItemIndex > currentPageIndex ? .reverse : .forward
-      } else {
-        direction = targetViewItemIndex > currentPageIndex ? .forward : .reverse
-      }
-
-      context.coordinator.isTransitioning = true
-      let shouldAnimateTransition = context.coordinator.hasCompletedInitialUpdate && animateTapTurns
-      let transitionControllers = pageCurlControllers(
-        primary: targetVC,
-        targetIndex: targetViewItemIndex,
-        animated: shouldAnimateTransition,
-        in: pageVC
-      )
-      PageCurlControllerPlanner.safeSetViewControllers(
-        transitionControllers,
-        on: pageVC,
-        direction: direction,
-        animated: shouldAnimateTransition
-      ) { completed in
-        Task { @MainActor in
-          context.coordinator.isTransitioning = false
-          if completed || !shouldAnimateTransition {
-            let committedControllers = pageCurlControllers(
-              primary: targetVC,
-              targetIndex: targetViewItemIndex,
-              animated: false,
-              in: pageVC
-            )
-            PageCurlControllerPlanner.safeSetViewControllers(
-              committedControllers,
-              on: pageVC,
-              direction: direction,
-              animated: false
-            )
-            context.coordinator.currentItem = viewModel.viewItem(at: targetViewItemIndex)
-            viewModel.updateCurrentPosition(
-              viewItem: context.coordinator.currentItem
-            )
-          }
-          viewModel.clearNavigationTarget()
-        }
-      }
+    static func dismantleUIViewController(
+      _ pageViewController: UIPageViewController,
+      coordinator: Coordinator
+    ) {
+      coordinator.teardown(from: pageViewController)
     }
 
     private func pageCurlBacksideStyle() -> PageCurlBacksideViewController.Style {
@@ -182,58 +71,141 @@
       mode.isVertical ? .vertical : .horizontal
     }
 
-    private func pageCurlBacksideController(
-      for targetIndex: Int,
-      mirroredSnapshot: PageCurlBacksideViewController.MirroredSnapshot? = nil
-    ) -> PageCurlBacksideViewController {
-      PageCurlBacksideViewController(
-        destinationToken: String(targetIndex),
-        style: pageCurlBacksideStyle(),
-        mirroredSnapshot: mirroredSnapshot
-      )
-    }
-
-    private func pageCurlControllers(
-      primary: UIViewController,
-      targetIndex: Int,
-      animated: Bool,
-      in pageVC: UIPageViewController
-    ) -> [UIViewController] {
-      PageCurlControllerPlanner.controllers(
-        primary: primary,
-        animated: animated,
-        in: pageVC,
-        makeBackside: {
-          let mirroredSnapshot = PageCurlBacksideViewController.makeMirroredSnapshot(
-            from: primary,
-            axis: pageCurlBacksideMirrorAxis()
-          )
-          return pageCurlBacksideController(
-            for: targetIndex,
-            mirroredSnapshot: mirroredSnapshot
-          )
-        }
-      )
-    }
-
     // MARK: - Coordinator
 
-    class Coordinator: NSObject, UIPageViewControllerDataSource, UIPageViewControllerDelegate,
+    @MainActor
+    final class Coordinator: NSObject, UIPageViewControllerDataSource, UIPageViewControllerDelegate,
       UIGestureRecognizerDelegate
     {
-      var parent: CurlPageView
-      var currentItem: ReaderViewItem?
-      weak var pageViewController: UIPageViewController?
-      var isTransitioning = false
-      var hasCompletedInitialUpdate = false
+      private var parent: CurlPageView
+      private weak var pageViewController: UIPageViewController?
+      private var isActive = false
+      private var isTransitioning = false
+      private var hasCompletedInitialUpdate = false
+      private var currentAnchor: ReaderPositionAnchor?
+      private var renderedSnapshot = PageCurlViewItemsSnapshot(items: [])
+      private var pendingSnapshot: PageCurlViewItemsSnapshot?
+      private var preloadTask: Task<Void, Never>?
+      private var navigationContinuationTask: Task<Void, Never>?
+      private var consumedNavigationTarget: ReaderPositionAnchor?
+      private var retriedNavigationTarget: ReaderPositionAnchor?
+      private let controllerIdentities =
+        NSMapTable<UIViewController, PageCurlControllerIdentity>.weakToStrongObjects()
+      private weak var singleTapRecognizer: UITapGestureRecognizer?
       private weak var doubleTapRecognizer: UITapGestureRecognizer?
-      private var lastViewItemsCount: Int = 0
-      private var lastFirstViewItem: ReaderViewItem?
-      private var lastLastViewItem: ReaderViewItem?
+      private weak var longPressRecognizer: UILongPressGestureRecognizer?
 
       init(_ parent: CurlPageView) {
         self.parent = parent
-        self.currentItem = parent.viewModel.currentViewItem()
+        super.init()
+      }
+
+      func attach(to pageViewController: UIPageViewController) {
+        self.pageViewController = pageViewController
+        isActive = true
+        pageViewController.dataSource = self
+        pageViewController.delegate = self
+      }
+
+      func installInitialControllers(on pageViewController: UIPageViewController) {
+        guard isCurrentAttachment(pageViewController) else { return }
+
+        renderedSnapshot = PageCurlViewItemsSnapshot(items: parent.viewModel.viewItems)
+        let modelAnchor = parent.viewModel.captureCurrentPositionAnchor()
+        guard let item = renderedSnapshot.resolvedItem(for: modelAnchor) else {
+          currentAnchor = nil
+          installPlaceholderControllers(on: pageViewController)
+          return
+        }
+
+        currentAnchor = localAnchor(for: item, preserving: modelAnchor)
+        installContentControllers(
+          for: item,
+          on: pageViewController,
+          direction: .forward,
+          animated: false
+        )
+      }
+
+      func update(parent: CurlPageView, pageViewController: UIPageViewController) {
+        self.parent = parent
+        if !isCurrentAttachment(pageViewController) {
+          attach(to: pageViewController)
+        }
+
+        guard isCurrentAttachment(pageViewController) else { return }
+        defer { hasCompletedInitialUpdate = true }
+
+        applyDoubleTapRecognizerState()
+        PageCurlControllerPlanner.configure(
+          pageViewController: pageViewController,
+          semanticContentAttribute: parent.mode.isRTL ? .forceRightToLeft : .forceLeftToRight
+        )
+        PageCurlBacksideViewController.applyStyle(
+          parent.pageCurlBacksideStyle(),
+          to: pageViewController
+        )
+
+        if !isTransitioning {
+          synchronizeCurrentAnchorWithVisibleController()
+        }
+
+        let newSnapshot = PageCurlViewItemsSnapshot(items: parent.viewModel.viewItems)
+        var didInstallSnapshot = false
+        if isTransitioning {
+          pendingSnapshot = newSnapshot == renderedSnapshot ? nil : newSnapshot
+        } else if newSnapshot != renderedSnapshot {
+          applySnapshot(
+            newSnapshot,
+            preserving: currentAnchor ?? parent.viewModel.captureCurrentPositionAnchor(),
+            on: pageViewController
+          )
+          didInstallSnapshot = true
+        }
+
+        guard !isTransitioning else { return }
+        if !didInstallSnapshot {
+          refreshVisibleControllerConfiguration()
+        }
+        processNavigationTarget(on: pageViewController)
+      }
+
+      func teardown(from pageViewController: UIPageViewController) {
+        guard self.pageViewController === pageViewController else { return }
+
+        isActive = false
+        preloadTask?.cancel()
+        preloadTask = nil
+        navigationContinuationTask?.cancel()
+        navigationContinuationTask = nil
+        consumedNavigationTarget = nil
+        retriedNavigationTarget = nil
+
+        pageViewController.dataSource = nil
+        pageViewController.delegate = nil
+        for recognizer in pageViewController.gestureRecognizers where recognizer.delegate === self {
+          recognizer.delegate = nil
+        }
+
+        let ownedRecognizers: [UIGestureRecognizer?] = [
+          singleTapRecognizer,
+          doubleTapRecognizer,
+          longPressRecognizer,
+        ]
+        for recognizer in ownedRecognizers.compactMap({ $0 }) {
+          recognizer.view?.removeGestureRecognizer(recognizer)
+        }
+        singleTapRecognizer = nil
+        doubleTapRecognizer = nil
+        longPressRecognizer = nil
+
+        controllerIdentities.removeAllObjects()
+        renderedSnapshot = PageCurlViewItemsSnapshot(items: [])
+        pendingSnapshot = nil
+        currentAnchor = nil
+        isTransitioning = false
+        hasCompletedInitialUpdate = false
+        self.pageViewController = nil
       }
 
       func installTapRecognizers(on view: UIView) {
@@ -242,6 +214,7 @@
         singleTap.cancelsTouchesInView = false
         singleTap.delegate = self
         view.addGestureRecognizer(singleTap)
+        singleTapRecognizer = singleTap
 
         let doubleTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTap(_:)))
         doubleTap.numberOfTapsRequired = 2
@@ -256,30 +229,100 @@
         longPress.delegate = self
         singleTap.require(toFail: longPress)
         view.addGestureRecognizer(longPress)
+        longPressRecognizer = longPress
         applyDoubleTapRecognizerState()
       }
 
-      func applyDoubleTapRecognizerState() {
+      private func applyDoubleTapRecognizerState() {
         doubleTapRecognizer?.isEnabled = parent.renderConfig.doubleTapZoomMode.isEnabled
       }
 
-      var totalPages: Int {
-        parent.viewModel.viewItems.count
+      private func isCurrentAttachment(_ pageViewController: UIPageViewController) -> Bool {
+        isActive && self.pageViewController === pageViewController
       }
 
-      @discardableResult
-      func updateViewItemsSnapshot(_ items: [ReaderViewItem]) -> Bool {
-        let firstItem = items.first
-        let lastItem = items.last
-        let didChange =
-          items.count != lastViewItemsCount
-          || firstItem != lastFirstViewItem
-          || lastItem != lastLastViewItem
+      private func localAnchor(
+        for item: ReaderViewItem,
+        preserving anchor: ReaderPositionAnchor?
+      ) -> ReaderPositionAnchor {
+        let focusedPageID: ReaderPageID?
+        if let preferredPageID = anchor?.focusedPageID,
+          item.pageIDs.contains(preferredPageID) || item.pageID == preferredPageID
+        {
+          focusedPageID = preferredPageID
+        } else {
+          focusedPageID = item.pageID
+        }
+        return ReaderPositionAnchor(item: item, focusedPageID: focusedPageID)
+      }
 
-        lastViewItemsCount = items.count
-        lastFirstViewItem = firstItem
-        lastLastViewItem = lastItem
-        return didChange
+      private func applySnapshot(
+        _ snapshot: PageCurlViewItemsSnapshot,
+        preserving anchor: ReaderPositionAnchor,
+        on pageViewController: UIPageViewController
+      ) {
+        guard isCurrentAttachment(pageViewController) else { return }
+
+        renderedSnapshot = snapshot
+        pendingSnapshot = nil
+        guard let item = snapshot.resolvedItem(for: anchor) else {
+          currentAnchor = nil
+          installPlaceholderControllers(on: pageViewController)
+          return
+        }
+
+        currentAnchor = localAnchor(for: item, preserving: anchor)
+        installContentControllers(
+          for: item,
+          on: pageViewController,
+          direction: .forward,
+          animated: false
+        )
+      }
+
+      private func applyPendingSnapshotIfNeeded(
+        preserving anchor: ReaderPositionAnchor? = nil,
+        on pageViewController: UIPageViewController
+      ) {
+        guard let pendingSnapshot else { return }
+        self.pendingSnapshot = nil
+        guard pendingSnapshot != renderedSnapshot else { return }
+
+        applySnapshot(
+          pendingSnapshot,
+          preserving: anchor ?? currentAnchor ?? parent.viewModel.captureCurrentPositionAnchor(),
+          on: pageViewController
+        )
+      }
+
+      private func registerIdentity(
+        _ role: PageCurlControllerIdentity.Role,
+        item: ReaderViewItem?,
+        for controller: UIViewController
+      ) {
+        controllerIdentities.setObject(
+          PageCurlControllerIdentity(item: item, role: role),
+          forKey: controller
+        )
+      }
+
+      private func identity(for controller: UIViewController) -> PageCurlControllerIdentity? {
+        controllerIdentities.object(forKey: controller)
+      }
+
+      private func visibleItem() -> ReaderViewItem? {
+        guard let visibleController = pageViewController?.viewControllers?.first else { return nil }
+        return identity(for: visibleController)?.item
+      }
+
+      private func synchronizeCurrentAnchorWithVisibleController() {
+        guard let item = visibleItem() else { return }
+        currentAnchor = localAnchor(for: item, preserving: currentAnchor)
+      }
+
+      private func currentResolvedIndex() -> Int? {
+        guard let currentAnchor else { return nil }
+        return renderedSnapshot.index(for: currentAnchor)
       }
 
       private func configureImageController(
@@ -326,58 +369,8 @@
         )
       }
 
-      func refreshVisibleControllerConfiguration() {
-        guard !isTransitioning else { return }
-        guard let pageViewController else { return }
-        guard let visibleController = pageViewController.viewControllers?.first else { return }
-        guard let index = resolvedIndex(for: visibleController) else { return }
-        guard let item = parent.viewModel.viewItem(at: index) else { return }
-
-        switch item {
-        case .end(let id):
-          if let endController = visibleController as? NativeEndPageViewController {
-            configureEndController(endController, segmentBookId: id.bookId)
-          } else if let replacement = self.pageViewController(for: index) {
-            let controllers = parent.pageCurlControllers(
-              primary: replacement,
-              targetIndex: index,
-              animated: false,
-              in: pageViewController
-            )
-            PageCurlControllerPlanner.safeSetViewControllers(
-              controllers,
-              on: pageViewController,
-              direction: .forward,
-              animated: false
-            )
-          }
-        case .page, .dual, .split:
-          if let imageController = visibleController as? NativeImagePageViewController {
-            configureImageController(imageController, with: item)
-          } else if let replacement = self.pageViewController(for: index) {
-            let controllers = parent.pageCurlControllers(
-              primary: replacement,
-              targetIndex: index,
-              animated: false,
-              in: pageViewController
-            )
-            PageCurlControllerPlanner.safeSetViewControllers(
-              controllers,
-              on: pageViewController,
-              direction: .forward,
-              animated: false
-            )
-          }
-        }
-      }
-
-      func pageViewController(for index: Int) -> UIViewController? {
-        guard index >= 0 && index < totalPages else { return nil }
-        guard parent.viewModel.hasPages else { return nil }
-        guard let item = parent.viewModel.viewItem(at: index) else { return nil }
-
+      private func makeContentController(for item: ReaderViewItem) -> UIViewController {
         let controller: UIViewController
-
         switch item {
         case .end(let id):
           let endController = NativeEndPageViewController()
@@ -388,9 +381,257 @@
           configureImageController(imageController, with: item)
           controller = imageController
         }
-
-        controller.view.tag = index
+        registerIdentity(.content, item: item, for: controller)
         return controller
+      }
+
+      private func makeBacksideController(
+        for item: ReaderViewItem,
+        mirroredSnapshot: PageCurlBacksideViewController.MirroredSnapshot? = nil
+      ) -> PageCurlBacksideViewController {
+        let controller = PageCurlBacksideViewController(
+          destinationToken: item.pageID.description,
+          style: parent.pageCurlBacksideStyle(),
+          mirroredSnapshot: mirroredSnapshot
+        )
+        registerIdentity(.backside, item: item, for: controller)
+        return controller
+      }
+
+      private func pageCurlControllers(
+        primary: UIViewController,
+        item: ReaderViewItem,
+        animated: Bool,
+        in pageViewController: UIPageViewController
+      ) -> [UIViewController] {
+        PageCurlControllerPlanner.controllers(
+          primary: primary,
+          animated: animated,
+          in: pageViewController,
+          makeBackside: {
+            let mirroredSnapshot = PageCurlBacksideViewController.makeMirroredSnapshot(
+              from: primary,
+              axis: self.parent.pageCurlBacksideMirrorAxis()
+            )
+            return self.makeBacksideController(
+              for: item,
+              mirroredSnapshot: mirroredSnapshot
+            )
+          }
+        )
+      }
+
+      private func installContentControllers(
+        for item: ReaderViewItem,
+        primary: UIViewController? = nil,
+        on pageViewController: UIPageViewController,
+        direction: UIPageViewController.NavigationDirection,
+        animated: Bool
+      ) {
+        let primaryController = primary ?? makeContentController(for: item)
+        let controllers = pageCurlControllers(
+          primary: primaryController,
+          item: item,
+          animated: animated,
+          in: pageViewController
+        )
+        PageCurlControllerPlanner.safeSetViewControllers(
+          controllers,
+          on: pageViewController,
+          direction: direction,
+          animated: animated
+        )
+      }
+
+      private func installPlaceholderControllers(on pageViewController: UIPageViewController) {
+        let controllers = PageCurlControllerPlanner.placeholderControllers(
+          in: pageViewController,
+          backgroundColor: UIColor(parent.renderConfig.readerBackground.color)
+        )
+        for controller in controllers {
+          registerIdentity(.placeholder, item: nil, for: controller)
+        }
+        PageCurlControllerPlanner.safeSetViewControllers(
+          controllers,
+          on: pageViewController,
+          direction: .forward,
+          animated: false
+        )
+      }
+
+      private func refreshVisibleControllerConfiguration() {
+        guard !isTransitioning else { return }
+        guard let pageViewController else { return }
+        guard let visibleController = pageViewController.viewControllers?.first else { return }
+        guard let visibleItem = identity(for: visibleController)?.item,
+          let visibleIndex = renderedSnapshot.index(for: visibleItem),
+          let item = renderedSnapshot.item(at: visibleIndex)
+        else {
+          return
+        }
+
+        switch item {
+        case .end(let id):
+          if let endController = visibleController as? NativeEndPageViewController {
+            configureEndController(endController, segmentBookId: id.bookId)
+          } else {
+            installContentControllers(
+              for: item,
+              on: pageViewController,
+              direction: .forward,
+              animated: false
+            )
+          }
+        case .page, .dual, .split:
+          if let imageController = visibleController as? NativeImagePageViewController {
+            configureImageController(imageController, with: item)
+          } else {
+            installContentControllers(
+              for: item,
+              on: pageViewController,
+              direction: .forward,
+              animated: false
+            )
+          }
+        }
+      }
+
+      private func processNavigationTarget(on pageViewController: UIPageViewController) {
+        guard isCurrentAttachment(pageViewController), !isTransitioning else { return }
+        guard let requestedTarget = parent.viewModel.navigationTarget else { return }
+        guard !renderedSnapshot.isEmpty else { return }
+
+        guard let targetItem = renderedSnapshot.matchingItem(for: requestedTarget),
+          let targetIndex = renderedSnapshot.index(for: targetItem)
+        else {
+          let modelSnapshot = PageCurlViewItemsSnapshot(items: parent.viewModel.viewItems)
+          if renderedSnapshot == modelSnapshot {
+            retriedNavigationTarget = nil
+            scheduleNavigationContinuation(consuming: requestedTarget, on: pageViewController)
+          }
+          return
+        }
+
+        let currentIndex = currentResolvedIndex() ?? targetIndex
+        guard targetIndex != currentIndex else {
+          retriedNavigationTarget = nil
+          commitCurrentPosition(
+            to: targetItem,
+            preserving: requestedTarget,
+            preloadPages: false
+          )
+          scheduleNavigationContinuation(consuming: requestedTarget, on: pageViewController)
+          return
+        }
+
+        let direction: UIPageViewController.NavigationDirection
+        if parent.mode.isRTL {
+          direction = targetIndex > currentIndex ? .reverse : .forward
+        } else {
+          direction = targetIndex > currentIndex ? .forward : .reverse
+        }
+
+        let targetController = makeContentController(for: targetItem)
+        let shouldAnimateTransition = hasCompletedInitialUpdate && parent.animateTapTurns
+        let transitionControllers = pageCurlControllers(
+          primary: targetController,
+          item: targetItem,
+          animated: shouldAnimateTransition,
+          in: pageViewController
+        )
+        isTransitioning = true
+
+        PageCurlControllerPlanner.safeSetViewControllers(
+          transitionControllers,
+          on: pageViewController,
+          direction: direction,
+          animated: shouldAnimateTransition
+        ) { [weak self, weak pageViewController] completed in
+          guard let self, let pageViewController else { return }
+          guard self.isCurrentAttachment(pageViewController) else { return }
+
+          self.isTransitioning = false
+          if completed || !shouldAnimateTransition {
+            self.retriedNavigationTarget = nil
+            self.installContentControllers(
+              for: targetItem,
+              primary: targetController,
+              on: pageViewController,
+              direction: direction,
+              animated: false
+            )
+            self.commitCurrentPosition(
+              to: targetItem,
+              preserving: requestedTarget,
+              preloadPages: false
+            )
+            self.applyPendingSnapshotIfNeeded(
+              preserving: self.parent.viewModel.captureCurrentPositionAnchor(),
+              on: pageViewController
+            )
+            self.scheduleNavigationContinuation(
+              consuming: requestedTarget,
+              on: pageViewController
+            )
+          } else {
+            self.synchronizeCurrentAnchorWithVisibleController()
+            self.applyPendingSnapshotIfNeeded(
+              preserving: self.currentAnchor,
+              on: pageViewController
+            )
+            self.refreshVisibleControllerConfiguration()
+            if self.retriedNavigationTarget != requestedTarget {
+              self.retriedNavigationTarget = requestedTarget
+              self.scheduleNavigationContinuation(consuming: nil, on: pageViewController)
+            }
+          }
+        }
+      }
+
+      private func scheduleNavigationContinuation(
+        consuming target: ReaderPositionAnchor?,
+        on pageViewController: UIPageViewController
+      ) {
+        if let target {
+          consumedNavigationTarget = target
+        }
+        guard navigationContinuationTask == nil else { return }
+
+        navigationContinuationTask = Task { @MainActor [weak self, weak pageViewController] in
+          await Task.yield()
+          guard !Task.isCancelled,
+            let self,
+            let pageViewController,
+            self.isCurrentAttachment(pageViewController)
+          else { return }
+
+          let consumedTarget = self.consumedNavigationTarget
+          self.consumedNavigationTarget = nil
+          self.navigationContinuationTask = nil
+          if let consumedTarget {
+            self.parent.viewModel.clearNavigationTarget(matching: consumedTarget)
+          }
+          self.processNavigationTarget(on: pageViewController)
+        }
+      }
+
+      private func commitCurrentPosition(
+        to item: ReaderViewItem,
+        preserving preferredAnchor: ReaderPositionAnchor?,
+        preloadPages: Bool
+      ) {
+        let anchor = localAnchor(for: item, preserving: preferredAnchor)
+        parent.viewModel.updateCurrentPosition(anchor: anchor)
+        currentAnchor = parent.viewModel.matchingPositionAnchor(for: anchor) ?? anchor
+
+        guard preloadPages else { return }
+        preloadTask?.cancel()
+        let viewModel = parent.viewModel
+        preloadTask = Task { @MainActor [weak self] in
+          await viewModel.preloadPages()
+          guard !Task.isCancelled else { return }
+          self?.preloadTask = nil
+        }
       }
 
       // MARK: - UIPageViewControllerDataSource
@@ -399,46 +640,56 @@
         _ pageViewController: UIPageViewController,
         viewControllerBefore viewController: UIViewController
       ) -> UIViewController? {
-        if let backsideController = viewController as? PageCurlBacksideViewController {
-          guard let targetIndex = Int(backsideController.destinationToken), isValidIndex(targetIndex) else {
-            return nil
-          }
-          return self.pageViewController(for: targetIndex)
+        guard isCurrentAttachment(pageViewController) else { return nil }
+        guard let identity = identity(for: viewController), let item = identity.item else { return nil }
+
+        switch identity.role {
+        case .backside:
+          guard renderedSnapshot.index(for: item) != nil else { return nil }
+          return makeContentController(for: item)
+        case .content:
+          guard let index = renderedSnapshot.index(for: item) else { return nil }
+          let targetIndex = parent.mode.isRTL ? index + 1 : index - 1
+          guard let targetItem = renderedSnapshot.item(at: targetIndex) else { return nil }
+          let mirroredSnapshot = mirroredSnapshotForBackside(
+            targetItem: targetItem,
+            currentController: viewController
+          )
+          return makeBacksideController(
+            for: targetItem,
+            mirroredSnapshot: mirroredSnapshot
+          )
+        case .placeholder:
+          return nil
         }
-        let index = viewController.view.tag
-        let targetIndex = parent.mode.isRTL ? index + 1 : index - 1
-        if !isValidIndex(targetIndex) { return nil }
-        let mirroredSnapshot = mirroredSnapshotForBackside(
-          targetIndex: targetIndex,
-          currentController: viewController
-        )
-        return parent.pageCurlBacksideController(
-          for: targetIndex,
-          mirroredSnapshot: mirroredSnapshot
-        )
       }
 
       func pageViewController(
         _ pageViewController: UIPageViewController,
         viewControllerAfter viewController: UIViewController
       ) -> UIViewController? {
-        if let backsideController = viewController as? PageCurlBacksideViewController {
-          guard let targetIndex = Int(backsideController.destinationToken), isValidIndex(targetIndex) else {
-            return nil
-          }
-          return self.pageViewController(for: targetIndex)
+        guard isCurrentAttachment(pageViewController) else { return nil }
+        guard let identity = identity(for: viewController), let item = identity.item else { return nil }
+
+        switch identity.role {
+        case .backside:
+          guard renderedSnapshot.index(for: item) != nil else { return nil }
+          return makeContentController(for: item)
+        case .content:
+          guard let index = renderedSnapshot.index(for: item) else { return nil }
+          let targetIndex = parent.mode.isRTL ? index - 1 : index + 1
+          guard let targetItem = renderedSnapshot.item(at: targetIndex) else { return nil }
+          let mirroredSnapshot = mirroredSnapshotForBackside(
+            targetItem: targetItem,
+            currentController: viewController
+          )
+          return makeBacksideController(
+            for: targetItem,
+            mirroredSnapshot: mirroredSnapshot
+          )
+        case .placeholder:
+          return nil
         }
-        let index = viewController.view.tag
-        let targetIndex = parent.mode.isRTL ? index - 1 : index + 1
-        if !isValidIndex(targetIndex) { return nil }
-        let mirroredSnapshot = mirroredSnapshotForBackside(
-          targetIndex: targetIndex,
-          currentController: viewController
-        )
-        return parent.pageCurlBacksideController(
-          for: targetIndex,
-          mirroredSnapshot: mirroredSnapshot
-        )
       }
 
       // MARK: - UIPageViewControllerDelegate
@@ -447,6 +698,7 @@
         _ pageViewController: UIPageViewController,
         willTransitionTo pendingViewControllers: [UIViewController]
       ) {
+        guard isCurrentAttachment(pageViewController) else { return }
         isTransitioning = true
       }
 
@@ -456,49 +708,33 @@
         previousViewControllers: [UIViewController],
         transitionCompleted completed: Bool
       ) {
+        guard isCurrentAttachment(pageViewController) else { return }
         isTransitioning = false
-        syncCurrentItemWithVisibleController()
-        guard completed,
-          let visibleController = pageViewController.viewControllers?.first
-        else { return }
 
-        let newIndex: Int
-        if let backsideController = visibleController as? PageCurlBacksideViewController {
-          guard
-            let targetIndex = Int(backsideController.destinationToken),
-            isValidIndex(targetIndex),
-            let targetVC = self.pageViewController(for: targetIndex)
-          else {
-            return
+        if completed, let item = visibleItem() {
+          if let visibleController = pageViewController.viewControllers?.first,
+            let identity = identity(for: visibleController)
+          {
+            if case .backside = identity.role {
+              installContentControllers(
+                for: item,
+                on: pageViewController,
+                direction: .forward,
+                animated: false
+              )
+            }
           }
-          let controllers = parent.pageCurlControllers(
-            primary: targetVC,
-            targetIndex: targetIndex,
-            animated: false,
-            in: pageViewController
+          commitCurrentPosition(
+            to: item,
+            preserving: currentAnchor,
+            preloadPages: true
           )
-          PageCurlControllerPlanner.safeSetViewControllers(
-            controllers,
-            on: pageViewController,
-            direction: .forward,
-            animated: false
-          )
-          newIndex = targetIndex
         } else {
-          let resolvedIndex = visibleController.view.tag
-          guard isValidIndex(resolvedIndex) else { return }
-          newIndex = resolvedIndex
+          synchronizeCurrentAnchorWithVisibleController()
         }
 
-        currentItem = parent.viewModel.viewItem(at: newIndex)
-
-        let viewModel = parent.viewModel
-        Task { @MainActor in
-          viewModel.updateCurrentPosition(viewItem: currentItem)
-        }
-        Task(priority: .utility) { @MainActor in
-          await viewModel.preloadPages()
-        }
+        applyPendingSnapshotIfNeeded(on: pageViewController)
+        scheduleNavigationContinuation(consuming: nil, on: pageViewController)
       }
 
       func pageViewController(
@@ -509,38 +745,6 @@
       }
 
       // MARK: - UIGestureRecognizerDelegate
-
-      private func isValidIndex(_ index: Int) -> Bool {
-        index >= 0 && index < totalPages
-      }
-
-      private func resolvedIndex(for viewController: UIViewController) -> Int? {
-        if let backsideController = viewController as? PageCurlBacksideViewController {
-          guard let targetIndex = Int(backsideController.destinationToken) else { return nil }
-          guard isValidIndex(targetIndex) else { return nil }
-          return targetIndex
-        }
-
-        let index = viewController.view.tag
-        guard isValidIndex(index) else { return nil }
-        return index
-      }
-
-      private func visiblePageIndex() -> Int? {
-        guard let visibleController = pageViewController?.viewControllers?.first else { return nil }
-        return resolvedIndex(for: visibleController)
-      }
-
-      func currentResolvedIndex() -> Int? {
-        guard let currentItem = parent.viewModel.resolvedViewItem(for: currentItem) else { return nil }
-        return parent.viewModel.viewItemIndex(for: currentItem)
-      }
-
-      func syncCurrentItemWithVisibleController() {
-        if let visibleIndex = visiblePageIndex() {
-          currentItem = parent.viewModel.viewItem(at: visibleIndex)
-        }
-      }
 
       private func beforeIndex(from index: Int) -> Int {
         parent.mode.isRTL ? index + 1 : index - 1
@@ -560,26 +764,22 @@
         return parent.mode.isVertical ? velocity.y : velocity.x
       }
 
-      private func isForwardNavigation(from currentIndex: Int, to targetIndex: Int) -> Bool {
-        if parent.mode.isRTL {
-          return targetIndex > currentIndex
-        }
-        return targetIndex > currentIndex
-      }
-
       private func mirroredSnapshotForBackside(
-        targetIndex: Int,
+        targetItem: ReaderViewItem,
         currentController: UIViewController
       ) -> PageCurlBacksideViewController.MirroredSnapshot? {
-        let currentIndex = currentController.view.tag
-        let sourceController: UIViewController
+        guard let currentItem = identity(for: currentController)?.item,
+          let currentIndex = renderedSnapshot.index(for: currentItem),
+          let targetIndex = renderedSnapshot.index(for: targetItem)
+        else {
+          return nil
+        }
 
-        if isForwardNavigation(from: currentIndex, to: targetIndex) {
+        let sourceController: UIViewController
+        if targetIndex > currentIndex {
           sourceController = currentController
-        } else if let targetController = pageViewController(for: targetIndex) {
-          sourceController = targetController
         } else {
-          sourceController = currentController
+          sourceController = makeContentController(for: targetItem)
         }
 
         return PageCurlBacksideViewController.makeMirroredSnapshot(
@@ -620,13 +820,11 @@
         guard !isTransitioning else { return false }
         guard !parent.viewModel.isZoomed else { return false }
 
-        syncCurrentItemWithVisibleController()
-        guard let currentPageIndex = currentResolvedIndex(), isValidIndex(currentPageIndex) else {
-          return false
-        }
+        synchronizeCurrentAnchorWithVisibleController()
+        guard let currentPageIndex = currentResolvedIndex() else { return false }
 
-        let beforeExists = isValidIndex(beforeIndex(from: currentPageIndex))
-        let afterExists = isValidIndex(afterIndex(from: currentPageIndex))
+        let beforeExists = renderedSnapshot.item(at: beforeIndex(from: currentPageIndex)) != nil
+        let afterExists = renderedSnapshot.item(at: afterIndex(from: currentPageIndex)) != nil
 
         if let pan = gestureRecognizer as? UIPanGestureRecognizer {
           let primaryTranslation = primaryTranslation(for: pan)

--- a/KMReader/Features/Reader/Views/DivinaReaderView.swift
+++ b/KMReader/Features/Reader/Views/DivinaReaderView.swift
@@ -589,9 +589,6 @@ struct DivinaReaderView: View {
         usesDualPagePresentation = newValue
         applyDualPagePresentationMode(newValue)
       }
-      .onChange(of: readerPresentationKey(useDualPage: useDualPage)) { _, _ in
-        viewModel.preserveCurrentPageForPresentationRebuild()
-      }
       #if os(tvOS)
         .onPlayPauseCommand {
           logger.debug("📺 onPlayPauseCommand: toggling controls, showingControls=\(showingControls)")
@@ -815,8 +812,8 @@ struct DivinaReaderView: View {
     }
     .animation(ReaderLoadingTransition.animation, value: viewModel.isLoading)
     .animation(ReaderLoadingTransition.animation, value: viewModel.hasPages)
-    .onChange(of: viewModel.currentReaderPage?.id) { _, _ in
-      handleReaderPageChange()
+    .onChange(of: viewModel.currentReaderPage?.id) { oldPageID, newPageID in
+      handleReaderPageChange(from: oldPageID, to: newPageID)
     }
   }
 
@@ -914,15 +911,20 @@ struct DivinaReaderView: View {
     #endif
   }
 
-  private func handleReaderPageChange() {
+  private func handleReaderPageChange(
+    from oldPageID: ReaderPageID?,
+    to newPageID: ReaderPageID?
+  ) {
+    let previousSnapshot = viewModel.captureProgressSnapshot(for: oldPageID)
+    let currentSnapshot = viewModel.captureProgressSnapshot(for: newPageID)
+    if let newPageID {
+      syncPresentedBookIfCrossedSegmentBoundary(toSegmentBookId: newPageID.bookId)
+    }
     updateHandoff()
     #if os(iOS)
       updateReaderLiveActivityProgress()
     #endif
-    // Keep progress sync responsive.
-    Task(priority: .userInitiated) {
-      await viewModel.updateProgress()
-    }
+    viewModel.enqueueProgressChange(from: previousSnapshot, to: currentSnapshot)
     schedulePageMaintenanceAfterPageChange()
     // Treat page changes as user activity: if we're inside the post-
     // resume auto-hide window, restart the timer so the overlay stays
@@ -1608,52 +1610,31 @@ struct DivinaReaderView: View {
       return false
     }
     viewModel.requestNavigation(toViewItem: adjacentItem)
-    syncPresentedBookIfCrossedSegmentBoundary(toSegmentBookId: adjacentItem.pageID.bookId)
     return true
   }
 
-  /// Sync presented-book identity with the segment the user just navigated
-  /// into. Without this, `session.book` stays pinned to the originally-opened
-  /// book; a later rebuild of the reader cover (memory pressure, parent
-  /// dependency churn) re-initializes `currentBookId` from `session.book.id`,
-  /// reruns `loadBook` for the stale book, lands the user at its stale
-  /// `readProgress.page`, and regresses its server-side completed state via
-  /// the ensuing ambient `updateProgress` write. PR #785's body explicitly
-  /// calls out this multi-segment reader scenario as a gap not covered by
-  /// the pending-progress conflict-resolution work.
-  ///
-  /// `currentBookId` is intentionally left untouched so the seamless
-  /// cross-volume UX is preserved — changing it retriggers `.task(id:)` and
-  /// shows a loading overlay mid-flip. Post-cross-boundary invariant:
-  ///   - `currentBookId` is the reader's load anchor (only changed by the
-  ///     explicit Next/Previous Book entry points or a fresh cover init).
-  ///   - `currentBook` / `session.book` follow the segment under the current
-  ///     reader page.
-  ///
-  /// Must be invoked from every view-level call site that hands a navigation
-  /// request to the viewmodel (`requestNavigation(toViewItem:)` /
-  /// `requestNavigation(toPageID:)`), because once the next/previous segment
-  /// has been proactively preloaded by `preloadNextSegmentForCurrentPositionIfNeeded`,
-  /// the common-case page turn near a boundary goes through the direct
-  /// adjacent-item branch in `goToPagedReaderPosition` rather than
-  /// `navigateAcrossBoundaryIfNeeded`.
+  /// Keep the presented-book identity aligned with the committed reader page.
+  /// The whole-book load anchor stays unchanged so seamless segment transitions
+  /// do not retrigger the reader loading task.
   private func syncPresentedBookIfCrossedSegmentBoundary(toSegmentBookId newSegmentBookId: String) {
     guard newSegmentBookId != currentBook?.id,
       let newBook = viewModel.currentBook(forSegmentBookId: newSegmentBookId)
     else {
       return
     }
-    // Flush the outgoing book's progress so any pending terminal state
-    // (e.g. freshly-completed) is durable before further writes for the
-    // new book.
-    viewModel.flushProgress()
     currentBook = newBook
+    if !incognito {
+      readerPresentation.trackVisitedBook(
+        sessionID: sessionID,
+        bookId: newBook.id,
+        seriesId: newBook.seriesId
+      )
+    }
   }
 
   private func jumpToPageID(_ pageID: ReaderPageID) {
     guard pageID != viewModel.currentReaderPage?.id else { return }
     viewModel.requestNavigation(toPageID: pageID)
-    syncPresentedBookIfCrossedSegmentBoundary(toSegmentBookId: pageID.bookId)
   }
 
   private func displayPageNumber(for pageID: ReaderPageID) -> Int {
@@ -1868,7 +1849,6 @@ struct DivinaReaderView: View {
 
     if let item = viewModel.adjacentViewItem(offset: offset) {
       viewModel.requestNavigation(toViewItem: item)
-      syncPresentedBookIfCrossedSegmentBoundary(toSegmentBookId: item.pageID.bookId)
     } else {
       Task { @MainActor in
         _ = await navigateAcrossBoundaryIfNeeded(offset: offset)

--- a/KMReader/Features/Reader/Views/Models/PageCurlControllerIdentity.swift
+++ b/KMReader/Features/Reader/Views/Models/PageCurlControllerIdentity.swift
@@ -1,0 +1,25 @@
+//
+// PageCurlControllerIdentity.swift
+//
+
+#if os(iOS)
+  import Foundation
+
+  final class PageCurlControllerIdentity: NSObject {
+    enum Role {
+      case content
+      case backside
+      case placeholder
+    }
+
+    let item: ReaderViewItem?
+    let role: Role
+    let slot: Int?
+
+    init(item: ReaderViewItem?, role: Role, slot: Int? = nil) {
+      self.item = item
+      self.role = role
+      self.slot = slot
+    }
+  }
+#endif

--- a/KMReader/Features/Reader/Views/Models/PageCurlViewItemsSnapshot.swift
+++ b/KMReader/Features/Reader/Views/Models/PageCurlViewItemsSnapshot.swift
@@ -1,0 +1,72 @@
+//
+// PageCurlViewItemsSnapshot.swift
+//
+
+import Foundation
+
+struct PageCurlViewItemsSnapshot: Equatable {
+  let items: [ReaderViewItem]
+
+  private let indexByItem: [ReaderViewItem: Int]
+  private let indexByPageID: [ReaderPageID: Int]
+
+  init(items: [ReaderViewItem]) {
+    self.items = items
+
+    var itemIndices: [ReaderViewItem: Int] = [:]
+    var pageIndices: [ReaderPageID: Int] = [:]
+    for (index, item) in items.enumerated() {
+      if itemIndices[item] == nil {
+        itemIndices[item] = index
+      }
+      for pageID in item.pageIDs where pageIndices[pageID] == nil {
+        pageIndices[pageID] = index
+      }
+    }
+    self.indexByItem = itemIndices
+    self.indexByPageID = pageIndices
+  }
+
+  var count: Int {
+    items.count
+  }
+
+  var isEmpty: Bool {
+    items.isEmpty
+  }
+
+  func item(at index: Int) -> ReaderViewItem? {
+    guard items.indices.contains(index) else { return nil }
+    return items[index]
+  }
+
+  func index(for item: ReaderViewItem) -> Int? {
+    indexByItem[item]
+  }
+
+  func matchingItem(for anchor: ReaderPositionAnchor) -> ReaderViewItem? {
+    if let item = anchor.item, indexByItem[item] != nil {
+      return item
+    }
+    if let focusedPageID = anchor.focusedPageID,
+      let index = indexByPageID[focusedPageID]
+    {
+      return item(at: index)
+    }
+    if let pageID = anchor.item?.pageID,
+      let index = indexByPageID[pageID]
+    {
+      return item(at: index)
+    }
+    return nil
+  }
+
+  func resolvedItem(for anchor: ReaderPositionAnchor) -> ReaderViewItem? {
+    matchingItem(for: anchor) ?? items.first
+  }
+
+  func index(for anchor: ReaderPositionAnchor) -> Int? {
+    guard let item = resolvedItem(for: anchor) else { return nil }
+    return index(for: item)
+  }
+}

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_iOS.swift
@@ -122,7 +122,7 @@
             // during the pan itself it is false, so an unguarded tap would call
             // `commitTransition` mid-drag and override the user's gesture.
             if isUserPanning {
-              parent.viewModel.clearNavigationTarget()
+              clearNavigationTargetIfMatching(navigationTarget)
             } else {
               handleNavigationTarget(navigationTarget)
             }
@@ -376,22 +376,19 @@
         applyCurrentItem(resolved)
       }
 
-      private func resolveNavigationTarget(_ target: ReaderViewItem) -> ReaderViewItem? {
-        if let exactIndex = parent.viewModel.viewItemIndex(for: target) {
-          return parent.viewModel.viewItem(at: exactIndex)
-        }
-        return parent.viewModel.viewItem(for: target.pageID)
+      private func resolveNavigationTarget(_ target: ReaderPositionAnchor) -> ReaderPositionAnchor? {
+        parent.viewModel.matchingPositionAnchor(for: target)
       }
 
-      private func clearNavigationTargetIfConsumed(_ consumedItem: ReaderViewItem) {
-        guard let navigationTarget = parent.viewModel.navigationTarget else { return }
-        guard resolveNavigationTarget(navigationTarget) == consumedItem else { return }
-        parent.viewModel.clearNavigationTarget()
+      private func clearNavigationTargetIfMatching(_ target: ReaderPositionAnchor) {
+        parent.viewModel.clearNavigationTarget(matching: target)
       }
 
-      private func handleNavigationTarget(_ target: ReaderViewItem) {
-        guard let targetItem = resolveNavigationTarget(target) else {
-          parent.viewModel.clearNavigationTarget()
+      private func handleNavigationTarget(_ target: ReaderPositionAnchor) {
+        guard let targetAnchor = resolveNavigationTarget(target),
+          let targetItem = targetAnchor.item
+        else {
+          clearNavigationTargetIfMatching(target)
           return
         }
 
@@ -399,34 +396,40 @@
           deckState.rebuild(around: targetItem, viewModel: parent.viewModel)
           syncSlotContent()
           updateSlotLayout()
-          applyCurrentItem(targetItem)
-          clearNavigationTargetIfConsumed(targetItem)
+          applyCurrentPosition(targetAnchor)
+          clearNavigationTargetIfMatching(target)
           return
         }
 
         guard let currentIndex = parent.viewModel.viewItemIndex(for: currentItem),
           let targetIndex = parent.viewModel.viewItemIndex(for: targetItem)
         else {
-          parent.viewModel.clearNavigationTarget()
+          clearNavigationTargetIfMatching(target)
           return
         }
 
         guard targetIndex != currentIndex else {
-          parent.viewModel.clearNavigationTarget()
+          applyCurrentPosition(targetAnchor)
+          clearNavigationTargetIfMatching(target)
           return
         }
 
         if abs(targetIndex - currentIndex) == 1 {
           dragOffset = 0
-          commitTransition(to: targetItem, animation: .tapNavigation)
+          commitTransition(
+            to: targetItem,
+            positionAnchor: targetAnchor,
+            navigationTarget: target,
+            animation: .tapNavigation
+          )
         } else {
           deckState.rebuild(around: targetItem, viewModel: parent.viewModel)
           transitionDirection = nil
           dragOffset = 0
           syncSlotContent()
           updateSlotLayout()
-          applyCurrentItem(targetItem)
-          clearNavigationTargetIfConsumed(targetItem)
+          applyCurrentPosition(targetAnchor)
+          clearNavigationTargetIfMatching(target)
         }
       }
 
@@ -501,13 +504,19 @@
 
       private func commitTransition(
         to targetItem: ReaderViewItem,
+        positionAnchor: ReaderPositionAnchor? = nil,
+        navigationTarget: ReaderPositionAnchor? = nil,
         animation: TransitionAnimationKind
       ) {
         guard let currentItem,
           let currentIndex = parent.viewModel.viewItemIndex(for: currentItem),
           let targetIndex = parent.viewModel.viewItemIndex(for: targetItem)
         else {
-          completeTransition(to: targetItem)
+          completeTransition(
+            to: targetItem,
+            positionAnchor: positionAnchor,
+            navigationTarget: navigationTarget
+          )
           return
         }
 
@@ -526,7 +535,11 @@
 
         if targetIndex > currentIndex {
           animateDragOffset(to: endOffset, duration: duration, token: token) {
-            self.completeTransition(to: targetItem)
+            self.completeTransition(
+              to: targetItem,
+              positionAnchor: positionAnchor,
+              navigationTarget: navigationTarget
+            )
           }
         } else {
           if abs(dragOffset) < TransitionMetrics.cancelThreshold {
@@ -534,12 +547,20 @@
             updateSlotLayout()
           }
           animateDragOffset(to: 0, duration: duration, token: token) {
-            self.completeTransition(to: targetItem)
+            self.completeTransition(
+              to: targetItem,
+              positionAnchor: positionAnchor,
+              navigationTarget: navigationTarget
+            )
           }
         }
       }
 
-      private func completeTransition(to targetItem: ReaderViewItem) {
+      private func completeTransition(
+        to targetItem: ReaderViewItem,
+        positionAnchor: ReaderPositionAnchor?,
+        navigationTarget: ReaderPositionAnchor?
+      ) {
         let direction = transitionDirection ?? 1
         deckState.rotateAfterCommit(
           to: targetItem,
@@ -551,8 +572,14 @@
         isAnimatingTransition = false
         syncSlotContent()
         updateSlotLayout()
-        applyCurrentItem(targetItem)
-        clearNavigationTargetIfConsumed(targetItem)
+        if let positionAnchor {
+          applyCurrentPosition(positionAnchor)
+        } else {
+          applyCurrentItem(targetItem)
+        }
+        if let navigationTarget {
+          clearNavigationTargetIfMatching(navigationTarget)
+        }
         applyPanRecognizerState()
         // A freshly committed page is never zoomed. Clear any stale scale left on
         // a slot that was zoomed while the transition animation was in flight
@@ -637,9 +664,18 @@
       }
 
       private func applyCurrentItem(_ item: ReaderViewItem) {
+        let currentAnchor = parent.viewModel.captureCurrentPositionAnchor()
+        let focusedPageID = currentAnchor.item == item ? currentAnchor.focusedPageID : item.pageID
+        applyCurrentPosition(
+          ReaderPositionAnchor(item: item, focusedPageID: focusedPageID)
+        )
+      }
+
+      private func applyCurrentPosition(_ anchor: ReaderPositionAnchor) {
+        guard let item = anchor.item else { return }
         postTransitionTask?.cancel()
         let token = transitionToken
-        parent.viewModel.updateCurrentPosition(viewItem: item)
+        parent.viewModel.updateCurrentPosition(anchor: anchor)
 
         postTransitionTask = Task(priority: .utility) {
           guard !Task.isCancelled else { return }

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_macOS.swift
@@ -123,7 +123,7 @@
             // during the pan itself it is false, so an unguarded tap would call
             // `commitTransition` mid-drag and override the user's gesture.
             if isUserPanning {
-              parent.viewModel.clearNavigationTarget()
+              clearNavigationTargetIfMatching(navigationTarget)
             } else {
               handleNavigationTarget(navigationTarget)
             }
@@ -361,22 +361,19 @@
         applyCurrentItem(resolved)
       }
 
-      private func resolveNavigationTarget(_ target: ReaderViewItem) -> ReaderViewItem? {
-        if let exactIndex = parent.viewModel.viewItemIndex(for: target) {
-          return parent.viewModel.viewItem(at: exactIndex)
-        }
-        return parent.viewModel.viewItem(for: target.pageID)
+      private func resolveNavigationTarget(_ target: ReaderPositionAnchor) -> ReaderPositionAnchor? {
+        parent.viewModel.matchingPositionAnchor(for: target)
       }
 
-      private func clearNavigationTargetIfConsumed(_ consumedItem: ReaderViewItem) {
-        guard let navigationTarget = parent.viewModel.navigationTarget else { return }
-        guard resolveNavigationTarget(navigationTarget) == consumedItem else { return }
-        parent.viewModel.clearNavigationTarget()
+      private func clearNavigationTargetIfMatching(_ target: ReaderPositionAnchor) {
+        parent.viewModel.clearNavigationTarget(matching: target)
       }
 
-      private func handleNavigationTarget(_ target: ReaderViewItem) {
-        guard let targetItem = resolveNavigationTarget(target) else {
-          parent.viewModel.clearNavigationTarget()
+      private func handleNavigationTarget(_ target: ReaderPositionAnchor) {
+        guard let targetAnchor = resolveNavigationTarget(target),
+          let targetItem = targetAnchor.item
+        else {
+          clearNavigationTargetIfMatching(target)
           return
         }
 
@@ -384,34 +381,40 @@
           deckState.rebuild(around: targetItem, viewModel: parent.viewModel)
           syncSlotContent()
           updateSlotLayout()
-          applyCurrentItem(targetItem)
-          clearNavigationTargetIfConsumed(targetItem)
+          applyCurrentPosition(targetAnchor)
+          clearNavigationTargetIfMatching(target)
           return
         }
 
         guard let currentIndex = parent.viewModel.viewItemIndex(for: currentItem),
           let targetIndex = parent.viewModel.viewItemIndex(for: targetItem)
         else {
-          parent.viewModel.clearNavigationTarget()
+          clearNavigationTargetIfMatching(target)
           return
         }
 
         guard targetIndex != currentIndex else {
-          parent.viewModel.clearNavigationTarget()
+          applyCurrentPosition(targetAnchor)
+          clearNavigationTargetIfMatching(target)
           return
         }
 
         if abs(targetIndex - currentIndex) == 1 {
           dragOffset = 0
-          commitTransition(to: targetItem, animation: .tapNavigation)
+          commitTransition(
+            to: targetItem,
+            positionAnchor: targetAnchor,
+            navigationTarget: target,
+            animation: .tapNavigation
+          )
         } else {
           deckState.rebuild(around: targetItem, viewModel: parent.viewModel)
           transitionDirection = nil
           dragOffset = 0
           syncSlotContent()
           updateSlotLayout()
-          applyCurrentItem(targetItem)
-          clearNavigationTargetIfConsumed(targetItem)
+          applyCurrentPosition(targetAnchor)
+          clearNavigationTargetIfMatching(target)
         }
       }
 
@@ -486,13 +489,19 @@
 
       private func commitTransition(
         to targetItem: ReaderViewItem,
+        positionAnchor: ReaderPositionAnchor? = nil,
+        navigationTarget: ReaderPositionAnchor? = nil,
         animation: TransitionAnimationKind
       ) {
         guard let currentItem,
           let currentIndex = parent.viewModel.viewItemIndex(for: currentItem),
           let targetIndex = parent.viewModel.viewItemIndex(for: targetItem)
         else {
-          completeTransition(to: targetItem)
+          completeTransition(
+            to: targetItem,
+            positionAnchor: positionAnchor,
+            navigationTarget: navigationTarget
+          )
           return
         }
 
@@ -511,7 +520,11 @@
 
         if targetIndex > currentIndex {
           animateDragOffset(to: endOffset, duration: duration, token: token) {
-            self.completeTransition(to: targetItem)
+            self.completeTransition(
+              to: targetItem,
+              positionAnchor: positionAnchor,
+              navigationTarget: navigationTarget
+            )
           }
         } else {
           animateBackwardCommitWithPreparedStartStateIfNeeded(
@@ -519,12 +532,20 @@
             duration: duration,
             token: token
           ) {
-            self.completeTransition(to: targetItem)
+            self.completeTransition(
+              to: targetItem,
+              positionAnchor: positionAnchor,
+              navigationTarget: navigationTarget
+            )
           }
         }
       }
 
-      private func completeTransition(to targetItem: ReaderViewItem) {
+      private func completeTransition(
+        to targetItem: ReaderViewItem,
+        positionAnchor: ReaderPositionAnchor?,
+        navigationTarget: ReaderPositionAnchor?
+      ) {
         let direction = transitionDirection ?? 1
         deckState.rotateAfterCommit(
           to: targetItem,
@@ -536,8 +557,14 @@
         isAnimatingTransition = false
         syncSlotContent()
         updateSlotLayout()
-        applyCurrentItem(targetItem)
-        clearNavigationTargetIfConsumed(targetItem)
+        if let positionAnchor {
+          applyCurrentPosition(positionAnchor)
+        } else {
+          applyCurrentItem(targetItem)
+        }
+        if let navigationTarget {
+          clearNavigationTargetIfMatching(navigationTarget)
+        }
         applyPanRecognizerState()
       }
 
@@ -640,9 +667,18 @@
       }
 
       private func applyCurrentItem(_ item: ReaderViewItem) {
+        let currentAnchor = parent.viewModel.captureCurrentPositionAnchor()
+        let focusedPageID = currentAnchor.item == item ? currentAnchor.focusedPageID : item.pageID
+        applyCurrentPosition(
+          ReaderPositionAnchor(item: item, focusedPageID: focusedPageID)
+        )
+      }
+
+      private func applyCurrentPosition(_ anchor: ReaderPositionAnchor) {
+        guard let item = anchor.item else { return }
         postTransitionTask?.cancel()
         let token = transitionToken
-        parent.viewModel.updateCurrentPosition(viewItem: item)
+        parent.viewModel.updateCurrentPosition(anchor: anchor)
 
         postTransitionTask = Task(priority: .utility) {
           guard !Task.isCancelled else { return }

--- a/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_iOS.swift
@@ -164,6 +164,7 @@
       private var needsViewportResyncAfterInteraction = false
       private var pendingProgrammaticTargetOffset: CGPoint?
       private var pendingUserInteractionTargetItem: ReaderViewItem?
+      private var pendingNavigationTarget: ReaderPositionAnchor?
       private var deferredViewModelCommitTask: Task<Void, Never>?
       private var visiblePreloadTask: Task<Void, Never>?
       private var visiblePreloadItem: ReaderViewItem?
@@ -185,6 +186,7 @@
         needsViewportResyncAfterInteraction = false
         pendingProgrammaticTargetOffset = nil
         pendingUserInteractionTargetItem = nil
+        pendingNavigationTarget = nil
         if let applicationWillResignActiveObserver {
           NotificationCenter.default.removeObserver(applicationWillResignActiveObserver)
           self.applicationWillResignActiveObserver = nil
@@ -393,23 +395,25 @@
       }
 
       private func handleNavigationChange(
-        _ navigationTarget: ReaderViewItem,
+        _ navigationTarget: ReaderPositionAnchor,
         in collectionView: UICollectionView
       ) {
         // While the user is in the middle of a swipe (drag or its deceleration), ignore
         // tap-initiated navigation. The drag's intent dominates; layering a programmatic
         // scroll over natural deceleration produces a double page advance.
         if isScrollInteractionActive(in: collectionView) {
-          parent.viewModel.clearNavigationTarget()
+          clearNavigationTargetIfCurrent(navigationTarget)
           return
         }
 
-        guard let resolvedTarget = parent.viewModel.resolvedViewItem(for: navigationTarget),
-          let targetItem = engine.resolveItem(resolvedTarget)
+        guard
+          let resolvedTarget = strictNavigationAnchor(for: navigationTarget),
+          let targetItem = resolvedTarget.item
         else {
-          parent.viewModel.clearNavigationTarget()
+          clearNavigationTargetIfCurrent(navigationTarget)
           return
         }
+        pendingNavigationTarget = navigationTarget
 
         guard engine.hasSyncedInitialPosition else {
           engine.setPendingInitialItem(targetItem)
@@ -428,6 +432,34 @@
         }
 
         _ = scrollToItem(targetItem, animated: true, in: collectionView)
+      }
+
+      private func strictNavigationAnchor(
+        for target: ReaderPositionAnchor
+      ) -> ReaderPositionAnchor? {
+        let resolvedItem: ReaderViewItem?
+        if let targetItem = target.item,
+          let exactItem = engine.renderedItems.first(where: { $0 == targetItem })
+        {
+          resolvedItem = exactItem
+        } else if let focusedPageID = target.focusedPageID {
+          resolvedItem = engine.renderedItems.first(where: { $0.pageIDs.contains(focusedPageID) })
+        } else {
+          resolvedItem = nil
+        }
+
+        guard let resolvedItem else { return nil }
+        let focusedPageID =
+          target.focusedPageID.flatMap { resolvedItem.pageIDs.contains($0) ? $0 : nil }
+          ?? resolvedItem.pageID
+        return ReaderPositionAnchor(item: resolvedItem, focusedPageID: focusedPageID)
+      }
+
+      private func clearNavigationTargetIfCurrent(_ target: ReaderPositionAnchor) {
+        parent.viewModel.clearNavigationTarget(matching: target)
+        if pendingNavigationTarget == target {
+          pendingNavigationTarget = nil
+        }
       }
 
       @discardableResult
@@ -541,13 +573,11 @@
       private func synchronizeViewModelCurrentPosition(to item: ReaderViewItem) {
         let resolvedItem = engine.resolveItem(item) ?? item
         engine.commit(resolvedItem)
-
-        if parent.viewModel.currentViewItem() != resolvedItem {
-          parent.viewModel.updateCurrentPosition(viewItem: resolvedItem)
-        }
-        if parent.viewModel.navigationTarget != nil {
-          parent.viewModel.clearNavigationTarget()
-        }
+        let commit = positionCommit(for: resolvedItem)
+        commitViewModelPosition(
+          commit.anchor,
+          matchingNavigationTarget: commit.navigationTarget
+        )
       }
 
       private func clearProgrammaticScrollState() {
@@ -557,9 +587,10 @@
 
       private func cancelProgrammaticNavigationIfNeeded() {
         guard engine.isProgrammaticScrolling || engine.hasPendingProgrammaticCommit else { return }
+        let navigationTarget = pendingNavigationTarget
         clearProgrammaticScrollState()
-        if parent.viewModel.navigationTarget != nil {
-          parent.viewModel.clearNavigationTarget()
+        if let navigationTarget {
+          clearNavigationTargetIfCurrent(navigationTarget)
         }
       }
 
@@ -676,6 +707,7 @@
         in collectionView: UICollectionView,
         synchronizeViewModelImmediately: Bool
       ) {
+        let commit = positionCommit(for: item)
         let previousCommittedItem = engine.committedItem
         engine.commit(item)
         preloadVisiblePages(for: item)
@@ -685,14 +717,16 @@
           in: collectionView
         )
         if synchronizeViewModelImmediately {
-          if parent.viewModel.currentViewItem() != item {
-            parent.viewModel.updateCurrentPosition(viewItem: item)
-          }
-          if parent.viewModel.navigationTarget != nil {
-            parent.viewModel.clearNavigationTarget()
-          }
+          commitViewModelPosition(
+            commit.anchor,
+            matchingNavigationTarget: commit.navigationTarget
+          )
         } else {
-          scheduleViewModelCommit(for: item)
+          scheduleViewModelCommit(
+            for: item,
+            anchor: commit.anchor,
+            matchingNavigationTarget: commit.navigationTarget
+          )
         }
       }
 
@@ -802,8 +836,53 @@
         }
       }
 
-      private func scheduleViewModelCommit(for item: ReaderViewItem) {
-        guard parent.viewModel.currentViewItem() != item || parent.viewModel.navigationTarget != nil else {
+      private func positionCommit(
+        for item: ReaderViewItem
+      ) -> (anchor: ReaderPositionAnchor, navigationTarget: ReaderPositionAnchor?) {
+        if let navigationTarget = pendingNavigationTarget,
+          parent.viewModel.navigationTarget == navigationTarget,
+          let navigationAnchor = strictNavigationAnchor(for: navigationTarget),
+          navigationAnchor.item == item
+        {
+          return (navigationAnchor, navigationTarget)
+        }
+
+        let currentFocusedPageID = parent.viewModel.captureCurrentPositionAnchor().focusedPageID
+        let focusedPageID =
+          currentFocusedPageID.flatMap { item.pageIDs.contains($0) ? $0 : nil }
+          ?? item.pageID
+        return (
+          ReaderPositionAnchor(item: item, focusedPageID: focusedPageID),
+          nil
+        )
+      }
+
+      private func commitViewModelPosition(
+        _ anchor: ReaderPositionAnchor,
+        matchingNavigationTarget navigationTarget: ReaderPositionAnchor?
+      ) {
+        guard parent.viewModel.navigationTarget == navigationTarget else { return }
+        if parent.viewModel.captureCurrentPositionAnchor() != anchor {
+          parent.viewModel.updateCurrentPosition(anchor: anchor)
+        }
+        if let navigationTarget {
+          clearNavigationTargetIfCurrent(navigationTarget)
+        }
+      }
+
+      private func scheduleViewModelCommit(
+        for item: ReaderViewItem,
+        anchor: ReaderPositionAnchor? = nil,
+        matchingNavigationTarget navigationTarget: ReaderPositionAnchor? = nil
+      ) {
+        let commit = anchor.map { ($0, navigationTarget) } ?? positionCommit(for: item)
+        guard parent.viewModel.navigationTarget == commit.1 else {
+          return
+        }
+        guard
+          parent.viewModel.captureCurrentPositionAnchor() != commit.0
+            || commit.1 != nil
+        else {
           return
         }
 
@@ -811,13 +890,10 @@
         deferredViewModelCommitTask = Task { @MainActor [weak self] in
           await Task.yield()
           guard let self, self.engine.committedItem == item else { return }
-
-          if self.parent.viewModel.currentViewItem() != item {
-            self.parent.viewModel.updateCurrentPosition(viewItem: item)
-          }
-          if self.parent.viewModel.navigationTarget != nil {
-            self.parent.viewModel.clearNavigationTarget()
-          }
+          self.commitViewModelPosition(
+            commit.0,
+            matchingNavigationTarget: commit.1
+          )
         }
       }
 

--- a/KMReader/Features/Reader/Views/ScrollPageView_macOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_macOS.swift
@@ -160,6 +160,7 @@
       private var visiblePreloadItem: ReaderViewItem?
       private var programmaticScrollToken: Int = 0
       private var lastObservedClipBounds: CGRect = .zero
+      private var pendingNavigationTarget: ReaderPositionAnchor?
       private var singleClickWorkItem: DispatchWorkItem?
       weak var longPressGesture: NSPressGestureRecognizer?
 
@@ -196,6 +197,7 @@
         visiblePreloadTask?.cancel()
         visiblePreloadTask = nil
         visiblePreloadItem = nil
+        pendingNavigationTarget = nil
         pagePresentationCoordinator.teardown()
         engine.teardown()
       }
@@ -448,7 +450,7 @@
       }
 
       private func handleNavigationChange(
-        _ navigationTarget: ReaderViewItem,
+        _ navigationTarget: ReaderPositionAnchor,
         in scrollView: NSScrollView,
         collectionView: NSCollectionView
       ) {
@@ -458,16 +460,18 @@
         // existing guard in `scrollViewWillBeginDragging` that lets a drag override an
         // in-flight programmatic scroll.
         if engine.isUserInteracting {
-          parent.viewModel.clearNavigationTarget()
+          clearNavigationTargetIfCurrent(navigationTarget)
           return
         }
 
-        guard let resolvedTarget = parent.viewModel.resolvedViewItem(for: navigationTarget),
-          let targetItem = engine.resolveItem(resolvedTarget)
+        guard
+          let resolvedTarget = strictNavigationAnchor(for: navigationTarget),
+          let targetItem = resolvedTarget.item
         else {
-          parent.viewModel.clearNavigationTarget()
+          clearNavigationTargetIfCurrent(navigationTarget)
           return
         }
+        pendingNavigationTarget = navigationTarget
 
         guard engine.hasSyncedInitialPosition else {
           engine.setPendingInitialItem(targetItem)
@@ -486,6 +490,34 @@
         }
 
         _ = scrollToItem(targetItem, animated: true, in: scrollView, collectionView: collectionView)
+      }
+
+      private func strictNavigationAnchor(
+        for target: ReaderPositionAnchor
+      ) -> ReaderPositionAnchor? {
+        let resolvedItem: ReaderViewItem?
+        if let targetItem = target.item,
+          let exactItem = engine.renderedItems.first(where: { $0 == targetItem })
+        {
+          resolvedItem = exactItem
+        } else if let focusedPageID = target.focusedPageID {
+          resolvedItem = engine.renderedItems.first(where: { $0.pageIDs.contains(focusedPageID) })
+        } else {
+          resolvedItem = nil
+        }
+
+        guard let resolvedItem else { return nil }
+        let focusedPageID =
+          target.focusedPageID.flatMap { resolvedItem.pageIDs.contains($0) ? $0 : nil }
+          ?? resolvedItem.pageID
+        return ReaderPositionAnchor(item: resolvedItem, focusedPageID: focusedPageID)
+      }
+
+      private func clearNavigationTargetIfCurrent(_ target: ReaderPositionAnchor) {
+        parent.viewModel.clearNavigationTarget(matching: target)
+        if pendingNavigationTarget == target {
+          pendingNavigationTarget = nil
+        }
       }
 
       @discardableResult
@@ -604,13 +636,11 @@
       private func synchronizeViewModelCurrentPosition(to item: ReaderViewItem) {
         let resolvedItem = engine.resolveItem(item) ?? item
         engine.commit(resolvedItem)
-
-        if parent.viewModel.currentViewItem() != resolvedItem {
-          parent.viewModel.updateCurrentPosition(viewItem: resolvedItem)
-        }
-        if parent.viewModel.navigationTarget != nil {
-          parent.viewModel.clearNavigationTarget()
-        }
+        let commit = positionCommit(for: resolvedItem)
+        commitViewModelPosition(
+          commit.anchor,
+          matchingNavigationTarget: commit.navigationTarget
+        )
       }
 
       private func centeredItem(
@@ -681,6 +711,7 @@
       }
 
       private func commitItemIfNeeded(_ item: ReaderViewItem, in collectionView: NSCollectionView) {
+        let commit = positionCommit(for: item)
         let previousCommittedItem = engine.committedItem
         engine.commit(item)
         preloadVisiblePages(for: item)
@@ -689,7 +720,11 @@
           to: item,
           in: collectionView
         )
-        scheduleViewModelCommit(for: item)
+        scheduleViewModelCommit(
+          for: item,
+          anchor: commit.anchor,
+          matchingNavigationTarget: commit.navigationTarget
+        )
       }
 
       private func refreshVisibleItems(
@@ -821,8 +856,53 @@
         }
       }
 
-      private func scheduleViewModelCommit(for item: ReaderViewItem) {
-        guard parent.viewModel.currentViewItem() != item || parent.viewModel.navigationTarget != nil else {
+      private func positionCommit(
+        for item: ReaderViewItem
+      ) -> (anchor: ReaderPositionAnchor, navigationTarget: ReaderPositionAnchor?) {
+        if let navigationTarget = pendingNavigationTarget,
+          parent.viewModel.navigationTarget == navigationTarget,
+          let navigationAnchor = strictNavigationAnchor(for: navigationTarget),
+          navigationAnchor.item == item
+        {
+          return (navigationAnchor, navigationTarget)
+        }
+
+        let currentFocusedPageID = parent.viewModel.captureCurrentPositionAnchor().focusedPageID
+        let focusedPageID =
+          currentFocusedPageID.flatMap { item.pageIDs.contains($0) ? $0 : nil }
+          ?? item.pageID
+        return (
+          ReaderPositionAnchor(item: item, focusedPageID: focusedPageID),
+          nil
+        )
+      }
+
+      private func commitViewModelPosition(
+        _ anchor: ReaderPositionAnchor,
+        matchingNavigationTarget navigationTarget: ReaderPositionAnchor?
+      ) {
+        guard parent.viewModel.navigationTarget == navigationTarget else { return }
+        if parent.viewModel.captureCurrentPositionAnchor() != anchor {
+          parent.viewModel.updateCurrentPosition(anchor: anchor)
+        }
+        if let navigationTarget {
+          clearNavigationTargetIfCurrent(navigationTarget)
+        }
+      }
+
+      private func scheduleViewModelCommit(
+        for item: ReaderViewItem,
+        anchor: ReaderPositionAnchor? = nil,
+        matchingNavigationTarget navigationTarget: ReaderPositionAnchor? = nil
+      ) {
+        let commit = anchor.map { ($0, navigationTarget) } ?? positionCommit(for: item)
+        guard parent.viewModel.navigationTarget == commit.1 else {
+          return
+        }
+        guard
+          parent.viewModel.captureCurrentPositionAnchor() != commit.0
+            || commit.1 != nil
+        else {
           return
         }
 
@@ -830,13 +910,10 @@
         deferredViewModelCommitTask = Task { @MainActor [weak self] in
           await Task.yield()
           guard let self, self.engine.committedItem == item else { return }
-
-          if self.parent.viewModel.currentViewItem() != item {
-            self.parent.viewModel.updateCurrentPosition(viewItem: item)
-          }
-          if self.parent.viewModel.navigationTarget != nil {
-            self.parent.viewModel.clearNavigationTarget()
-          }
+          self.commitViewModelPosition(
+            commit.0,
+            matchingNavigationTarget: commit.1
+          )
         }
       }
 

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_iOS.swift
@@ -436,20 +436,45 @@
           scrollToInitialPage(currentPageID)
         }
 
-        if let targetPageID = viewModel.navigationTarget?.pageID,
-          itemIndex(forPageID: targetPageID) != nil
-        {
-          scrollToPage(targetPageID, animated: true)
-          viewModel.clearNavigationTarget()
-          if self.scrollEngine.currentPageID != targetPageID {
+        if let navigationTarget = viewModel.navigationTarget {
+          if let targetPageID = navigationPageID(for: navigationTarget),
+            itemIndex(forPageID: targetPageID) != nil
+          {
+            scrollToPage(targetPageID, animated: true)
             self.scrollEngine.currentPageID = targetPageID
-            viewModel.updateCurrentPosition(pageID: targetPageID)
+            let committedAnchor = ReaderPositionAnchor(
+              item: navigationTarget.item,
+              focusedPageID: targetPageID
+            )
+            if viewModel.captureCurrentPositionAnchor() != committedAnchor {
+              viewModel.updateCurrentPosition(anchor: committedAnchor)
+            }
+            clearNavigationTargetIfMatching(navigationTarget)
+          } else {
+            clearNavigationTargetIfMatching(navigationTarget)
+            if self.scrollEngine.currentPageID != currentPageID {
+              self.scrollEngine.currentPageID = currentPageID
+            }
           }
         } else {
           if self.scrollEngine.currentPageID != currentPageID {
             self.scrollEngine.currentPageID = currentPageID
           }
         }
+      }
+
+      private func navigationPageID(for target: ReaderPositionAnchor) -> ReaderPageID? {
+        guard let item = target.item else { return nil }
+        if let focusedPageID = target.focusedPageID,
+          item.pageIDs.contains(focusedPageID) || item.pageID == focusedPageID
+        {
+          return focusedPageID
+        }
+        return item.pageID
+      }
+
+      private func clearNavigationTargetIfMatching(_ target: ReaderPositionAnchor) {
+        viewModel?.clearNavigationTarget(matching: target)
       }
 
       private func resetContentInsetsIfNeeded(for collectionView: UICollectionView) {

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
@@ -441,18 +441,43 @@
           scrollToInitialPage(currentPageID)
         }
 
-        if let targetPageID = viewModel.navigationTarget?.pageID,
-          itemIndex(forPageID: targetPageID) != nil
-        {
-          scrollToPage(targetPageID, animated: true)
-          viewModel.clearNavigationTarget()
-          if self.scrollEngine.currentPageID != targetPageID {
+        if let navigationTarget = viewModel.navigationTarget {
+          if let targetPageID = navigationPageID(for: navigationTarget),
+            itemIndex(forPageID: targetPageID) != nil
+          {
+            scrollToPage(targetPageID, animated: true)
             self.scrollEngine.currentPageID = targetPageID
-            viewModel.updateCurrentPosition(pageID: targetPageID)
+            let committedAnchor = ReaderPositionAnchor(
+              item: navigationTarget.item,
+              focusedPageID: targetPageID
+            )
+            if viewModel.captureCurrentPositionAnchor() != committedAnchor {
+              viewModel.updateCurrentPosition(anchor: committedAnchor)
+            }
+            clearNavigationTargetIfMatching(navigationTarget)
+          } else {
+            clearNavigationTargetIfMatching(navigationTarget)
+            if self.scrollEngine.currentPageID != currentPageID {
+              self.scrollEngine.currentPageID = currentPageID
+            }
           }
         } else if self.scrollEngine.currentPageID != currentPageID {
           self.scrollEngine.currentPageID = currentPageID
         }
+      }
+
+      private func navigationPageID(for target: ReaderPositionAnchor) -> ReaderPageID? {
+        guard let item = target.item else { return nil }
+        if let focusedPageID = target.focusedPageID,
+          item.pageIDs.contains(focusedPageID) || item.pageID == focusedPageID
+        {
+          return focusedPageID
+        }
+        return item.pageID
+      }
+
+      private func clearNavigationTargetIfMatching(_ target: ReaderPositionAnchor) {
+        viewModel?.clearNavigationTarget(matching: target)
       }
 
       private func handleDataReload(


### PR DESCRIPTION
## What changed

- Preserve committed reader positions and pending navigation as semantic page anchors across single-page and dual-page presentation rebuilds.
- Rework Page Curl coordinators around immutable view-item snapshots and stable controller identities, including bounded transition retry and teardown-safe tasks.
- Dispatch progress from committed snapshots so crossing volume boundaries flushes the outgoing book before submitting progress for the next book.
- Apply the same semantic navigation target across Cover, Scroll, and Webtoon readers, and document the ownership boundary.

## User impact

Rotating an iPad between single-page and double-page Page Curl layouts keeps the current manga, volume, page, and progress instead of resetting progress or reopening a previous volume.

## Validation

- `make build`
- `git diff --check`
