### PR TITLE
fix(reader): preserve active turns across presentation rebuilds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,10 @@ This file provides guidance to coding agents working with code in this repositor
 
 - `ReaderSettingsSheet` is reserved for persisted reader preferences. Session-only reader options belong in the reader controls menu or the platform command menu.
 - Page rotation is session-only, applies only to paged DIVINA modes, and must not be exposed or applied in Webtoon mode.
-- `ReaderViewModel` owns the committed semantic reader position and navigation commands as a full `ReaderViewItem` plus its focused `ReaderPageID`. Page Curl adapters must not publish a position while mounting or dismantling; restoration may fall back to the first item, but command resolution must be strict and discard invalid targets.
+- `ReaderViewModel` owns the committed semantic reader position as a full `ReaderViewItem` plus its focused `ReaderPageID`. Page Curl adapters must not publish a position while mounting or dismantling; restoration may fall back to the first item, but explicit command resolution must be strict and discard invalid targets.
+- `navigationTarget` is reserved for explicit navigation commands. Presentation rebuilds restore from the committed position and adapter-owned snapshots; they must not synthesize navigation commands, and a later interactive commit supersedes any earlier restoration anchor.
 - Page Curl indices are local to one coordinator-owned immutable snapshot. UIKit controllers and asynchronous completions must cross update, preload, rotation, and teardown boundaries using stable reader-item identities rather than array indices or view tags.
-- During seamless DIVINA cross-book navigation, `currentReaderPage` is the committed position, `currentBook` and `ReaderSession.book` follow its segment, and `currentBookId` remains the explicit whole-book load anchor.
+- During seamless DIVINA cross-book navigation, the committed `ReaderPositionAnchor` is the source of truth. `currentReaderPage` is its focused or backing page projection; `.end` items retain their segment's final `ReaderPageID` so book identity remains available. `currentBook` and `ReaderSession.book` follow that segment, while `currentBookId` remains the explicit whole-book load anchor.
 
 ### Offline & Downloads
 

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 508;
+				CURRENT_PROJECT_VERSION = 509;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 508;
+				CURRENT_PROJECT_VERSION = 509;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 508;
+				CURRENT_PROJECT_VERSION = 509;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 508;
+				CURRENT_PROJECT_VERSION = 509;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/ReaderViewModel.swift
@@ -17,7 +17,7 @@ class ReaderViewModel {
   private(set) var bookIdsWithMissingPageDimensions: Set<String> = []
   private var currentPageID: ReaderPageID?
   private var currentViewItemID: ReaderViewItem?
-  var navigationTarget: ReaderPositionAnchor?
+  private(set) var navigationTarget: ReaderPositionAnchor?
   var isLoading = true
   var loadingTitle = String(localized: "Loading book...")
   var loadingDetail = String(localized: "Resolving page metadata")
@@ -1411,13 +1411,10 @@ class ReaderViewModel {
     let pendingNavigationTarget = navigationTarget
     mutation()
     regenerateViewState(preserving: positionAnchor)
-    if let pendingNavigationTarget,
-      let remappedTarget = matchingPositionAnchor(for: pendingNavigationTarget)
-    {
-      navigationTarget = remappedTarget
-    } else {
-      let restoredAnchor = captureCurrentPositionAnchor()
-      navigationTarget = restoredAnchor.item == nil ? nil : restoredAnchor
+    // Presentation restoration follows the committed position. Only explicit
+    // navigation commands survive a rebuild, and only when they still resolve strictly.
+    navigationTarget = pendingNavigationTarget.flatMap {
+      matchingPositionAnchor(for: $0)
     }
   }
 


### PR DESCRIPTION
## What changed

- Keep `navigationTarget` exclusive to explicit navigation commands during reader presentation rebuilds.
- Remap only a command that was already pending before the rebuild, while committed anchors and adapter-owned snapshots continue to restore presentation state.
- Clarify the committed-position, end-page projection, and restoration ownership boundaries in `AGENTS.md`.

## Why

This follows up on #948. A rebuild during an in-flight reader transition could synthesize a command for the previously committed page. After the user transition committed its newer page, an adapter continuation could replay that stale command and navigate backward.

The fix removes the competing restoration command instead of adding timing flags or generations. Existing Page Curl snapshots, Cover decks, Scroll viewport anchors, and Webtoon offsets remain responsible for presentation restoration.

## Validation

- Scoped `swift-format`
- `swiftc -parse KMReader/Features/Reader/ViewModels/ReaderViewModel.swift`
- `git diff --check`
- `make build` (iOS, macOS, and tvOS)
