### PR TITLE
fix(reader): defer zoom state writes out of gesture callbacks

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 510;
+				CURRENT_PROJECT_VERSION = 511;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 510;
+				CURRENT_PROJECT_VERSION = 511;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 510;
+				CURRENT_PROJECT_VERSION = 511;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 510;
+				CURRENT_PROJECT_VERSION = 511;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/NativeImagePageViewController.swift
+++ b/KMReader/Features/Reader/Views/NativeImagePageViewController.swift
@@ -307,7 +307,11 @@
     func scrollViewDidZoom(_ scrollView: UIScrollView) {
       guard let viewModel else { return }
       let zoomed = scrollView.zoomScale > (scrollView.minimumZoomScale + 0.01)
-      if viewModel.isZoomed != zoomed {
+      guard viewModel.isZoomed != zoomed else { return }
+      // Defer the observable write out of the zoom gesture callback; publishing
+      // SwiftUI state synchronously here can crash AttributeGraph on iOS 18.
+      DispatchQueue.main.async { [weak viewModel] in
+        guard let viewModel, viewModel.isZoomed != zoomed else { return }
         viewModel.isZoomed = zoomed
       }
     }

--- a/KMReader/Features/Reader/Views/NativePagedPageContentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/NativePagedPageContentView_iOS.swift
@@ -214,6 +214,17 @@
     }
 
     private func resetScrollViewportState() {
+      // Never reset the zoom scale while a pinch gesture is in flight; changing
+      // the scale mid-gesture desyncs UIScrollView's gesture state and can crash
+      // on iPadOS 18. Retry on the next runloop until the gesture settles.
+      #if os(iOS)
+        if let pinch = scrollView.pinchGestureRecognizer, pinch.state == .began || pinch.state == .changed {
+          DispatchQueue.main.async { [weak self] in
+            self?.resetScrollViewportState()
+          }
+          return
+        }
+      #endif
       isUpdatingZoomState = true
       scrollView.setZoomScale(scrollView.minimumZoomScale, animated: false)
       scrollView.contentOffset = .zero
@@ -238,7 +249,11 @@
       guard let viewModel else { return }
 
       let zoomed = scrollView.zoomScale > (scrollView.minimumZoomScale + 0.01)
-      if viewModel.isZoomed != zoomed {
+      guard viewModel.isZoomed != zoomed else { return }
+      // Defer the observable write out of the zoom gesture callback; publishing
+      // SwiftUI state synchronously here can crash AttributeGraph on iOS 18.
+      DispatchQueue.main.async { [weak viewModel] in
+        guard let viewModel, viewModel.isZoomed != zoomed else { return }
         viewModel.isZoomed = zoomed
       }
     }


### PR DESCRIPTION
## Summary

Fixes the DIVINA reader crashes on iPadOS 18 reported in #958, where the app crashed on the first pinch-to-zoom gesture and on subsequent tap/drag gestures.

## Root Cause

`scrollViewDidZoom` in the paged DIVINA reader (`NativePagedPageContentView`) and the Page Curl reader (`NativeImagePageViewController`) published `viewModel.isZoomed` **synchronously** from inside the scroll view's zoom gesture callback. This triggers a SwiftUI re-render chain (`DivinaReaderView` re-renders → controls hide → `updateUIView` → slot content reconfigure/layout) while the pinch gesture is still in flight — a state publication pattern that crashes AttributeGraph on iOS 18. `PageScrollView` already defers this write via `DispatchQueue.main.async`; these two zoom hosts were missing that guard.

## Changes

- Defer the `isZoomed` write to the next runloop in both remaining zoom hosts (with a stale-value recheck), matching the existing `PageScrollView` pattern.
- Skip zoom-scale resets in `NativePagedPageContentView.resetScrollViewportState()` while a pinch gesture is `.began`/`.changed`, retrying on the next runloop until the gesture settles. Resetting the scale mid-gesture desyncs `UIScrollView`'s internal gesture state. (iOS only; `pinchGestureRecognizer` is unavailable on tvOS, where zoom is not user-driven anyway.)

## Validation

- `make build-ios` / `make build-macos` / `make build-tvos` all pass.
- Not yet verified on a physical iPadOS 18 device; a crash log from the reporter (Settings → Privacy & Security → Analytics & Improvements → Analytics Data) would help confirm the exact stack.
