### PR TITLE
fix(browse): defer sheet presentation out of menu actions

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 511;
+				CURRENT_PROJECT_VERSION = 512;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 511;
+				CURRENT_PROJECT_VERSION = 512;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 511;
+				CURRENT_PROJECT_VERSION = 512;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 511;
+				CURRENT_PROJECT_VERSION = 512;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Views/BookContextMenu.swift
+++ b/KMReader/Features/Book/Views/BookContextMenu.swift
@@ -45,7 +45,7 @@ struct BookContextMenu: View {
 
       if !isOffline {
         Button {
-          onShowReadListPicker?()
+          deferMenuActionPresentation { onShowReadListPicker?() }
         } label: {
           Label("Add to Read List", systemImage: ContentIcon.readList)
         }
@@ -68,7 +68,7 @@ struct BookContextMenu: View {
         if current.isAdmin {
           Menu {
             Button {
-              onEditRequested?()
+              deferMenuActionPresentation { onEditRequested?() }
             } label: {
               Label("Edit", systemImage: "pencil")
             }
@@ -86,7 +86,7 @@ struct BookContextMenu: View {
             if onDeleteRequested != nil {
               Divider()
               Button(role: .destructive) {
-                onDeleteRequested?()
+                deferMenuActionPresentation { onDeleteRequested?() }
               } label: {
                 Label("Delete Book", systemImage: "trash")
               }

--- a/KMReader/Features/Book/Views/BookDetailView.swift
+++ b/KMReader/Features/Book/Views/BookDetailView.swift
@@ -285,7 +285,7 @@ struct BookDetailView: View {
       Menu {
         if current.isAdmin {
           Button {
-            showEditSheet = true
+            deferMenuActionPresentation { showEditSheet = true }
           } label: {
             Label("Edit", systemImage: "pencil")
           }
@@ -308,7 +308,7 @@ struct BookDetailView: View {
         Divider()
 
         Button {
-          showReadListPicker = true
+          deferMenuActionPresentation { showReadListPicker = true }
         } label: {
           Label("Add to Read List", systemImage: ContentIcon.readList)
         }
@@ -335,7 +335,7 @@ struct BookDetailView: View {
 
         if current.isAdmin {
           Button(role: .destructive) {
-            showDeleteConfirmation = true
+            deferMenuActionPresentation { showDeleteConfirmation = true }
           } label: {
             Label("Delete Book", systemImage: "trash")
           }

--- a/KMReader/Features/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailView.swift
@@ -332,7 +332,7 @@ struct OneshotDetailView: View {
       Menu {
         if current.isAdmin {
           Button {
-            showEditSheet = true
+            deferMenuActionPresentation { showEditSheet = true }
           } label: {
             Label("Edit", systemImage: "pencil")
           }
@@ -355,13 +355,13 @@ struct OneshotDetailView: View {
         Divider()
 
         Button {
-          showCollectionPicker = true
+          deferMenuActionPresentation { showCollectionPicker = true }
         } label: {
           Label("Add to Collection", systemImage: ContentIcon.collection)
         }
 
         Button {
-          showReadListPicker = true
+          deferMenuActionPresentation { showReadListPicker = true }
         } label: {
           Label("Add to Read List", systemImage: ContentIcon.readList)
         }
@@ -390,7 +390,7 @@ struct OneshotDetailView: View {
 
         if current.isAdmin {
           Button(role: .destructive) {
-            showDeleteConfirmation = true
+            deferMenuActionPresentation { showDeleteConfirmation = true }
           } label: {
             Label("Delete Oneshot", systemImage: "trash")
           }

--- a/KMReader/Features/Series/Views/SeriesContextMenu.swift
+++ b/KMReader/Features/Series/Views/SeriesContextMenu.swift
@@ -75,7 +75,7 @@ struct SeriesContextMenu: View {
 
       if !isOffline {
         Button {
-          onShowCollectionPicker?()
+          deferMenuActionPresentation { onShowCollectionPicker?() }
         } label: {
           Label("Add to Collection", systemImage: ContentIcon.collection)
         }
@@ -101,7 +101,7 @@ struct SeriesContextMenu: View {
         if current.isAdmin {
           Menu {
             Button {
-              onEditRequested?()
+              deferMenuActionPresentation { onEditRequested?() }
             } label: {
               Label("Edit", systemImage: "pencil")
             }
@@ -119,7 +119,7 @@ struct SeriesContextMenu: View {
             if onDeleteRequested != nil {
               Divider()
               Button(role: .destructive) {
-                onDeleteRequested?()
+                deferMenuActionPresentation { onDeleteRequested?() }
               } label: {
                 Label("Delete Series", systemImage: "trash")
               }

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -419,7 +419,7 @@ extension SeriesDetailView {
 
         if current.isAdmin {
           Button {
-            showEditSheet = true
+            deferMenuActionPresentation { showEditSheet = true }
           } label: {
             Label("Edit", systemImage: "pencil")
           }
@@ -442,7 +442,7 @@ extension SeriesDetailView {
         Divider()
 
         Button {
-          showCollectionPicker = true
+          deferMenuActionPresentation { showCollectionPicker = true }
         } label: {
           Label("Add to Collection", systemImage: ContentIcon.collection)
         }
@@ -469,7 +469,7 @@ extension SeriesDetailView {
 
         if current.isAdmin {
           Button(role: .destructive) {
-            showDeleteConfirmation = true
+            deferMenuActionPresentation { showDeleteConfirmation = true }
           } label: {
             Label("Delete Series", systemImage: "trash")
           }

--- a/KMReader/Shared/Helpers/MenuActionPresentation.swift
+++ b/KMReader/Shared/Helpers/MenuActionPresentation.swift
@@ -1,0 +1,15 @@
+//
+// MenuActionPresentation.swift
+//
+//
+
+import Foundation
+
+/// Defers a presentation-state mutation out of a menu item action.
+/// Presenting a sheet or alert synchronously from an NSMenu action can leave
+/// macOS stuck mid-presentation (menu bar disabled, beachball) while the menu
+/// tracking loop is still active. Running the mutation on the next runloop lets
+/// the menu finish dismissing first. Safe no-op timing-wise on other platforms.
+func deferMenuActionPresentation(_ action: @escaping () -> Void) {
+  DispatchQueue.main.async(execute: action)
+}


### PR DESCRIPTION
## Summary

Fixes the macOS freeze reported in #959: adding a book to a read list from the Home screen, a Collection/Series context menu, or the book detail page made the app beachball and become completely unresponsive, with the menu bar disabled and only CMD+Q still working.

## Root Cause

Every reported path triggers the read-list picker sheet **synchronously from an NSMenu item action** — context menus on cards/rows and the toolbar `Menu` on detail pages. Presenting a SwiftUI sheet while the menu's event-tracking loop is still active can wedge the presentation on macOS 15, leaving the app in a stuck modal state (matching the report exactly: sheet "stuck halfway before being shown", menu unavailable, clean CMD+Q).

## Changes

- Add a shared `deferMenuActionPresentation` helper that runs the presentation-state mutation on the next runloop, letting the menu finish dismissing before the sheet session begins.
- Apply it to all menu-action presentation triggers in the affected flows: the read-list and collection pickers, plus the adjacent edit/delete sheet and alert presentations in the same menus (`BookContextMenu`, `SeriesContextMenu`, and the book/series/oneshot detail toolbars) so the whole defect class is covered, not just the reported item.

No behavior change on iOS/tvOS beyond a one-runloop delay before the sheet appears.

## Validation

- `make build-macos` / `make build-ios` / `make build-tvos` all pass.
- Not verified on macOS 15 (dev machine runs a newer macOS). If the reporter can still reproduce after this lands, a spindump (`sudo spindump KMReader` while hung) would pinpoint any remaining blocking frame.

Refs #959
