### PR TITLE
fix(tvos): push login view instead of nesting sheets

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 512;
+				CURRENT_PROJECT_VERSION = 513;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 512;
+				CURRENT_PROJECT_VERSION = 513;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 512;
+				CURRENT_PROJECT_VERSION = 513;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 512;
+				CURRENT_PROJECT_VERSION = 513;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -192,11 +192,21 @@ struct ServerListView: View {
     } message: {
       Text(String(localized: "Are you sure you want to logout?"))
     }
-    .sheet(isPresented: $showLogin) {
-      SheetView(title: String(localized: "Connect to a Server"), size: .large) {
+    #if os(tvOS)
+      // tvOS focus engine fails to reach sheet-over-sheet content, leaving only
+      // the toolbar Close button focusable (#951). Push the login form onto the
+      // existing navigation stack instead of presenting a second sheet.
+      .navigationDestination(isPresented: $showLogin) {
         LoginView(authViewModel: authViewModel)
+          .inlineNavigationBarTitle(String(localized: "Connect to a Server"))
       }
-    }
+    #else
+      .sheet(isPresented: $showLogin) {
+        SheetView(title: String(localized: "Connect to a Server"), size: .large) {
+          LoginView(authViewModel: authViewModel)
+        }
+      }
+    #endif
     .task {
       resetProtectedVisibilityIfNeeded()
       await loadInstances()


### PR DESCRIPTION
## Summary

Fixes #951: on tvOS, after opening the login ("Connect to a Server") screen, the Siri Remote could not move focus to the server address field — only the Close button was focusable, making login impossible.

## Root Cause

The login form was presented as a `.sheet` on top of the Get Started `.sheet`. The tvOS focus engine does not reliably reach sheet-over-sheet content, so the login form's fields never entered the focus hierarchy.

## Changes

On tvOS, `LoginView` is now pushed onto the existing navigation stack (via `navigationDestination(isPresented:)`) instead of being presented as a second sheet. Both call sites of `ServerListView` (onboarding sheet and the Servers management destination) already live inside a `NavigationStack`, so the push works in both modes; the Menu button pops back as usual, and successful login still dismisses via the existing `dismiss()` path. iOS and macOS keep the sheet presentation unchanged.

## Validation

- `make build-tvos` / `make build-ios` / `make build-macos` all pass.
- App launches and renders correctly on the tvOS simulator. Interactive remote-focus verification could not be automated in this environment; worth a quick manual check on a tvOS simulator or device (arrow keys should now move focus between the URL field, auth picker, and Login button).
