### PR TITLE
fix(reader): stop PDF overlay toggle glitches on iPadOS 18

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 513;
+				CURRENT_PROJECT_VERSION = 514;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 513;
+				CURRENT_PROJECT_VERSION = 514;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 513;
+				CURRENT_PROJECT_VERSION = 514;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 513;
+				CURRENT_PROJECT_VERSION = 514;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_iOS.swift
@@ -29,6 +29,7 @@
       applyPresentationConfiguration(to: pdfView, coordinator: context.coordinator)
       context.coordinator.bind(pdfView: pdfView)
       loadDocument(into: pdfView, coordinator: context.coordinator)
+      disableScrollInsetAdjustment(in: pdfView)
       return pdfView
     }
 
@@ -107,6 +108,10 @@
       coordinator.lastResolvedReadingDirection = direction
       coordinator.lastResolvedIsolateCoverPage = isolateCoverPage
 
+      // usePageViewController rebuilds PDFView's internal view hierarchy, so
+      // re-apply the inset lock after every configuration change.
+      disableScrollInsetAdjustment(in: pdfView)
+
       if pdfView.document != nil {
         goToPage(targetPageAfterConfiguration, in: pdfView)
       }
@@ -159,6 +164,18 @@
       return document.index(for: page) + 1
     }
 
+    // PDFView's internal scroll views use .automatic inset adjustment, so a
+    // status bar / safe area change (controls overlay toggles it) shifts the
+    // rendered page vertically on iOS 18. Lock all of them to .never (#956).
+    private func disableScrollInsetAdjustment(in view: UIView) {
+      if let scrollView = view as? UIScrollView {
+        scrollView.contentInsetAdjustmentBehavior = .never
+      }
+      for subview in view.subviews {
+        disableScrollInsetAdjustment(in: subview)
+      }
+    }
+
     final class Coordinator: NSObject, UIGestureRecognizerDelegate {
       var onPageChange: (Int, Int) -> Void
       var onSingleTap: (CGPoint) -> Void
@@ -172,6 +189,13 @@
       private weak var doubleTapRecognizer: UITapGestureRecognizer?
       private weak var longPressRecognizer: UILongPressGestureRecognizer?
       private var hadSelectionAtTouchStart = false
+      private var singleTapStartPoint: CGPoint?
+      private var singleTapStartTime: TimeInterval = 0
+
+      // Stricter than UITapGestureRecognizer's built-in slop: slow/short drags
+      // must not toggle the reader overlays (#957).
+      private let singleTapMaximumMovement: CGFloat = 10
+      private let singleTapMaximumDuration: TimeInterval = 0.5
 
       init(
         onPageChange: @escaping (Int, Int) -> Void,
@@ -278,6 +302,14 @@
           return
         }
 
+        if let startPoint = singleTapStartPoint {
+          let endPoint = recognizer.location(in: pdfView)
+          let movement = hypot(endPoint.x - startPoint.x, endPoint.y - startPoint.y)
+          let duration = ProcessInfo.processInfo.systemUptime - singleTapStartTime
+          singleTapStartPoint = nil
+          guard movement <= singleTapMaximumMovement, duration <= singleTapMaximumDuration else { return }
+        }
+
         let size = pdfView.bounds.size
         guard size.width > 0, size.height > 0 else { return }
 
@@ -313,6 +345,10 @@
 
       func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         hadSelectionAtTouchStart = (observedPDFView?.currentSelection != nil)
+        if gestureRecognizer === singleTapRecognizer, let view = touch.view {
+          singleTapStartPoint = touch.location(in: view)
+          singleTapStartTime = touch.timestamp
+        }
         return !isInteractiveElement(touch.view)
       }
 


### PR DESCRIPTION
## Summary

Fixes two native PDF reader issues reported on iPadOS 18 (also observable on iOS 26 for the tap issue): #956 (page content shifts vertically whenever the controls overlay is shown or hidden) and #957 (slow/short drag gestures incorrectly toggle the controls overlay).

## Changes

Both changes are in `PdfDocumentView_iOS`:

- **#956 — vertical content shift.** Toggling the overlay also toggles the status bar (`.statusBarHidden(!shouldShowControls)`), which changes safe-area insets; PDFView's internal scroll views use `.automatic` content-inset adjustment, so the rendered page shifts vertically. All internal scroll views are now locked to `.never`, re-applied after every presentation configuration change because `usePageViewController(_:)` rebuilds PDFView's internal hierarchy.
- **#957 — accidental drags toggle the overlay.** `UITapGestureRecognizer`'s built-in movement slop lets slow/short drags through as taps. The coordinator now records the touch-down location and timestamp and rejects recognized "taps" that moved more than 10 pt or lasted longer than 0.5 s, so incidental contact while reading no longer pops the overlays.

## Validation

- `make build-ios` / `make build-macos` / `make build-tvos` all pass.
- Behavior change is iOS-only; macOS uses a separate `PdfDocumentView` and is untouched. Not verified on a physical iPadOS 18 device — feedback from the reporter on the next build would confirm.
