### PR TITLE
feat(reader): add keep-screen-awake setting for reading sessions

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 514;
+				CURRENT_PROJECT_VERSION = 515;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 514;
+				CURRENT_PROJECT_VERSION = 515;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 514;
+				CURRENT_PROJECT_VERSION = 515;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 514;
+				CURRENT_PROJECT_VERSION = 515;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/BookReaderView.swift
+++ b/KMReader/Features/Reader/Views/BookReaderView.swift
@@ -125,5 +125,6 @@ struct BookReaderView: View {
       }
     }
     .environment(\.readerActions, .live(readerPresentation: readerPresentation))
+    .keepScreenAwakeWhileReading()
   }
 }

--- a/KMReader/Features/Settings/Components/SettingsSection.swift
+++ b/KMReader/Features/Settings/Components/SettingsSection.swift
@@ -11,6 +11,9 @@ enum SettingsSection: String, CaseIterable {
   case dashboard
   case cache
   case divinaReader
+  #if os(iOS) || os(tvOS)
+    case reading
+  #endif
   #if os(iOS) || os(macOS)
     case pdfReader
   #endif
@@ -38,6 +41,10 @@ enum SettingsSection: String, CaseIterable {
       return "externaldrive"
     case .divinaReader:
       return "photo.on.rectangle.angled"
+    #if os(iOS) || os(tvOS)
+      case .reading:
+        return "book"
+    #endif
     #if os(iOS) || os(macOS)
       case .pdfReader:
         return "doc.richtext"
@@ -75,6 +82,10 @@ enum SettingsSection: String, CaseIterable {
       return String(localized: "Cache")
     case .divinaReader:
       return String(localized: "DIVINA Reader")
+    #if os(iOS) || os(tvOS)
+      case .reading:
+        return String(localized: "Reading")
+    #endif
     #if os(iOS) || os(macOS)
       case .pdfReader:
         return String(localized: "PDF Reader")

--- a/KMReader/Features/Settings/SettingsReadingView.swift
+++ b/KMReader/Features/Settings/SettingsReadingView.swift
@@ -1,0 +1,41 @@
+//
+// SettingsReadingView.swift
+//
+//
+
+#if os(iOS) || os(tvOS)
+  import SwiftUI
+
+  struct SettingsReadingView: View {
+    @AppStorage("keepScreenAwakeWhileReading") private var keepScreenAwakeWhileReading: Bool = false
+
+    var body: some View {
+      Form {
+        Section {
+          Toggle(isOn: $keepScreenAwakeWhileReading) {
+            VStack(alignment: .leading, spacing: 4) {
+              HStack(spacing: 6) {
+                Image(systemName: "sun.max")
+                Text(String(localized: "Keep Screen Awake While Reading"))
+              }
+              Text(String(localized: "Prevents the screen from dimming or locking while a reader is open."))
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+          }
+        } header: {
+          Text(String(localized: "Screen"))
+        } footer: {
+          Text(
+            String(
+              localized:
+                "Applies to all readers (DIVINA, EPUB, and PDF). The screen returns to normal when you close the reader."
+            )
+          )
+        }
+      }
+      .formStyle(.grouped)
+      .inlineNavigationBarTitle(SettingsSection.reading.title)
+    }
+  }
+#endif

--- a/KMReader/Features/Settings/SettingsView.swift
+++ b/KMReader/Features/Settings/SettingsView.swift
@@ -6,11 +6,14 @@
 import SwiftUI
 
 struct SettingsView: View {
-  @AppStorage("keepScreenAwakeWhileReading") private var keepScreenAwakeWhileReading: Bool = false
-
   var body: some View {
     Form {
       Section(header: Text(String(localized: "Reader"))) {
+        #if os(iOS) || os(tvOS)
+          NavigationLink(value: NavDestination.settingsReading) {
+            SettingsSectionRow(section: .reading)
+          }
+        #endif
         NavigationLink(value: NavDestination.settingsDivinaReader) {
           SettingsSectionRow(section: .divinaReader)
         }
@@ -25,16 +28,6 @@ struct SettingsView: View {
           }
           NavigationLink(value: NavDestination.settingsEpubSettings) {
             SettingsSectionRow(section: .epubSettings)
-          }
-        #endif
-        #if os(iOS) || os(tvOS)
-          Toggle(isOn: $keepScreenAwakeWhileReading) {
-            VStack(alignment: .leading, spacing: 2) {
-              Text(String(localized: "Keep Screen Awake While Reading"))
-              Text(String(localized: "Prevents the screen from dimming or locking while a reader is open."))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
           }
         #endif
       }

--- a/KMReader/Features/Settings/SettingsView.swift
+++ b/KMReader/Features/Settings/SettingsView.swift
@@ -6,6 +6,8 @@
 import SwiftUI
 
 struct SettingsView: View {
+  @AppStorage("keepScreenAwakeWhileReading") private var keepScreenAwakeWhileReading: Bool = false
+
   var body: some View {
     Form {
       Section(header: Text(String(localized: "Reader"))) {
@@ -23,6 +25,16 @@ struct SettingsView: View {
           }
           NavigationLink(value: NavDestination.settingsEpubSettings) {
             SettingsSectionRow(section: .epubSettings)
+          }
+        #endif
+        #if os(iOS) || os(tvOS)
+          Toggle(isOn: $keepScreenAwakeWhileReading) {
+            VStack(alignment: .leading, spacing: 2) {
+              Text(String(localized: "Keep Screen Awake While Reading"))
+              Text(String(localized: "Prevents the screen from dimming or locking while a reader is open."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
           }
         #endif
       }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -4994,6 +4994,70 @@
         }
       }
     },
+    "Applies to all readers (DIVINA, EPUB, and PDF). The screen returns to normal when you close the reader." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gilt für alle Reader (DIVINA, EPUB und PDF). Der Bildschirm kehrt zum Normalzustand zurück, sobald du den Reader schließt."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Applies to all readers (DIVINA, EPUB, and PDF). The screen returns to normal when you close the reader."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se aplica a todos los lectores (DIVINA, EPUB y PDF). La pantalla vuelve a la normalidad al cerrar el lector."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S'applique à tous les lecteurs (DIVINA, EPUB et PDF). L'écran redevient normal à la fermeture du lecteur."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si applica a tutti i lettori (DIVINA, EPUB e PDF). Lo schermo torna alla normalità quando chiudi il lettore."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのリーダー（DIVINA、EPUB、PDF）に適用されます。リーダーを閉じると画面は通常に戻ります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 리더(DIVINA, EPUB, PDF)에 적용됩니다. 리더를 닫으면 화면이 정상으로 돌아갑니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Применяется ко всем просмотрщикам (DIVINA, EPUB и PDF). После закрытия просмотрщика экран работает как обычно."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "适用于所有阅读器（DIVINA、EPUB 和 PDF）。关闭阅读器后屏幕恢复正常。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "適用於所有閱讀器（DIVINA、EPUB 和 PDF）。關閉閱讀器後螢幕恢復正常。"
+          }
+        }
+      }
+    },
     "Apply Filter" : {
       "localizations" : {
         "de" : {
@@ -58697,6 +58761,70 @@
         }
       }
     },
+    "Reading" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lesen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lectura"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lettura"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽기"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чтение"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀"
+          }
+        }
+      }
+    },
     "Reading & Language" : {
       "localizations" : {
         "de" : {
@@ -63045,6 +63173,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "深度掃描圖書館檔案"
+          }
+        }
+      }
+    },
+    "Screen" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildschirm"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Screen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pantalla"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écran"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schermo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画面"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "화면"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Экран"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "屏幕"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "螢幕"
           }
         }
       }

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -26051,6 +26051,7 @@
       }
     },
     "error.bookIdEmpty" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -26307,6 +26308,7 @@
       }
     },
     "error.failedToLoadImageData" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -26563,6 +26565,7 @@
       }
     },
     "error.imageNotCached" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -27587,6 +27590,7 @@
       }
     },
     "error.photoLibraryAccessDenied" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -33406,6 +33410,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保留更多已解碼的附近頁面以獲得更流暢的翻頁，但會增加記憶體使用量。"
+          }
+        }
+      }
+    },
+    "Keep Screen Awake While Reading" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bildschirm beim Lesen aktiv halten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep Screen Awake While Reading"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantener la pantalla activa al leer"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Garder l'écran allumé pendant la lecture"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mantieni lo schermo attivo durante la lettura"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読書中は画面をスリープしない"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽는 동안 화면 켜짐 유지"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не гасить экран во время чтения"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读时保持屏幕常亮"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀時保持螢幕常亮"
           }
         }
       }
@@ -47619,6 +47687,7 @@
       }
     },
     "notification.reader.imageSaved" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {
@@ -54912,6 +54981,70 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "預設"
+          }
+        }
+      }
+    },
+    "Prevents the screen from dimming or locking while a reader is open." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verhindert, dass der Bildschirm gedimmt oder gesperrt wird, solange ein Reader geöffnet ist."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prevents the screen from dimming or locking while a reader is open."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Evita que la pantalla se atenúe o se bloquee mientras un lector está abierto."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empêche l'écran de s'assombrir ou de se verrouiller lorsqu'un lecteur est ouvert."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impedisce l'attenuazione o il blocco dello schermo mentre un lettore è aperto."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リーダーを開いている間、画面の減光やロックを防ぎます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "리더가 열려 있는 동안 화면이 어두워지거나 잠기지 않도록 합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запрещает затемнение и блокировку экрана, пока открыт просмотрщик."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读器打开期间，防止屏幕变暗或锁定。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閱讀器開啟期間，防止螢幕變暗或鎖定。"
           }
         }
       }

--- a/KMReader/Shared/Extensions/View+KeepScreenAwake.swift
+++ b/KMReader/Shared/Extensions/View+KeepScreenAwake.swift
@@ -1,0 +1,45 @@
+//
+// View+KeepScreenAwake.swift
+//
+//
+
+import SwiftUI
+
+#if os(iOS) || os(tvOS)
+  import UIKit
+#endif
+
+extension View {
+  /// Disables the idle timer while a reader is open when the global
+  /// "keepScreenAwakeWhileReading" setting is enabled. No-op on macOS.
+  func keepScreenAwakeWhileReading() -> some View {
+    #if os(iOS) || os(tvOS)
+      self.modifier(KeepScreenAwakeModifier())
+    #else
+      self
+    #endif
+  }
+}
+
+#if os(iOS) || os(tvOS)
+  private struct KeepScreenAwakeModifier: ViewModifier {
+    @AppStorage("keepScreenAwakeWhileReading") private var enabled: Bool = false
+
+    func body(content: Content) -> some View {
+      content
+        .onAppear {
+          apply()
+        }
+        .onChange(of: enabled) { _, _ in
+          apply()
+        }
+        .onDisappear {
+          UIApplication.shared.isIdleTimerDisabled = false
+        }
+    }
+
+    private func apply() {
+      UIApplication.shared.isIdleTimerDisabled = enabled
+    }
+  }
+#endif

--- a/KMReader/Shared/Foundation/Models/NavDestination.swift
+++ b/KMReader/Shared/Foundation/Models/NavDestination.swift
@@ -40,6 +40,9 @@ enum NavDestination: Hashable {
   case settingsDashboard
   case settingsCache
   case settingsDivinaReader
+  #if os(iOS) || os(tvOS)
+    case settingsReading
+  #endif
   #if os(iOS) || os(macOS)
     case settingsPdfReader
   #endif
@@ -180,6 +183,10 @@ enum NavDestination: Hashable {
       SettingsCacheView()
     case .settingsDivinaReader:
       DivinaPreferencesView()
+    #if os(iOS) || os(tvOS)
+      case .settingsReading:
+        SettingsReadingView()
+    #endif
     #if os(iOS) || os(macOS)
       case .settingsPdfReader:
         PdfPreferencesView()


### PR DESCRIPTION
## Summary

Implements #953: an option to keep the screen awake while reading. Users who stay on one page for a while currently have the screen dim or lock mid-reading.

## Changes

- New **Settings → Reader → Reading** page (iOS/tvOS) following the existing settings pattern (`SettingsSection` + `NavDestination` + dedicated detail view). It is scoped to reader-global session behavior that has no per-reader meaning — starting with the "Keep Screen Awake While Reading" toggle, which defaults to **off**. Existing per-reader keys (tap zones, overlay toggles, keyboard help) are intentionally untouched.
- A `keepScreenAwakeWhileReading()` view modifier toggles `UIApplication.isIdleTimerDisabled` for the lifetime of a reading session. It is applied once in `BookReaderView`, so it covers all three readers (DIVINA, EPUB, native PDF) and restores normal behavior when the reader closes or the setting is turned off mid-session.
- macOS is unaffected (no idle timer; reader runs in separate windows), and the Reading page is not listed there.
- All new strings localized in the 10 supported languages.

## Validation

- `make build-ios` / `make build-macos` / `make build-tvos` all pass; `make localize` run, `translate.py list` reports no missing translations.
