### PR TITLE
fix(browse): restore collection and read list sections on detail pages

### DIFF
--- a/KMReader/Features/Book/Views/BookReadListsSection.swift
+++ b/KMReader/Features/Book/Views/BookReadListsSection.swift
@@ -17,7 +17,7 @@ struct BookReadListsSection: View {
   }
 
   var body: some View {
-    Group {
+    VStack(alignment: .leading, spacing: 6) {
       if !readLists.isEmpty {
         VStack(alignment: .leading, spacing: 6) {
           HStack(spacing: 4) {
@@ -48,6 +48,7 @@ struct BookReadListsSection: View {
         }
       }
     }
+    .frame(maxWidth: .infinity, alignment: .leading)
     .task(id: "\(current.instanceId)|\(readListIdsKey)") {
       await loadReadLists()
     }

--- a/KMReader/Features/Series/Views/SeriesCollectionsSection.swift
+++ b/KMReader/Features/Series/Views/SeriesCollectionsSection.swift
@@ -17,7 +17,7 @@ struct SeriesCollectionsSection: View {
   }
 
   var body: some View {
-    Group {
+    VStack(alignment: .leading, spacing: 8) {
       if !collections.isEmpty {
         VStack(alignment: .leading, spacing: 8) {
           HStack(spacing: 4) {
@@ -48,6 +48,7 @@ struct SeriesCollectionsSection: View {
         }
       }
     }
+    .frame(maxWidth: .infinity, alignment: .leading)
     .task(id: "\(current.instanceId)|\(collectionIdsKey)") {
       await loadCollections()
     }


### PR DESCRIPTION
Fixes #967

## Problem

Since 4.14.466, series and book detail pages no longer show their associated Collections / Read Lists sections. The reporter bisected it to the SwiftData-to-DTO refactor in #862.

## Root Cause

That refactor rewrote `SeriesCollectionsSection` and `BookReadListsSection` from live `@Query` models into `@State` lists loaded by a `.task(id:)`. The task is attached to a `Group` whose content stays empty until the first load finishes. Inside the detail pages' `LazyVStack`, that conditionally-empty `Group` is never realized, so the task never fires and the sections never render — even though the sync layer keeps fetching and caching the ids correctly.

Verified at runtime on macOS against a live server: opening a series detail fetched `/api/v1/series/{id}/collections` and persisted the ids, but the section's task never ran (instrumented), and nothing rendered.

## Fix

Give both sections a permanent full-width `VStack` shell so the `.task` anchor is always laid out; the conditional content stays inside it.

Re-verified on macOS: the task now fires, loads the cached collections/read lists, and both the series detail (Collections) and book detail (Read Lists) render their sections again.

## Validation

- `make build` passes on iOS, macOS, and tvOS
- Runtime-verified on macOS with a live Komga server (deep-linked series/book detail pages render the sections)
