### PR TITLE
fix(reader): never regress EPUB reading progress on transient fetch failures

### DIFF
--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -79,6 +79,11 @@
     private var textLengthTask: Task<Void, Never>?
     private var initialChapterIndex: Int?
     private var initialProgression: Double?
+    /// When the remote progression fetch fails transiently and there is no local
+    /// progression to restore from, the reader falls back to page 0. Submitting
+    /// that fallback position would regress the server's progress, so all
+    /// progression submissions are suppressed for the session.
+    private var progressSubmissionSuppressed = false
     private var downloadResumeTask: Task<Void, Never>?
     private var lastUpdateTime: Date = Date()
     private let updateThrottleInterval: TimeInterval = 2.0
@@ -190,6 +195,7 @@
       textLengthTask = nil
       initialChapterIndex = nil
       initialProgression = nil
+      progressSubmissionSuppressed = false
 
       do {
         logger.debug("WebPub load started for bookId=\(bookId)")
@@ -241,10 +247,17 @@
 
         var savedProgression: R2Progression?
         if shouldResumeFromProgression, !incognito {
+          var remoteFetchFailed = false
           if !AppConfig.isOffline {
-            await syncRemoteProgressionToLocal(bookId: bookId)
+            remoteFetchFailed = await syncRemoteProgressionToLocal(bookId: bookId)
           }
           savedProgression = await database.fetchBookEpubProgression(bookId: bookId)
+          if remoteFetchFailed && savedProgression == nil {
+            progressSubmissionSuppressed = true
+            logger.warning(
+              "⚠️ [Progress/Epub] Remote progression fetch failed and no local progression exists; suppressing progress submission for this session: book=\(bookId)"
+            )
+          }
         }
 
         if let savedProgression {
@@ -925,6 +938,12 @@
       chapterProgressOverride: Double? = nil,
       totalProgressOverride: Double? = nil
     ) async {
+      guard !progressSubmissionSuppressed else {
+        logger.warning(
+          "⏭️ [Progress/Epub] Submission suppressed: position was not restored from a trusted source this session, book=\(bookId)"
+        )
+        return
+      }
       guard let location = pageLocation(chapterIndex: chapterIndex, pageIndex: pageIndex) else { return }
       let chapterProgress =
         chapterProgressOverride
@@ -1119,8 +1138,10 @@
       return readingOrder.firstIndex { Self.normalizedHref($0.href) == normalized }
     }
 
-    private func syncRemoteProgressionToLocal(bookId: String) async {
-      guard let database = await DatabaseOperator.databaseIfConfigured() else { return }
+    /// Syncs the remote progression into local storage. Returns `true` when the
+    /// fetch failed transiently, meaning the server-side position is unknown.
+    private func syncRemoteProgressionToLocal(bookId: String) async -> Bool {
+      guard let database = await DatabaseOperator.databaseIfConfigured() else { return true }
 
       let remoteState = await BookService.fetchRemoteWebPubProgression(bookId: bookId)
 
@@ -1133,24 +1154,43 @@
         logger.debug(
           "Synced remote EPUB progression to local storage: href=\(progression.locator.href), progression=\(progression.locator.locations?.progression ?? 0)"
         )
+        return false
       case .missing:
-        await database.updateBookEpubProgression(
-          bookId: bookId,
-          progression: nil
-        )
-        logger.debug("Synced remote EPUB progression to local storage: missing progression")
+        // A bare GET must never destroy a locally saved position: a busy or
+        // misbehaving server can answer with a missing-shaped response, and
+        // wiping local state here makes the reader reopen at page 0 and then
+        // upload that regressed position back to the server. Only record
+        // "missing" when there is no local progression to lose.
+        if await database.fetchBookEpubProgression(bookId: bookId) == nil {
+          await database.updateBookEpubProgression(
+            bookId: bookId,
+            progression: nil
+          )
+          logger.debug("Synced remote EPUB progression to local storage: missing progression")
+        } else {
+          logger.warning(
+            "⚠️ Remote EPUB progression reported missing but a local progression exists; keeping local position for book \(bookId)"
+          )
+        }
+        return false
       case .retryableFailure(let error):
         logger.warning(
           "Failed to fetch remote EPUB progression for book \(bookId): \(error.localizedDescription)"
         )
+        return true
       case .invalidPayload(let error):
-        await database.updateBookEpubProgression(
-          bookId: bookId,
-          progression: nil
-        )
+        // Same rule as .missing: never downgrade a local available progression
+        // on an unparseable or non-retryable response.
+        if await database.fetchBookEpubProgression(bookId: bookId) == nil {
+          await database.updateBookEpubProgression(
+            bookId: bookId,
+            progression: nil
+          )
+        }
         logger.warning(
           "Ignoring non-retryable remote EPUB progression payload for book \(bookId): \(error.localizedDescription)"
         )
+        return false
       }
     }
 


### PR DESCRIPTION
Fixes #966

## Problem

Two users lost their reading position (server `READ_PROGRESS` reset to page 0) after opening an EPUB while the Komga server was busy with a scan storm. The reporter's hypothesis — fetch fails or misbehaves on open, the client falls back to a local page-0 position, then uploads it back — matches a real path in the EPUB reader.

## Root Cause

1. `syncRemoteProgressionToLocal` (reader open) treated a missing-shaped (`204`/`404`/empty body/empty locator) or invalid progression response as authoritative and overwrote the locally saved progression with `nil` — even when a valid local position existed.
2. With no progression left, the reader reopened at page 0.
3. The next page-change capture or close flush submitted that fallback position with a fresh timestamp; the server accepted it and `READ_PROGRESS` went to 0.

## Fix

- `.missing` / `.invalidPayload` now only persist the "no progression" state when **no local progression exists**. An existing local position is always kept — a bare GET no longer destroys local state.
- When the remote fetch fails transiently (timeout/5xx/network) **and** there is no local progression to restore from, the server-side position is unknown, so all progression submissions are suppressed for that session instead of uploading the page-0 fallback. The reader still opens normally; it just refuses to push an untrusted position.

Deliberate remote deletions still propagate through the book DTO sync (`applyBook` clears `readProgress`); this change only removes the destructive side effect of the progression GET.

## Answers to the reporter's questions

1. Yes — the reader awaits the remote progression fetch before restoring the position. The bug was in how failure shapes were handled, not in ordering.
2. On failure: `retryableFailure` (timeout/5xx/network) kept local state, but `missing` and `invalidPayload` actively wiped it. That is what this PR changes.
3. A hard "never upload lower than server" rule would break legitimate re-reading (jumping back is a valid position). Instead, uploads are now suppressed only in the specific unsafe case: fetch failed transiently *and* nothing trustworthy to restore from.

## Validation

- `make build` passes on iOS, macOS, and tvOS
- Code-path review of the full chain: `EpubReaderView.loadBook` → `EpubReaderViewModel.load` → `syncRemoteProgressionToLocal` → `updateProgression` → `ReaderProgressDispatchService`
