### PR TITLE
feat(browse): dock the series reading bar trailing and collapse it on scroll

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 515;
+				CURRENT_PROJECT_VERSION = 518;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 515;
+				CURRENT_PROJECT_VERSION = 518;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 515;
+				CURRENT_PROJECT_VERSION = 518;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 515;
+				CURRENT_PROJECT_VERSION = 518;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -14,6 +14,7 @@ struct SeriesDetailView: View {
   @AppStorage("seriesDetailLayout") private var seriesDetailLayout: BrowseLayoutMode = .list
 
   @Environment(\.dismiss) private var dismiss
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
   @Environment(\.readerActions) private var readerActions
 
   @State private var item: SeriesDisplayItem?
@@ -28,6 +29,7 @@ struct SeriesDetailView: View {
   @State private var readingTargetIsOffline: Bool?
   @State private var isResolvingReadingTarget = false
   @State private var readingTargetResolutionID = 0
+  @State private var readingBarCollapsed = false
   @AppStorage("seriesBookBrowseOptions") private var seriesBookBrowseOptions: BookBrowseOptions =
     BookBrowseOptions()
 
@@ -76,6 +78,35 @@ struct SeriesDetailView: View {
 
   private var shouldShowReadingBar: Bool {
     canRead
+  }
+
+  /// Wide layouts dock the bar to the trailing corner; collapsed state
+  /// (while scrolling) always docks trailing as a compact FAB.
+  private var docksReadingBarTrailing: Bool {
+    horizontalSizeClass == .regular || readingBarCollapsed
+  }
+
+  private var readingBarMaxWidth: CGFloat {
+    horizontalSizeClass == .regular ? 420 : 720
+  }
+
+  private func updateReadingBarCollapsed(oldOffset: CGFloat, newOffset: CGFloat) {
+    let delta = newOffset - oldOffset
+
+    let collapsed: Bool
+    if newOffset <= 8 {
+      collapsed = false
+    } else if delta > 1 {
+      collapsed = true
+    } else if delta < -1 {
+      collapsed = false
+    } else {
+      return
+    }
+    guard collapsed != readingBarCollapsed else { return }
+    withAnimation(.easeInOut(duration: 0.25)) {
+      readingBarCollapsed = collapsed
+    }
   }
 
   private var readingTargetBookForCurrentContext: Book? {
@@ -148,21 +179,30 @@ struct SeriesDetailView: View {
     #endif
     .safeAreaInset(edge: .bottom, spacing: 0) {
       if shouldShowReadingBar {
-        SeriesReadingActionBar(
-          actionTitle: readLabel,
-          book: readingTargetBookForCurrentContext,
-          fallbackTitle: navigationTitle,
-          isResuming: isResumingReading,
-          isResolving: isResolvingReadingTarget,
-          action: {
-            continueReading()
+        HStack {
+          if docksReadingBarTrailing {
+            Spacer(minLength: 0)
           }
-        )
-        .frame(maxWidth: 720)
+          SeriesReadingActionBar(
+            actionTitle: readLabel,
+            book: readingTargetBookForCurrentContext,
+            fallbackTitle: navigationTitle,
+            isResuming: isResumingReading,
+            isResolving: isResolvingReadingTarget,
+            isCollapsed: readingBarCollapsed,
+            action: {
+              continueReading()
+            }
+          )
+          .frame(maxWidth: readingBarCollapsed ? nil : readingBarMaxWidth)
+        }
         .padding(.horizontal, 16)
         .padding(.top, 6)
         .padding(.bottom, 8)
       }
+    }
+    .trackReadingBarCollapse { oldOffset, newOffset in
+      updateReadingBarCollapsed(oldOffset: oldOffset, newOffset: newOffset)
     }
     .alert("Delete Series?", isPresented: $showDeleteConfirmation) {
       Button("Delete", role: .destructive) {
@@ -580,5 +620,30 @@ extension SeriesDetailView {
       return [id]
     }
     return []
+  }
+}
+
+private struct ReadingBarCollapseModifier: ViewModifier {
+  let onOffsetChange: (CGFloat, CGFloat) -> Void
+
+  func body(content: Content) -> some View {
+    if #available(iOS 18.0, macOS 15.0, tvOS 18.0, *) {
+      content
+        .onScrollGeometryChange(
+          for: CGFloat.self,
+          of: { $0.contentOffset.y + $0.contentInsets.top },
+          action: onOffsetChange
+        )
+    } else {
+      content
+    }
+  }
+}
+
+extension View {
+  func trackReadingBarCollapse(
+    onOffsetChange: @escaping (CGFloat, CGFloat) -> Void
+  ) -> some View {
+    modifier(ReadingBarCollapseModifier(onOffsetChange: onOffsetChange))
   }
 }

--- a/KMReader/Features/Series/Views/SeriesReadingActionBar.swift
+++ b/KMReader/Features/Series/Views/SeriesReadingActionBar.swift
@@ -11,6 +11,7 @@ struct SeriesReadingActionBar: View {
   let fallbackTitle: String
   let isResuming: Bool
   let isResolving: Bool
+  var isCollapsed: Bool = false
   let action: () -> Void
 
   @ScaledMetric(relativeTo: .callout) private var iconSize = 36.0
@@ -48,6 +49,7 @@ struct SeriesReadingActionBar: View {
         .contentShape(Capsule(style: .continuous))
     }
     .adaptiveButtonStyle(.plain)
+    .accessibilityLabel(Text("\(actionSummary), \(displayTitle)"))
   }
 
   @ViewBuilder
@@ -71,24 +73,26 @@ struct SeriesReadingActionBar: View {
 
   private var content: some View {
     HStack(spacing: 12) {
-      VStack(alignment: .leading, spacing: 2) {
-        Text(actionSummary)
-          .font(.caption)
-          .fontWeight(.semibold)
-          .foregroundStyle(.secondary)
-          .lineLimit(1)
+      if !isCollapsed {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(actionSummary)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
 
-        Text(displayTitle)
-          .font(.callout.weight(.semibold))
-          .foregroundStyle(.primary)
-          .lineLimit(1)
-      }
+          Text(displayTitle)
+            .font(.callout.weight(.semibold))
+            .foregroundStyle(.primary)
+            .lineLimit(1)
+        }
 
-      Spacer(minLength: 8)
+        Spacer(minLength: 8)
 
-      if isResolving {
-        ProgressView()
-          .controlSize(.small)
+        if isResolving {
+          ProgressView()
+            .controlSize(.small)
+        }
       }
 
       HStack(spacing: 12) {
@@ -103,9 +107,9 @@ struct SeriesReadingActionBar: View {
           }
       }
     }
-    .padding(.leading, 16)
+    .padding(.leading, isCollapsed ? 10 : 16)
     .padding(.trailing, 10)
     .padding(.vertical, 9)
-    .frame(maxWidth: .infinity, alignment: .leading)
+    .frame(maxWidth: isCollapsed ? nil : .infinity, alignment: .leading)
   }
 }


### PR DESCRIPTION
Fixes #965

## What changed

The bottom reading action bar on series detail pages was a wide capsule centered across the page, which looked unbalanced on iPad and covered content while scrolling.

- **Trailing dock on wide layouts**: on iPad/macOS the bar now docks to the trailing corner with a 420pt cap instead of a 720pt centered capsule.
- **Collapse on scroll**: scrolling down collapses the bar into a compact circular action button; scrolling back up (or returning to the top) expands it again.
- Collapse tracking uses `onScrollGeometryChange`, so it applies on iOS 18 / macOS 15 / tvOS 18 and later; older systems keep the static bar (same as before).
- The collapsed icon-only button keeps an explicit accessibility label.

## Validation

- `make build` passes on iOS, macOS, and tvOS
- Runtime-verified on macOS with a live server: bar docks trailing, collapses on scroll-down, expands on scroll-up
