### PR TITLE
fix(reader): resume EPUB books from page-based server progress

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 518;
+				CURRENT_PROJECT_VERSION = 519;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 518;
+				CURRENT_PROJECT_VERSION = 519;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 518;
+				CURRENT_PROJECT_VERSION = 519;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 518;
+				CURRENT_PROJECT_VERSION = 519;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -84,6 +84,11 @@
     /// that fallback position would regress the server's progress, so all
     /// progression submissions are suppressed for the session.
     private var progressSubmissionSuppressed = false
+    /// Page-based read progress from the book DTO. Komga reports page-based
+    /// progress (written by KOReader/Kindle sync, paged readers, or the web UI)
+    /// as an empty locator on the progression endpoint, so the page number is
+    /// the only resume hint for EPUB books in that state.
+    private var fallbackPageNumber: Int?
     private var downloadResumeTask: Task<Void, Never>?
     private var lastUpdateTime: Date = Date()
     private let updateThrottleInterval: TimeInterval = 2.0
@@ -151,6 +156,7 @@
     func load(book: Book) async {
       downloadInfo = book.downloadInfo
       let shouldResumeFromProgression = !book.isCompleted
+      fallbackPageNumber = shouldResumeFromProgression ? book.readProgress?.page : nil
       await load(
         bookId: book.id,
         shouldResumeFromProgression: shouldResumeFromProgression
@@ -252,7 +258,30 @@
             remoteFetchFailed = await syncRemoteProgressionToLocal(bookId: bookId)
           }
           savedProgression = await database.fetchBookEpubProgression(bookId: bookId)
-          if remoteFetchFailed && savedProgression == nil {
+
+          if savedProgression == nil,
+            let fallbackPage = fallbackPageNumber,
+            fallbackPage > 1
+          {
+            // Komga answers the progression GET with an empty locator whenever
+            // the stored read progress is page-based (KOReader/Kindle sync,
+            // paged readers, web UI). That is not "no progress": map the known
+            // page to a locator via the positions endpoint so the EPUB reader
+            // resumes there instead of falling back to the first page.
+            savedProgression = await restoreProgressionFromServerPage(
+              bookId: bookId,
+              page: fallbackPage,
+              database: database
+            )
+            if savedProgression == nil {
+              // The server has progress but it could not be located; never let
+              // this session upload the first-page fallback over it.
+              progressSubmissionSuppressed = true
+              logger.warning(
+                "⚠️ [Progress/Epub] Server has page-based progress (page \(fallbackPage)) that could not be mapped to a locator; suppressing progress submission for this session: book=\(bookId)"
+              )
+            }
+          } else if remoteFetchFailed && savedProgression == nil {
             progressSubmissionSuppressed = true
             logger.warning(
               "⚠️ [Progress/Epub] Remote progression fetch failed and no local progression exists; suppressing progress submission for this session: book=\(bookId)"
@@ -1192,6 +1221,61 @@
         )
         return false
       }
+    }
+
+    /// Maps a page-based server read progress to a locator using the WebPub
+    /// positions endpoint. Returns nil when the page cannot be mapped, in which
+    /// case the caller must treat the position as unknown rather than falling
+    /// back to the first page.
+    private func restoreProgressionFromServerPage(
+      bookId: String,
+      page: Int,
+      database: DatabaseOperator
+    ) async -> R2Progression? {
+      guard !AppConfig.isOffline else { return nil }
+
+      let positions: R2Positions
+      do {
+        positions = try await BookService.getWebPubPositions(bookId: bookId)
+      } catch {
+        logger.warning(
+          "⚠️ [Progress/Epub] Failed to fetch positions for page-based resume: book=\(bookId), error=\(error.localizedDescription)"
+        )
+        return nil
+      }
+
+      let candidates = positions.positions.compactMap { locator -> (position: Int, locator: R2Locator)? in
+        guard let position = locator.locations?.position else { return nil }
+        return (position, locator)
+      }
+      guard !candidates.isEmpty else { return nil }
+
+      let sorted = candidates.sorted { $0.position < $1.position }
+      guard let match = sorted.last(where: { $0.position <= page }) ?? sorted.first else {
+        return nil
+      }
+
+      let locator = match.locator
+      guard chapterIndexForHref(locator.href) != nil else {
+        logger.warning(
+          "⚠️ [Progress/Epub] Position locator does not match any chapter: book=\(bookId), href=\(locator.href)"
+        )
+        return nil
+      }
+
+      let progression = R2Progression(
+        modified: Date(),
+        device: R2Device(
+          id: AppConfig.deviceIdentifier,
+          name: AppConfig.userAgent
+        ),
+        locator: locator
+      )
+      await database.updateBookEpubProgression(bookId: bookId, progression: progression)
+      logger.info(
+        "📖 [Progress/Epub] Resumed from page-based server progress: book=\(bookId), page=\(page), href=\(locator.href)"
+      )
+      return progression
     }
 
     private func stripResourcePrefix(_ href: String) -> String {


### PR DESCRIPTION
Refs #966 (follow-up to #969)

## New evidence from the reporter

The wipe recurred on build 504 with instrumentation running, and the details ruled out the original theory: the server wrote page 1 (not 0), the trigger was a few seconds of unrelated host load (no scan storm, Komga never restarted), and a different phone produced the same behavior.

## Actual mechanism

Komga's progression endpoint returns `200` with an **empty locator** (`R2Locator("", "")`) whenever the stored `ReadProgress` row is page-based — i.e. written by a KOReader/Kindle sync, a paged reader, or the web UI (`ReadProgress.toR2Progression()` uses `locator ?: R2Locator("", "")`).

KMReader classified that empty locator as "no progression", so opening an EPUB in that state discarded the server's position and — on the next page-change capture or close flush — uploaded the first-page fallback, overwriting the server's progress. No server malfunction is required; the load spikes on both reported days were incidental. The Kindle-written page (1744) was destroyed on the next KMReader EPUB open.

## What this PR changes

- When the progression GET yields no usable locator **and** the book DTO carries page-based progress (`readProgress.page > 1`), the reader now maps the page to a locator through the WebPub positions endpoint, persists it as the local progression, and resumes there — so Kindle ↔ KMReader EPUB handoff resumes correctly.
- If the page cannot be mapped (positions unavailable, locator matches no chapter), the session suppresses all progression submissions, so the server position is never overwritten by the first-page fallback.
- Together with #969 (no local wipe on missing/invalid responses + suppression on transient fetch failure), both sides of the wipe chain are now closed.

## Validation

- `make build` passes on iOS, macOS, and tvOS
- Verified against Komga server source (`CommonBookController.getBookProgression`, `ReadProgress.toR2Progression`) to confirm the empty-locator behavior
