### PR TITLE
fix(reader): resolve end-page colors against the view appearance on macOS

### DIFF
--- a/KMReader/Features/Reader/Views/NativeEndPageContentView_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativeEndPageContentView_macOS.swift
@@ -73,6 +73,29 @@
       setupUI()
     }
 
+    override func viewDidChangeEffectiveAppearance() {
+      super.viewDidChangeEffectiveAppearance()
+      applyAppearanceColors()
+    }
+
+    /// Dynamic colors (the `.system` reader background and `.primary` content
+    /// color) must be snapshotted under this view's own appearance. `configure`
+    /// can run before the view enters a window, where the current drawing
+    /// appearance still reflects the system light mode, baking a white
+    /// background that then clashes with the dark-mode text.
+    private func applyAppearanceColors() {
+      let backgroundColor = NSColor(renderConfig.readerBackground.color)
+      let textColor = NSColor(renderConfig.readerBackground.contentColor)
+      effectiveAppearance.performAsCurrentDrawingAppearance {
+        layer?.backgroundColor = backgroundColor.cgColor
+        leadingDivider.layer?.backgroundColor = textColor.withAlphaComponent(0.3).cgColor
+        trailingDivider.layer?.backgroundColor = textColor.withAlphaComponent(0.3).cgColor
+        verticalDivider.layer?.backgroundColor = textColor.withAlphaComponent(0.3).cgColor
+      }
+      previousCoverView.useLightShadow = shouldUseLightCoverShadow
+      nextCoverView.useLightShadow = shouldUseLightCoverShadow
+    }
+
     required init?(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
     }
@@ -105,7 +128,7 @@
 
     private func setupUI() {
       wantsLayer = true
-      layer?.backgroundColor = NSColor(renderConfig.readerBackground.color).cgColor
+      applyAppearanceColors()
 
       contentStack.translatesAutoresizingMaskIntoConstraints = false
       contentStack.orientation = .vertical
@@ -314,7 +337,7 @@
       )
       let relationTitle = presentation.relationTitle
 
-      layer?.backgroundColor = NSColor(renderConfig.readerBackground.color).cgColor
+      applyAppearanceColors()
 
       dividerTitleLabel.stringValue = relationTitle
       dividerTitleLabel.isHidden = relationTitle.isEmpty
@@ -338,11 +361,6 @@
       caughtUpIconView.contentTintColor = textColor
       caughtUpLabel.textColor = textColor
       dividerTitleLabel.textColor = textColor.withAlphaComponent(0.8)
-      leadingDivider.layer?.backgroundColor = textColor.withAlphaComponent(0.3).cgColor
-      trailingDivider.layer?.backgroundColor = textColor.withAlphaComponent(0.3).cgColor
-      verticalDivider.layer?.backgroundColor = textColor.withAlphaComponent(0.3).cgColor
-      previousCoverView.useLightShadow = shouldUseLightCoverShadow
-      nextCoverView.useLightShadow = shouldUseLightCoverShadow
       previousCoverView.imageBlendTintColor = coverBlendTintColor
       nextCoverView.imageBlendTintColor = coverBlendTintColor
 


### PR DESCRIPTION
## Problem

Reported by a user on v6.1 (515), macOS 26.5.2, Dark color scheme: the transition page between volumes/chapters flashes dark for a split second, then flips to white — and since the text is also white, nothing is readable.

## Root Cause

The macOS end-page view bakes its dynamic background color into a `CGColor` when `configure()` runs:

```swift
layer?.backgroundColor = NSColor(renderConfig.readerBackground.color).cgColor
```

`configure()` can run before the view enters a window, where the current drawing appearance still reflects the system appearance. With macOS in light mode and KMReader set to dark, the background bakes to white, while the labels keep dynamic colors that later resolve to white text against the view's real (dark) effective appearance — white on white. The "dark for a split second" is the outgoing page; the white is the mis-baked end page.

## Fix

- All appearance-dependent `CGColor` snapshots (background layer, divider lines) now resolve inside `effectiveAppearance.performAsCurrentDrawingAppearance`, i.e. against the view's own appearance rather than the call-time global one.
- `viewDidChangeEffectiveAppearance` re-applies them, so colors correct themselves the moment the view enters the window with its real appearance.
- Cover shadow selection moved into the same entry point.

Scope note: the same bake pattern exists in a few other macOS reader views (`NativePagedPageContentView`, `NativeCoverSlotView`, `WebtoonPageCell`, …), but those are configured while already in a window and are not implicated by the report, so they are intentionally untouched.

No version bump — intended to ride along with the next batched bump.

## Validation

- `make build` passes on iOS, macOS, tvOS (change is macOS-only, wrapped in `#if os(macOS)`)
- Not yet verified on-device in the reporter's exact setup (macOS light + app dark); the mechanism fix is appearance-scope correctness, which holds regardless
