### PR TITLE
feat: refresh EPUB locators during recently-read sync for offline resume

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 519;
+				CURRENT_PROJECT_VERSION = 520;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 519;
+				CURRENT_PROJECT_VERSION = 520;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 519;
+				CURRENT_PROJECT_VERSION = 520;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 519;
+				CURRENT_PROJECT_VERSION = 520;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Metadata.swift
@@ -672,6 +672,40 @@ extension DatabaseOperator {
     return bookIds
   }
 
+  /// Returns the `modified` timestamp of the cached Readium locator for each
+  /// requested book that is a downloaded EPUB. A nil timestamp means no usable
+  /// locator is cached (never fetched or recorded as missing).
+  func fetchDownloadedEpubProgressionModifiedDates(
+    instanceId: String,
+    bookIds: [String]
+  ) async -> [(bookId: String, progressionModified: Date?)] {
+    guard !bookIds.isEmpty else { return [] }
+    guard
+      let results = try? read({ db in
+        try KomgaBook
+          .filter(KomgaBook.Columns.instanceId == instanceId)
+          .filter(bookIds.contains(KomgaBook.Columns.bookId))
+          .filter(KomgaBook.Columns.downloadStatusRaw == "downloaded")
+          .filter(KomgaBook.Columns.mediaProfile == MediaProfile.epub.rawValue)
+          .fetchAll(db)
+      })
+    else {
+      return []
+    }
+    var checkpoints: [(bookId: String, progressionModified: Date?)] = []
+    checkpoints.reserveCapacity(results.count)
+    for book in results {
+      if case .available(let progression) = await decodeStoredEpubProgressionState(
+        book.epubProgressionRaw
+      ) {
+        checkpoints.append((book.bookId, progression.modified))
+      } else {
+        checkpoints.append((book.bookId, nil))
+      }
+    }
+    return checkpoints
+  }
+
   func fetchReadBooksEligibleForAutoDelete(instanceId: String) -> [(id: String, seriesId: String)] {
     (try? read { db in
       let now = Date.now

--- a/KMReader/Core/Storage/GRDB/GRDBRecords.swift
+++ b/KMReader/Core/Storage/GRDB/GRDBRecords.swift
@@ -119,6 +119,7 @@ nonisolated extension KomgaBook: FetchableRecord, MutablePersistableRecord {
     static let metaReleaseDate = Column(CodingKeys.metaReleaseDate)
     static let progressReadDate = Column(CodingKeys.progressReadDate)
     static let downloadStatusRaw = Column(CodingKeys.downloadStatusRaw)
+    static let mediaProfile = Column(CodingKeys.mediaProfile)
     static let downloadAt = Column(CodingKeys.downloadAt)
   }
 

--- a/KMReader/Features/Book/Services/EpubPageProgressionMapper.swift
+++ b/KMReader/Features/Book/Services/EpubPageProgressionMapper.swift
@@ -1,0 +1,50 @@
+//
+// EpubPageProgressionMapper.swift
+//
+//
+
+import Foundation
+
+/// Maps a page-based server read progress to a Readium progression using the
+/// WebPub positions endpoint. Used when the server stores page-based progress
+/// (KOReader/Kindle sync, paged readers, web UI) and the progression endpoint
+/// answers with an empty locator. Returns nil when the page cannot be mapped,
+/// in which case callers must treat the position as unknown rather than
+/// falling back to the first page.
+enum EpubPageProgressionMapper {
+  static let logger = AppLogger(.reader)
+
+  static func progression(bookId: String, page: Int) async -> R2Progression? {
+    guard !AppConfig.isOffline else { return nil }
+
+    let positions: R2Positions
+    do {
+      positions = try await BookService.getWebPubPositions(bookId: bookId)
+    } catch {
+      logger.warning(
+        "⚠️ [Progress/Epub] Failed to fetch positions for page-based mapping: book=\(bookId), error=\(error.localizedDescription)"
+      )
+      return nil
+    }
+
+    let candidates = positions.positions.compactMap { locator -> (position: Int, locator: R2Locator)? in
+      guard let position = locator.locations?.position else { return nil }
+      return (position, locator)
+    }
+    guard !candidates.isEmpty else { return nil }
+
+    let sorted = candidates.sorted { $0.position < $1.position }
+    guard let match = sorted.last(where: { $0.position <= page }) ?? sorted.first else {
+      return nil
+    }
+
+    return R2Progression(
+      modified: Date(),
+      device: R2Device(
+        id: AppConfig.deviceIdentifier,
+        name: AppConfig.userAgent
+      ),
+      locator: match.locator
+    )
+  }
+}

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -1232,48 +1232,25 @@
       page: Int,
       database: DatabaseOperator
     ) async -> R2Progression? {
-      guard !AppConfig.isOffline else { return nil }
+      guard
+        let progression = await EpubPageProgressionMapper.progression(
+          bookId: bookId,
+          page: page
+        )
+      else {
+        return nil
+      }
 
-      let positions: R2Positions
-      do {
-        positions = try await BookService.getWebPubPositions(bookId: bookId)
-      } catch {
+      guard chapterIndexForHref(progression.locator.href) != nil else {
         logger.warning(
-          "⚠️ [Progress/Epub] Failed to fetch positions for page-based resume: book=\(bookId), error=\(error.localizedDescription)"
+          "⚠️ [Progress/Epub] Position locator does not match any chapter: book=\(bookId), href=\(progression.locator.href)"
         )
         return nil
       }
 
-      let candidates = positions.positions.compactMap { locator -> (position: Int, locator: R2Locator)? in
-        guard let position = locator.locations?.position else { return nil }
-        return (position, locator)
-      }
-      guard !candidates.isEmpty else { return nil }
-
-      let sorted = candidates.sorted { $0.position < $1.position }
-      guard let match = sorted.last(where: { $0.position <= page }) ?? sorted.first else {
-        return nil
-      }
-
-      let locator = match.locator
-      guard chapterIndexForHref(locator.href) != nil else {
-        logger.warning(
-          "⚠️ [Progress/Epub] Position locator does not match any chapter: book=\(bookId), href=\(locator.href)"
-        )
-        return nil
-      }
-
-      let progression = R2Progression(
-        modified: Date(),
-        device: R2Device(
-          id: AppConfig.deviceIdentifier,
-          name: AppConfig.userAgent
-        ),
-        locator: locator
-      )
       await database.updateBookEpubProgression(bookId: bookId, progression: progression)
       logger.info(
-        "📖 [Progress/Epub] Resumed from page-based server progress: book=\(bookId), page=\(page), href=\(locator.href)"
+        "📖 [Progress/Epub] Resumed from page-based server progress: book=\(bookId), page=\(page), href=\(progression.locator.href)"
       )
       return progression
     }

--- a/KMReader/Features/Sync/Services/SyncWorker.swift
+++ b/KMReader/Features/Sync/Services/SyncWorker.swift
@@ -180,6 +180,11 @@ actor SyncWorker {
             instanceId: instanceId
           )
           syncedCount += booksToSync.count
+          await refreshDownloadedEpubProgressions(
+            books: booksToSync,
+            instanceId: instanceId,
+            database: database
+          )
         }
 
         page += 1
@@ -196,6 +201,97 @@ actor SyncWorker {
     } catch {
       logger.warning("⚠️ Failed to sync latest recently-read progress: \(error)")
       return false
+    }
+  }
+
+  /// Tolerates clock skew between the server-side readProgress.lastModified
+  /// and the client-supplied locator `modified` timestamp, so a locator this
+  /// device just uploaded is not immediately re-fetched.
+  private let epubProgressionSkewTolerance: TimeInterval = 60
+
+  /// Refreshes cached Readium locators for downloaded, in-progress EPUBs whose
+  /// server-side read progress changed. Batch book endpoints only expose
+  /// page-based progress, so the locator stored in `epubProgressionRaw` must
+  /// be re-fetched per book here; otherwise reopening the book offline resumes
+  /// from a stale position.
+  private func refreshDownloadedEpubProgressions(
+    books: [Book],
+    instanceId: String,
+    database: DatabaseOperator
+  ) async {
+    let inProgress = books.filter { $0.isInProgress }
+    guard !inProgress.isEmpty else { return }
+
+    let checkpoints = await database.fetchDownloadedEpubProgressionModifiedDates(
+      instanceId: instanceId,
+      bookIds: inProgress.map(\.id)
+    )
+    guard !checkpoints.isEmpty else { return }
+
+    let lastModifiedByBookId = Dictionary(
+      uniqueKeysWithValues: inProgress.compactMap { book in
+        book.readProgress.map { (book.id, $0.lastModified) }
+      }
+    )
+    let pageByBookId = Dictionary(
+      uniqueKeysWithValues: inProgress.compactMap { book in
+        book.readProgress.map { (book.id, $0.page) }
+      }
+    )
+
+    var refreshedCount = 0
+    for checkpoint in checkpoints {
+      guard let serverLastModified = lastModifiedByBookId[checkpoint.bookId] else { continue }
+      if let localModified = checkpoint.progressionModified,
+        serverLastModified <= localModified.addingTimeInterval(epubProgressionSkewTolerance)
+      {
+        continue
+      }
+
+      switch await BookService.fetchRemoteWebPubProgression(bookId: checkpoint.bookId) {
+      case .available(let progression):
+        await database.updateBookEpubProgression(
+          bookId: checkpoint.bookId,
+          progression: progression
+        )
+        refreshedCount += 1
+      case .missing:
+        // A missing locator with a non-zero page means the server stores
+        // page-based progress (KOReader/Kindle sync, paged readers, web UI);
+        // map the page to a locator so offline resume can use it.
+        let page = pageByBookId[checkpoint.bookId] ?? 0
+        if page > 0,
+          let progression = await EpubPageProgressionMapper.progression(
+            bookId: checkpoint.bookId,
+            page: page
+          )
+        {
+          await database.updateBookEpubProgression(
+            bookId: checkpoint.bookId,
+            progression: progression
+          )
+          refreshedCount += 1
+        } else if checkpoint.progressionModified == nil {
+          // Never downgrade a locally cached locator on a missing-shaped
+          // response; only record "missing" when there is no local position.
+          await database.updateBookEpubProgression(
+            bookId: checkpoint.bookId,
+            progression: nil
+          )
+        }
+      case .retryableFailure(let error):
+        logger.warning(
+          "⚠️ Failed to refresh EPUB progression for book \(checkpoint.bookId): \(error.localizedDescription)"
+        )
+      case .invalidPayload(let error):
+        logger.warning(
+          "⚠️ Ignoring non-retryable EPUB progression payload for book \(checkpoint.bookId): \(error.localizedDescription)"
+        )
+      }
+    }
+
+    if refreshedCount > 0 {
+      logger.info("📖 Refreshed EPUB progression for \(refreshedCount) downloaded books")
     }
   }
 


### PR DESCRIPTION
## 背景

Komga 的批量书籍接口（含最近阅读）只携带 page-based 的 `ReadProgressDto`，EPUB 的精确位置（Readium locator）只能通过单书接口 `GET /api/v1/books/{id}/progression` 获取。此前本地缓存的 locator（`epubProgressionRaw`）只会在打开 EPUB 阅读器且在线时刷新，批量同步链路从不更新它——导致在其他设备上读过之后，离线打开 EPUB 总是回到旧位置。

## 改动

- **最近阅读同步时刷新 locator**：`SyncWorker.syncReadingProgress` 每轮增量同步后，对在读且已下载的 EPUB，比较服务端 `readProgress.lastModified` 与本地缓存 locator 的 `modified`（含 60 秒时钟偏移容差，避免本机刚上传的 locator 被立即回抓），仅在服务端更新时重新拉取 `/progression` 并写入本地。候选集本身被 readDate marker 限定为进度有变化的书，请求量有界。
- **page-based 进度的在线预映射**：`/progression` 返回空 locator 但服务端 `page > 0` 时（KOReader/Kindle 同步、分页阅读器、Web UI 写入的进度），同步路径直接通过 `/positions` 把页码映射为 locator 存下，离线打开也能准确定位。已读完的书不参与刷新与映射。
- **提取共享 mapper**：`EpubReaderViewModel` 原有的 page→locator 映射逻辑提取为 `EpubPageProgressionMapper`，阅读器与同步 worker 复用；阅读器侧保留 chapter 匹配校验，行为不变。
- `.missing` 响应不会覆盖本地已有 locator（沿用"bare GET 不毁本地位置"的保护规则）；失败仅记日志，不影响同步结果。无 schema 变更，无需新 migration。

## 验证

- `make build`：iOS / macOS / tvOS 全部构建成功
- `make format`：已格式化
