### PR TITLE
fix(browse): polish series reading bar collapse animation and icon styling

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 520;
+				CURRENT_PROJECT_VERSION = 521;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 520;
+				CURRENT_PROJECT_VERSION = 521;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 520;
+				CURRENT_PROJECT_VERSION = 521;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 520;
+				CURRENT_PROJECT_VERSION = 521;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -104,7 +104,7 @@ struct SeriesDetailView: View {
       return
     }
     guard collapsed != readingBarCollapsed else { return }
-    withAnimation(.easeInOut(duration: 0.25)) {
+    withAnimation(.spring(duration: 0.45, bounce: 0.35)) {
       readingBarCollapsed = collapsed
     }
   }

--- a/KMReader/Features/Series/Views/SeriesReadingActionBar.swift
+++ b/KMReader/Features/Series/Views/SeriesReadingActionBar.swift
@@ -97,19 +97,14 @@ struct SeriesReadingActionBar: View {
 
       HStack(spacing: 12) {
         Image(systemName: actionIcon)
-          .font(.subheadline.weight(.bold))
+          .font(.title3.weight(.bold))
           .foregroundStyle(Color.accentColor)
           .frame(width: iconSize, height: iconSize)
-          .background(Color.primary.opacity(0.08), in: Circle())
-          .overlay {
-            Circle()
-              .strokeBorder(Color.primary.opacity(0.06))
-          }
       }
     }
     .padding(.leading, isCollapsed ? 10 : 16)
     .padding(.trailing, 10)
-    .padding(.vertical, 9)
+    .padding(.vertical, isCollapsed ? 10 : 9)
     .frame(maxWidth: isCollapsed ? nil : .infinity, alignment: .leading)
   }
 }


### PR DESCRIPTION
## Summary

Polish follow-up for the collapsible series reading action bar from #965:

- Collapse/expand now uses a spring animation (`.spring(duration: 0.45, bounce: 0.35)`) instead of `easeInOut`, matching the bouncy feel of the system tab bar collapsing.
- The action icon no longer renders an inner circle background and stroke ring inside the capsule. Collapsed state previously showed two nested rings (outer capsule + inner circle); both states now show a clean accent icon.
- Icon glyph enlarged from `.subheadline` to `.title3` so it stays well-proportioned without the inner ring, especially in the circular collapsed button.
- Collapsed padding is symmetric (10pt all around) so the capsule forms a perfect 56×56 circle instead of a slight oval.

## Validation

- `make build-ios` passes.
