### PR TITLE
fix(series): simplify reading bar collapse to top-only, reduce bounce

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 521;
+				CURRENT_PROJECT_VERSION = 522;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 521;
+				CURRENT_PROJECT_VERSION = 522;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 521;
+				CURRENT_PROJECT_VERSION = 522;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 521;
+				CURRENT_PROJECT_VERSION = 522;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -91,20 +91,9 @@ struct SeriesDetailView: View {
   }
 
   private func updateReadingBarCollapsed(oldOffset: CGFloat, newOffset: CGFloat) {
-    let delta = newOffset - oldOffset
-
-    let collapsed: Bool
-    if newOffset <= 8 {
-      collapsed = false
-    } else if delta > 1 {
-      collapsed = true
-    } else if delta < -1 {
-      collapsed = false
-    } else {
-      return
-    }
+    let collapsed = newOffset > 8
     guard collapsed != readingBarCollapsed else { return }
-    withAnimation(.spring(duration: 0.45, bounce: 0.35)) {
+    withAnimation(.spring(duration: 0.35, bounce: 0.12)) {
       readingBarCollapsed = collapsed
     }
   }


### PR DESCRIPTION
- Reading bar now only shows when scrolled to top (offset <= 8), stays collapsed otherwise
- Remove expand-on-scroll-up behavior
- Reduce spring bounce from 0.35 → 0.12 for subtler collapse animation