### PR TITLE
fix(offline): remove leftover book directories on cancel and early failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ This file provides guidance to coding agents working with code in this repositor
 - **Series Policies**: Manual, unread-only, or all books per series/read list.
 - **Offline Mode**: Full reader functionality with downloaded content. Progress syncs when reconnected.
 - **Two-Tier Caching**: Pages and thumbnails with adjustable limits and auto-cleanup.
+- **Download Directory Lifecycle**: Cancelling a download removes its on-disk book directory. Failed downloads keep partial content for resume on retry, but empty directories left by early failures are removed immediately instead of becoming orphans.
 
 ### Browse & Dashboards
 

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -222,6 +222,41 @@ actor OfflineManager {
     return url
   }
 
+  /// On-disk location for a book's offline files. Unlike `bookDirectory`, never creates it.
+  private static func bookDirectoryURL(instanceId: String, bookId: String) -> URL {
+    offlineDirectory(for: instanceId)
+      .appendingPathComponent(bookId, isDirectory: true)
+  }
+
+  /// Removes the book's offline directory if present. Never creates it.
+  private func removeBookDirectory(instanceId: String, bookId: String) {
+    let dir = Self.bookDirectoryURL(instanceId: instanceId, bookId: bookId)
+    guard FileManager.default.fileExists(atPath: dir.path) else { return }
+    do {
+      try FileManager.default.removeItem(at: dir)
+      logger.info("🗑️ Removed offline directory for book: \(bookId)")
+    } catch {
+      logger.error("❌ Failed to remove offline directory \(bookId): \(error)")
+    }
+  }
+
+  /// Removes the book's offline directory only when it holds no files, so downloads
+  /// that failed or were cancelled before writing content don't leave empty shells
+  /// behind. Directories with partial content are kept for resume on retry.
+  private func removeBookDirectoryIfEmpty(instanceId: String, bookId: String) {
+    let dir = Self.bookDirectoryURL(instanceId: instanceId, bookId: bookId)
+    var isDir: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: dir.path, isDirectory: &isDir),
+      isDir.boolValue, !Self.directoryContainsFiles(dir)
+    else { return }
+    do {
+      try FileManager.default.removeItem(at: dir)
+      logger.info("🗑️ Removed empty offline directory for book: \(bookId)")
+    } catch {
+      logger.error("❌ Failed to remove empty offline directory \(bookId): \(error)")
+    }
+  }
+
   private func webPubRootURL(bookDir: URL) -> URL {
     let url = bookDir.appendingPathComponent("webpub", isDirectory: true)
     Self.ensureDirectoryExists(at: url)
@@ -417,7 +452,6 @@ actor OfflineManager {
   ) async {
     await cancelDownload(
       bookId: bookId, instanceId: instanceId, commit: false, syncSeriesStatus: syncSeriesStatus)
-    let dir = bookDirectory(instanceId: instanceId, bookId: bookId)
 
     // Update local database
     try? await DatabaseOperator.database().updateBookDownloadStatus(
@@ -429,17 +463,8 @@ actor OfflineManager {
       await refreshQueueStatus(instanceId: instanceId)
     }
 
-    // Then delete files
-    Task.detached { [logger] in
-      do {
-        if FileManager.default.fileExists(atPath: dir.path) {
-          try FileManager.default.removeItem(at: dir)
-        }
-        logger.info("🗑️ Deleted offline book: \(bookId)")
-      } catch {
-        logger.error("❌ Failed to delete book \(bookId): \(error)")
-      }
-    }
+    // Safety net: cancelDownload already removed the on-disk directory.
+    removeBookDirectory(instanceId: instanceId, bookId: bookId)
 
     #if os(iOS) || os(macOS)
       SpotlightIndexService.removeBook(bookId: bookId, instanceId: instanceId)
@@ -604,10 +629,15 @@ actor OfflineManager {
   ) async {
     removeActiveTask(bookId)
     let resolvedInstanceId = instanceId ?? AppConfig.current.instanceId
+    #if os(iOS)
+      await BackgroundDownloadManager.shared.cancelDownloads(forBookId: bookId)
+      clearBackgroundDownloadContext(bookId: bookId)
+    #endif
     try? await DatabaseOperator.database().updateBookDownloadStatus(
       bookId: bookId, instanceId: resolvedInstanceId, status: .notDownloaded,
       syncSeriesStatus: syncSeriesStatus
     )
+    removeBookDirectory(instanceId: resolvedInstanceId, bookId: bookId)
     if commit {
       await postDownloadProjectionDidChange(bookId: bookId, instanceId: resolvedInstanceId)
       await refreshQueueStatus(instanceId: resolvedInstanceId)
@@ -1002,6 +1032,7 @@ actor OfflineManager {
         await BackgroundDownloadManager.shared.cancelDownloads(forBookId: info.bookId)
         clearBackgroundDownloadContext(bookId: info.bookId)
         removeActiveTask(info.bookId)
+        removeBookDirectoryIfEmpty(instanceId: instanceId, bookId: info.bookId)
         try? await DatabaseOperator.database().updateBookDownloadStatus(
           bookId: info.bookId,
           instanceId: instanceId,
@@ -1836,17 +1867,7 @@ actor OfflineManager {
   }
 
   private func removeOfflineFiles(instanceId: String, bookId: String) {
-    let dir = bookDirectory(instanceId: instanceId, bookId: bookId)
-    Task.detached { [logger] in
-      do {
-        if FileManager.default.fileExists(atPath: dir.path) {
-          try FileManager.default.removeItem(at: dir)
-        }
-        logger.info("🗑️ Deleted offline book files: \(bookId)")
-      } catch {
-        logger.error("❌ Failed to delete offline book files \(bookId): \(error)")
-      }
-    }
+    removeBookDirectory(instanceId: instanceId, bookId: bookId)
 
     #if os(iOS) || os(macOS)
       SpotlightIndexService.removeBook(bookId: bookId, instanceId: instanceId)
@@ -2181,6 +2202,7 @@ actor OfflineManager {
       await BackgroundDownloadManager.shared.cancelDownloads(forBookId: bookId)
       clearBackgroundDownloadContext(bookId: bookId)
       removeActiveTask(bookId)
+      removeBookDirectoryIfEmpty(instanceId: info.instanceId, bookId: bookId)
 
       // Update Live Activity or end if no more pending
       let pendingBooks =
@@ -2348,6 +2370,7 @@ actor OfflineManager {
           await postDownloadProjectionDidChange(bookId: bookId, instanceId: info.instanceId)
           clearBackgroundDownloadContext(bookId: bookId)
           removeActiveTask(bookId)
+          removeBookDirectoryIfEmpty(instanceId: info.instanceId, bookId: bookId)
           await refreshQueueStatus(instanceId: info.instanceId)
           await syncDownloadQueue(instanceId: info.instanceId)
           return


### PR DESCRIPTION
## Problem

Cleaning up orphaned downloaded files always reported a correct count but **0 bytes freed**. Investigation showed the orphans are empty directory shells, not real leftover content:

- `bookDirectory()` calls `ensureDirectoryExists`, so the directory is created eagerly at download start — and even in delete/inspect paths that never downloaded anything.
- Failure and cancellation paths only flipped the database status (`failed` / `notDownloaded`) and never removed the on-disk directory.
- `deleteBook` / `removeOfflineFiles` created the directory first and then deleted it in a `Task.detached`; if the app was killed in between, an empty orphan remained.

Since orphan cleanup only considers books in `downloaded` state, these empty shells were counted but contributed 0 bytes.

## Changes

- Add a non-creating `bookDirectoryURL` plus `removeBookDirectory` / `removeBookDirectoryIfEmpty` helpers; removal paths never create the directory anymore.
- `cancelDownload` now cancels iOS background URLSession tasks, clears the background download context, and removes the on-disk book directory instead of only updating the database status.
- iOS background download failure paths (start failure, per-file failure, finalize with missing archive/resources) remove the directory **only when it holds no files**; directories with partial pages are kept so retry can resume from existing pages.
- `deleteBook` and `removeOfflineFiles` use the non-creating removal path, closing the create-then-detached-delete race.
- Document the download directory lifecycle boundary in AGENTS.md.

## Resulting behavior

Empty shells no longer accumulate, so orphan cleanup stops reporting "N items, 0 bytes". Remaining orphans (e.g. from force-kill edge cases) contain real files and report real sizes. Partial downloads still survive failure for resume on retry; explicit cancel/delete removes everything as before.

## Validation

- `make build-ios`, `make build-macos`, `make build-tvos` all pass (run sequentially).
