### PR TITLE
feat(dashboard): horizontal cards for Keep Reading (#970)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ This file provides guidance to coding agents working with code in this repositor
 ### Browse & Dashboards
 
 - **Dynamic Dashboards**: Keep Reading, On Deck, Recently Added, Recently Updated with real-time SSE updates.
+- **Dashboard Book Card Style**: The Keep Reading section renders books as horizontal cards (`BookHorizontalCardView`: cover left, series/title/progress right) by default; classic cover cards remain available via the `dashboardHorizontalBookCards` toggle in Dashboard settings. Pinned read list/collection cards (`ReadListHorizontalCardView`, `CollectionHorizontalCardView`) share the same sizing via `LayoutConfig.horizontalCardWidth` / `LayoutConfig.horizontalCoverWidth`.
 - **Advanced Filters**: Search with metadata filters (authors, genres, tags, publishers) using all/any logic.
 - **Grid/List Layouts**: Multiple density options (compact, standard, comfortable).
 - **Library Filtering**: Browse per-library or across all libraries.

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 524;
+				CURRENT_PROJECT_VERSION = 525;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 524;
+				CURRENT_PROJECT_VERSION = 525;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 524;
+				CURRENT_PROJECT_VERSION = 525;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 524;
+				CURRENT_PROJECT_VERSION = 525;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Views/BookHorizontalCardPlaceholder.swift
+++ b/KMReader/Features/Book/Views/BookHorizontalCardPlaceholder.swift
@@ -1,0 +1,59 @@
+//
+// BookHorizontalCardPlaceholder.swift
+//
+//
+
+import SwiftUI
+
+/// Placeholder skeleton matching BookHorizontalCardView while data is loading
+struct BookHorizontalCardPlaceholder: View {
+  var coverWidth: CGFloat = 60
+
+  private let cornerRadius: CGFloat = 8
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 10) {
+      RoundedRectangle(cornerRadius: cornerRadius)
+        .fill(Color.gray.opacity(0.2))
+        .aspectRatio(CoverAspectRatio.widthToHeight, contentMode: .fit)
+        .frame(width: coverWidth)
+
+      VStack(alignment: .leading, spacing: 2) {
+        placeholderLine(textStyle: .caption, text: "Series Title", widthScale: 0.45, opacity: 0.18)
+        placeholderLine(textStyle: .footnote, text: "Book Title", widthScale: 0.8, opacity: 0.2)
+
+        Spacer(minLength: 2)
+
+        placeholderLine(textStyle: .caption, text: "Page 42 • 36%", widthScale: 0.55, opacity: 0.15)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    }
+    .padding(8)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background {
+      RoundedRectangle(cornerRadius: 12)
+        .fill(.regularMaterial)
+        .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
+    }
+  }
+
+  private func placeholderLine(
+    textStyle: Font.TextStyle,
+    text: String,
+    widthScale: CGFloat,
+    opacity: Double
+  ) -> some View {
+    Text(text)
+      .font(Font.system(textStyle))
+      .foregroundColor(.clear)
+      .lineLimit(1)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .overlay(alignment: .leading) {
+        RoundedRectangle(cornerRadius: cornerRadius)
+          .fill(Color.gray.opacity(opacity))
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .scaleEffect(x: widthScale, anchor: .leading)
+      }
+      .accessibilityHidden(true)
+  }
+}

--- a/KMReader/Features/Book/Views/BookHorizontalCardView.swift
+++ b/KMReader/Features/Book/Views/BookHorizontalCardView.swift
@@ -1,0 +1,190 @@
+//
+// BookHorizontalCardView.swift
+//
+//
+
+import SwiftUI
+
+/// Horizontal book card: cover on the left,
+/// series/title/progress on the right, inside a rounded material card.
+struct BookHorizontalCardView: View {
+  let item: BookDisplayItem
+  var coverWidth: CGFloat = 60
+  var onReadBook: ((Bool) -> Void)? = nil
+  var onMutationCompleted: (() -> Void)? = nil
+  var onDeleteRequested: (() -> Void)? = nil
+  var showSeriesNavigation: Bool = true
+
+  @AppStorage("thumbnailShowUnreadIndicator") private var thumbnailShowUnreadIndicator: Bool = true
+  @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
+  @State private var showReadListPicker = false
+  @State private var showEditSheet = false
+
+  private var progress: Double {
+    guard let progressPage = item.progressPage else { return 0 }
+    guard item.mediaPagesCount > 0 else { return 0 }
+    return Double(progressPage) / Double(item.mediaPagesCount)
+  }
+
+  var bookTitleLine: String {
+    if item.oneshot {
+      return item.metaTitle
+    }
+    return String("\(item.metaNumber) - \(item.metaTitle)")
+  }
+
+  private var coverBlurRadius: CGFloat {
+    thumbnailBlurUnreadCovers && item.isUnread ? CoverBlurStyle.unreadRadius : 0
+  }
+
+  private var completedMetaText: String {
+    item.completedLastReadText ?? "\(item.mediaPagesCount) pages"
+  }
+
+  private var bookContextMenu: some View {
+    BookContextMenu(
+      book: item.book,
+      downloadStatus: item.downloadStatus,
+      onReadBook: onReadBook,
+      onShowReadListPicker: {
+        showReadListPicker = true
+      },
+      onDeleteRequested: onDeleteRequested,
+      onEditRequested: {
+        showEditSheet = true
+      },
+      onMutationCompleted: onMutationCompleted,
+      showSeriesNavigation: showSeriesNavigation
+    )
+  }
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 10) {
+      Button {
+        onReadBook?(false)
+      } label: {
+        ThumbnailImage(
+          id: item.bookId,
+          type: .book,
+          shadowStyle: .platform,
+          contentBlurRadius: coverBlurRadius,
+          width: coverWidth,
+          preserveAspectRatioOverride: false
+        ) {
+          if item.isUnread && thumbnailShowUnreadIndicator {
+            UnreadIndicator()
+              .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+          }
+        }
+        .frame(width: coverWidth)
+      }
+      .adaptiveButtonStyle(.plain)
+
+      Button {
+        onReadBook?(false)
+      } label: {
+        VStack(alignment: .leading, spacing: 2) {
+          if item.oneshot {
+            Text("Oneshot")
+              .font(.caption)
+              .foregroundColor(.blue)
+              .lineLimit(1)
+          } else if !item.seriesTitle.isEmpty {
+            Text(item.seriesTitle)
+              .font(.caption)
+              .foregroundColor(.secondary)
+              .lineLimit(1)
+          }
+
+          Text(bookTitleLine)
+            .font(.footnote)
+            .foregroundColor(item.isCompleted ? .secondary : .primary)
+            .lineLimit(2, reservesSpace: true)
+            .multilineTextAlignment(.leading)
+
+          Spacer(minLength: 2)
+
+          bottomBar
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+      }
+      .adaptiveButtonStyle(.plain)
+    }
+    .padding(8)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background {
+      RoundedRectangle(cornerRadius: 12)
+        .fill(.regularMaterial)
+        .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
+    }
+    .contentShape(Rectangle())
+    #if os(iOS)
+      .contentShape(.contextMenuPreview, RoundedRectangle(cornerRadius: 12))
+    #endif
+    .contextMenu {
+      bookContextMenu
+    }
+    .sheet(isPresented: $showReadListPicker) {
+      ReadListPickerSheet(
+        bookId: item.bookId,
+        onSelect: { readListId in
+          addToReadList(readListId: readListId)
+        }
+      )
+    }
+    .sheet(isPresented: $showEditSheet) {
+      BookEditSheet(book: item.book)
+    }
+  }
+
+  @ViewBuilder
+  private var bottomBar: some View {
+    HStack(spacing: 4) {
+      let mediaStatus = item.media.statusValue
+      if item.isUnavailable {
+        Text("Unavailable")
+          .foregroundColor(.red)
+      } else if mediaStatus != .ready {
+        Text(mediaStatus.label)
+          .foregroundColor(mediaStatus.color)
+      } else {
+        if progress > 0 && progress < 1 {
+          Text(progress, format: .percent.precision(.fractionLength(0)))
+          Text("•")
+        }
+        if progress == 1 {
+          Image(systemName: "checkmark.circle.fill")
+            .foregroundColor(.secondary)
+            .font(.caption2)
+        }
+        Text(progress == 1 ? completedMetaText : "\(item.mediaPagesCount) pages")
+      }
+      if item.downloadStatus != .notDownloaded {
+        Spacer()
+        Image(systemName: item.downloadStatus.displayIcon)
+          .foregroundColor(item.downloadStatus.displayColor)
+          .font(.caption2)
+      }
+    }
+    .font(.caption)
+    .foregroundColor(.secondary)
+    .lineLimit(1)
+  }
+
+  private func addToReadList(readListId: String) {
+    Task {
+      do {
+        try await ReadListService.addBooksToReadList(
+          readListId: readListId,
+          bookIds: [item.bookId]
+        )
+        ErrorManager.shared.notify(
+          message: String(localized: "notification.book.booksAddedToReadList"))
+        onMutationCompleted?()
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
+  }
+}

--- a/KMReader/Features/Book/Views/BookQueryItemView.swift
+++ b/KMReader/Features/Book/Views/BookQueryItemView.swift
@@ -12,6 +12,7 @@ struct BookQueryItemView: View {
   var showSeriesTitle: Bool = true
   var showSeriesNavigation: Bool = true
   var readListContext: ReaderReadListContext? = nil
+  var horizontalCoverWidth: CGFloat? = nil
   var onItemMissing: (() -> Void)? = nil
 
   @AppStorage("currentAccount") private var current: Current = .init()
@@ -25,6 +26,7 @@ struct BookQueryItemView: View {
     showSeriesTitle: Bool = true,
     showSeriesNavigation: Bool = true,
     readListContext: ReaderReadListContext? = nil,
+    horizontalCoverWidth: CGFloat? = nil,
     onItemMissing: (() -> Void)? = nil
   ) {
     self.bookId = bookId
@@ -32,6 +34,7 @@ struct BookQueryItemView: View {
     self.showSeriesTitle = showSeriesTitle
     self.showSeriesNavigation = showSeriesNavigation
     self.readListContext = readListContext
+    self.horizontalCoverWidth = horizontalCoverWidth
     self.onItemMissing = onItemMissing
 
   }
@@ -39,10 +42,10 @@ struct BookQueryItemView: View {
   var body: some View {
     Group {
       if let item {
-        switch layout {
-        case .grid:
-          BookCardView(
+        if let horizontalCoverWidth, layout == .grid {
+          BookHorizontalCardView(
             item: item,
+            coverWidth: horizontalCoverWidth,
             onReadBook: { incognito in
               readerActions.open(
                 book: item.book,
@@ -54,33 +57,56 @@ struct BookQueryItemView: View {
             onDeleteRequested: {
               showDeleteConfirmation = true
             },
-            showSeriesTitle: showSeriesTitle,
             showSeriesNavigation: showSeriesNavigation
           )
-        case .list:
-          BookRowView(
-            item: item,
-            onReadBook: { incognito in
-              readerActions.open(
-                book: item.book,
-                incognito: incognito,
-                readListContext: readListContext
-              )
-            },
-            onMutationCompleted: reloadItem,
-            onDeleteRequested: {
-              showDeleteConfirmation = true
-            },
-            showSeriesTitle: showSeriesTitle,
-            showSeriesNavigation: showSeriesNavigation
-          )
+        } else {
+          switch layout {
+          case .grid:
+            BookCardView(
+              item: item,
+              onReadBook: { incognito in
+                readerActions.open(
+                  book: item.book,
+                  incognito: incognito,
+                  readListContext: readListContext
+                )
+              },
+              onMutationCompleted: reloadItem,
+              onDeleteRequested: {
+                showDeleteConfirmation = true
+              },
+              showSeriesTitle: showSeriesTitle,
+              showSeriesNavigation: showSeriesNavigation
+            )
+          case .list:
+            BookRowView(
+              item: item,
+              onReadBook: { incognito in
+                readerActions.open(
+                  book: item.book,
+                  incognito: incognito,
+                  readListContext: readListContext
+                )
+              },
+              onMutationCompleted: reloadItem,
+              onDeleteRequested: {
+                showDeleteConfirmation = true
+              },
+              showSeriesTitle: showSeriesTitle,
+              showSeriesNavigation: showSeriesNavigation
+            )
+          }
         }
       } else {
-        CardPlaceholder(
-          layout: layout,
-          kind: .book,
-          showBookSeriesTitle: showSeriesTitle
-        )
+        if let horizontalCoverWidth, layout == .grid {
+          BookHorizontalCardPlaceholder(coverWidth: horizontalCoverWidth)
+        } else {
+          CardPlaceholder(
+            layout: layout,
+            kind: .book,
+            showBookSeriesTitle: showSeriesTitle
+          )
+        }
       }
     }
     .task(id: "\(current.instanceId)|\(bookId)") {

--- a/KMReader/Features/Collection/Views/CollectionHorizontalCardView.swift
+++ b/KMReader/Features/Collection/Views/CollectionHorizontalCardView.swift
@@ -1,13 +1,13 @@
 //
-// ReadListCompactCardView.swift
+// CollectionHorizontalCardView.swift
 //
 //
 
 import SwiftUI
 
 @MainActor
-struct ReadListCompactCardView: View {
-  let item: ReadListDisplayItem
+struct CollectionHorizontalCardView: View {
+  let item: CollectionDisplayItem
   var coverWidth: CGFloat = 80
   var onChanged: () -> Void = {}
   let onDeleteRequested: () -> Void
@@ -15,21 +15,24 @@ struct ReadListCompactCardView: View {
   @State private var showEditSheet = false
 
   var body: some View {
-    NavigationLink(value: NavDestination.readListDetail(readListId: item.readListId)) {
+    NavigationLink(
+      value: NavDestination.collectionDetail(collectionId: item.collectionId)
+    ) {
       HStack(alignment: .top, spacing: 10) {
-        ThumbnailImage(id: item.readListId, type: .readlist, width: coverWidth)
-          .frame(width: coverWidth)
-          .allowsHitTesting(false)
+        ThumbnailImage(
+          id: item.collectionId, type: .collection, width: coverWidth, preserveAspectRatioOverride: false
+        )
+        .frame(width: coverWidth)
+        .allowsHitTesting(false)
 
         VStack(alignment: .leading, spacing: 4) {
           Text(item.name)
-            .font(.headline)
-            .fontWeight(.medium)
+            .font(.footnote)
             .lineLimit(2)
             .multilineTextAlignment(.leading)
 
-          Text("\(item.bookCount) books")
-            .font(.footnote)
+          Text("\(item.seriesCount) series")
+            .font(.caption)
             .foregroundColor(.secondary)
 
           Text(item.lastModifiedDate.formattedMediumDate)
@@ -52,12 +55,9 @@ struct ReadListCompactCardView: View {
     }
     .adaptiveButtonStyle(.plain)
     .contextMenu {
-      ReadListContextMenu(
-        readListId: item.readListId,
+      CollectionContextMenu(
+        collectionId: item.collectionId,
         menuTitle: item.name,
-        downloadStatus: item.downloadStatus,
-        offlinePolicy: item.offlinePolicy,
-        offlinePolicyLimit: item.offlinePolicyLimit,
         isPinned: item.isPinned,
         onDeleteRequested: {
           onDeleteRequested()
@@ -67,12 +67,11 @@ struct ReadListCompactCardView: View {
         },
         onPinToggleRequested: {
           togglePinned()
-        },
-        onMutationCompleted: onChanged
+        }
       )
     }
     .sheet(isPresented: $showEditSheet, onDismiss: onChanged) {
-      ReadListEditSheet(readList: item.readList)
+      CollectionEditSheet(collection: item.collection)
     }
   }
 
@@ -81,8 +80,8 @@ struct ReadListCompactCardView: View {
     Task {
       do {
         let database = try await DatabaseOperator.database()
-        await database.setReadListPinned(
-          readListId: item.readListId,
+        await database.setCollectionPinned(
+          collectionId: item.collectionId,
           instanceId: item.instanceId,
           isPinned: nextPinned
         )

--- a/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
@@ -81,17 +81,12 @@ struct DashboardPinnedSectionView: View {
     }
   }
 
-  private var compactCardWidth: CGFloat {
-    let proposed = LayoutConfig.cardWidth(for: gridDensity) * 2.0
-    #if os(tvOS)
-      return min(max(proposed, 360), 680)
-    #else
-      return min(max(proposed, 220), 480)
-    #endif
+  private var horizontalCardWidth: CGFloat {
+    LayoutConfig.horizontalCardWidth(for: gridDensity)
   }
 
-  private var compactCoverWidth: CGFloat {
-    min(max(compactCardWidth * 0.24, 64), 132)
+  private var horizontalCoverWidth: CGFloat {
+    LayoutConfig.horizontalCoverWidth(for: gridDensity)
   }
 
   private var spacing: CGFloat {
@@ -135,9 +130,9 @@ struct DashboardPinnedSectionView: View {
                 switch section.contentKind {
                 case .collections:
                   ForEach(pinnedCollections) { collection in
-                    CollectionCompactCardView(
+                    CollectionHorizontalCardView(
                       item: collection,
-                      coverWidth: compactCoverWidth,
+                      coverWidth: horizontalCoverWidth,
                       onChanged: schedulePinnedItemsReload,
                       onDeleteRequested: {
                         collectionPendingDelete = collection
@@ -145,13 +140,13 @@ struct DashboardPinnedSectionView: View {
                       }
                     )
                     .id(collection.collectionId)
-                    .frame(width: compactCardWidth)
+                    .frame(width: horizontalCardWidth)
                   }
                 case .readLists:
                   ForEach(pinnedReadLists) { readList in
-                    ReadListCompactCardView(
+                    ReadListHorizontalCardView(
                       item: readList,
-                      coverWidth: compactCoverWidth,
+                      coverWidth: horizontalCoverWidth,
                       onChanged: schedulePinnedItemsReload,
                       onDeleteRequested: {
                         readListPendingDelete = readList
@@ -159,7 +154,7 @@ struct DashboardPinnedSectionView: View {
                       }
                     )
                     .id(readList.readListId)
-                    .frame(width: compactCardWidth)
+                    .frame(width: horizontalCardWidth)
                   }
                 default:
                   EmptyView()

--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -11,6 +11,8 @@ struct DashboardSectionView: View {
 
   @AppStorage("dashboard") private var dashboard: DashboardConfiguration = DashboardConfiguration()
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
+  @AppStorage("dashboardHorizontalBookCards")
+  private var dashboardHorizontalBookCards: Bool = true
   @AppStorage("showDashboardSectionGradientBackground")
   private var showDashboardSectionGradientBackground: Bool =
     AppConfig.showDashboardSectionGradientBackground
@@ -40,6 +42,23 @@ struct DashboardSectionView: View {
 
   private var cardWidth: CGFloat {
     LayoutConfig.cardWidth(for: gridDensity)
+  }
+
+  /// Horizontal cards only apply to Keep Reading.
+  private var useHorizontalBookCards: Bool {
+    section == .keepReading && dashboardHorizontalBookCards
+  }
+
+  private var horizontalCardWidth: CGFloat {
+    LayoutConfig.horizontalCardWidth(for: gridDensity)
+  }
+
+  private var horizontalCoverWidth: CGFloat {
+    LayoutConfig.horizontalCoverWidth(for: gridDensity)
+  }
+
+  private var itemWidth: CGFloat {
+    useHorizontalBookCards ? horizontalCardWidth : cardWidth
   }
 
   private var spacing: CGFloat {
@@ -82,7 +101,7 @@ struct DashboardSectionView: View {
               ForEach(pagination.items) { item in
                 itemView(for: item.id)
                   .id(item.id)
-                  .frame(width: cardWidth)
+                  .frame(width: itemWidth)
                   .onAppear {
                     if pagination.shouldLoadMore(after: item) {
                       Task {
@@ -132,6 +151,7 @@ struct DashboardSectionView: View {
         bookId: itemId,
         layout: .grid,
         showSeriesTitle: true,
+        horizontalCoverWidth: useHorizontalBookCards ? horizontalCoverWidth : nil,
         onItemMissing: {
           removeItem(id: itemId)
         }

--- a/KMReader/Features/ReadList/Views/ReadListHorizontalCardView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListHorizontalCardView.swift
@@ -1,13 +1,13 @@
 //
-// CollectionCompactCardView.swift
+// ReadListHorizontalCardView.swift
 //
 //
 
 import SwiftUI
 
 @MainActor
-struct CollectionCompactCardView: View {
-  let item: CollectionDisplayItem
+struct ReadListHorizontalCardView: View {
+  let item: ReadListDisplayItem
   var coverWidth: CGFloat = 80
   var onChanged: () -> Void = {}
   let onDeleteRequested: () -> Void
@@ -15,23 +15,22 @@ struct CollectionCompactCardView: View {
   @State private var showEditSheet = false
 
   var body: some View {
-    NavigationLink(
-      value: NavDestination.collectionDetail(collectionId: item.collectionId)
-    ) {
+    NavigationLink(value: NavDestination.readListDetail(readListId: item.readListId)) {
       HStack(alignment: .top, spacing: 10) {
-        ThumbnailImage(id: item.collectionId, type: .collection, width: coverWidth)
-          .frame(width: coverWidth)
-          .allowsHitTesting(false)
+        ThumbnailImage(
+          id: item.readListId, type: .readlist, width: coverWidth, preserveAspectRatioOverride: false
+        )
+        .frame(width: coverWidth)
+        .allowsHitTesting(false)
 
         VStack(alignment: .leading, spacing: 4) {
           Text(item.name)
-            .font(.headline)
-            .fontWeight(.medium)
+            .font(.footnote)
             .lineLimit(2)
             .multilineTextAlignment(.leading)
 
-          Text("\(item.seriesCount) series")
-            .font(.footnote)
+          Text("\(item.bookCount) books")
+            .font(.caption)
             .foregroundColor(.secondary)
 
           Text(item.lastModifiedDate.formattedMediumDate)
@@ -54,9 +53,12 @@ struct CollectionCompactCardView: View {
     }
     .adaptiveButtonStyle(.plain)
     .contextMenu {
-      CollectionContextMenu(
-        collectionId: item.collectionId,
+      ReadListContextMenu(
+        readListId: item.readListId,
         menuTitle: item.name,
+        downloadStatus: item.downloadStatus,
+        offlinePolicy: item.offlinePolicy,
+        offlinePolicyLimit: item.offlinePolicyLimit,
         isPinned: item.isPinned,
         onDeleteRequested: {
           onDeleteRequested()
@@ -66,11 +68,12 @@ struct CollectionCompactCardView: View {
         },
         onPinToggleRequested: {
           togglePinned()
-        }
+        },
+        onMutationCompleted: onChanged
       )
     }
     .sheet(isPresented: $showEditSheet, onDismiss: onChanged) {
-      CollectionEditSheet(collection: item.collection)
+      ReadListEditSheet(readList: item.readList)
     }
   }
 
@@ -79,8 +82,8 @@ struct CollectionCompactCardView: View {
     Task {
       do {
         let database = try await DatabaseOperator.database()
-        await database.setCollectionPinned(
-          collectionId: item.collectionId,
+        await database.setReadListPinned(
+          readListId: item.readListId,
           instanceId: item.instanceId,
           isPinned: nextPinned
         )

--- a/KMReader/Features/Server/ServerListView.swift
+++ b/KMReader/Features/Server/ServerListView.swift
@@ -198,7 +198,7 @@ struct ServerListView: View {
       // existing navigation stack instead of presenting a second sheet.
       .navigationDestination(isPresented: $showLogin) {
         LoginView(authViewModel: authViewModel)
-          .inlineNavigationBarTitle(String(localized: "Connect to a Server"))
+        .inlineNavigationBarTitle(String(localized: "Connect to a Server"))
       }
     #else
       .sheet(isPresented: $showLogin) {

--- a/KMReader/Features/Settings/SettingsDashboardView.swift
+++ b/KMReader/Features/Settings/SettingsDashboardView.swift
@@ -25,6 +25,8 @@ struct SettingsDashboardView: View {
   private struct SettingsDashboardView_iOS: View {
     @AppStorage("dashboard") private var dashboard: DashboardConfiguration =
       DashboardConfiguration()
+    @AppStorage("dashboardHorizontalBookCards")
+    private var dashboardHorizontalBookCards: Bool = true
     @Environment(\.editMode) private var editMode
 
     private var controller: DashboardSectionsController {
@@ -37,6 +39,18 @@ struct SettingsDashboardView: View {
 
     var body: some View {
       List {
+        Section {
+          Toggle(isOn: $dashboardHorizontalBookCards) {
+            Label(
+              String(localized: "dashboard.horizontalBookCards"),
+              systemImage: "rectangle.lefthalf.inset.filled"
+            )
+          }
+        } footer: {
+          Text(String(localized: "dashboard.horizontalBookCards.footer"))
+            .font(.footnote)
+        }
+
         Section {
           ForEach(controller.sections) { section in
             HStack(spacing: 12) {
@@ -119,6 +133,8 @@ struct SettingsDashboardView: View {
   private struct SettingsDashboardView_macOS: View {
     @AppStorage("dashboard") private var dashboard: DashboardConfiguration =
       DashboardConfiguration()
+    @AppStorage("dashboardHorizontalBookCards")
+    private var dashboardHorizontalBookCards: Bool = true
     @State private var draggedSection: DashboardSection?
 
     private var controller: DashboardSectionsController {
@@ -127,6 +143,20 @@ struct SettingsDashboardView: View {
 
     var body: some View {
       Form {
+        Section {
+          Toggle(isOn: $dashboardHorizontalBookCards) {
+            Label(
+              String(localized: "dashboard.horizontalBookCards"),
+              systemImage: "rectangle.lefthalf.inset.filled"
+            )
+          }
+          .toggleStyle(.switch)
+        } footer: {
+          Text(String(localized: "dashboard.horizontalBookCards.footer"))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+
         Section {
           VStack(spacing: 0) {
             ForEach(Array(controller.sections.enumerated()), id: \.element.id) { index, section in
@@ -266,6 +296,8 @@ struct SettingsDashboardView: View {
   private struct SettingsDashboardView_tvOS: View {
     @AppStorage("dashboard") private var dashboard: DashboardConfiguration =
       DashboardConfiguration()
+    @AppStorage("dashboardHorizontalBookCards")
+    private var dashboardHorizontalBookCards: Bool = true
     @State private var editModeValue: EditMode = .inactive
     @State private var workingSections: [DashboardSection] = []
 
@@ -289,6 +321,17 @@ struct SettingsDashboardView: View {
 
     var body: some View {
       List {
+        // Book Card Style
+        Section {
+          Toggle(isOn: $dashboardHorizontalBookCards) {
+            Label(
+              String(localized: "dashboard.horizontalBookCards"),
+              systemImage: "rectangle.lefthalf.inset.filled"
+            )
+            .font(.title3)
+          }
+        }
+
         // Edit/Done Button (Top)
         Section {
           HStack {

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -379,6 +379,17 @@
         }
       }
     },
+    "%@, %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@, %2$@"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
     "%@:" : {
       "localizations" : {
         "en" : {
@@ -15874,6 +15885,134 @@
         }
       }
     },
+    "dashboard.horizontalBookCards" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Horizontale Buchkarten"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Horizontal Book Cards"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tarjetas de libro horizontales"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cartes de livre horizontales"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schede libro orizzontali"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "横向きブックカード"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가로 책 카드"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Горизонтальные карточки книг"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "横向书籍卡片"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "橫向書籍卡片"
+          }
+        }
+      }
+    },
+    "dashboard.horizontalBookCards.footer" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeigt den Bereich „Weiterlesen“ als horizontale Karten statt als Coverkarten an."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show the Keep Reading section as horizontal cards instead of cover cards."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra la sección «Seguir leyendo» con tarjetas horizontales en lugar de tarjetas de portada."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Affiche la section « Poursuivre la lecture » sous forme de cartes horizontales plutôt que de cartes de couverture."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostra la sezione «Continua a leggere» con schede orizzontali invece delle schede di copertina."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「読書を続ける」セクションを表紙カードではなく横向きカードで表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "'이어보기' 섹션을 표지 카드 대신 가로 카드로 표시합니다."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать раздел «Продолжить Чтение» горизонтальными карточками вместо карточек с обложками."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以横向卡片显示「继续阅读」分区，而非封面卡片。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以橫向卡片顯示「繼續閱讀」分區，而非封面卡片。"
+          }
+        }
+      }
+    },
     "dashboard.keepReading" : {
       "localizations" : {
         "de" : {
@@ -26114,71 +26253,6 @@
         }
       }
     },
-    "error.bookIdEmpty" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buch-ID ist leer"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Book ID is empty"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El ID del libro esta vacio"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'identifiant du livre est vide"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'ID libro e vuoto"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ブック ID が空です"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "책 ID가 비어 있습니다"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID книги пуст"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "书籍 ID 为空"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "書籍 ID 為空"
-          }
-        }
-      }
-    },
     "error.configurationError" : {
       "localizations" : {
         "de" : {
@@ -26371,71 +26445,6 @@
         }
       }
     },
-    "error.failedToLoadImageData" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bilddaten konnten nicht geladen werden"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to load image data"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudieron cargar los datos de imagen"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec du chargement des données d'image"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile caricare i dati immagine"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像データの読み込みに失敗しました"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이미지 데이터 로드 실패"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось загрузить данные изображения"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法加载图像数据"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法載入影像資料"
-          }
-        }
-      }
-    },
     "error.fileNotFound" : {
       "localizations" : {
         "de" : {
@@ -26624,71 +26633,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "寫入檔案 %1$@ 失敗：%2$@"
-          }
-        }
-      }
-    },
-    "error.imageNotCached" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bild nicht zwischengespeichert"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image not cached yet"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imagen aun no cacheada"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image pas encore en cache"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Immagine non ancora in cache"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "画像はまだキャッシュされていません"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이미지가 아직 캐시되지 않음"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изображение еще не закэшировано"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "图像尚未缓存"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "圖像尚未快取"
           }
         }
       }
@@ -27649,71 +27593,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不允許的操作：%@"
-          }
-        }
-      }
-    },
-    "error.photoLibraryAccessDenied" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zugriff auf Fotomediathek verweigert"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Photo library access denied"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acceso a la fototeca denegado"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accès à la photothèque refusé"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accesso alla libreria foto negato"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "写真ライブラリへのアクセスが拒否されました"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사진 라이브러리 액세스 거부됨"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Доступ к фотобиблиотеке запрещен"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "照片库访问被拒绝"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "相簿存取被拒"
           }
         }
       }
@@ -47746,71 +47625,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "閱讀進度同步失敗"
-          }
-        }
-      }
-    },
-    "notification.reader.imageSaved" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bild gespeichert"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image saved to Photos successfully"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imagen guardada en Fotos correctamente"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Image enregistrée dans Photos"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Immagine salvata in Foto con successo"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "写真に保存しました"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이미지가 사진에 성공적으로 저장되었습니다"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изображение успешно сохранено в Фото"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "图片已保存到照片"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "圖片已儲存到照片"
           }
         }
       }

--- a/KMReader/Shared/Helpers/LayoutConfig.swift
+++ b/KMReader/Shared/Helpers/LayoutConfig.swift
@@ -33,6 +33,26 @@ struct LayoutConfig {
     baseCardWidth * CGFloat(density)
   }
 
+  /// Width of horizontal cards (dashboard book sections, pinned read lists/collections)
+  static func horizontalCardWidth(for density: Double) -> CGFloat {
+    let proposed = cardWidth(for: density) * 2.2
+    #if os(tvOS)
+      return min(max(proposed, 360), 660)
+    #else
+      return min(max(proposed, 240), 480)
+    #endif
+  }
+
+  /// Cover width inside horizontal cards
+  static func horizontalCoverWidth(for density: Double) -> CGFloat {
+    let cardWidth = horizontalCardWidth(for: density)
+    #if os(tvOS)
+      return min(max(cardWidth * 0.21, 56), 140)
+    #else
+      return min(max(cardWidth * 0.21, 48), 96)
+    #endif
+  }
+
   /// Default spacing between cards
   static var defaultSpacing: CGFloat {
     #if os(tvOS)


### PR DESCRIPTION
Implements #970: the Keep Reading dashboard section gets a horizontal card style — cover on the left, series / title / progress on the right, inside a rounded material card.

## What changed

- New `BookHorizontalCardView` (+ loading placeholder): tapping the cover or text opens the reader; long-press shows the same book context menu as grid cards. The progress line matches `BookCardView` (`42% · 120 pages`, or a checkmark + last-read date when finished), with the download status icon trailing on the same line.
- `DashboardSectionView` renders Keep Reading with horizontal cards by default; the classic cover cards remain available via a new **Horizontal Book Cards** toggle in Dashboard settings (`dashboardHorizontalBookCards`), on iOS, macOS, and tvOS.
- Card and cover sizing is shared through `LayoutConfig.horizontalCardWidth` / `horizontalCoverWidth`, and the pinned read list / collection cards (renamed to `ReadListHorizontalCardView` / `CollectionHorizontalCardView`) now use the same sizing and typography so all horizontal cards on the dashboard look consistent.
- Horizontal card covers force a uniform slot size (`preserveAspectRatioOverride: false`) so mixed cover aspect ratios no longer make cards uneven.
- Translations added for all supported languages.

## Validation

- `make build-ios`, `make build-macos`, `make build-tvos` all pass.
- Verified visually on iPhone simulator (card size, typography, and alignment iterated against the reference in #970).
