### PR TITLE
fix: include reading direction value when locking series metadata

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 525;
+				CURRENT_PROJECT_VERSION = 526;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 525;
+				CURRENT_PROJECT_VERSION = 526;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 525;
+				CURRENT_PROJECT_VERSION = 526;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 525;
+				CURRENT_PROJECT_VERSION = 526;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Series/Models/Metadata/SeriesMetadataUpdate.swift
+++ b/KMReader/Features/Series/Models/Metadata/SeriesMetadataUpdate.swift
@@ -112,8 +112,11 @@ struct SeriesMetadataUpdate: Codable {
     }
     dict["languageLock"] = languageLock
 
-    let currentReadingDirection = ReadingDirection.fromString(original.metadata.readingDirection)
-    if readingDirection != currentReadingDirection {
+    // Compare against the raw server value: an unset direction must not be
+    // treated as equal to the default fallback (.ltr), or locking it would
+    // send the lock flag without the direction value.
+    let currentReadingDirection = original.metadata.readingDirection?.uppercased() ?? ""
+    if readingDirection.rawValue != currentReadingDirection {
       dict["readingDirection"] = readingDirection.rawValue
     }
     dict["readingDirectionLock"] = readingDirectionLock


### PR DESCRIPTION
## Problem

Setting a series' reading direction to **Left to Right** from KMReader did not stick: Komga showed the direction as locked but with no value listed.

## Root cause

In `SeriesMetadataUpdate.toAPIDict(against:)`, the current direction was derived via `ReadingDirection.fromString(_:)`, which falls back to `.ltr` when the server value is `nil` (unset). Choosing Left to Right therefore compared equal to the "current" direction, so the PATCH body omitted `readingDirection` while still sending `readingDirectionLock: true` — Komga locked an empty value.

Other directions (RTL / Vertical / Webtoon) were unaffected, which is why this only surfaced with LTR.

## Fix

Compare the pending value against the raw server string (`nil` treated as unset) instead of the normalized enum, so an unset direction is never considered equal to a chosen one and the value is always sent alongside the lock.

Affects both the series edit sheet and the one-shot edit sheet, which share `SeriesMetadataUpdate`.

## Validation

- `make build` — iOS, macOS, tvOS all build successfully.
