### PR TITLE
fix(ui): tighten dashboard section headers and detail page divider spacing

### DIFF
--- a/KMReader/Features/Book/Views/BookReadListsSection.swift
+++ b/KMReader/Features/Book/Views/BookReadListsSection.swift
@@ -17,40 +17,45 @@ struct BookReadListsSection: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      if !readLists.isEmpty {
-        VStack(alignment: .leading, spacing: 6) {
-          HStack(spacing: 4) {
-            Image(systemName: ContentIcon.readList)
-              .font(.caption)
-            Text("Read Lists")
-              .font(.headline)
-          }
-          .foregroundColor(.secondary)
+    sectionContent
+      .task(id: "\(current.instanceId)|\(readListIdsKey)") {
+        await loadReadLists()
+      }
+  }
 
-          VStack(alignment: .leading, spacing: 8) {
-            ForEach(readLists) { readList in
-              NavigationLink(value: NavDestination.readListDetail(readListId: readList.readListId)) {
-                HStack {
-                  Label(readList.name, systemImage: ContentIcon.readList)
-                    .foregroundColor(.primary)
-                  Spacer()
-                  Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                }
-                .padding()
-                .background(Color.secondary.opacity(0.1))
-                .cornerRadius(16)
-              }.adaptiveButtonStyle(.plain)
-            }
+  // Renders nothing when empty: an always-present zero-height container would
+  // swallow the parent VStack spacing and make adjacent Dividers hug the content.
+  @ViewBuilder
+  private var sectionContent: some View {
+    if !readLists.isEmpty {
+      VStack(alignment: .leading, spacing: 6) {
+        HStack(spacing: 4) {
+          Image(systemName: ContentIcon.readList)
+            .font(.caption)
+          Text("Read Lists")
+            .font(.headline)
+        }
+        .foregroundColor(.secondary)
+
+        VStack(alignment: .leading, spacing: 8) {
+          ForEach(readLists) { readList in
+            NavigationLink(value: NavDestination.readListDetail(readListId: readList.readListId)) {
+              HStack {
+                Label(readList.name, systemImage: ContentIcon.readList)
+                  .foregroundColor(.primary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+              }
+              .padding()
+              .background(Color.secondary.opacity(0.1))
+              .cornerRadius(16)
+            }.adaptiveButtonStyle(.plain)
           }
         }
       }
-    }
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .task(id: "\(current.instanceId)|\(readListIdsKey)") {
-      await loadReadLists()
+      .frame(maxWidth: .infinity, alignment: .leading)
     }
   }
 

--- a/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardPinnedSectionView.swift
@@ -118,7 +118,8 @@ struct DashboardPinnedSectionView: View {
             }
           }
           .buttonStyle(.plain)
-          .padding()
+          .padding(.horizontal)
+          .padding(.top)
           #if os(macOS)
             .padding(.leading, 16)
           #endif

--- a/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
+++ b/KMReader/Features/Dashboard/Views/DashboardSectionView.swift
@@ -89,7 +89,8 @@ struct DashboardSectionView: View {
           }
         }
         .buttonStyle(.plain)
-        .padding()
+        .padding(.horizontal)
+        .padding(.top)
         #if os(macOS)
           .padding(.leading, 16)
         #endif

--- a/KMReader/Features/Series/Views/SeriesCollectionsSection.swift
+++ b/KMReader/Features/Series/Views/SeriesCollectionsSection.swift
@@ -17,40 +17,45 @@ struct SeriesCollectionsSection: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 8) {
-      if !collections.isEmpty {
-        VStack(alignment: .leading, spacing: 8) {
-          HStack(spacing: 4) {
-            Text("Collections")
-              .font(.headline)
-          }
-          .foregroundColor(.secondary)
+    sectionContent
+      .task(id: "\(current.instanceId)|\(collectionIdsKey)") {
+        await loadCollections()
+      }
+  }
 
-          VStack(alignment: .leading, spacing: 8) {
-            ForEach(collections) { collection in
-              NavigationLink(
-                value: NavDestination.collectionDetail(collectionId: collection.collectionId)
-              ) {
-                HStack {
-                  Label(collection.name, systemImage: ContentIcon.collection)
-                    .foregroundColor(.primary)
-                  Spacer()
-                  Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                }
-                .padding()
-                .background(Color.secondary.opacity(0.1))
-                .cornerRadius(16)
-              }.adaptiveButtonStyle(.plain)
-            }
+  // Renders nothing when empty: an always-present zero-height container would
+  // swallow the parent VStack spacing and make the Divider below hug the content above.
+  @ViewBuilder
+  private var sectionContent: some View {
+    if !collections.isEmpty {
+      VStack(alignment: .leading, spacing: 8) {
+        HStack(spacing: 4) {
+          Text("Collections")
+            .font(.headline)
+        }
+        .foregroundColor(.secondary)
+
+        VStack(alignment: .leading, spacing: 8) {
+          ForEach(collections) { collection in
+            NavigationLink(
+              value: NavDestination.collectionDetail(collectionId: collection.collectionId)
+            ) {
+              HStack {
+                Label(collection.name, systemImage: ContentIcon.collection)
+                  .foregroundColor(.primary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+              }
+              .padding()
+              .background(Color.secondary.opacity(0.1))
+              .cornerRadius(16)
+            }.adaptiveButtonStyle(.plain)
           }
         }
       }
-    }
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .task(id: "\(current.instanceId)|\(collectionIdsKey)") {
-      await loadCollections()
+      .frame(maxWidth: .infinity, alignment: .leading)
     }
   }
 


### PR DESCRIPTION
Two UI spacing fixes from dyphire's reports.

## Dashboard section title spacing (#984)

Dashboard section titles used `.padding()` on all sides, which stacked with the card list's `.padding(.vertical)` and produced a ~32pt gap between a section title and its cards, making the hierarchy unclear. The title now keeps only horizontal and top padding, so the title-to-cards gap drops to ~16pt while the spacing between sections is unchanged. Applied to both `DashboardSectionView` and `DashboardPinnedSectionView`.

## Detail page divider hugging content (#986)

The timestamp chips and summary on the series detail page appeared glued to the divider below them. The root cause is structural, not padding size: `SeriesCollectionsSection` always rendered an outer VStack even when the series had no collections, and that zero-height container collapses the surrounding VStack spacing to zero, so the divider touched the content above it.

Verified with an offscreen SwiftUI render probe measuring real pixel gaps around `Divider()`:

- normal content → divider: 8pt
- zero-height container → divider: 0pt (the bug)
- conditional `EmptyView` → divider: 8pt (the fix)

Both `SeriesCollectionsSection` and `BookReadListsSection` (same anti-pattern on the book detail page) now render conditional content — nothing at all when empty — with the loading task attached to the conditional content so initial loading still triggers.

## Validation

- `make build` passes for iOS, macOS, and tvOS.

Closes #984
Closes #986
