### PR TITLE
feat(browse): use book icon and Apple Music style press for reading buttons

### DIFF
--- a/KMReader/Features/Book/Views/Sections/BookActionsSection.swift
+++ b/KMReader/Features/Book/Views/Sections/BookActionsSection.swift
@@ -16,7 +16,7 @@ struct BookActionsSection: View {
       Button {
         readerActions.open(book: book, incognito: false)
       } label: {
-        Label("Read", systemImage: "play")
+        Label("Read", systemImage: "book.fill")
       }
       .adaptiveButtonStyle(.borderedProminent)
 

--- a/KMReader/Features/Series/Views/SeriesReadingActionBar.swift
+++ b/KMReader/Features/Series/Views/SeriesReadingActionBar.swift
@@ -31,10 +31,6 @@ struct SeriesReadingActionBar: View {
     return "\(actionTitle) · \(progressSummary)"
   }
 
-  private var actionIcon: String {
-    isResuming ? "forward.fill" : "play.fill"
-  }
-
   private var progressSummary: String? {
     guard let book, let progress = book.readProgress, !progress.completed else { return nil }
     let page = progress.page
@@ -48,7 +44,19 @@ struct SeriesReadingActionBar: View {
       styledContent
         .contentShape(Capsule(style: .continuous))
     }
-    .adaptiveButtonStyle(.plain)
+    #if os(tvOS)
+      .adaptiveButtonStyle(.plain)
+    #elseif os(iOS)
+      // Deeper squeeze than the default 0.95 squish, closer to the
+      // Apple Music capsule button press feel.
+      .buttonStyle(.squish(scale: 0.93))
+      .hoverEffect(.lift)
+    #elseif os(macOS)
+      .buttonStyle(.squish(scale: 0.93))
+      .macHoverEffect()
+    #else
+      .buttonStyle(.plain)
+    #endif
     .accessibilityLabel(Text("\(actionSummary), \(displayTitle)"))
   }
 
@@ -96,7 +104,7 @@ struct SeriesReadingActionBar: View {
       }
 
       HStack(spacing: 12) {
-        Image(systemName: actionIcon)
+        Image(systemName: "book.fill")
           .font(.title3.weight(.bold))
           .foregroundStyle(Color.accentColor)
           .frame(width: iconSize, height: iconSize)


### PR DESCRIPTION
Implements the reading button polish requested by dyphire.

## Book icon instead of playback icons

The series reading bar switched between `play.fill` (start) and `forward.fill` (resume), and the book detail `Read` button used `play` — all video playback metaphors. They now use `book.fill`, including the resume state, so the icon always reads as "reading".

## Apple Music style press interaction

The reading bar previously used the shared plain adaptive style (squish at 0.95). On iOS and macOS it now uses a deeper squish (0.93) with the same springy bounce, making the capsule's press squeeze palpable — the feel of Apple Music's capsule buttons demonstrated in the issue video. On iOS 26 the interactive glass effect (`.glassEffect(.regular.interactive())`) already provides the native squeeze, and tvOS keeps its `.card` style; both are unchanged.

Note: the issue's demo video shows Apple Music's floating bars, so this interprets the request as the press micro-interaction. If the intent was the scroll-linked morph or a zoom transition into the reader, happy to follow up separately.

## Validation

- `make build` passes for iOS, macOS, and tvOS.

Refs #985
