### PR TITLE
fix(dashboard): keep horizontal card width proportional in compact density

### DIFF
--- a/KMReader/Features/Book/Views/BookHorizontalCardView.swift
+++ b/KMReader/Features/Book/Views/BookHorizontalCardView.swift
@@ -17,8 +17,15 @@ struct BookHorizontalCardView: View {
 
   @AppStorage("thumbnailShowUnreadIndicator") private var thumbnailShowUnreadIndicator: Bool = true
   @AppStorage("thumbnailBlurUnreadCovers") private var thumbnailBlurUnreadCovers: Bool = false
+  @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
   @State private var showReadListPicker = false
   @State private var showEditSheet = false
+
+  /// Compact density shows the title on a single line so the card height can
+  /// actually shrink with the cover instead of being held up by reserved text space.
+  private var titleLineLimit: Int {
+    gridDensity < GridDensity.standard.rawValue ? 1 : 2
+  }
 
   private var progress: Double {
     guard let progressPage = item.progressPage else { return 0 }
@@ -99,7 +106,7 @@ struct BookHorizontalCardView: View {
           Text(bookTitleLine)
             .font(.footnote)
             .foregroundColor(item.isCompleted ? .secondary : .primary)
-            .lineLimit(2, reservesSpace: true)
+            .lineLimit(titleLineLimit, reservesSpace: true)
             .multilineTextAlignment(.leading)
 
           Spacer(minLength: 2)

--- a/KMReader/Shared/Helpers/LayoutConfig.swift
+++ b/KMReader/Shared/Helpers/LayoutConfig.swift
@@ -36,20 +36,24 @@ struct LayoutConfig {
   /// Width of horizontal cards (dashboard book sections, pinned read lists/collections)
   static func horizontalCardWidth(for density: Double) -> CGFloat {
     let proposed = cardWidth(for: density) * 2.2
+    // Fixed floors stay below the smallest compact-density proposal (176pt on
+    // iPhone) so every density renders at its natural proportional width.
     #if os(tvOS)
       return min(max(proposed, 360), 660)
     #else
-      return min(max(proposed, 240), 480)
+      return min(max(proposed, 160), 480)
     #endif
   }
 
   /// Cover width inside horizontal cards
   static func horizontalCoverWidth(for density: Double) -> CGFloat {
     let cardWidth = horizontalCardWidth(for: density)
+    // Fixed floor stays below the smallest compact-density proposal (37pt on
+    // iPhone) so covers keep shrinking with the card.
     #if os(tvOS)
       return min(max(cardWidth * 0.21, 56), 140)
     #else
-      return min(max(cardWidth * 0.21, 48), 96)
+      return min(max(cardWidth * 0.21, 32), 96)
     #endif
   }
 


### PR DESCRIPTION
Dashboard horizontal cards (Keep Reading books, pinned read lists/collections) barely changed at compact density — neither in width nor in height.

## Cause

Two fixed floors plus reserved text space held the card size up:

- `horizontalCardWidth` clamped to a fixed 240pt floor. On iPhone, standard density (1.0x) already proposes 220pt — below the floor — so compact (0.8x) and standard both rendered 240pt wide.
- `horizontalCoverWidth` clamped to a fixed 48pt floor, keeping the cover (and thus the card height) nearly identical between standard and compact.
- The card title always reserved two lines (`lineLimit(2, reservesSpace: true)`), so the right-side text stack pinned the card height even when the cover shrank.

## Fix

- Card width floor: 240pt → 160pt (fixed, just below the smallest compact proposal of 176pt on iPhone). Widths are now naturally proportional: iPhone compact 176 / standard 220 / cozy 286. Note iPhone standard moves from the clamped 240pt to its true 220pt — slightly smaller, intended.
- Cover width floor: 48pt → 32pt (fixed, below the 37pt compact proposal).
- Title: single line at compact density, two lines (reserved) at standard/cozy — so the text stack no longer pins the card height at compact.

tvOS values are unchanged (its compact proposals already clear the floors).

## Validation

- `make build-ios` passes.
