### PR TITLE
refactor(ios): consolidate the server tab into the settings page on iPhone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ This file provides guidance to coding agents working with code in this repositor
 - **macOS**: Separate reader windows, comprehensive keyboard shortcuts, keyboard help overlay.
 - **tvOS**: Remote control navigation, TV-optimized interface (DIVINA only).
 - **Series continue-reading accessory**: Rendered by the system via `tabViewBottomAccessory(isEnabled:)` in `PhoneTabView` on iOS 26.1+ only, driven by the shared `ReadingActionBarContext` written from `SeriesDetailView`. The modifier must stay permanently attached with `isEnabled` toggling visibility; conditionally attaching it rebuilds the tab subtree and causes a refresh loop. It intentionally does not exist on iOS < 26.1, iPad, macOS, or tvOS (see convention 21); do not reintroduce a hand-written bar for those platforms.
+- **Server page placement**: iPhone has no Server tab. The current-server card (`ServerCardView`) and the Management/Account sections live at the top of `SettingsView` on iPhone only; iPad (sidebar) and tvOS keep the full `ServerView` page.
 
 ## Commands
 

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 526;
+				CURRENT_PROJECT_VERSION = 527;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 526;
+				CURRENT_PROJECT_VERSION = 527;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 526;
+				CURRENT_PROJECT_VERSION = 527;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 526;
+				CURRENT_PROJECT_VERSION = 527;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Server/ServerCardView.swift
+++ b/KMReader/Features/Server/ServerCardView.swift
@@ -1,0 +1,87 @@
+//
+// ServerCardView.swift
+//
+//
+
+import SwiftUI
+
+/// Current-server summary card: display name, role badge, switch button,
+/// account and server rows, and last-update status. Shown on the Server page
+/// (iPad and macOS sidebar, tvOS).
+struct ServerCardView: View {
+  @AppStorage("currentAccount") private var current: Current = .init()
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(alignment: .top, spacing: 12) {
+        VStack(alignment: .leading, spacing: 4) {
+          HStack(spacing: 8) {
+            Text(serverDisplayName)
+              .font(.title2)
+              .fontWeight(.semibold)
+
+            if let roleLabel {
+              Text(roleLabel)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.accentColor.opacity(0.15), in: Capsule())
+                .foregroundColor(Color.accentColor)
+            }
+          }
+        }
+
+        Spacer()
+
+        NavigationLink(value: NavDestination.settingsServers) {
+          Label(String(localized: "server.switch"), systemImage: "arrow.left.arrow.right")
+        }
+        .font(.caption)
+        .controlSize(.small)
+        .adaptiveButtonStyle(.borderedProminent)
+      }
+
+      if let userEmail = accountDisplayValue {
+        InfoRow(
+          label: ServerSection.account.title,
+          value: userEmail,
+          icon: "person"
+        )
+      }
+
+      InfoRow(
+        label: String(localized: "Server"),
+        value: current.serverURL.isEmpty ? current.serverDisplayName : current.serverURL,
+        icon: "globe"
+      )
+
+      ServerUpdateStatusView()
+        .foregroundColor(.secondary)
+        .font(.footnote)
+
+    }
+    .padding(12)
+    .background(.thinMaterial)
+    .clipShape(RoundedRectangle(cornerRadius: 16))
+  }
+
+  private var serverDisplayName: String {
+    if !current.serverDisplayName.isEmpty {
+      return current.serverDisplayName
+    }
+    return String(localized: "Server")
+  }
+
+  private var roleLabel: String? {
+    guard accountDisplayValue != nil else { return nil }
+    return String(localized: current.isAdmin ? "user.role.admin" : "user.role.user")
+  }
+
+  private var accountDisplayValue: String? {
+    if !current.username.isEmpty {
+      return current.username
+    }
+    return nil
+  }
+}

--- a/KMReader/Features/Server/ServerView.swift
+++ b/KMReader/Features/Server/ServerView.swift
@@ -15,7 +15,7 @@ struct ServerView: View {
   var body: some View {
     ScrollView {
       VStack(alignment: .leading, spacing: 16) {
-        serverSummaryCard
+        ServerCardView()
         managementSection
         accountSection
       }
@@ -23,61 +23,6 @@ struct ServerView: View {
       .padding(.vertical, 12)
     }
     .inlineNavigationBarTitle(String(localized: "tab.server"))
-  }
-
-  private var serverSummaryCard: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      HStack(alignment: .top, spacing: 12) {
-        VStack(alignment: .leading, spacing: 4) {
-          HStack(spacing: 8) {
-            Text(serverDisplayName)
-              .font(.title2)
-              .fontWeight(.semibold)
-
-            if let roleLabel {
-              Text(roleLabel)
-                .font(.caption)
-                .fontWeight(.semibold)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(Color.accentColor.opacity(0.15), in: Capsule())
-                .foregroundColor(Color.accentColor)
-            }
-          }
-        }
-
-        Spacer()
-
-        NavigationLink(value: NavDestination.settingsServers) {
-          Label(String(localized: "server.switch"), systemImage: "arrow.left.arrow.right")
-        }
-        .font(.caption)
-        .controlSize(.small)
-        .adaptiveButtonStyle(.borderedProminent)
-      }
-
-      if let userEmail = accountDisplayValue {
-        InfoRow(
-          label: ServerSection.account.title,
-          value: userEmail,
-          icon: "person"
-        )
-      }
-
-      InfoRow(
-        label: String(localized: "Server"),
-        value: current.serverURL.isEmpty ? current.serverDisplayName : current.serverURL,
-        icon: "globe"
-      )
-
-      ServerUpdateStatusView()
-        .foregroundColor(.secondary)
-        .font(.footnote)
-
-    }
-    .padding(12)
-    .background(.thinMaterial)
-    .clipShape(RoundedRectangle(cornerRadius: 16))
   }
 
   private var managementSection: some View {
@@ -257,18 +202,6 @@ struct ServerView: View {
     #else
       return [GridItem(.adaptive(minimum: 160), spacing: actionGridSpacing)]
     #endif
-  }
-
-  private var serverDisplayName: String {
-    if !current.serverDisplayName.isEmpty {
-      return current.serverDisplayName
-    }
-    return String(localized: "Server")
-  }
-
-  private var roleLabel: String? {
-    guard accountDisplayValue != nil else { return nil }
-    return String(localized: current.isAdmin ? "user.role.admin" : "user.role.user")
   }
 
   private var accountDisplayValue: String? {

--- a/KMReader/Features/Settings/Components/SettingsServerCardView.swift
+++ b/KMReader/Features/Settings/Components/SettingsServerCardView.swift
@@ -1,0 +1,82 @@
+//
+// SettingsServerCardView.swift
+//
+//
+
+import Flow
+import SwiftUI
+
+/// Current-server summary shown at the top of the iPhone Settings page.
+/// The whole card is a link to the server list, following the Apple ID card
+/// idiom from iOS Settings: server name on the first line, the account's
+/// Komga roles as badges, then account, URL, and status as secondary lines.
+struct SettingsServerCardView: View {
+  @AppStorage("currentAccount") private var current: Current = .init()
+
+  var body: some View {
+    NavigationLink(value: NavDestination.settingsServers) {
+      VStack(alignment: .leading, spacing: 8) {
+        Text(serverDisplayName)
+          .font(.title3)
+          .fontWeight(.semibold)
+
+        if !current.userRoles.isEmpty {
+          HFlow(spacing: 6) {
+            ForEach(current.userRoles, id: \.self) { role in
+              RoleBadge(role: role)
+            }
+          }
+        } else if !current.userId.isEmpty {
+          Text(String(localized: "user.role.none"))
+            .font(.footnote)
+            .foregroundColor(.secondary)
+            .italic()
+        }
+
+        if let accountDisplayValue {
+          iconRow(icon: "person", text: accountDisplayValue, font: .subheadline)
+        }
+
+        iconRow(
+          icon: "globe",
+          text: current.serverURL.isEmpty ? current.serverDisplayName : current.serverURL,
+          font: .footnote
+        )
+
+        ServerUpdateStatusView()
+          .foregroundColor(.secondary)
+          .font(.footnote)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .contentShape(Rectangle())
+    }
+  }
+
+  private var serverDisplayName: String {
+    if !current.serverDisplayName.isEmpty {
+      return current.serverDisplayName
+    }
+    return String(localized: "Server")
+  }
+
+  /// Small fixed-width icon column so the text aligns with the other
+  /// secondary lines instead of Label's wide list icon gutter.
+  private func iconRow(icon: String, text: String, font: Font) -> some View {
+    HStack(spacing: 8) {
+      Image(systemName: icon)
+        .font(.footnote)
+        .frame(width: 16, alignment: .center)
+      Text(text)
+        .font(font)
+        .lineLimit(1)
+    }
+    .foregroundColor(.secondary)
+  }
+
+  private var accountDisplayValue: String? {
+    if !current.username.isEmpty {
+      return current.username
+    }
+    return nil
+  }
+}

--- a/KMReader/Features/Settings/SettingsView.swift
+++ b/KMReader/Features/Settings/SettingsView.swift
@@ -6,8 +6,31 @@
 import SwiftUI
 
 struct SettingsView: View {
+  let authViewModel: AuthViewModel
+
+  @AppStorage("currentAccount") private var current: Current = .init()
+  @AppStorage("taskQueueStatus") private var taskQueueStatus: TaskQueueSSEDto = TaskQueueSSEDto()
+  @State private var showingUpdatePassword = false
+
+  /// iPhone has no Server tab; the current-server card and the
+  /// management/account entries live at the top of Settings instead.
+  /// iPad keeps the sidebar Server page, tvOS keeps its Server tab.
+  private var showsServerSections: Bool {
+    #if os(iOS)
+      return !PlatformHelper.isPad
+    #else
+      return false
+    #endif
+  }
+
   var body: some View {
     Form {
+      if showsServerSections {
+        Section {
+          SettingsServerCardView()
+        }
+      }
+
       Section(header: Text(String(localized: "Reader"))) {
         #if os(iOS) || os(tvOS)
           NavigationLink(value: NavDestination.settingsReading) {
@@ -44,6 +67,63 @@ struct SettingsView: View {
         }
       }
 
+      if showsServerSections {
+        Section(header: Text(String(localized: "Server"))) {
+          NavigationLink(value: NavDestination.settingsLibraries) {
+            Label(ServerSection.libraries.title, systemImage: ServerSection.libraries.icon)
+          }
+          NavigationLink(value: NavDestination.settingsReadingStats) {
+            Label(ServerSection.readingStats.title, systemImage: ServerSection.readingStats.icon)
+          }
+          if current.isAdmin {
+            NavigationLink(value: NavDestination.settingsServerInfo) {
+              Label(ServerSection.serverInfo.title, systemImage: ServerSection.serverInfo.icon)
+            }
+            NavigationLink(value: NavDestination.settingsTasks) {
+              HStack {
+                Label(ServerSection.tasks.title, systemImage: ServerSection.tasks.icon)
+                Spacer()
+                if taskQueueStatus.count > 0 {
+                  Text("\(taskQueueStatus.count)")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(Color.accentColor)
+                }
+              }
+            }
+            NavigationLink(value: NavDestination.settingsHistory) {
+              Label(ServerSection.history.title, systemImage: ServerSection.history.icon)
+            }
+            NavigationLink(value: NavDestination.settingsMedia) {
+              Label(ServerSection.media.title, systemImage: ServerSection.media.icon)
+            }
+          }
+        }
+
+        Section(header: Text(ServerSection.account.title)) {
+          if !current.userId.isEmpty {
+            Button {
+              showingUpdatePassword = true
+            } label: {
+              Label(
+                String(localized: "account.details.changePassword"),
+                systemImage: "key"
+              )
+              .foregroundColor(.primary)
+            }
+          }
+          NavigationLink(value: NavDestination.settingsApiKey) {
+            Label(ServerSection.apiKeys.title, systemImage: ServerSection.apiKeys.icon)
+          }
+          NavigationLink(value: NavDestination.settingsAuthenticationActivity) {
+            Label(
+              ServerSection.authenticationActivity.title,
+              systemImage: ServerSection.authenticationActivity.icon
+            )
+          }
+        }
+      }
+
       Section(header: Text(String(localized: "Behavior"))) {
         NavigationLink(value: NavDestination.settingsSSE) {
           SettingsSectionRow(section: .sse)
@@ -74,5 +154,9 @@ struct SettingsView: View {
     }
     .formStyle(.grouped)
     .inlineNavigationBarTitle(String(localized: "title.settings"))
+    .sheet(isPresented: $showingUpdatePassword) {
+      UpdatePasswordSheet(authViewModel: authViewModel)
+        .presentationDetents([.medium])
+    }
   }
 }

--- a/KMReader/OldTabView.swift
+++ b/KMReader/OldTabView.swift
@@ -25,11 +25,13 @@ struct OldTabView: View {
       .tabItem { TabItem.offline.label }
       .tag(TabItem.offline)
 
-      NavigationStack {
-        rootContent(for: .server)
-      }
-      .tabItem { TabItem.server.label }
-      .tag(TabItem.server)
+      #if os(tvOS)
+        NavigationStack {
+          rootContent(for: .server)
+        }
+        .tabItem { TabItem.server.label }
+        .tag(TabItem.server)
+      #endif
 
       NavigationStack {
         rootContent(for: .settings)

--- a/KMReader/PhoneTabView.swift
+++ b/KMReader/PhoneTabView.swift
@@ -62,12 +62,6 @@ import SwiftUI
           }
         }
 
-        Tab(TabItem.server.title, systemImage: TabItem.server.icon, value: TabItem.server) {
-          NavigationStack {
-            rootContent(for: .server)
-          }
-        }
-
         Tab(TabItem.settings.title, systemImage: TabItem.settings.icon, value: TabItem.settings) {
           NavigationStack {
             rootContent(for: .settings)

--- a/KMReader/Shared/Foundation/Models/NavDestination.swift
+++ b/KMReader/Shared/Foundation/Models/NavDestination.swift
@@ -117,7 +117,7 @@ enum NavDestination: Hashable {
     case .server:
       ServerView(authViewModel: context.authViewModel)
     case .settings:
-      SettingsView()
+      SettingsView(authViewModel: context.authViewModel)
 
     // NOTE: library selection passed via environment
     case .browseLibrary(_):

--- a/KMReader/Shared/Foundation/Models/TabItem.swift
+++ b/KMReader/Shared/Foundation/Models/TabItem.swift
@@ -71,7 +71,7 @@ enum TabItem: Hashable, Identifiable {
     case .server:
       ServerView(authViewModel: context.authViewModel)
     case .settings:
-      SettingsView()
+      SettingsView(authViewModel: context.authViewModel)
     }
   }
 }


### PR DESCRIPTION
Declutters the iPhone tab bar by folding the Server tab into the Settings page.

## What changes

- **Server tab removed on iPhone** (`PhoneTabView`, and `OldTabView` on iOS — tvOS keeps its Server tab, iPad/macOS keep the sidebar Server page).
- **Settings page top**: a dedicated `SettingsServerCardView` shows the current server in the Apple ID card idiom — the whole row links to the server list, with the server name on the first line, the account's Komga roles as badge chips, and account / URL / last-update status as secondary lines.
- **Two new form sections between Display and Behavior**, styled like the existing settings sections:
  - *Server*: Libraries, Reading Stats, and admin-only Server Info / Tasks (with live queue badge) / History / Media.
  - *Account*: Change Password (sheet), API Keys, Authentication Activity.
- **Standalone Server page untouched**: the original card is extracted verbatim as `ServerCardView` (material background, Switch Server button) and reused by `ServerView` on iPad/macOS/tvOS exactly as before.
- `SettingsView` takes `authViewModel` for the change-password sheet. `AGENTS.md` documents the new placement boundary.

## Validation

- `make build` passes for iOS, macOS, and tvOS.
- Verified on an iPhone (iOS 27) simulator: tab bar shows Home / Offline / Settings / Browse; the Settings page renders the server card and both sections with admin rows.
