### PR TITLE
feat: add progress ring to dashboard horizontal book cards

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 528;
+				CURRENT_PROJECT_VERSION = 529;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 528;
+				CURRENT_PROJECT_VERSION = 529;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 528;
+				CURRENT_PROJECT_VERSION = 529;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 528;
+				CURRENT_PROJECT_VERSION = 529;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Views/BookHorizontalCardView.swift
+++ b/KMReader/Features/Book/Views/BookHorizontalCardView.swift
@@ -33,6 +33,19 @@ struct BookHorizontalCardView: View {
     return Double(progressPage) / Double(item.mediaPagesCount)
   }
 
+  /// The ring only appears for in-progress books; unread and completed books
+  /// keep the plain bottom bar to avoid visual noise.
+  private var showsProgressRing: Bool {
+    !item.isUnavailable && item.media.statusValue == .ready && progress > 0 && progress < 1
+  }
+
+  /// The cover slot uses a fixed √2 height ratio and always drives the row
+  /// height, so this ring (smaller than the cover) can never affect the card
+  /// height. The 16pt total inset keeps its top/bottom/right margins equal.
+  private var progressRingDiameter: CGFloat {
+    coverWidth * CoverAspectRatio.heightToWidth - 16
+  }
+
   var bookTitleLine: String {
     if item.oneshot {
       return item.metaTitle
@@ -90,30 +103,38 @@ struct BookHorizontalCardView: View {
       Button {
         onReadBook?(false)
       } label: {
-        VStack(alignment: .leading, spacing: 2) {
-          if item.oneshot {
-            Text("Oneshot")
-              .font(.caption)
-              .foregroundColor(.blue)
-              .lineLimit(1)
-          } else if !item.seriesTitle.isEmpty {
-            Text(item.seriesTitle)
-              .font(.caption)
-              .foregroundColor(.secondary)
-              .lineLimit(1)
+        HStack(spacing: 8) {
+          VStack(alignment: .leading, spacing: 2) {
+            if item.oneshot {
+              Text("Oneshot")
+                .font(.caption)
+                .foregroundColor(.blue)
+                .lineLimit(1)
+            } else if !item.seriesTitle.isEmpty {
+              Text(item.seriesTitle)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+            }
+
+            Text(bookTitleLine)
+              .font(.footnote)
+              .foregroundColor(item.isCompleted ? .secondary : .primary)
+              .lineLimit(titleLineLimit, reservesSpace: true)
+              .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 2)
+
+            bottomBar
           }
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
 
-          Text(bookTitleLine)
-            .font(.footnote)
-            .foregroundColor(item.isCompleted ? .secondary : .primary)
-            .lineLimit(titleLineLimit, reservesSpace: true)
-            .multilineTextAlignment(.leading)
-
-          Spacer(minLength: 2)
-
-          bottomBar
+          if showsProgressRing {
+            ProgressRingView(progress: progress, diameter: progressRingDiameter)
+              .frame(maxHeight: .infinity, alignment: .center)
+              .padding(.trailing, 8)
+          }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         .contentShape(Rectangle())
       }
       .adaptiveButtonStyle(.plain)
@@ -156,10 +177,6 @@ struct BookHorizontalCardView: View {
         Text(mediaStatus.label)
           .foregroundColor(mediaStatus.color)
       } else {
-        if progress > 0 && progress < 1 {
-          Text(progress, format: .percent.precision(.fractionLength(0)))
-          Text("•")
-        }
         if progress == 1 {
           Image(systemName: "checkmark.circle.fill")
             .foregroundColor(.secondary)
@@ -168,7 +185,6 @@ struct BookHorizontalCardView: View {
         Text(progress == 1 ? completedMetaText : "\(item.mediaPagesCount) pages")
       }
       if item.downloadStatus != .notDownloaded {
-        Spacer()
         Image(systemName: item.downloadStatus.displayIcon)
           .foregroundColor(item.downloadStatus.displayColor)
           .font(.caption2)

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -55055,6 +55055,70 @@
         }
       }
     },
+    "Progress" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fortschritt"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progress"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progreso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Progression"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avanzamento"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進捗"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "진행"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Прогресс"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "进度"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進度"
+          }
+        }
+      }
+    },
     "Protected" : {
       "localizations" : {
         "de" : {

--- a/KMReader/Shared/Helpers/LayoutConfig.swift
+++ b/KMReader/Shared/Helpers/LayoutConfig.swift
@@ -35,8 +35,8 @@ struct LayoutConfig {
 
   /// Width of horizontal cards (dashboard book sections, pinned read lists/collections)
   static func horizontalCardWidth(for density: Double) -> CGFloat {
-    let proposed = cardWidth(for: density) * 2.2
-    // Fixed floors stay below the smallest compact-density proposal (176pt on
+    let proposed = cardWidth(for: density) * 2.6
+    // Fixed floors stay below the smallest compact-density proposal (208pt on
     // iPhone) so every density renders at its natural proportional width.
     #if os(tvOS)
       return min(max(proposed, 360), 660)
@@ -48,8 +48,10 @@ struct LayoutConfig {
   /// Cover width inside horizontal cards
   static func horizontalCoverWidth(for density: Double) -> CGFloat {
     let cardWidth = horizontalCardWidth(for: density)
-    // Fixed floor stays below the smallest compact-density proposal (37pt on
-    // iPhone) so covers keep shrinking with the card.
+    // Fixed floor stays below the smallest compact-density proposal (43pt on
+    // iPhone) so covers keep shrinking with the card. The ratio keeps the
+    // cover taller than the text column (series + two-line title + bottom
+    // bar) at every density, so the cover always drives the card height.
     #if os(tvOS)
       return min(max(cardWidth * 0.21, 56), 140)
     #else

--- a/KMReader/Shared/UI/ProgressRingView.swift
+++ b/KMReader/Shared/UI/ProgressRingView.swift
@@ -1,0 +1,43 @@
+//
+// ProgressRingView.swift
+//
+//
+
+import SwiftUI
+
+/// Small circular progress indicator with the percentage centered inside.
+struct ProgressRingView: View {
+  let progress: Double
+  var diameter: CGFloat = 28
+
+  private var lineWidth: CGFloat {
+    max(2.5, diameter * 0.1)
+  }
+
+  var body: some View {
+    ZStack {
+      Circle()
+        .stroke(Color.secondary.opacity(0.25), lineWidth: lineWidth)
+      Circle()
+        .trim(from: 0, to: min(max(progress, 0), 1))
+        .stroke(
+          Color.accentColor,
+          style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+        )
+        .rotationEffect(.degrees(-90))
+    }
+    // Inset the strokes so their outer edge aligns with the view's frame
+    // instead of overflowing it by half the line width.
+    .padding(lineWidth / 2)
+    .overlay {
+      Text(min(max(progress, 0), 1), format: .percent.precision(.fractionLength(0)))
+        .font(.system(size: diameter * 0.25, weight: .medium))
+        .foregroundColor(.secondary)
+        .minimumScaleFactor(0.6)
+        .lineLimit(1)
+    }
+    .frame(width: diameter, height: diameter)
+    .accessibilityLabel(Text("Progress"))
+    .accessibilityValue(Text(min(max(progress, 0), 1), format: .percent.precision(.fractionLength(0))))
+  }
+}


### PR DESCRIPTION
## What

The Keep Reading dashboard section renders books as horizontal cards (`BookHorizontalCardView`). This replaces the inline percentage text in the bottom bar with a circular progress ring on the trailing side of the card, showing the percentage inside the ring.

## How

- New `ProgressRingView` (Shared/UI): track + accent-colored trim ring with the percentage centered inside. Strokes are inset by half the line width so the visual edge matches the layout frame exactly.
- Ring diameter derives from the exact cover height (the thumbnail slot uses a fixed 1:√2 aspect) minus a 16pt inset, plus an 8pt trailing offset — its top/bottom/right margins are all 16pt and it can never drive the card height.
- `LayoutConfig.horizontalCoverWidth` ratio goes back to 0.21 so the cover stays taller than the text column (series + reserved two-line title + bottom bar) at every density: the cover always drives the card height and keeps symmetric 8pt padding on all sides. Pinned read list/collection cards share this sizing as before.
- The download status icon moves inline next to the page count in the bottom bar instead of floating near the ring.
- The ring only appears for in-progress books (0% < progress < 100%, media ready). Unread and completed cards keep the plain bottom bar; completed books keep the checkmark.
- Adds the extracted `Progress` accessibility label key with translations for all 10 supported languages.

## Validation

- `make build` passes on iOS, macOS, and tvOS.
- Verified on iPhone simulator: margins measured on screenshots (cover ~8pt all around, ring ~16pt top/bottom/right), one-line and two-line title cards both keep cover-driven height.
