### PR TITLE
feat: cover-derived textured background for dashboard horizontal book cards

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 530;
+				CURRENT_PROJECT_VERSION = 531;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 530;
+				CURRENT_PROJECT_VERSION = 531;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 530;
+				CURRENT_PROJECT_VERSION = 531;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 530;
+				CURRENT_PROJECT_VERSION = 531;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Views/BookHorizontalCardView.swift
+++ b/KMReader/Features/Book/Views/BookHorizontalCardView.swift
@@ -20,6 +20,19 @@ struct BookHorizontalCardView: View {
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
   @State private var showReadListPicker = false
   @State private var showEditSheet = false
+  @State private var coverArtwork: PlatformImage?
+
+  private var isCoverTinted: Bool {
+    coverArtwork != nil
+  }
+
+  private var primaryTextColor: Color {
+    isCoverTinted ? .white : .primary
+  }
+
+  private var secondaryTextColor: Color {
+    isCoverTinted ? .white.opacity(0.65) : .secondary
+  }
 
   /// Compact density shows the title on a single line so the card height can
   /// actually shrink with the cover instead of being held up by reserved text space.
@@ -94,18 +107,18 @@ struct BookHorizontalCardView: View {
           if item.oneshot {
             Text("Oneshot")
               .font(.caption)
-              .foregroundColor(.blue)
+              .foregroundColor(isCoverTinted ? secondaryTextColor : .blue)
               .lineLimit(1)
           } else if !item.seriesTitle.isEmpty {
             Text(item.seriesTitle)
               .font(.caption)
-              .foregroundColor(.secondary)
+              .foregroundColor(secondaryTextColor)
               .lineLimit(1)
           }
 
           Text(bookTitleLine)
             .font(.footnote)
-            .foregroundColor(item.isCompleted ? .secondary : .primary)
+            .foregroundColor(item.isCompleted ? secondaryTextColor : primaryTextColor)
             .lineLimit(titleLineLimit, reservesSpace: true)
             .multilineTextAlignment(.leading)
 
@@ -123,7 +136,21 @@ struct BookHorizontalCardView: View {
     .background {
       RoundedRectangle(cornerRadius: 12)
         .fill(.regularMaterial)
+        .overlay {
+          // Overlay content never contributes to layout size, so the flexible
+          // blurred image can neither inflate the card nor bleed past it.
+          if let coverArtwork {
+            Image(platformImage: coverArtwork)
+              .resizable()
+              .scaledToFill()
+              .blur(radius: 28)
+              .overlay(Color.black.opacity(0.5))
+              .transition(.opacity)
+          }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 12))
         .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
+        .animation(.easeInOut(duration: 0.2), value: isCoverTinted)
     }
     .contentShape(Rectangle())
     #if os(iOS)
@@ -131,6 +158,24 @@ struct BookHorizontalCardView: View {
     #endif
     .contextMenu {
       bookContextMenu
+    }
+    .task(id: item.bookId) {
+      coverArtwork = await CoverBackgroundProvider.shared.backgroundImage(
+        instanceId: item.instanceId, id: item.bookId, type: .book)
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .thumbnailDidRefresh)) { notification in
+      guard let userInfo = notification.userInfo,
+        let id = userInfo["id"] as? String,
+        let type = userInfo["type"] as? String,
+        id == item.bookId,
+        type == ThumbnailType.book.rawValue
+      else { return }
+      Task {
+        await CoverBackgroundProvider.shared.invalidate(
+          instanceId: item.instanceId, id: item.bookId, type: .book)
+        coverArtwork = await CoverBackgroundProvider.shared.backgroundImage(
+          instanceId: item.instanceId, id: item.bookId, type: .book)
+      }
     }
     .sheet(isPresented: $showReadListPicker) {
       ReadListPickerSheet(
@@ -162,7 +207,7 @@ struct BookHorizontalCardView: View {
         }
         if progress == 1 {
           Image(systemName: "checkmark.circle.fill")
-            .foregroundColor(.secondary)
+            .foregroundColor(secondaryTextColor)
             .font(.caption2)
         }
         Text(progress == 1 ? completedMetaText : "\(item.mediaPagesCount) pages")
@@ -175,7 +220,7 @@ struct BookHorizontalCardView: View {
       }
     }
     .font(.caption)
-    .foregroundColor(.secondary)
+    .foregroundColor(secondaryTextColor)
     .lineLimit(1)
   }
 

--- a/KMReader/Shared/Helpers/LayoutConfig.swift
+++ b/KMReader/Shared/Helpers/LayoutConfig.swift
@@ -48,12 +48,14 @@ struct LayoutConfig {
   /// Cover width inside horizontal cards
   static func horizontalCoverWidth(for density: Double) -> CGFloat {
     let cardWidth = horizontalCardWidth(for: density)
-    // Fixed floor stays below the smallest compact-density proposal (37pt on
-    // iPhone) so covers keep shrinking with the card.
+    // Fixed floor stays below the smallest compact-density proposal (44pt on
+    // iPhone) so covers keep shrinking with the card. The ratio keeps the
+    // cover taller than the text column (series + two-line title + bottom
+    // bar) at every density, so the cover always drives the card height.
     #if os(tvOS)
-      return min(max(cardWidth * 0.21, 56), 140)
+      return min(max(cardWidth * 0.25, 56), 140)
     #else
-      return min(max(cardWidth * 0.21, 32), 96)
+      return min(max(cardWidth * 0.25, 32), 96)
     #endif
   }
 

--- a/KMReader/Shared/UI/CoverBackgroundProvider.swift
+++ b/KMReader/Shared/UI/CoverBackgroundProvider.swift
@@ -1,0 +1,54 @@
+//
+// CoverBackgroundProvider.swift
+//
+//
+
+import CoreGraphics
+import Foundation
+import SwiftUI
+
+/// Provides a heavily downscaled copy of a cached cover thumbnail, intended to
+/// be rendered scaled-to-fill with a strong blur as a textured card background
+/// (Apple Books style). Covers are always opaque JPEGs, so the image fully
+/// covers the card without needing a base color.
+actor CoverBackgroundProvider {
+  static let shared = CoverBackgroundProvider()
+
+  private var cache: [String: PlatformImage?] = [:]
+
+  private init() {}
+
+  func backgroundImage(instanceId: String, id: String, type: ThumbnailType) async -> PlatformImage? {
+    let key = "\(instanceId)#\(type.rawValue)#\(id)"
+    if let cached = cache[key] { return cached }
+    let image = await load(id: id, type: type)
+    cache[key] = image
+    return image
+  }
+
+  func invalidate(instanceId: String, id: String, type: ThumbnailType) {
+    cache["\(instanceId)#\(type.rawValue)#\(id)"] = nil
+  }
+
+  private func load(id: String, type: ThumbnailType) async -> PlatformImage? {
+    guard let url = try? await ThumbnailCache.shared.ensureThumbnail(id: id, type: type),
+      let data = try? Data(contentsOf: url),
+      let source = CGImageSourceCreateWithData(data as CFData, nil)
+    else { return nil }
+    let options: [CFString: Any] = [
+      kCGImageSourceThumbnailMaxPixelSize: 96,
+      kCGImageSourceCreateThumbnailFromImageAlways: true,
+      kCGImageSourceCreateThumbnailWithTransform: true,
+    ]
+    guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+    else { return nil }
+    #if os(iOS) || os(tvOS)
+      return UIImage(cgImage: thumbnail)
+    #else
+      return NSImage(
+        cgImage: thumbnail,
+        size: NSSize(width: thumbnail.width, height: thumbnail.height)
+      )
+    #endif
+  }
+}


### PR DESCRIPTION
## What

Gives the Keep Reading horizontal book card an Apple Books style background: the card's cached cover thumbnail is downscaled to 96px, rendered scaled-to-fill with a heavy blur and a dark scrim, so each card gets a textured tint derived from its own cover art instead of the plain material background.

Refs #970

## Details

- New `CoverBackgroundProvider` (Shared/UI): reuses the local thumbnail cache (no extra network cost), decodes a 96px downscale via `CGImageSourceCreateThumbnailAtIndex`, and caches the result per instance + book. Thumbnail refreshes (`thumbnailDidRefresh`) invalidate and reload automatically.
- The blurred image renders inside an `overlay` of the material card background, so it never contributes to layout size, with an outer `clipShape` containing the blur bleed. The material background stays as the fallback until the cover is available; the tint fades in.
- Title, series, and bottom bar text switch to light colors while the tinted background is shown.
- Cover width ratio goes from 0.21 to 0.25 so the cover is taller than the text column (series + reserved two-line title + bottom bar) at every density: the cover drives the card height and keeps symmetric padding on all sides. Pinned read list/collection cards share this sizing.

## Validation

- `make build` passes on iOS, macOS, and tvOS.
- Verified on iPhone simulator: textured tint renders per cover, card heights stay cover-driven, no layout inflation or blur bleed.
