### PR TITLE
feat(dashboard): scale horizontal card fonts with density and unify card button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ This file provides guidance to coding agents working with code in this repositor
 ### Browse & Dashboards
 
 - **Dynamic Dashboards**: Keep Reading, On Deck, Recently Added, Recently Updated with real-time SSE updates.
-- **Dashboard Book Card Style**: The Keep Reading section renders books as horizontal cards (`BookHorizontalCardView`: cover left, series/title/progress right) by default; classic cover cards remain available via the `dashboardHorizontalBookCards` toggle in Dashboard settings. Pinned read list/collection cards (`ReadListHorizontalCardView`, `CollectionHorizontalCardView`) share the same sizing via `LayoutConfig.horizontalCardWidth` / `LayoutConfig.horizontalCoverWidth`.
+- **Dashboard Book Card Style**: The Keep Reading section renders books as horizontal cards (`BookHorizontalCardView`: cover left, series/title/progress right) by default; classic cover cards remain available via the `dashboardHorizontalBookCards` toggle in Dashboard settings. Pinned read list/collection cards (`ReadListHorizontalCardView`, `CollectionHorizontalCardView`) share the same sizing via `LayoutConfig.horizontalCardWidth` / `LayoutConfig.horizontalCoverWidth`, and all three horizontal card types take their text styles from `LayoutConfig.horizontalCard{Title,Secondary,Tertiary}TextStyle(for:)`, which steps fonts up one tier in cozy density only.
 - **Advanced Filters**: Search with metadata filters (authors, genres, tags, publishers) using all/any logic.
 - **Grid/List Layouts**: Multiple density options (compact, standard, comfortable).
 - **Library Filtering**: Browse per-library or across all libraries.

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 531;
+				CURRENT_PROJECT_VERSION = 532;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 531;
+				CURRENT_PROJECT_VERSION = 532;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 531;
+				CURRENT_PROJECT_VERSION = 532;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 531;
+				CURRENT_PROJECT_VERSION = 532;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Views/BookHorizontalCardPlaceholder.swift
+++ b/KMReader/Features/Book/Views/BookHorizontalCardPlaceholder.swift
@@ -9,6 +9,8 @@ import SwiftUI
 struct BookHorizontalCardPlaceholder: View {
   var coverWidth: CGFloat = 60
 
+  @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
+
   private let cornerRadius: CGFloat = 8
 
   var body: some View {
@@ -19,12 +21,18 @@ struct BookHorizontalCardPlaceholder: View {
         .frame(width: coverWidth)
 
       VStack(alignment: .leading, spacing: 2) {
-        placeholderLine(textStyle: .caption, text: "Series Title", widthScale: 0.45, opacity: 0.18)
-        placeholderLine(textStyle: .footnote, text: "Book Title", widthScale: 0.8, opacity: 0.2)
+        placeholderLine(
+          textStyle: LayoutConfig.horizontalCardSecondaryTextStyle(for: gridDensity),
+          text: "Series Title", widthScale: 0.45, opacity: 0.18)
+        placeholderLine(
+          textStyle: LayoutConfig.horizontalCardTitleTextStyle(for: gridDensity),
+          text: "Book Title", widthScale: 0.8, opacity: 0.2)
 
         Spacer(minLength: 2)
 
-        placeholderLine(textStyle: .caption, text: "Page 42 • 36%", widthScale: 0.55, opacity: 0.15)
+        placeholderLine(
+          textStyle: LayoutConfig.horizontalCardSecondaryTextStyle(for: gridDensity),
+          text: "Page 42 • 36%", widthScale: 0.55, opacity: 0.15)
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
     }

--- a/KMReader/Features/Book/Views/BookHorizontalCardView.swift
+++ b/KMReader/Features/Book/Views/BookHorizontalCardView.swift
@@ -40,6 +40,18 @@ struct BookHorizontalCardView: View {
     gridDensity < GridDensity.standard.rawValue ? 1 : 2
   }
 
+  private var titleTextStyle: Font.TextStyle {
+    LayoutConfig.horizontalCardTitleTextStyle(for: gridDensity)
+  }
+
+  private var secondaryTextStyle: Font.TextStyle {
+    LayoutConfig.horizontalCardSecondaryTextStyle(for: gridDensity)
+  }
+
+  private var tertiaryTextStyle: Font.TextStyle {
+    LayoutConfig.horizontalCardTertiaryTextStyle(for: gridDensity)
+  }
+
   private var progress: Double {
     guard let progressPage = item.progressPage else { return 0 }
     guard item.mediaPagesCount > 0 else { return 0 }
@@ -79,10 +91,12 @@ struct BookHorizontalCardView: View {
   }
 
   var body: some View {
-    HStack(alignment: .top, spacing: 10) {
-      Button {
-        onReadBook?(false)
-      } label: {
+    // The whole card is a single button so cover and text highlight together
+    // and form one focus target on tvOS.
+    Button {
+      onReadBook?(false)
+    } label: {
+      HStack(alignment: .top, spacing: 10) {
         ThumbnailImage(
           id: item.bookId,
           type: .book,
@@ -97,27 +111,22 @@ struct BookHorizontalCardView: View {
           }
         }
         .frame(width: coverWidth)
-      }
-      .adaptiveButtonStyle(.plain)
 
-      Button {
-        onReadBook?(false)
-      } label: {
         VStack(alignment: .leading, spacing: 2) {
           if item.oneshot {
             Text("Oneshot")
-              .font(.caption)
+              .font(.system(secondaryTextStyle))
               .foregroundColor(isCoverTinted ? secondaryTextColor : .blue)
               .lineLimit(1)
           } else if !item.seriesTitle.isEmpty {
             Text(item.seriesTitle)
-              .font(.caption)
+              .font(.system(secondaryTextStyle))
               .foregroundColor(secondaryTextColor)
               .lineLimit(1)
           }
 
           Text(bookTitleLine)
-            .font(.footnote)
+            .font(.system(titleTextStyle))
             .foregroundColor(item.isCompleted ? secondaryTextColor : primaryTextColor)
             .lineLimit(titleLineLimit, reservesSpace: true)
             .multilineTextAlignment(.leading)
@@ -127,12 +136,11 @@ struct BookHorizontalCardView: View {
           bottomBar
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-        .contentShape(Rectangle())
       }
-      .adaptiveButtonStyle(.plain)
+      .padding(8)
+      .frame(maxWidth: .infinity, alignment: .leading)
     }
-    .padding(8)
-    .frame(maxWidth: .infinity, alignment: .leading)
+    .adaptiveButtonStyle(.plain)
     .background {
       RoundedRectangle(cornerRadius: 12)
         .fill(.regularMaterial)
@@ -208,7 +216,7 @@ struct BookHorizontalCardView: View {
         if progress == 1 {
           Image(systemName: "checkmark.circle.fill")
             .foregroundColor(secondaryTextColor)
-            .font(.caption2)
+            .font(.system(tertiaryTextStyle))
         }
         Text(progress == 1 ? completedMetaText : "\(item.mediaPagesCount) pages")
       }
@@ -216,10 +224,10 @@ struct BookHorizontalCardView: View {
         Spacer()
         Image(systemName: item.downloadStatus.displayIcon)
           .foregroundColor(item.downloadStatus.displayColor)
-          .font(.caption2)
+          .font(.system(tertiaryTextStyle))
       }
     }
-    .font(.caption)
+    .font(.system(secondaryTextStyle))
     .foregroundColor(secondaryTextColor)
     .lineLimit(1)
   }

--- a/KMReader/Features/Collection/Views/CollectionHorizontalCardView.swift
+++ b/KMReader/Features/Collection/Views/CollectionHorizontalCardView.swift
@@ -12,6 +12,7 @@ struct CollectionHorizontalCardView: View {
   var onChanged: () -> Void = {}
   let onDeleteRequested: () -> Void
 
+  @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
   @State private var showEditSheet = false
 
   var body: some View {
@@ -27,16 +28,16 @@ struct CollectionHorizontalCardView: View {
 
         VStack(alignment: .leading, spacing: 4) {
           Text(item.name)
-            .font(.footnote)
+            .font(.system(LayoutConfig.horizontalCardTitleTextStyle(for: gridDensity)))
             .lineLimit(2)
             .multilineTextAlignment(.leading)
 
           Text("\(item.seriesCount) series")
-            .font(.caption)
+            .font(.system(LayoutConfig.horizontalCardSecondaryTextStyle(for: gridDensity)))
             .foregroundColor(.secondary)
 
           Text(item.lastModifiedDate.formattedMediumDate)
-            .font(.caption)
+            .font(.system(LayoutConfig.horizontalCardSecondaryTextStyle(for: gridDensity)))
             .foregroundColor(.secondary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/KMReader/Features/ReadList/Views/ReadListHorizontalCardView.swift
+++ b/KMReader/Features/ReadList/Views/ReadListHorizontalCardView.swift
@@ -12,6 +12,7 @@ struct ReadListHorizontalCardView: View {
   var onChanged: () -> Void = {}
   let onDeleteRequested: () -> Void
 
+  @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
   @State private var showEditSheet = false
 
   var body: some View {
@@ -25,16 +26,16 @@ struct ReadListHorizontalCardView: View {
 
         VStack(alignment: .leading, spacing: 4) {
           Text(item.name)
-            .font(.footnote)
+            .font(.system(LayoutConfig.horizontalCardTitleTextStyle(for: gridDensity)))
             .lineLimit(2)
             .multilineTextAlignment(.leading)
 
           Text("\(item.bookCount) books")
-            .font(.caption)
+            .font(.system(LayoutConfig.horizontalCardSecondaryTextStyle(for: gridDensity)))
             .foregroundColor(.secondary)
 
           Text(item.lastModifiedDate.formattedMediumDate)
-            .font(.caption)
+            .font(.system(LayoutConfig.horizontalCardSecondaryTextStyle(for: gridDensity)))
             .foregroundColor(.secondary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/KMReader/Shared/Helpers/LayoutConfig.swift
+++ b/KMReader/Shared/Helpers/LayoutConfig.swift
@@ -59,6 +59,22 @@ struct LayoutConfig {
     #endif
   }
 
+  /// Title text style inside horizontal cards (book title, read list/collection name).
+  /// Cozy density steps text up one tier so the wider card doesn't look sparse.
+  static func horizontalCardTitleTextStyle(for density: Double) -> Font.TextStyle {
+    density > GridDensity.standard.rawValue ? .subheadline : .footnote
+  }
+
+  /// Secondary text style inside horizontal cards (series, progress, metadata).
+  static func horizontalCardSecondaryTextStyle(for density: Double) -> Font.TextStyle {
+    density > GridDensity.standard.rawValue ? .footnote : .caption
+  }
+
+  /// Tertiary text style for small icons in horizontal card accessory rows.
+  static func horizontalCardTertiaryTextStyle(for density: Double) -> Font.TextStyle {
+    density > GridDensity.standard.rawValue ? .caption : .caption2
+  }
+
   /// Default spacing between cards
   static var defaultSpacing: CGFloat {
     #if os(tvOS)


### PR DESCRIPTION
## What

Two dashboard horizontal-card refinements:

1. **Cozy density fonts**: density previously scaled only card geometry (`horizontalCardWidth` / `horizontalCoverWidth`), so in cozy density the cards grew ~30% while text stayed at compact/standard sizes and looked sparse. `LayoutConfig` now provides `horizontalCardTitleTextStyle` / `horizontalCardSecondaryTextStyle` / `horizontalCardTertiaryTextStyle(for:)`, stepping each style up one tier (footnote→subheadline, caption→footnote, caption2→caption) **only when density > standard**. Compact and standard rendering is unchanged.

2. **Whole-card button**: `BookHorizontalCardView` had two separate buttons (cover, text) that highlighted independently and formed two focus targets on tvOS. Cover and text are now a single button label, so the card presses as one unit. The pinned `ReadListHorizontalCardView` / `CollectionHorizontalCardView` already behave this way via `NavigationLink`; they now also read `gridDensity` (previously density-agnostic) to pick up the cozy text styles. `BookHorizontalCardPlaceholder` uses the same styles so the skeleton doesn't jump when loading finishes.

## Validation

- `make build` passes on iOS, macOS, and tvOS.
- Verified on iPhone simulator: cozy density shows visibly larger, better-proportioned text; standard density is pixel-identical to before.
- Includes a `make bump` commit (build 532) for TestFlight delivery.
