### PR TITLE
feat(series): batch mark books as read/unread in series detail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ This file provides guidance to coding agents working with code in this repositor
 - **Advanced Filters**: Search with metadata filters (authors, genres, tags, publishers) using all/any logic.
 - **Grid/List Layouts**: Multiple density options (compact, standard, comfortable).
 - **Library Filtering**: Browse per-library or across all libraries.
+- **Series Batch Read Status**: Series detail book lists support a selection mode (Select button in the Books header, iOS/macOS only, hidden while offline) for batch Mark Read/Unread, mirroring the read list selection mode. `ReadStatusSelectionToolbar` reuses `BookSelectionItemView` cells; Select All covers the whole series via GRDB `fetchAllSeriesBookIds`, not just the loaded page. Marking loops per-book `BookService.markAsRead/markAsUnread` calls (Komga has no batch endpoint), tolerates partial failures, then resyncs the series and posts `postSeriesBooksDidChange` + `postReadStatusChanged`.
 
 ### Multi-Server Vault
 

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 535;
+				CURRENT_PROJECT_VERSION = 536;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 535;
+				CURRENT_PROJECT_VERSION = 536;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 535;
+				CURRENT_PROJECT_VERSION = 536;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 535;
+				CURRENT_PROJECT_VERSION = 536;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Views/ListViews/BooksListViewForSeries.swift
+++ b/KMReader/Features/Book/Views/ListViews/BooksListViewForSeries.swift
@@ -15,6 +15,21 @@ struct BooksListViewForSeries: View {
   @AppStorage("seriesDetailLayout") private var layoutMode: BrowseLayoutMode = .list
   @AppStorage("seriesBookBrowseOptions") private var browseOpts: BookBrowseOptions =
     BookBrowseOptions()
+  @AppStorage("currentAccount") private var current: Current = .init()
+  @AppStorage("isOffline") private var isOffline: Bool = false
+
+  @State private var selectedBookIds: Set<String> = []
+  @State private var isSelectionMode = false
+  @State private var isSubmitting = false
+  @State private var allSeriesBookIds: [String] = []
+
+  private var supportsSelectionMode: Bool {
+    #if os(tvOS)
+      return false
+    #else
+      return true
+    #endif
+  }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
@@ -35,21 +50,73 @@ struct BooksListViewForSeries: View {
 
         Spacer()
 
-        BookFilterView(
-          browseOpts: $browseOpts,
-          showFilterSheet: $showFilterSheet,
-          showSavedFilters: $showSavedFilters,
-          filterType: .seriesBooks,
-          seriesId: seriesId
-        )
+        HStack(spacing: 8) {
+          BookFilterView(
+            browseOpts: $browseOpts,
+            showFilterSheet: $showFilterSheet,
+            showSavedFilters: $showSavedFilters,
+            filterType: .seriesBooks,
+            seriesId: seriesId
+          )
+
+          if supportsSelectionMode && !isSelectionMode && !isOffline {
+            Button {
+              withAnimation {
+                isSelectionMode = true
+              }
+            } label: {
+              Image(systemName: "square.and.pencil")
+            }
+            .adaptiveButtonStyle(.borderedProminent)
+            .optimizedControlSize()
+            .transition(.opacity.combined(with: .scale))
+          }
+        }
       }
       .padding(.horizontal)
+
+      if supportsSelectionMode && isSelectionMode {
+        ReadStatusSelectionToolbar(
+          selectedCount: selectedBookIds.count,
+          totalCount: allSeriesBookIds.count,
+          isSubmitting: isSubmitting,
+          onSelectAll: {
+            if selectedBookIds.count == allSeriesBookIds.count {
+              selectedBookIds.removeAll()
+            } else {
+              selectedBookIds = Set(allSeriesBookIds)
+            }
+          },
+          onMarkRead: {
+            Task {
+              await markSelected(read: true)
+            }
+          },
+          onMarkUnread: {
+            Task {
+              await markSelected(read: false)
+            }
+          },
+          onCancel: {
+            isSelectionMode = false
+            selectedBookIds.removeAll()
+          }
+        )
+        .padding(.horizontal)
+      }
 
       SeriesBooksQueryView(
         seriesId: seriesId,
         bookViewModel: bookViewModel,
         browseOpts: browseOpts,
-        browseLayout: layoutMode
+        browseLayout: layoutMode,
+        isSelectionMode: supportsSelectionMode && isSelectionMode,
+        selectedBookIds: $selectedBookIds,
+        refreshBooks: {
+          Task {
+            await refreshBooks(refresh: true)
+          }
+        }
       )
     }
     .task(id: seriesId) {
@@ -60,6 +127,21 @@ struct BooksListViewForSeries: View {
         await refreshBooks(refresh: true)
       }
     }
+    .onChange(of: isSelectionMode) {
+      if isSelectionMode {
+        Task {
+          await loadAllSeriesBookIds()
+        }
+      }
+    }
+  }
+
+  private func loadAllSeriesBookIds() async {
+    guard let database = try? await DatabaseOperator.database() else { return }
+    allSeriesBookIds = await database.fetchAllSeriesBookIds(
+      seriesId: seriesId,
+      instanceId: current.instanceId
+    )
   }
 
   private func refreshBooks(refresh: Bool) async {
@@ -68,5 +150,71 @@ struct BooksListViewForSeries: View {
       browseOpts: browseOpts,
       refresh: refresh
     )
+  }
+
+  private func markSelected(read: Bool) async {
+    guard !selectedBookIds.isEmpty, !isSubmitting else { return }
+
+    isSubmitting = true
+    defer { isSubmitting = false }
+
+    let bookIds = Array(selectedBookIds)
+    let outcome = await withTaskGroup(
+      of: Error?.self,
+      returning: (firstError: Error?, failureCount: Int).self
+    ) { group in
+      for bookId in bookIds {
+        group.addTask {
+          do {
+            if read {
+              try await BookService.markAsRead(bookId: bookId)
+            } else {
+              try await BookService.markAsUnread(bookId: bookId)
+            }
+            return nil
+          } catch {
+            return error
+          }
+        }
+      }
+      var firstError: Error?
+      var failureCount = 0
+      for await result in group {
+        if let result {
+          failureCount += 1
+          if firstError == nil { firstError = result }
+        }
+      }
+      return (firstError: firstError, failureCount: failureCount)
+    }
+
+    // Sync whatever succeeded so the UI never goes stale, then report failures.
+    if outcome.failureCount < bookIds.count {
+      _ = try? await SyncService.syncSeriesDetail(seriesId: seriesId)
+      try? await SyncService.syncAllSeriesBooks(seriesId: seriesId)
+      await ContentProjectionNotifier.postSeriesBooksDidChange(
+        seriesId: seriesId,
+        reason: .readingProgress
+      )
+      await DashboardSectionRefreshNotifier.postReadStatusChanged(
+        source: .manual,
+        reason: "Books read status changed"
+      )
+    }
+
+    if let firstError = outcome.firstError {
+      ErrorManager.shared.alert(error: firstError)
+    } else if read {
+      ErrorManager.shared.notify(message: String(localized: "notification.book.markedRead"))
+    } else {
+      ErrorManager.shared.notify(message: String(localized: "notification.book.markedUnread"))
+    }
+
+    withAnimation {
+      selectedBookIds.removeAll()
+      isSelectionMode = false
+    }
+
+    await refreshBooks(refresh: true)
   }
 }

--- a/KMReader/Features/Book/Views/ListViews/SeriesBooksQueryView.swift
+++ b/KMReader/Features/Book/Views/ListViews/SeriesBooksQueryView.swift
@@ -10,6 +10,9 @@ struct SeriesBooksQueryView: View {
   let bookViewModel: BookViewModel
   let browseOpts: BookBrowseOptions
   let browseLayout: BrowseLayoutMode
+  let isSelectionMode: Bool
+  @Binding var selectedBookIds: Set<String>
+  let refreshBooks: () -> Void
 
   @AppStorage("gridDensity") private var gridDensity: Double = GridDensity.standard.rawValue
 
@@ -26,11 +29,17 @@ struct SeriesBooksQueryView: View {
     bookViewModel: BookViewModel,
     browseOpts: BookBrowseOptions,
     browseLayout: BrowseLayoutMode,
+    isSelectionMode: Bool,
+    selectedBookIds: Binding<Set<String>>,
+    refreshBooks: @escaping () -> Void
   ) {
     self.seriesId = seriesId
     self.bookViewModel = bookViewModel
     self.browseOpts = browseOpts
     self.browseLayout = browseLayout
+    self.isSelectionMode = isSelectionMode
+    self._selectedBookIds = selectedBookIds
+    self.refreshBooks = refreshBooks
   }
 
   var body: some View {
@@ -44,15 +53,27 @@ struct SeriesBooksQueryView: View {
         case .grid:
           LazyVGrid(columns: columns, spacing: spacing) {
             ForEach(bookViewModel.pagination.items) { book in
-              BookQueryItemView(
-                bookId: book.id,
-                layout: .grid,
-                showSeriesTitle: false,
-                showSeriesNavigation: false,
-                onItemMissing: {
-                  bookViewModel.removeBook(id: book.id)
+              Group {
+                if isSelectionMode {
+                  BookSelectionItemView(
+                    bookId: book.id,
+                    layout: .grid,
+                    selectedBookIds: $selectedBookIds,
+                    refreshBooks: refreshBooks,
+                    showSeriesTitle: false
+                  )
+                } else {
+                  BookQueryItemView(
+                    bookId: book.id,
+                    layout: .grid,
+                    showSeriesTitle: false,
+                    showSeriesNavigation: false,
+                    onItemMissing: {
+                      bookViewModel.removeBook(id: book.id)
+                    }
+                  )
                 }
-              )
+              }
               .padding(.bottom)
               .onAppear {
                 if bookViewModel.pagination.shouldLoadMore(after: book) {
@@ -65,15 +86,27 @@ struct SeriesBooksQueryView: View {
         case .list:
           LazyVStack {
             ForEach(bookViewModel.pagination.items) { book in
-              BookQueryItemView(
-                bookId: book.id,
-                layout: .list,
-                showSeriesTitle: false,
-                showSeriesNavigation: false,
-                onItemMissing: {
-                  bookViewModel.removeBook(id: book.id)
+              Group {
+                if isSelectionMode {
+                  BookSelectionItemView(
+                    bookId: book.id,
+                    layout: .list,
+                    selectedBookIds: $selectedBookIds,
+                    refreshBooks: refreshBooks,
+                    showSeriesTitle: false
+                  )
+                } else {
+                  BookQueryItemView(
+                    bookId: book.id,
+                    layout: .list,
+                    showSeriesTitle: false,
+                    showSeriesNavigation: false,
+                    onItemMissing: {
+                      bookViewModel.removeBook(id: book.id)
+                    }
+                  )
                 }
-              )
+              }
               .onAppear {
                 if bookViewModel.pagination.shouldLoadMore(after: book) {
                   loadBooks(refresh: false)

--- a/KMReader/Localizable.xcstrings
+++ b/KMReader/Localizable.xcstrings
@@ -40845,6 +40845,134 @@
         }
       }
     },
+    "Mark Read" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gelesen markieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark Read"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marcar como leído"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marquer comme lu"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Segna come letto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "既読にする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽음으로 표시"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отметить прочитанным"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标记已读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標記已讀"
+          }
+        }
+      }
+    },
+    "Mark Unread" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungelesen markieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark Unread"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marcar como no leído"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marquer comme non lu"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Segna come non letto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未読にする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "읽지 않음으로 표시"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отметить непрочитанным"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标记未读"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "標記未讀"
+          }
+        }
+      }
+    },
     "Matches" : {
       "localizations" : {
         "de" : {

--- a/KMReader/Shared/UI/ReadStatusSelectionToolbar.swift
+++ b/KMReader/Shared/UI/ReadStatusSelectionToolbar.swift
@@ -1,0 +1,83 @@
+//
+// ReadStatusSelectionToolbar.swift
+//
+//
+
+import SwiftUI
+
+/// Selection-mode toolbar for batch read status changes (mark read/unread).
+struct ReadStatusSelectionToolbar: View {
+  let selectedCount: Int
+  let totalCount: Int
+  let isSubmitting: Bool
+  let onSelectAll: () -> Void
+  let onMarkRead: () -> Void
+  let onMarkUnread: () -> Void
+  let onCancel: () -> Void
+
+  var selectAllLabel: String {
+    selectedCount == totalCount
+      ? String(localized: "Deselect All")
+      : String(localized: "Select All")
+  }
+
+  var selectAllImage: String {
+    selectedCount == totalCount ? "checkmark.circle.fill" : "checkmark.circle"
+  }
+
+  var submitDisabled: Bool {
+    isSubmitting || selectedCount == 0
+  }
+
+  var body: some View {
+    HStack(spacing: 12) {
+      Button {
+        withAnimation {
+          onSelectAll()
+        }
+      } label: {
+        Label(selectAllLabel, systemImage: selectAllImage)
+          .font(.footnote)
+      }
+      .adaptiveButtonStyle(.bordered)
+
+      if selectedCount > 0 {
+        Text("\(selectedCount) / \(totalCount)")
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+          .transition(.opacity)
+      }
+
+      Spacer()
+
+      Button {
+        onMarkRead()
+      } label: {
+        Image(systemName: "checkmark.circle")
+      }
+      .adaptiveButtonStyle(.borderedProminent)
+      .disabled(submitDisabled)
+      .accessibilityLabel(String(localized: "Mark Read"))
+
+      Button {
+        onMarkUnread()
+      } label: {
+        Image(systemName: "circle")
+      }
+      .adaptiveButtonStyle(.borderedProminent)
+      .disabled(submitDisabled)
+      .accessibilityLabel(String(localized: "Mark Unread"))
+
+      Button(role: .cancel) {
+        withAnimation {
+          onCancel()
+        }
+      } label: {
+        Image(systemName: "xmark")
+      }
+      .adaptiveButtonStyle(.bordered)
+      .accessibilityLabel(String(localized: "Cancel"))
+    }
+    .transition(.opacity.combined(with: .move(edge: .top)))
+  }
+}


### PR DESCRIPTION
## Summary

Add batch read status marking to series detail, as requested in #1002 (Aidoku-style).

- New **Select** button in the series detail Books header (iOS/macOS; hidden on tvOS and while offline) enters selection mode
- Book cells switch to the existing `BookSelectionItemView` (grid and list layouts), same as the read list selection mode
- New `ReadStatusSelectionToolbar`: **Select All** (whole series, not just the loaded page), **Mark Read** / **Mark Unread** (icon buttons with a selected-count indicator), and **Cancel**
- Marking loops per-book `markAsRead`/`markAsUnread` calls via a task group (Komga has no batch endpoint, same approach as komga-webui), tolerates partial failures: successes are synced and reported, the first failure is alerted
- After marking, the series detail and books are resynced and projection/dashboard refresh notifications are posted so progress badges update in place

## Verification

End-to-end on iOS simulator against a test Komga server (2-book series):

- Select All → both cells highlighted, counter shows 2 / 2, mark buttons enable
- Mark Read → header badge flips to "All read", both rows show read checkmarks; server confirms `completed: true` for both books
- Mark Unread → badges/checkmarks clear, "Resume Reading" reverts to "Start Reading"; server confirms `readProgress` deleted for both books

`make build-ios` passes; swift-format lint clean; localizations added for all 10 supported languages.
