### PR TITLE
fix(reader): repair macOS end page close button and typography

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 540;
+				CURRENT_PROJECT_VERSION = 541;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 540;
+				CURRENT_PROJECT_VERSION = 541;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 540;
+				CURRENT_PROJECT_VERSION = 541;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 540;
+				CURRENT_PROJECT_VERSION = 541;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Reader/Views/NativeCoverPageView_macOS.swift
+++ b/KMReader/Features/Reader/Views/NativeCoverPageView_macOS.swift
@@ -960,7 +960,10 @@
         if gestureRecognizer === panRecognizer {
           return !parent.viewModel.isZoomed && !isAnimatingTransition
         }
-        if gestureRecognizer === longPressRecognizer,
+        // Clicks/presses landing on interactive elements (e.g. the end card's
+        // Close button) must reach the control, not the tap-zone recognizers.
+        if gestureRecognizer === clickRecognizer || gestureRecognizer === doubleClickRecognizer
+          || gestureRecognizer === longPressRecognizer,
           let containerView,
           isInteractiveElement(at: gestureRecognizer.location(in: containerView), in: containerView)
         {

--- a/KMReader/Features/Reader/Views/NativeEndPageLayoutMetrics.swift
+++ b/KMReader/Features/Reader/Views/NativeEndPageLayoutMetrics.swift
@@ -76,29 +76,23 @@ struct NativeEndPageLayoutMetrics {
     static var badgeFont: PlatformFont {
       #if os(tvOS)
         .preferredFont(forTextStyle: .caption2)
-      #elseif os(iOS)
+      #else
         preferredFont(textStyle: .caption1, weight: .semibold)
-      #elseif os(macOS)
-        .preferredFont(forTextStyle: .caption1)
       #endif
     }
 
     static var titleFont: PlatformFont {
       #if os(tvOS)
         .preferredFont(forTextStyle: .headline)
-      #elseif os(iOS)
+      #else
         preferredFont(textStyle: .title3, design: .serif, weight: .bold)
-      #elseif os(macOS)
-        .preferredFont(forTextStyle: .title3)
       #endif
     }
 
     static var detailFont: PlatformFont {
       #if os(tvOS)
         .preferredFont(forTextStyle: .caption2)
-      #elseif os(iOS)
-        .preferredFont(forTextStyle: .caption1)
-      #elseif os(macOS)
+      #else
         .preferredFont(forTextStyle: .caption1)
       #endif
     }
@@ -163,6 +157,23 @@ struct NativeEndPageLayoutMetrics {
           ])
         }
         return UIFont(descriptor: descriptor, size: 0)
+      }
+    #elseif os(macOS)
+      private static func preferredFont(
+        textStyle: NSFont.TextStyle,
+        design: NSFontDescriptor.SystemDesign? = nil,
+        weight: NSFont.Weight? = nil
+      ) -> NSFont {
+        var descriptor = NSFontDescriptor.preferredFontDescriptor(forTextStyle: textStyle)
+        if let design, let designedDescriptor = descriptor.withDesign(design) {
+          descriptor = designedDescriptor
+        }
+        if let weight {
+          descriptor = descriptor.addingAttributes([
+            NSFontDescriptor.AttributeName.traits: [NSFontDescriptor.TraitKey.weight: weight.rawValue]
+          ])
+        }
+        return NSFont(descriptor: descriptor, size: 0) ?? NSFont.preferredFont(forTextStyle: textStyle)
       }
     #endif
   }

--- a/KMReader/Features/Reader/Views/ScrollPageView_macOS.swift
+++ b/KMReader/Features/Reader/Views/ScrollPageView_macOS.swift
@@ -1052,6 +1052,18 @@
         parent.onTapZoneTap(normalizedX, normalizedY)
       }
 
+      func gestureRecognizerShouldBegin(_ gestureRecognizer: NSGestureRecognizer) -> Bool {
+        // Clicks/presses landing on interactive elements (e.g. the end card's
+        // Close button) must reach the control, not the tap-zone recognizers.
+        if gestureRecognizer is NSClickGestureRecognizer || gestureRecognizer is NSPressGestureRecognizer,
+          let scrollView,
+          isInteractiveElement(at: gestureRecognizer.location(in: scrollView), in: scrollView)
+        {
+          return false
+        }
+        return true
+      }
+
       func gestureRecognizer(
         _ gestureRecognizer: NSGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: NSGestureRecognizer

--- a/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
+++ b/KMReader/Features/Reader/Views/Webtoon/WebtoonReaderView_macOS.swift
@@ -1044,6 +1044,18 @@
         }
       }
 
+      func gestureRecognizerShouldBegin(_ gestureRecognizer: NSGestureRecognizer) -> Bool {
+        // Clicks/presses landing on interactive elements (e.g. the end card's
+        // Close button) must reach the control, not the tap-zone recognizers.
+        if gestureRecognizer is NSClickGestureRecognizer || gestureRecognizer is NSPressGestureRecognizer,
+          let cv = collectionView,
+          isInteractiveElement(at: gestureRecognizer.location(in: cv), in: cv)
+        {
+          return false
+        }
+        return true
+      }
+
       func gestureRecognizer(
         _ gestureRecognizer: NSGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: NSGestureRecognizer


### PR DESCRIPTION
## Summary

Two fixes for the macOS reader end-of-series card ("You're all caught up!"):

- **The Close button did nothing.** The tap-zone `NSClickGestureRecognizer`s on the card's ancestor views keep `delaysPrimaryMouseButtonEvents` at its default (`true`), so the recognizer always consumed clicks landing on the button and the event never reached the `NSControl`. The callback chain itself was fine (Esc and the toolbar X close the reader); event delivery was not.
- **Typography didn't match the design.** The title rendered as plain `title3` and the badge as plain `caption1`, while iOS uses a serif (New York) bold title and a semibold badge.

## Fix

- All three macOS DIVINA coordinators (scroll, cover, webtoon) now refuse to begin click/press recognizers over interactive elements (`gestureRecognizerShouldBegin` + the existing `isInteractiveElement` check), matching the iOS `shouldReceive` pattern and the cover coordinator's existing long-press exemption. Clicks on the Close button now reach the button; tap-zone behavior elsewhere is unchanged (the dispatch-time guards remain).
- `NativeEndPageLayoutMetrics`'s iOS font definitions (serif bold `title3` title, semibold `caption1` badge) now cover macOS too, via a new `NSFontDescriptor` variant of the `preferredFont` helper. tvOS is unchanged.

## Validation

- `make build` passes on iOS / macOS / tvOS.
- Font resolution verified with a standalone script using the same descriptor code: title resolves to `.NewYork-Bold`, badge to `.SFNS-Semibold`.
- Note: the Close button fix was verified by code-path analysis (recognizer no longer begins over the button, so the event reaches `handleClose` → `onDismiss` → `closeReader`); macOS UI automation was not available, a quick manual check on a series' last book is appreciated.
