### PR TITLE
fix(reader): tolerate href-less WebPub toc entries from Komga

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 541;
+				CURRENT_PROJECT_VERSION = 542;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 541;
+				CURRENT_PROJECT_VERSION = 542;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 541;
+				CURRENT_PROJECT_VERSION = 542;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 541;
+				CURRENT_PROJECT_VERSION = 542;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -2833,10 +2833,10 @@ actor OfflineManager {
 
     return collections.flatMap { links in
       links.compactMap { link in
-        guard !link.href.isEmpty else { return nil }
+        guard let href = link.href, !href.isEmpty else { return nil }
         if link.templated == true { return nil }
-        if link.href.hasPrefix("#") || link.href.hasPrefix("data:") { return nil }
-        return link.href
+        if href.hasPrefix("#") || href.hasPrefix("data:") { return nil }
+        return href
       }
     }
   }

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -362,9 +362,11 @@
 
       func collect(_ links: [WebPubLink]) {
         for link in links {
-          let normalized = normalizedHref(link.href)
-          if let safePath = EpubResourceSafeRelativePath(normalized), let type = link.type {
-            map[safePath] = type
+          if let href = link.href {
+            let normalized = normalizedHref(href)
+            if let safePath = EpubResourceSafeRelativePath(normalized), let type = link.type {
+              map[safePath] = type
+            }
           }
           if let children = link.children {
             collect(children)
@@ -542,7 +544,7 @@
     }
 
     func goToChapter(link: WebPubLink) {
-      guard let chapterIndex = chapterIndexForHref(link.href) else { return }
+      guard let href = link.href, let chapterIndex = chapterIndexForHref(href) else { return }
       setTarget(chapterIndex: chapterIndex, pageIndex: 0)
     }
 
@@ -681,7 +683,7 @@
       updateLocation(chapterIndex: lastPosition.chapterIndex, pageIndex: lastPosition.pageIndex)
 
       Task {
-        let href = readingOrder[lastPosition.chapterIndex].href
+        guard let href = readingOrder[lastPosition.chapterIndex].href else { return }
         let overrideProgression = await maxProgressionOverride(for: href)
         guard let overrideProgression else {
           logger.debug(
@@ -708,11 +710,12 @@
       guard let cachedURL = chapterURLCache[chapterIndex] else { return nil }
 
       let link = readingOrder[chapterIndex]
-      let normalizedHref = Self.normalizedHref(link.href)
+      guard let href = link.href else { return nil }
+      let normalizedHref = Self.normalizedHref(href)
       let title = link.title ?? tocTitleByHref[normalizedHref]
 
       return WebPubPageLocation(
-        href: link.href,
+        href: href,
         title: title,
         type: link.type,
         chapterIndex: chapterIndex,
@@ -778,7 +781,7 @@
 
       // Store in memory cache only (no file persistence)
       let effectiveViewport = viewportSize.width > 0 ? viewportSize : Self.defaultViewportSize
-      let href = readingOrder[chapterIndex].href
+      guard let href = readingOrder[chapterIndex].href else { return }
       let cacheKey = pageCountCacheKey(for: href, viewport: effectiveViewport)
       pageCountCache[cacheKey] = normalizedCount
     }
@@ -900,8 +903,8 @@
       var map: [String: String] = [:]
       func collect(_ links: [WebPubLink]) {
         for link in links {
-          if let title = link.title, !title.isEmpty {
-            map[Self.normalizedHref(link.href)] = title
+          if let href = link.href, let title = link.title, !title.isEmpty {
+            map[Self.normalizedHref(href)] = title
           }
           if let children = link.children {
             collect(children)
@@ -1054,7 +1057,7 @@
       }
 
       for (index, link) in readingOrder.enumerated() {
-        let cacheKey = pageCountCacheKey(for: link.href, viewport: effectiveViewport)
+        let cacheKey = pageCountCacheKey(for: link.href ?? "", viewport: effectiveViewport)
         let cachedCount = pageCountCache[cacheKey]
         chapterPageCounts[index] = max(1, cachedCount ?? 1)
       }
@@ -1068,7 +1071,7 @@
     private func refreshChapterTextWeights() {
       chapterTextWeights = [:]
       for (index, link) in readingOrder.enumerated() {
-        let key = Self.normalizedHref(link.href)
+        let key = Self.normalizedHref(link.href ?? "")
         if let cached = textLengthCache[key] {
           chapterTextWeights[index] = max(1, cached)
         }
@@ -1095,7 +1098,7 @@
 
         for (index, link) in readingOrder.enumerated() {
           if Task.isCancelled { return }
-          let key = Self.normalizedHref(link.href)
+          let key = Self.normalizedHref(link.href ?? "")
           if localCache[key] != nil { continue }
           guard let url = chapterURLCache[index] else { continue }
           guard let data = try? Data(contentsOf: url) else { continue }
@@ -1117,17 +1120,18 @@
     private func cacheChapterURLs() async throws {
       chapterURLCache = [:]
       for (index, link) in readingOrder.enumerated() {
-        let normalizedHref = Self.normalizedHref(link.href)
+        let normalizedHref = Self.normalizedHref(link.href ?? "")
         guard
+          let href = link.href,
           let cachedURL = await OfflineManager.shared.cachedOfflineWebPubResourceURL(
             instanceId: AppConfig.current.instanceId,
             bookId: bookId,
-            href: link.href
+            href: href
           )
         else {
           let rootPath = resourceRootURL?.path ?? "unknown"
           logger.error(
-            "❌ Offline WebPub resource missing for book \(bookId): chapterIndex=\(index), href=\(normalizedHref), originalHref=\(link.href), root=\(rootPath)"
+            "❌ Offline WebPub resource missing for book \(bookId): chapterIndex=\(index), href=\(normalizedHref), originalHref=\(link.href ?? "<missing>"), root=\(rootPath)"
           )
           throw AppErrorType.unknown(message: offlineEpubRecoveryMessage())
         }
@@ -1164,7 +1168,7 @@
 
     private func chapterIndexForHref(_ href: String) -> Int? {
       let normalized = Self.normalizedHref(href)
-      return readingOrder.firstIndex { Self.normalizedHref($0.href) == normalized }
+      return readingOrder.firstIndex { Self.normalizedHref($0.href ?? "") == normalized }
     }
 
     /// Syncs the remote progression into local storage. Returns `true` when the

--- a/KMReader/Features/Reader/Views/Sheets/EpubTocSheetView.swift
+++ b/KMReader/Features/Reader/Views/Sheets/EpubTocSheetView.swift
@@ -11,13 +11,21 @@
     let currentLink: WebPubLink?
     let goToChapter: (WebPubLink) -> Void
 
+    /// Rows for links with an href keep the href as their scroll identity;
+    /// href-less container headings get a path-based id so siblings never
+    /// collide.
+    static func rowID(for link: WebPubLink, path: String) -> String {
+      link.href ?? "heading:\(path)"
+    }
+
     var body: some View {
       SheetView(title: String(localized: "title.chapters"), size: .large, applyFormStyle: true) {
         ScrollViewReader { proxy in
           List {
-            ForEach(chapters, id: \.href) { link in
+            ForEach(Array(chapters.enumerated()), id: \.offset) { index, link in
               ChapterRow(
                 link: link,
+                rowID: Self.rowID(for: link, path: "\(index)"),
                 currentLink: currentLink,
                 goToChapter: goToChapter
               )
@@ -26,8 +34,8 @@
           .optimizedListStyle()
           .onAppear {
             DispatchQueue.main.async {
-              if let target = currentLink {
-                proxy.scrollTo(target.href, anchor: .center)
+              if let target = currentLink, let href = target.href {
+                proxy.scrollTo(href, anchor: .center)
               }
             }
           }
@@ -39,28 +47,31 @@
 
   private struct ChapterRow: View {
     let link: WebPubLink
+    let rowID: String
     let currentLink: WebPubLink?
     let goToChapter: (WebPubLink) -> Void
 
     @State private var isExpanded: Bool = false
 
-    init(link: WebPubLink, currentLink: WebPubLink?, goToChapter: @escaping (WebPubLink) -> Void) {
+    init(link: WebPubLink, rowID: String, currentLink: WebPubLink?, goToChapter: @escaping (WebPubLink) -> Void) {
       self.link = link
+      self.rowID = rowID
       self.currentLink = currentLink
       self.goToChapter = goToChapter
 
       // Initialize isExpanded based on whether this group contains the current link
-      if let children = link.children, !children.isEmpty, let currentLink = currentLink {
-        _isExpanded = State(initialValue: Self.containsLink(currentLink.href, in: children))
+      if let children = link.children, !children.isEmpty, let currentHref = currentLink?.href {
+        _isExpanded = State(initialValue: Self.containsLink(currentHref, in: children))
       }
     }
 
     var body: some View {
       if let children = link.children, !children.isEmpty {
         DisclosureGroup(isExpanded: $isExpanded) {
-          ForEach(children, id: \.href) { child in
+          ForEach(Array(children.enumerated()), id: \.offset) { index, child in
             ChapterRow(
               link: child,
+              rowID: EpubTocSheetView.rowID(for: child, path: "\(rowID)/\(index)"),
               currentLink: currentLink,
               goToChapter: goToChapter
             )
@@ -73,7 +84,7 @@
           }
           .buttonStyle(.plain)
         }
-        .id(link.href)
+        .id(rowID)
       } else {
         Button {
           goToChapter(link)
@@ -82,7 +93,7 @@
         }
         .buttonStyle(.plain)
         .contentShape(Rectangle())
-        .id(link.href)
+        .id(rowID)
       }
     }
 
@@ -104,13 +115,13 @@
     let currentLink: WebPubLink?
 
     var isCurrent: Bool {
-      guard let currentLink else { return false }
-      return currentLink.href == link.href
+      guard let currentHref = currentLink?.href else { return false }
+      return currentHref == link.href
     }
 
     var body: some View {
       HStack {
-        Text(link.title ?? link.href)
+        Text(link.title ?? link.href ?? "")
           .foregroundStyle(isCurrent ? .secondary : .primary)
         Spacer()
         if isCurrent {

--- a/KMReader/Features/WebPub/WebPubManifest.swift
+++ b/KMReader/Features/WebPub/WebPubManifest.swift
@@ -82,7 +82,9 @@ nonisolated struct WebPubPublication: Codable, Sendable {
 }
 
 nonisolated struct WebPubLink: Codable, Sendable {
-  let href: String
+  /// Komga omits `href` for EPUB toc container headings (title + children, no
+  /// content link), so this must stay optional.
+  let href: String?
   let title: String?
   let type: String?
   let rel: String?


### PR DESCRIPTION
## Problem

Opening or downloading certain EPUB books fails with:

> Operation failed: Failed to decode response: The data couldn't be read because it is missing.

## Root Cause

Komga declares `WPLinkDto.href` as `String?` with `@JsonInclude(NON_EMPTY)`. EPUB NCX/nav "container heading" entries (a title with children but no content link of their own) are serialized **without the `href` key** in toc/landmarks/pageList links. KMReader's `WebPubLink.href` was non-optional, so decoding such manifests threw `DecodingError.keyNotFound("href")` and the whole book open/offline-download flow failed. The Komga WebUI is unaffected because JavaScript tolerates missing fields.

## Fix

- Make `WebPubLink.href` optional (`String?`) with a comment documenting Komga's behavior.
- Guard all consumers:
  - `EpubReaderViewModel`: skip/guard nil hrefs when building href-keyed maps (media types, TOC titles, text weights, chapter URLs, page counts) and when resolving navigation targets.
  - `EpubTocSheetView`: href-less container headings get path-based row identities (`heading:<path>`) so SwiftUI `ForEach` ids never collide; current-chapter scroll and highlight tolerate nil hrefs.
  - `OfflineManager.collectWebPubResourceLinks`: skip links without hrefs.

Note: `readingOrder` hrefs are always generated by Komga, so nil hrefs can only appear in toc/landmarks/pageList; the reading-order consumers keep defensive guards anyway.

## Validation

- `make build-ios`, `make build-macos`, `make build-tvos` all pass.
- Diagnosable from logs: Settings → Advanced → Logs (category `API`) shows `❌ Missing key 'href' at path: toc.Index N` for affected books.
