### PR TITLE
docs: refresh 6.2 store copy

### DIFF
--- a/APP_STORE_CHANGELOG.txt
+++ b/APP_STORE_CHANGELOG.txt
@@ -1,20 +1,17 @@
 New
-- The series reading action bar now docks to the trailing corner on iPad and macOS, and collapses into a compact button while you scroll.
-- Keep the screen awake while reading with a new toggle in Reader > Reading settings.
-- Page rotation in DIVINA now applies to the whole reading session, so you do not need to rotate each page individually.
+- A dedicated Library tab on iPhone for content-first browsing; the Browse tab is now a focused Search tab.
+- Mark multiple books as read or unread at once from a series page.
+- Keep Reading on the Dashboard now shows rich horizontal cards tinted by each book's cover.
 
 Improvements
-- Resume EPUB books from page-based server progress (KOReader, Kindle sync, web UI) instead of losing the position.
-- Offline EPUB reading position now refreshes from the server during sync so it stays current across devices.
-- Transient server failures no longer wipe EPUB reading progress.
-- PDF overlay toggling is smoother on iPadOS 18.
-- DIVINA pinch-to-zoom no longer crashes on iPadOS 18.
-- Page position stays stable across layout rebuilds and Page Curl orientation changes.
-- Share the original un-cropped page image from the page context menu.
-- tvOS login now works correctly with the Siri Remote.
-- Fix macOS freezes when adding books to read lists or collections from the menu bar.
-- Dashboard scrolling is smoother on macOS.
-- Server URLs with trailing slashes are now handled automatically.
+- The series continue-reading bar now docks into the iPhone tab bar and follows navigation instantly.
+- Settings is reorganized into clearer sections, and Reading Stats now lives on the Dashboard.
+- Reading position stays exactly where you left it when rotating between portrait and landscape, including split wide pages and page curl.
+- Dashboard card fonts now scale with the layout density.
 
 Fixes
-- Restore missing Collections and Read Lists sections on series and book detail pages.
+- EPUB books whose table of contents contains heading-only entries now open and download correctly.
+- The end-of-book Close button on macOS responds to clicks again, and the end page typography matches iOS.
+- The continue-reading bar no longer gets stuck on screen after quickly leaving a series page.
+- Locking series metadata no longer drops the reading direction value.
+- Cancelling a download no longer leaves empty folders behind.

--- a/APP_STORE_DESCRIPTION.txt
+++ b/APP_STORE_DESCRIPTION.txt
@@ -9,8 +9,8 @@ Read comics and books with DIVINA on iOS, macOS, and tvOS, plus EPUB and PDF on 
 Rotate individual pages, crop empty page borders in DIVINA, tune preloading for memory or smoother page turns, keep lightweight progress visible while reading, and choose native PDF presentation modes that adapt cleanly between portrait and landscape.
 
 - Browse and discover
-Use Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/read lists, reading history, a 90-day pages-read heatmap, saved filters, advanced metadata filters with all/any matching, optional unread-cover blur, Spotlight indexing, widgets, and Home Screen quick actions.
-KMReader keeps a local database for responsive browsing, dashboards, logs, and downloaded-library workflows, including large libraries. Dashboard library scopes stay tied to each saved server, and widgets mirror refreshed dashboard content.
+Use Keep Reading, On Deck, Recently Added, Recently Updated, pinned collections/read lists, reading history, a 90-day pages-read heatmap, saved filters, advanced metadata filters with all/any matching, optional unread-cover blur, batch read-status updates from series pages, Spotlight indexing, widgets, and Home Screen quick actions.
+iPhone offers a dedicated Library tab for content-first browsing and a focused Search tab. KMReader keeps a local database for responsive browsing, dashboards, logs, and downloaded-library workflows, including large libraries. Dashboard library scopes stay tied to each saved server, and widgets mirror refreshed dashboard content.
 
 - Offline and sync
 Download books for offline reading, set per-series and per-read-list download policies, browse downloaded items with count and storage summaries, queue dashboard sections, keep reading with iOS background downloads and Live Activities, prepare local pages on demand with offline-first reading, and sync progress when you reconnect.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@
 
 ### Browse and Discovery
 
-- Dashboard sections for Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists, with quick offline actions for current or full book sections where supported.
-- Browse Series, Books, Collections, and Read Lists with metadata filters, all/any matching, saved filters, reading history, a 90-day pages-read heatmap, dashboard search access on larger layouts, and optional unread-cover blur.
+- Dashboard sections for Keep Reading, On Deck, Recently Added, Recently Updated, and pinned collections/read lists, with rich cover-tinted cards and quick offline actions for current or full book sections where supported.
+- Browse Series, Books, Collections, and Read Lists with metadata filters, all/any matching, saved filters, reading history, a 90-day pages-read heatmap, dashboard search access on larger layouts, optional unread-cover blur, and batch read-status updates from series pages.
+- iPhone gets a dedicated Library tab for content-first browsing plus a focused Search tab.
 - Local database storage keeps large libraries, dashboards, logs, downloaded content, and offline browsing responsive.
 - Server-specific dashboard library scopes, refreshed widget payloads, Spotlight indexing for downloaded content, plus iOS widgets and Home Screen quick actions for Keep Reading, Search, and Downloads.
 

--- a/static/index.html
+++ b/static/index.html
@@ -102,7 +102,9 @@
                             Updated, pinned collections/read lists, reading
                             history, a 90-day pages-read heatmap, metadata
                             filters with all/any matching, saved filters,
-                            optional unread-cover blur,
+                            optional unread-cover blur, batch read-status
+                            updates from series pages, a dedicated iPhone
+                            Library tab,
                             dashboard download and search actions,
                             server-scoped library filters, local database
                             storage, widgets, quick actions, and Spotlight


### PR DESCRIPTION
## Problem
The public documentation and App Store release copy need to match the 6.2 release.

## Approach
Refresh README, App Store description, landing page copy, and App Store changelog from the current user-visible product changes.

## Validation
- [x] Reviewed latest-tag-to-HEAD commits
- [x] Ran git diff --check
