### PR TITLE
fix(sync): refresh reading progress on foreground so cross-device progress isn't stale

### DIFF
--- a/KMReader/ContentView.swift
+++ b/KMReader/ContentView.swift
@@ -220,7 +220,7 @@ struct ContentView: View {
                 OfflineManager.shared.triggerSync(
                   instanceId: AppConfig.current.instanceId, restart: true)
               }
-              await syncViewModel.syncReadingProgressOnly()
+              await syncViewModel.syncReadingProgressOnForeground()
 
               if enableSSE && !isOffline {
                 await SSEService.shared.connect()

--- a/KMReader/Features/Sync/Services/SyncWorker.swift
+++ b/KMReader/Features/Sync/Services/SyncWorker.swift
@@ -137,6 +137,7 @@ actor SyncWorker {
     var shouldContinue = true
     var latestServerReadDate = marker
     var syncedCount = 0
+    var syncedBookIds: [String] = []
 
     do {
       while shouldContinue {
@@ -180,6 +181,7 @@ actor SyncWorker {
             instanceId: instanceId
           )
           syncedCount += booksToSync.count
+          syncedBookIds.append(contentsOf: booksToSync.map { $0.id })
           await refreshDownloadedEpubProgressions(
             books: booksToSync,
             instanceId: instanceId,
@@ -192,6 +194,18 @@ actor SyncWorker {
 
       if let latestServerReadDate {
         AppConfig.setRecentlyReadRecordTime(latestServerReadDate, instanceId: instanceId)
+      }
+
+      // Notify so dashboard cover badges and any BookQueryItemView reload the
+      // freshly-pulled progress. Without this, the incremental upsert updates the
+      // GRDB cache but the already-rendered cards (which reload on
+      // `.bookProjectionDidChange`, not via live DB observation) keep showing
+      // stale progress until the book is opened.
+      if !syncedBookIds.isEmpty {
+        await ContentProjectionNotifier.postBooksDidChange(
+          bookIds: syncedBookIds,
+          reason: .readingProgress
+        )
       }
 
       logger.debug(

--- a/KMReader/Features/Sync/ViewModels/SyncViewModel.swift
+++ b/KMReader/Features/Sync/ViewModels/SyncViewModel.swift
@@ -70,12 +70,39 @@ final class SyncViewModel {
     )
   }
 
-  func syncReadingProgressOnly(force: Bool = false) async {
+  /// Debounce for the foreground catch-up sync. Deliberately independent of the
+  /// user-facing `readingHistoryAutoSyncIntervalHours` (default 24h), which
+  /// throttles the periodic history sync — not the on-activation freshness pull
+  /// that keeps cross-device reading progress current on the dashboard. Short
+  /// enough that picking up a second device shows current progress, long enough
+  /// to coalesce the rapid scene-phase cycles iOS emits (Control Center, app
+  /// switcher, notification banners).
+  private static let foregroundSyncMinimumInterval: TimeInterval = 30
+
+  /// Pull recent cross-device reading progress when the app becomes active.
+  /// Uses the short foreground debounce instead of the 24h periodic cadence and
+  /// stays silent (no completion toast) since it is routine background freshness,
+  /// not an explicit user-triggered sync.
+  func syncReadingProgressOnForeground() async {
+    await syncReadingProgressOnly(
+      minimumInterval: Self.foregroundSyncMinimumInterval,
+      showsCompletionNotice: false
+    )
+  }
+
+  func syncReadingProgressOnly(
+    force: Bool = false,
+    minimumInterval: TimeInterval? = nil,
+    showsCompletionNotice: Bool = true
+  ) async {
     guard !isSyncing, !isSyncingReadingProgress else { return }
     let instanceId = AppConfig.current.instanceId
     guard !instanceId.isEmpty else { return }
     guard force || !AppConfig.isOffline else { return }
-    guard force || !shouldSkipReadingProgressSync(instanceId: instanceId) else { return }
+    guard force || !shouldSkipReadingProgressSync(
+      instanceId: instanceId,
+      minimumInterval: minimumInterval
+    ) else { return }
 
     isSyncingReadingProgress = true
     defer { isSyncingReadingProgress = false }
@@ -84,6 +111,7 @@ final class SyncViewModel {
     guard syncSucceeded else { return }
 
     AppConfig.setReadingProgressSyncTime(Date(), instanceId: instanceId)
+    guard showsCompletionNotice else { return }
     ErrorManager.shared.notify(
       message: String(
         localized: "notification.offline.readHistorySyncCompleted",
@@ -92,9 +120,22 @@ final class SyncViewModel {
     )
   }
 
-  private func shouldSkipReadingProgressSync(instanceId: String) -> Bool {
-    guard let interval = AppConfig.readingHistoryAutoSyncMinimumInterval else {
-      return true
+  /// - Parameter overrideInterval: when non-nil, used in place of the user's
+  ///   `readingHistoryAutoSyncMinimumInterval`, so the foreground catch-up can
+  ///   pull far more often than the 24h periodic cadence while other callers
+  ///   keep honoring the user setting.
+  private func shouldSkipReadingProgressSync(
+    instanceId: String,
+    minimumInterval overrideInterval: TimeInterval?
+  ) -> Bool {
+    let interval: TimeInterval
+    if let overrideInterval {
+      interval = overrideInterval
+    } else {
+      guard let configured = AppConfig.readingHistoryAutoSyncMinimumInterval else {
+        return true
+      }
+      interval = configured
     }
     guard let lastSyncTime = AppConfig.readingProgressSyncTime(instanceId: instanceId) else {
       return false


### PR DESCRIPTION
Closes #1014

## Problem
Reading on one device and later opening the app on a second device (same account) leaves the dashboard showing stale reading progress on the book cover until the book is opened.

Root cause: on foreground (`scenePhase == .active`), the app runs `syncReadingProgressOnly()`, which is throttled by `readingHistoryAutoSyncMinimumInterval` (from `readingHistoryAutoSyncIntervalHours`, default 24h). The foreground catch-up is therefore skipped whenever the device synced within the last 24h. The device also missed the live `ReadProgressChanged` SSE while backgrounded (SSE disconnects on background; reconnect does not replay missed events). And even when the incremental sync does run, it upserts the local cache without notifying, so already-rendered cards — which reload on `.bookProjectionDidChange`, not via live DB observation — keep showing stale progress.

## Approach
- **Decouple the foreground catch-up from the 24h periodic throttle.** New `syncReadingProgressOnForeground()` runs the incremental progress sync with a short 30s debounce (coalesces the rapid scene-phase cycles iOS emits) instead of the 24h interval. `ContentView`'s `.active` handler calls it. The periodic trigger and other callers still honor the user's `readingHistoryAutoSyncIntervalHours`.
- **Make the sync notify.** `SyncWorker.syncReadingProgress` now posts `ContentProjectionNotifier.postBooksDidChange(reason: .readingProgress)` for the books it upserts, so dashboard cover badges and any `BookQueryItemView` reload the fresh progress from GRDB (local reload, no extra server calls).
- **Keep the foreground sync silent** (no "Reading history sync completed" toast), since it now runs routinely; the toast remains for explicit/periodic syncs.

## Why this shape, not another
- The 24h interval is right for the heavy periodic history sync but wrong for on-open freshness. A separate short debounce fixes freshness without server spam: the worker is incremental and marker-bounded, so a foreground sync with nothing new is a single cheap request.
- Notifying from the sync worker ("I changed these books' progress → tell the app") fixes the render gap for every caller, not just this one dashboard path, and reuses the existing `.readingProgress` projection-change channel that per-book reads already use.

## Validation
- `make build` passes on iOS, macOS, and tvOS.
- Reproduced before/after on two simulators (iPad Pro 11-inch + iPad A16) against a local Komga. **Before the fix:** with device B backgrounded, updating a book's progress on device A and then foregrounding device B produced only an SSE reconnect and no progress sync (the 24h throttle skipped it), so the cover stayed stale. **After the fix:** the same foreground runs the incremental sync (`📘 Synced latest recently-read progress: count=2`) and the cover badge updates from ~9% to 83% with no book-open required.

## Manual test plan
1. Two devices, same account. On device B open the app (dashboard), then background it (not force-quit).
2. On device A, advance progress in a book and close it.
3. Foreground device B → the book's cover badge updates to the new progress within the debounce window (no book-open required).
4. Single-device: normal reading/closing still updates covers; no repeated "sync completed" toast on every app open.
5. Offline: no behavior change (guarded by `!isOffline`).

## Cohort impact
- Multi-device (one account, 2+ devices): progress stays current on foreground — the reported case.
- Single-device: unaffected; the incremental fetch is a cheap no-op.
- Offline users: unchanged.
- Frequent app-switchers: 30s debounce prevents sync spam.
