### PR TITLE
fix: PDF reader tap/overlay regressions and macOS picker freeze (#956, #957, #959, #1022)

### DIFF
--- a/KMReader/Features/Book/Views/BookCardView.swift
+++ b/KMReader/Features/Book/Views/BookCardView.swift
@@ -90,7 +90,14 @@ struct BookCardView: View {
           downloadStatus: item.downloadStatus,
           onReadBook: onReadBook,
           onShowReadListPicker: {
-            showReadListPicker = true
+            #if os(macOS)
+              // Present in a standalone window: a view-attached sheet
+              // triggered from an NSMenu action can wedge the app on
+              // macOS 15 (#959).
+              PickerWindowOpener.shared.open(.readList(bookId: item.bookId))
+            #else
+              showReadListPicker = true
+            #endif
           },
           onDeleteRequested: onDeleteRequested,
           onEditRequested: {

--- a/KMReader/Features/Book/Views/BookDetailView.swift
+++ b/KMReader/Features/Book/Views/BookDetailView.swift
@@ -308,7 +308,13 @@ struct BookDetailView: View {
         Divider()
 
         Button {
-          deferMenuActionPresentation { showReadListPicker = true }
+          #if os(macOS)
+            // Present in a standalone window: a view-attached sheet triggered
+            // from an NSMenu action can wedge the app on macOS 15 (#959).
+            PickerWindowOpener.shared.open(.readList(bookId: bookId))
+          #else
+            deferMenuActionPresentation { showReadListPicker = true }
+          #endif
         } label: {
           Label("Add to Read List", systemImage: ContentIcon.readList)
         }

--- a/KMReader/Features/Book/Views/BookHorizontalCardView.swift
+++ b/KMReader/Features/Book/Views/BookHorizontalCardView.swift
@@ -79,7 +79,13 @@ struct BookHorizontalCardView: View {
       downloadStatus: item.downloadStatus,
       onReadBook: onReadBook,
       onShowReadListPicker: {
-        showReadListPicker = true
+        #if os(macOS)
+          // Present in a standalone window: a view-attached sheet triggered
+          // from an NSMenu action can wedge the app on macOS 15 (#959).
+          PickerWindowOpener.shared.open(.readList(bookId: item.bookId))
+        #else
+          showReadListPicker = true
+        #endif
       },
       onDeleteRequested: onDeleteRequested,
       onEditRequested: {

--- a/KMReader/Features/Book/Views/BookRowView.swift
+++ b/KMReader/Features/Book/Views/BookRowView.swift
@@ -140,7 +140,14 @@ struct BookRowView: View {
               downloadStatus: item.downloadStatus,
               onReadBook: onReadBook,
               onShowReadListPicker: {
-                showReadListPicker = true
+                #if os(macOS)
+                  // Present in a standalone window: a view-attached sheet
+                  // triggered from an NSMenu action can wedge the app on
+                  // macOS 15 (#959).
+                  PickerWindowOpener.shared.open(.readList(bookId: item.bookId))
+                #else
+                  showReadListPicker = true
+                #endif
               },
               onDeleteRequested: onDeleteRequested,
               onEditRequested: {

--- a/KMReader/Features/Browse/Models/PickerWindowRequest.swift
+++ b/KMReader/Features/Browse/Models/PickerWindowRequest.swift
@@ -1,0 +1,17 @@
+//
+// PickerWindowRequest.swift
+//
+//
+
+#if os(macOS)
+  import Foundation
+
+  /// Payload for the standalone picker window (`WindowGroup(for:)`).
+  /// Presenting the read-list / collection pickers as independent windows
+  /// instead of view-attached sheets avoids wedging the app when the picker
+  /// is triggered from an NSMenu action on macOS 15 (#959).
+  enum PickerWindowRequest: Codable, Hashable {
+    case readList(bookId: String)
+    case collection(seriesId: String)
+  }
+#endif

--- a/KMReader/Features/Browse/Views/Sheets/PickerWindowView.swift
+++ b/KMReader/Features/Browse/Views/Sheets/PickerWindowView.swift
@@ -1,0 +1,65 @@
+//
+// PickerWindowView.swift
+//
+//
+
+#if os(macOS)
+  import SwiftUI
+
+  /// Root view of the standalone picker window on macOS. Hosts the same
+  /// picker sheets used on other platforms; the mutation and the refresh
+  /// notifications are centralized here because call-site closures cannot
+  /// reach into a separate window (#959).
+  struct PickerWindowView: View {
+    let request: PickerWindowRequest
+
+    var body: some View {
+      switch request {
+      case .readList(let bookId):
+        ReadListPickerSheet(bookId: bookId) { readListId in
+          Task {
+            await addBook(bookId, toReadList: readListId)
+          }
+        }
+      case .collection(let seriesId):
+        CollectionPickerSheet(seriesId: seriesId) { collectionId in
+          Task {
+            await addSeries(seriesId, toCollection: collectionId)
+          }
+        }
+      }
+    }
+
+    private func addBook(_ bookId: String, toReadList readListId: String) async {
+      do {
+        try await ReadListService.addBooksToReadList(
+          readListId: readListId,
+          bookIds: [bookId]
+        )
+        // Sync so the local membership reflects the change immediately.
+        _ = try? await SyncService.syncReadList(id: readListId)
+        ErrorManager.shared.notify(
+          message: String(localized: "notification.book.booksAddedToReadList"))
+        await ContentProjectionNotifier.postReadListDidChange(readListId: readListId)
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
+
+    private func addSeries(_ seriesId: String, toCollection collectionId: String) async {
+      do {
+        try await CollectionService.addSeriesToCollection(
+          collectionId: collectionId,
+          seriesIds: [seriesId]
+        )
+        // Sync so the local membership reflects the change immediately.
+        _ = try? await SyncService.syncCollection(id: collectionId)
+        ErrorManager.shared.notify(
+          message: String(localized: "notification.series.addedToCollection"))
+        await ContentProjectionNotifier.postCollectionDidChange(collectionId: collectionId)
+      } catch {
+        ErrorManager.shared.alert(error: error)
+      }
+    }
+  }
+#endif

--- a/KMReader/Features/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailView.swift
@@ -355,13 +355,25 @@ struct OneshotDetailView: View {
         Divider()
 
         Button {
-          deferMenuActionPresentation { showCollectionPicker = true }
+          #if os(macOS)
+            // Present in a standalone window: a view-attached sheet triggered
+            // from an NSMenu action can wedge the app on macOS 15 (#959).
+            PickerWindowOpener.shared.open(.collection(seriesId: seriesId))
+          #else
+            deferMenuActionPresentation { showCollectionPicker = true }
+          #endif
         } label: {
           Label("Add to Collection", systemImage: ContentIcon.collection)
         }
 
         Button {
-          deferMenuActionPresentation { showReadListPicker = true }
+          #if os(macOS)
+            if let book {
+              PickerWindowOpener.shared.open(.readList(bookId: book.id))
+            }
+          #else
+            deferMenuActionPresentation { showReadListPicker = true }
+          #endif
         } label: {
           Label("Add to Read List", systemImage: ContentIcon.readList)
         }

--- a/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_iOS.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfDocumentView_iOS.swift
@@ -193,9 +193,11 @@
       private var singleTapStartTime: TimeInterval = 0
 
       // Stricter than UITapGestureRecognizer's built-in slop: slow/short drags
-      // must not toggle the reader overlays (#957).
+      // must not toggle the reader overlays (#957). The duration budget includes
+      // the wait for the double-tap/long-press failure requirements, so it must
+      // stay comfortably above a quick tap's handler delivery latency.
       private let singleTapMaximumMovement: CGFloat = 10
-      private let singleTapMaximumDuration: TimeInterval = 0.5
+      private let singleTapMaximumDuration: TimeInterval = 0.75
 
       init(
         onPageChange: @escaping (Int, Int) -> Void,
@@ -345,8 +347,12 @@
 
       func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         hadSelectionAtTouchStart = (observedPDFView?.currentSelection != nil)
-        if gestureRecognizer === singleTapRecognizer, let view = touch.view {
-          singleTapStartPoint = touch.location(in: view)
+        // Record the start point in the PDFView's coordinate space, matching
+        // the end point measured in handleSingleTap. touch.view is a private
+        // subview with its own origin/scroll offset, so mixing the two spaces
+        // inflates the movement and rejects every tap (#956, #957).
+        if gestureRecognizer === singleTapRecognizer, let pdfView = gestureRecognizer.view {
+          singleTapStartPoint = touch.location(in: pdfView)
           singleTapStartTime = touch.timestamp
         }
         return !isInteractiveElement(touch.view)

--- a/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
+++ b/KMReader/Features/Reader/Views/Pdf/PdfReaderView.swift
@@ -94,6 +94,12 @@
         contentView
 
         controlsOverlay
+          .simultaneousGesture(
+            // Touching the controls (close button, title, ⋯ menu, page jump)
+            // is explicit intent to keep the overlay: cancel the post-resume
+            // auto-hide instead of letting it dismiss an open menu (#1022).
+            TapGesture().onEnded { cancelAutoHideAfterResume() }
+          )
 
         keyboardHelpOverlay
       }
@@ -201,6 +207,13 @@
       .onChange(of: scenePhase) { oldPhase, newPhase in
         handleScenePhaseChange(from: oldPhase, to: newPhase)
       }
+      .onChange(of: isPresentingModalSheet) { _, presenting in
+        // A sheet opening (menu action, keyboard command) is controls
+        // interaction: the post-resume glance window ends here (#1022).
+        if presenting {
+          cancelAutoHideAfterResume()
+        }
+      }
       .background(
         KeyboardEventHandler(
           isEnabled: isKeyboardCaptureEnabled,
@@ -272,6 +285,12 @@
       autoHideAfterResumeTask = Task { @MainActor in
         try? await Task.sleep(for: .seconds(1))
         guard !Task.isCancelled else { return }
+        // Belt and braces: never pull the overlay out from under an open
+        // sheet or menu interaction (#1022).
+        guard !isPresentingModalSheet else {
+          autoHideAfterResumeTask = nil
+          return
+        }
         withAnimation {
           showingControls = false
         }

--- a/KMReader/Features/Series/Views/SeriesCardView.swift
+++ b/KMReader/Features/Series/Views/SeriesCardView.swift
@@ -74,7 +74,14 @@ struct SeriesCardView: View {
           booksReadCount: item.booksReadCount,
           booksInProgressCount: item.booksInProgressCount,
           onShowCollectionPicker: {
-            showCollectionPicker = true
+            #if os(macOS)
+              // Present in a standalone window: a view-attached sheet
+              // triggered from an NSMenu action can wedge the app on
+              // macOS 15 (#959).
+              PickerWindowOpener.shared.open(.collection(seriesId: item.seriesId))
+            #else
+              showCollectionPicker = true
+            #endif
           },
           onDeleteRequested: onDeleteRequested,
           onEditRequested: {

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -463,7 +463,13 @@ extension SeriesDetailView {
         Divider()
 
         Button {
-          deferMenuActionPresentation { showCollectionPicker = true }
+          #if os(macOS)
+            // Present in a standalone window: a view-attached sheet triggered
+            // from an NSMenu action can wedge the app on macOS 15 (#959).
+            PickerWindowOpener.shared.open(.collection(seriesId: seriesId))
+          #else
+            deferMenuActionPresentation { showCollectionPicker = true }
+          #endif
         } label: {
           Label("Add to Collection", systemImage: ContentIcon.collection)
         }

--- a/KMReader/Features/Series/Views/SeriesRowView.swift
+++ b/KMReader/Features/Series/Views/SeriesRowView.swift
@@ -111,7 +111,14 @@ struct SeriesRowView: View {
               booksReadCount: item.booksReadCount,
               booksInProgressCount: item.booksInProgressCount,
               onShowCollectionPicker: {
-                showCollectionPicker = true
+                #if os(macOS)
+                  // Present in a standalone window: a view-attached sheet
+                  // triggered from an NSMenu action can wedge the app on
+                  // macOS 15 (#959).
+                  PickerWindowOpener.shared.open(.collection(seriesId: item.seriesId))
+                #else
+                  showCollectionPicker = true
+                #endif
               },
               onDeleteRequested: onDeleteRequested,
               onEditRequested: {

--- a/KMReader/MainApp.swift
+++ b/KMReader/MainApp.swift
@@ -169,6 +169,11 @@ struct MainApp: App {
           }
         )
       )
+      .task {
+        PickerWindowOpener.shared.configure { request in
+          openWindow(value: request)
+        }
+      }
       .overlay(alignment: .bottom) {
         NotificationOverlay()
       }
@@ -429,6 +434,16 @@ struct MainApp: App {
       }
       .windowToolbarStyle(.unifiedCompact)
       .defaultSize(width: 800, height: 600)
+
+      WindowGroup(for: PickerWindowRequest.self) { $request in
+        Group {
+          if let request {
+            PickerWindowView(request: request)
+          }
+        }
+        .preferredColorScheme(appColorScheme.colorScheme)
+      }
+      .defaultSize(width: 720, height: 600)
     #endif
   }
 }

--- a/KMReader/Shared/Helpers/PickerWindowOpener.swift
+++ b/KMReader/Shared/Helpers/PickerWindowOpener.swift
@@ -1,0 +1,28 @@
+//
+// PickerWindowOpener.swift
+//
+//
+
+#if os(macOS)
+  import Foundation
+
+  /// Routes picker-window open requests from deep view hierarchies (context
+  /// menus, toolbar menus) to the `openWindow` environment captured at the
+  /// app scene root (#959).
+  @MainActor
+  final class PickerWindowOpener {
+    static let shared = PickerWindowOpener()
+
+    private var openWindowHandler: ((PickerWindowRequest) -> Void)?
+
+    private init() {}
+
+    func configure(_ handler: @escaping (PickerWindowRequest) -> Void) {
+      openWindowHandler = handler
+    }
+
+    func open(_ request: PickerWindowRequest) {
+      openWindowHandler?(request)
+    }
+  }
+#endif


### PR DESCRIPTION
Fixes three regressions/issues reported after 6.2 by the same user.

## #956 / #957 — PDF single tap stopped working entirely

The anti-accidental-touch filter from `78d3f63d` recorded the tap start point in `touch.view` — a private PDFView subview with its own origin and scroll offset — while measuring the end point in PDFView coordinates. Mixing the two coordinate spaces inflated the movement past the 10 pt threshold, so every tap was rejected and the controls overlay could no longer be toggled on any iOS/iPadOS version or device.

The start point is now recorded in the recognizer view's (PDFView) coordinate space, and the duration budget is relaxed from 0.5 s to 0.75 s since the handler only fires after the double-tap/long-press failure requirements resolve.

## #1022 — Opened menu dismissed by the resume auto-hide

Returning from the app switcher force-shows the PDF controls and auto-hides them after one second (intended). But the auto-hide task was only cancelled on page taps, so opening the ellipsis menu or any sheet inside that window still let the overlay vanish — taking the open menu with it.

Now any touch on the controls overlay and any modal sheet opening (including keyboard-command presentations on macOS) cancels the auto-hide, and the task re-checks sheet state before hiding.

## #959 — Adding to read lists/collections still freezes on macOS Sequoia

Deferring the sheet state mutation to the next runloop (`59f58213`) was not enough: presenting a view-attached `.sheet` from an NSMenu action still wedges the app on macOS 15 (no beachball, dead menu bar, CMD+Q works). The sheet presentation races the menu tracking loop teardown.

Root fix: on macOS, "Add to Read List" / "Add to Collection" now open in an independent `WindowGroup(for:)` window instead of a sheet attached to the context-menu row, fully decoupling presentation from menu dismissal. Adds `PickerWindowRequest` / `PickerWindowOpener` / `PickerWindowView`; the add mutation, local sync, and projection refresh notifications are centralized in the window view since call-site closures cannot reach into a separate window. iOS keeps the existing sheet flow unchanged; edit/delete sheets keep the deferral as a fallback.

## Validation

- `make build`: iOS / macOS / tvOS all compile.
- No XCTest targets in this repo; the PDF gesture and macOS window flows need on-device verification (no Komga environment available for end-to-end testing here).

Refs #956, refs #957, refs #959, refs #1022.
