### PR TITLE
fix(ui): hoist collection/read list loading out of lazily-rendered detail sections

### DIFF
--- a/KMReader/Features/Book/Views/BookDetailView.swift
+++ b/KMReader/Features/Book/Views/BookDetailView.swift
@@ -13,6 +13,7 @@ struct BookDetailView: View {
   @AppStorage("currentAccount") private var current: Current = .init()
 
   @State private var item: BookDisplayItem?
+  @State private var readLists: [SidebarReadListItem] = []
   @State private var hasError = false
   @State private var showDeleteConfirmation = false
   @State private var showReadListPicker = false
@@ -54,8 +55,8 @@ struct BookDetailView: View {
             inSheet: false
           )
 
-          if let item {
-            BookReadListsSection(readListIds: item.readListIds)
+          if item != nil {
+            BookReadListsSection(readLists: readLists)
           }
         } else if hasError {
           VStack(spacing: 16) {
@@ -246,6 +247,7 @@ struct BookDetailView: View {
   private func loadLocalBook() async {
     guard let database = try? await DatabaseOperator.database() else {
       item = nil
+      readLists = []
       return
     }
     item = try? await database.fetchBookDisplayItem(
@@ -253,6 +255,29 @@ struct BookDetailView: View {
       instanceId: current.instanceId,
       includeOfflineProtection: true
     )
+    await loadReadLists()
+  }
+
+  private func loadReadLists() async {
+    let instanceId = current.instanceId
+    guard let readListIds = item?.readListIds, !instanceId.isEmpty, !readListIds.isEmpty else {
+      readLists = []
+      return
+    }
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedReadLists = try await database.fetchSidebarReadLists(
+        instanceId: instanceId,
+        readListIds: Set(readListIds)
+      )
+      if readLists != loadedReadLists {
+        withAnimation {
+          readLists = loadedReadLists
+        }
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
   }
 
   private func addToReadList(readListId: String) {

--- a/KMReader/Features/Book/Views/BookReadListsSection.swift
+++ b/KMReader/Features/Book/Views/BookReadListsSection.swift
@@ -6,27 +6,13 @@
 import SwiftUI
 
 struct BookReadListsSection: View {
-  @AppStorage("currentAccount") private var current: Current = .init()
+  let readLists: [SidebarReadListItem]
 
-  let readListIds: [String]
-
-  @State private var readLists: [SidebarReadListItem] = []
-
-  private var readListIdsKey: String {
-    readListIds.sorted().joined(separator: ",")
-  }
-
+  // Pure display component: loading is hoisted to the parent detail view's
+  // always-realized task. A self-loading .task here never fires while the body
+  // renders empty inside the parent's LazyVStack (#967), and an always-present
+  // zero-height anchor would collapse the surrounding stack spacing (#986).
   var body: some View {
-    sectionContent
-      .task(id: "\(current.instanceId)|\(readListIdsKey)") {
-        await loadReadLists()
-      }
-  }
-
-  // Renders nothing when empty: an always-present zero-height container would
-  // swallow the parent VStack spacing and make adjacent Dividers hug the content.
-  @ViewBuilder
-  private var sectionContent: some View {
     if !readLists.isEmpty {
       VStack(alignment: .leading, spacing: 6) {
         HStack(spacing: 4) {
@@ -56,33 +42,6 @@ struct BookReadListsSection: View {
         }
       }
       .frame(maxWidth: .infinity, alignment: .leading)
-    }
-  }
-
-  private func loadReadLists() async {
-    let instanceId = current.instanceId
-    guard !instanceId.isEmpty, !readListIds.isEmpty else {
-      if !readLists.isEmpty {
-        withAnimation {
-          readLists = []
-        }
-      }
-      return
-    }
-
-    do {
-      let database = try await DatabaseOperator.database()
-      let loadedReadLists = try await database.fetchSidebarReadLists(
-        instanceId: instanceId,
-        readListIds: Set(readListIds)
-      )
-      if readLists != loadedReadLists {
-        withAnimation {
-          readLists = loadedReadLists
-        }
-      }
-    } catch {
-      ErrorManager.shared.alert(error: error)
     }
   }
 }

--- a/KMReader/Features/OneShot/OneShotDetailView.swift
+++ b/KMReader/Features/OneShot/OneShotDetailView.swift
@@ -14,6 +14,8 @@ struct OneshotDetailView: View {
 
   @State private var seriesItem: SeriesDisplayItem?
   @State private var bookItem: BookDisplayItem?
+  @State private var collections: [SidebarCollectionItem] = []
+  @State private var readLists: [SidebarReadListItem] = []
   @State private var isLoading = true
   @State private var hasError = false
   @State private var showDeleteConfirmation = false
@@ -62,12 +64,12 @@ struct OneshotDetailView: View {
             inSheet: false
           )
 
-          if let seriesItem {
-            SeriesCollectionsSection(collectionIds: seriesItem.collectionIds)
+          if seriesItem != nil {
+            SeriesCollectionsSection(collections: collections)
           }
 
-          if let bookItem {
-            BookReadListsSection(readListIds: bookItem.readListIds)
+          if bookItem != nil {
+            BookReadListsSection(readLists: readLists)
           }
         } else if hasError {
           VStack(spacing: 16) {
@@ -170,6 +172,8 @@ struct OneshotDetailView: View {
     guard let database = try? await DatabaseOperator.database() else {
       seriesItem = nil
       bookItem = nil
+      collections = []
+      readLists = []
       return
     }
 
@@ -182,6 +186,54 @@ struct OneshotDetailView: View {
       instanceId: current.instanceId,
       includeOfflineProtection: true
     )
+    await loadCollections()
+    await loadReadLists()
+  }
+
+  private func loadCollections() async {
+    let instanceId = current.instanceId
+    guard let collectionIds = seriesItem?.collectionIds, !instanceId.isEmpty,
+      !collectionIds.isEmpty
+    else {
+      collections = []
+      return
+    }
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedCollections = try await database.fetchSidebarCollections(
+        instanceId: instanceId,
+        collectionIds: Set(collectionIds)
+      )
+      if collections != loadedCollections {
+        withAnimation {
+          collections = loadedCollections
+        }
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
+  }
+
+  private func loadReadLists() async {
+    let instanceId = current.instanceId
+    guard let readListIds = bookItem?.readListIds, !instanceId.isEmpty, !readListIds.isEmpty else {
+      readLists = []
+      return
+    }
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedReadLists = try await database.fetchSidebarReadLists(
+        instanceId: instanceId,
+        readListIds: Set(readListIds)
+      )
+      if readLists != loadedReadLists {
+        withAnimation {
+          readLists = loadedReadLists
+        }
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
   }
 
   private func clearCache() {

--- a/KMReader/Features/Series/Views/SeriesCollectionsSection.swift
+++ b/KMReader/Features/Series/Views/SeriesCollectionsSection.swift
@@ -6,27 +6,13 @@
 import SwiftUI
 
 struct SeriesCollectionsSection: View {
-  @AppStorage("currentAccount") private var current: Current = .init()
+  let collections: [SidebarCollectionItem]
 
-  let collectionIds: [String]
-
-  @State private var collections: [SidebarCollectionItem] = []
-
-  private var collectionIdsKey: String {
-    collectionIds.sorted().joined(separator: ",")
-  }
-
+  // Pure display component: loading is hoisted to the parent detail view's
+  // always-realized task. A self-loading .task here never fires while the body
+  // renders empty inside the parent's LazyVStack (#967), and an always-present
+  // zero-height anchor would collapse the surrounding stack spacing (#986).
   var body: some View {
-    sectionContent
-      .task(id: "\(current.instanceId)|\(collectionIdsKey)") {
-        await loadCollections()
-      }
-  }
-
-  // Renders nothing when empty: an always-present zero-height container would
-  // swallow the parent VStack spacing and make the Divider below hug the content above.
-  @ViewBuilder
-  private var sectionContent: some View {
     if !collections.isEmpty {
       VStack(alignment: .leading, spacing: 8) {
         HStack(spacing: 4) {
@@ -56,33 +42,6 @@ struct SeriesCollectionsSection: View {
         }
       }
       .frame(maxWidth: .infinity, alignment: .leading)
-    }
-  }
-
-  private func loadCollections() async {
-    let instanceId = current.instanceId
-    guard !instanceId.isEmpty, !collectionIds.isEmpty else {
-      if !collections.isEmpty {
-        withAnimation {
-          collections = []
-        }
-      }
-      return
-    }
-
-    do {
-      let database = try await DatabaseOperator.database()
-      let loadedCollections = try await database.fetchSidebarCollections(
-        instanceId: instanceId,
-        collectionIds: Set(collectionIds)
-      )
-      if collections != loadedCollections {
-        withAnimation {
-          collections = loadedCollections
-        }
-      }
-    } catch {
-      ErrorManager.shared.alert(error: error)
     }
   }
 }

--- a/KMReader/Features/Series/Views/SeriesDetailView.swift
+++ b/KMReader/Features/Series/Views/SeriesDetailView.swift
@@ -17,6 +17,7 @@ struct SeriesDetailView: View {
   @Environment(\.readerActions) private var readerActions
 
   @State private var item: SeriesDisplayItem?
+  @State private var collections: [SidebarCollectionItem] = []
   @State private var bookViewModel = BookViewModel()
   @State private var showDeleteConfirmation = false
   @State private var showCollectionPicker = false
@@ -108,8 +109,8 @@ struct SeriesDetailView: View {
 
             SeriesDetailContentView(series: series)
 
-            if let item {
-              SeriesCollectionsSection(collectionIds: item.collectionIds)
+            if item != nil {
+              SeriesCollectionsSection(collections: collections)
             }
 
             Divider()
@@ -286,12 +287,37 @@ extension SeriesDetailView {
   private func loadLocalSeries() async {
     guard let database = try? await DatabaseOperator.database() else {
       item = nil
+      collections = []
       return
     }
     item = try? await database.fetchSeriesDisplayItem(
       seriesId: seriesId,
       instanceId: current.instanceId
     )
+    await loadCollections()
+  }
+
+  private func loadCollections() async {
+    let instanceId = current.instanceId
+    guard let collectionIds = item?.collectionIds, !instanceId.isEmpty, !collectionIds.isEmpty
+    else {
+      collections = []
+      return
+    }
+    do {
+      let database = try await DatabaseOperator.database()
+      let loadedCollections = try await database.fetchSidebarCollections(
+        instanceId: instanceId,
+        collectionIds: Set(collectionIds)
+      )
+      if collections != loadedCollections {
+        withAnimation {
+          collections = loadedCollections
+        }
+      }
+    } catch {
+      ErrorManager.shared.alert(error: error)
+    }
   }
 
   private func analyzeSeries() {


### PR DESCRIPTION
## What

Fixes the #967 regression reported in [this comment](https://github.com/everpcpc/KMReader/issues/967#issuecomment-5637316352): series detail pages no longer show their Collections section, and book/oneshot detail pages no longer show their Read Lists section.

## Root Cause

9b793ed fixed the divider spacing issue (#986) by making `SeriesCollectionsSection` / `BookReadListsSection` render nothing while their data is empty, with the `.task(id:)` hoisted onto that conditional content. Inside the parent `LazyVStack`, a section whose body renders empty is never realized, so the task never fires, the fetch never runs, and the sections stay invisible forever — the exact mechanism behind the original #967.

The two constraints conflict inside the section itself:

- an always-present zero-height anchor gets realized but collapses the surrounding stack spacing (#986);
- a conditionally-empty body keeps spacing intact but is never realized, so a self-loading `.task` never fires (#967).

## Fix

Move the fetch out of the lazily-rendered sections entirely:

- Both sections are now pure display components taking the already-loaded `[SidebarCollectionItem]` / `[SidebarReadListItem]`; they render nothing for an empty list, preserving the #986 spacing fix.
- Loading is hoisted into the parent detail views' always-realized task chains: `SeriesDetailView.loadLocalSeries()`, `BookDetailView.loadLocalBook()`, and `OneShotDetailView.loadLocalOneshot()` now also fetch the sidebar collections / read lists after loading the display item.
- Existing behavior is preserved: state clears when ids are empty or loading fails, updates animate, failures still route through `ErrorManager.alert`, and notification-driven revalidation (`refreshLocalSeriesData`) also refreshes collections.

## Validation

- `make build-ios`, `make build-macos`, `make build-tvos` all pass.
