### PR TITLE
fix(server): declutter iPhone settings server card chevrons

### DIFF
--- a/KMReader/Features/Dashboard/Views/ServerUpdateStatusView.swift
+++ b/KMReader/Features/Dashboard/Views/ServerUpdateStatusView.swift
@@ -10,6 +10,11 @@ struct ServerUpdateStatusView: View {
   @AppStorage("taskQueueStatus") private var taskQueueStatusRaw: String = ""
   @AppStorage("isOffline") private var isOffline: Bool = false
 
+  /// Whether the running-tasks segment links to the Tasks page. Disable when
+  /// embedded inside another NavigationLink (e.g. the iPhone settings server
+  /// card) to avoid stacked disclosure indicators.
+  var showsTasksLink: Bool = true
+
   private var taskStatus: TaskQueueSSEDto {
     TaskQueueSSEDto(rawValue: taskQueueStatusRaw) ?? TaskQueueSSEDto()
   }
@@ -29,12 +34,17 @@ struct ServerUpdateStatusView: View {
         if taskStatus.count > 0 {
           Text("•")
             .foregroundColor(.secondary)
-          NavigationLink(value: NavDestination.settingsTasks) {
-            HStack(spacing: 4) {
-              Text("Running Tasks: \(taskStatus.count)")
-              Image(systemName: "chevron.right")
-            }
-          }.adaptiveButtonStyle(.plain)
+          if showsTasksLink {
+            NavigationLink(value: NavDestination.settingsTasks) {
+              HStack(spacing: 4) {
+                Text("Running Tasks: \(taskStatus.count)")
+                Image(systemName: "chevron.right")
+              }
+            }.adaptiveButtonStyle(.plain)
+          } else {
+            Text("Running Tasks: \(taskStatus.count)")
+              .foregroundColor(.secondary)
+          }
         }
       }
     }

--- a/KMReader/Features/Settings/Components/SettingsServerCardView.swift
+++ b/KMReader/Features/Settings/Components/SettingsServerCardView.swift
@@ -43,7 +43,7 @@ struct SettingsServerCardView: View {
           .frame(maxWidth: .infinity, alignment: .leading)
         }
 
-        ServerUpdateStatusView()
+        ServerUpdateStatusView(showsTasksLink: false)
       }
       .contentShape(Rectangle())
     }


### PR DESCRIPTION
## Summary

Fixes #1023 — the iPhone settings server card showed three directional icons at once: the outer card `NavigationLink` disclosure indicator, the nested running-tasks `NavigationLink` disclosure indicator, and a hand-written chevron inside the tasks link label.

## Changes

`ServerUpdateStatusView` gains a `showsTasksLink` flag (default `true`). `SettingsServerCardView` passes `false`, so on iPhone the card keeps only the outer disclosure indicator and the running-tasks count renders as plain text.

The tasks page remains one tap away via the Management entry in Settings. The tappable tasks link is preserved where there is no enclosing list link: the iPad/macOS/tvOS Server card and the Dashboard header.

## Validation

- `make build-ios`, `make build-macos`, `make build-tvos` all build successfully.
