### PR TITLE
fix: even out tinted dashboard card background

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 544;
+				CURRENT_PROJECT_VERSION = 545;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 544;
+				CURRENT_PROJECT_VERSION = 545;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 544;
+				CURRENT_PROJECT_VERSION = 545;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 544;
+				CURRENT_PROJECT_VERSION = 545;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Book/Views/BookHorizontalCardView.swift
+++ b/KMReader/Features/Book/Views/BookHorizontalCardView.swift
@@ -154,26 +154,20 @@ struct BookHorizontalCardView: View {
           // Overlay content never contributes to layout size, so the flexible
           // blurred image can neither inflate the card nor bleed past it.
           if let coverArtwork {
+            // No scaledToFill: stretch the whole cover into the card so the
+            // tint mixes the cover's overall tone instead of only the cropped
+            // middle strip. The heavy blur hides the distortion.
             Image(platformImage: coverArtwork)
               .resizable()
-              .scaledToFill()
+              // Overscan before blurring: the blur samples transparent black
+              // beyond the image bounds, which darkened the card edges.
+              .scaleEffect(1.3)
               .compositingGroup()
               .blur(radius: 28)
-              .saturation(0.55)
-              .overlay(
-                LinearGradient(
-                  gradient: Gradient(stops: [
-                    // Keep a minimum darkness at the top: tinted cards force
-                    // white text, so light covers still need enough overlay
-                    // for the title to stay readable.
-                    .init(color: .black.opacity(0.3), location: 0.0),
-                    .init(color: .black.opacity(0.4), location: 0.45),
-                    .init(color: .black.opacity(0.5), location: 1.0),
-                  ]),
-                  startPoint: .top,
-                  endPoint: .bottom
-                )
-              )
+              .saturation(0.7)
+              // Even dimming layer: tinted cards force white text, so light
+              // covers still need enough overlay for the title to stay readable.
+              .overlay(Color.black.opacity(0.4))
               .transition(.opacity)
           }
         }


### PR DESCRIPTION
## Summary

Polishes the tinted cover background of the dashboard horizontal book cards (Keep Reading). The tint is now even across the whole card and reflects the whole cover's tone.

## Changes

- **Fixed the black trailing edge**: SwiftUI blur samples transparent black beyond the image bounds. A portrait cover rendered with scaledToFill sat exactly on the card's left/right edges, so the blur darkened both sides; the left side was hidden behind the cover thumbnail while the right side showed as a persistent black edge. The image now overscans (scaleEffect 1.3) before blurring so the darkened edges fall outside the clipped card.
- **Tint now reflects the whole cover**: dropped scaledToFill and stretch the cover into the card instead. Previously only the cover's cropped middle strip contributed to the tint; now every part of the cover mixes in. The heavy blur hides the stretching distortion.
- **Even texture**: replaced the 0.3 → 0.5 vertical black gradient with a uniform 0.4 dimming layer, and raised saturation from 0.55 to 0.7 so the cover identity comes through more clearly. White title text stays readable on light covers.

## Validation

- make build-ios succeeds
- Verified in the iOS simulator: cards render with an even, full-cover tint and no black edge; text remains readable on both light and dark covers
