### PR TITLE
fix: stop force-casting GRDB row values (macOS launch crash)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,7 +376,7 @@ KMReader/
 ## Coding Conventions
 
 1. **Comments**: Minimal, in English only
-2. **Commit messages**: Concise, clear, semantic format, in English
+2. **Commit messages**: Concise, clear, semantic format, in English. All GitHub-facing text follows the same rule: PR titles, PR bodies, issue/PR comments, and review replies are always written in English, regardless of the conversation language.
 3. **UI framework choice**: SwiftUI, UIKit, and AppKit may all be used. Pick the approach that best fits the feature, platform APIs, and maintainability.
 4. **No inline Binding**: Avoid inline Binding usage
 5. **No confirmationDialog**: Do not use confirmationDialog

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,6 +396,7 @@ KMReader/
 19. **If a temporary compatibility layer is unavoidable, mark it explicitly**: State why it exists, what the intended final design is, and what should be removed later. Temporary layers should be rare and treated as debt, not as the default implementation style.
 20. **Keep boundary documentation current**: When a change introduces or changes a lifetime, ownership, persistence, navigation, platform, reader-mode, or UI-placement boundary, update `AGENTS.md` in the same change so the boundary remains explicit and enforceable.
 21. **No compatibility shims for OS-gated features**: Unless a feature is explicitly required, do not hand-roll fallback implementations of newer system APIs for older OS versions. Gate the feature to the OS version that supports it natively and omit it on older systems, instead of building and maintaining a parallel custom implementation.
+22. **No force casts**: Do not use `as!` in app code. A force cast that passes compilation can still crash at runtime on real data (e.g. `row["created_date"] as! Date` on a GRDB `Row` subscript, which returns the raw storage value — `String`/`Int64`/`Double`/`Data` — without conversion). For GRDB rows, bind through the generic converting subscript instead (`let created: Date = row["created_date"]`), which decodes TEXT/INTEGER storage into `Date`/`Bool`/etc. For other casts, use `as?` with an explicit fallback or `guard`.
 
 Additional patterns:
 

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 545;
+				CURRENT_PROJECT_VERSION = 546;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 545;
+				CURRENT_PROJECT_VERSION = 546;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 545;
+				CURRENT_PROJECT_VERSION = 546;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 545;
+				CURRENT_PROJECT_VERSION = 546;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 546;
+				CURRENT_PROJECT_VERSION = 547;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 546;
+				CURRENT_PROJECT_VERSION = 547;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 546;
+				CURRENT_PROJECT_VERSION = 547;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 546;
+				CURRENT_PROJECT_VERSION = 547;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/DatabaseOperator+Collections.swift
+++ b/KMReader/Core/Storage/DatabaseOperator+Collections.swift
@@ -44,12 +44,17 @@ extension DatabaseOperator {
     let items:
       [(id: String, name: String, createdDate: Date, lastModifiedDate: Date, isPinned: Bool, seriesCount: Int)] =
         rows.map { row in
-          (
-            id: row["collection_id"] as! String,
-            name: row["name"] as! String,
-            createdDate: row["created_date"] as! Date,
-            lastModifiedDate: row["last_modified_date"] as! Date,
-            isPinned: row["is_pinned"] as! Bool,
+          let id: String = row["collection_id"]
+          let name: String = row["name"]
+          let createdDate: Date = row["created_date"]
+          let lastModifiedDate: Date = row["last_modified_date"]
+          let isPinned: Bool = row["is_pinned"]
+          return (
+            id: id,
+            name: name,
+            createdDate: createdDate,
+            lastModifiedDate: lastModifiedDate,
+            isPinned: isPinned,
             seriesCount: Self.decodeJSONStringArray(row["series_ids_raw"] as? Data).count
           )
         }
@@ -97,12 +102,17 @@ extension DatabaseOperator {
       )
       let items: [(id: String, name: String, createdDate: Date, lastModifiedDate: Date, isPinned: Bool)] =
         rows.map { row in
-          (
-            id: row["collection_id"] as! String,
-            name: row["name"] as! String,
-            createdDate: row["created_date"] as! Date,
-            lastModifiedDate: row["last_modified_date"] as! Date,
-            isPinned: row["is_pinned"] as! Bool
+          let id: String = row["collection_id"]
+          let name: String = row["name"]
+          let createdDate: Date = row["created_date"]
+          let lastModifiedDate: Date = row["last_modified_date"]
+          let isPinned: Bool = row["is_pinned"]
+          return (
+            id: id,
+            name: name,
+            createdDate: createdDate,
+            lastModifiedDate: lastModifiedDate,
+            isPinned: isPinned
           )
         }
       let filtered =
@@ -275,13 +285,19 @@ extension DatabaseOperator {
     )
     let items: [(id: String, name: String, createdDate: Date, lastModifiedDate: Date, isPinned: Bool, bookCount: Int)] =
       rows.map { row in
-        (
-          id: row["read_list_id"] as! String,
-          name: row["name"] as! String,
-          createdDate: row["created_date"] as! Date,
-          lastModifiedDate: row["last_modified_date"] as! Date,
-          isPinned: row["is_pinned"] as! Bool,
-          bookCount: row["book_count"] as! Int
+        let id: String = row["read_list_id"]
+        let name: String = row["name"]
+        let createdDate: Date = row["created_date"]
+        let lastModifiedDate: Date = row["last_modified_date"]
+        let isPinned: Bool = row["is_pinned"]
+        let bookCount: Int = row["book_count"]
+        return (
+          id: id,
+          name: name,
+          createdDate: createdDate,
+          lastModifiedDate: lastModifiedDate,
+          isPinned: isPinned,
+          bookCount: bookCount
         )
       }
     return Self.sortedByBrowseOrder(
@@ -327,13 +343,19 @@ extension DatabaseOperator {
       let items:
         [(id: String, name: String, summary: String, createdDate: Date, lastModifiedDate: Date, isPinned: Bool)] =
           rows.map { row in
-            (
-              id: row["read_list_id"] as! String,
-              name: row["name"] as! String,
-              summary: row["summary"] as! String,
-              createdDate: row["created_date"] as! Date,
-              lastModifiedDate: row["last_modified_date"] as! Date,
-              isPinned: row["is_pinned"] as! Bool
+            let id: String = row["read_list_id"]
+            let name: String = row["name"]
+            let summary: String = row["summary"]
+            let createdDate: Date = row["created_date"]
+            let lastModifiedDate: Date = row["last_modified_date"]
+            let isPinned: Bool = row["is_pinned"]
+            return (
+              id: id,
+              name: name,
+              summary: summary,
+              createdDate: createdDate,
+              lastModifiedDate: lastModifiedDate,
+              isPinned: isPinned
             )
           }
       let filtered =

--- a/KMReader/Features/Collection/ViewModels/CollectionsViewModel.swift
+++ b/KMReader/Features/Collection/ViewModels/CollectionsViewModel.swift
@@ -68,11 +68,13 @@ class CollectionsViewModel {
       if refresh {
         serverPage = 0
         if let database = try? await DatabaseOperator.database() {
-          pinnedIds = await database.fetchPinnedCollectionIds(
+          let pinned = await database.fetchPinnedCollectionIds(
             instanceId: instanceId,
             searchText: searchText,
             sort: sort
           )
+          guard loadID == pagination.loadID else { return }
+          pinnedIds = pinned
         }
       }
       do {
@@ -93,6 +95,8 @@ class CollectionsViewModel {
         guard loadID == pagination.loadID else { return }
         if refresh {
           ErrorManager.shared.alert(error: error)
+        } else {
+          pagination.hasMorePages = false
         }
       }
     }
@@ -128,7 +132,15 @@ class CollectionsViewModel {
   }
 
   private func applyPage(ids: [String], moreAvailable: Bool) {
-    let wrappedIds = ids.map(IdentifiedString.init)
+    // Appended pages dedupe against loaded items: the server stream can shift
+    // between page fetches, and duplicate ids break ForEach.
+    let wrappedIds: [IdentifiedString]
+    if pagination.currentPage == 0 {
+      wrappedIds = ids.map(IdentifiedString.init)
+    } else {
+      let loaded = Set(pagination.items.map(\.id))
+      wrappedIds = ids.filter { !loaded.contains($0) }.map(IdentifiedString.init)
+    }
     withAnimation {
       _ = pagination.applyPage(wrappedIds)
     }

--- a/KMReader/Features/ReadList/ViewModels/ReadListsViewModel.swift
+++ b/KMReader/Features/ReadList/ViewModels/ReadListsViewModel.swift
@@ -68,11 +68,13 @@ class ReadListsViewModel {
       if refresh {
         serverPage = 0
         if let database = try? await DatabaseOperator.database() {
-          pinnedIds = await database.fetchPinnedReadListIds(
+          let pinned = await database.fetchPinnedReadListIds(
             instanceId: instanceId,
             searchText: searchText,
             sort: sort
           )
+          guard loadID == pagination.loadID else { return }
+          pinnedIds = pinned
         }
       }
       do {
@@ -93,6 +95,8 @@ class ReadListsViewModel {
         guard loadID == pagination.loadID else { return }
         if refresh {
           ErrorManager.shared.alert(error: error)
+        } else {
+          pagination.hasMorePages = false
         }
       }
     }
@@ -128,7 +132,15 @@ class ReadListsViewModel {
   }
 
   private func applyPage(ids: [String], moreAvailable: Bool) {
-    let wrappedIds = ids.map(IdentifiedString.init)
+    // Appended pages dedupe against loaded items: the server stream can shift
+    // between page fetches, and duplicate ids break ForEach.
+    let wrappedIds: [IdentifiedString]
+    if pagination.currentPage == 0 {
+      wrappedIds = ids.map(IdentifiedString.init)
+    } else {
+      let loaded = Set(pagination.items.map(\.id))
+      wrappedIds = ids.filter { !loaded.contains($0) }.map(IdentifiedString.init)
+    }
     withAnimation {
       _ = pagination.applyPage(wrappedIds)
     }


### PR DESCRIPTION
## Problem

Launch crash on macOS (and iPad): `swift_dynamicCastFailure` on `GRDB.DatabaseQueue` → SIGABRT.

The 6.3 paginated-browsing commit (ec02d799) added four lightweight row readers (`sidebarCollectionRows`, `sidebarReadListRows`, `fetchAllCollectionIds`, `fetchAllReadListIds`) using force casts like `row["col"] as! Date/Bool`. GRDB's bare `Row` subscript returns raw storage values (TEXT → `String`, INTEGER → `Int64`) without conversion, so `String as! Date` fails deterministically for any stored collection/read list. Sidebar fetches only run in the macOS/iPad split view, which is why only those platforms crash at launch.

## Fix

- Replace all 20 force casts with typed bindings (`let created: Date = row["created_date"]`) so GRDB's generic converting subscript decodes TEXT→Date and INTEGER→Bool correctly

## Pagination hardening

- Guard the `pinnedIds` assignment with loadID so a slower superseded refresh cannot overwrite a newer one
- Dedupe appended pages against loaded ids so a shifting server stream cannot feed duplicate ids to `ForEach`
- Set `hasMorePages = false` after a failed non-refresh page load to stop scroll-triggered retries

## Repository rule

- AGENTS.md convention 22: force casts (`as!`) are banned in app code, with the correct GRDB row pattern documented

## Validation

- `make build` passes on all platforms (iOS / macOS / tvOS)
- Ran the macOS build locally against the exact database from the crash: survives well past the original ~3s crash point, Dashboard and sidebar Collections render correctly, no new crash reports

Build number bumped twice (545 → 547) to skip 546, which was already uploaded before the force push.
