### PR TITLE
fix(reader): surface full ArchiveError details for EPUB failures

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 547;
+				CURRENT_PROJECT_VERSION = 548;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 547;
+				CURRENT_PROJECT_VERSION = 548;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 547;
+				CURRENT_PROJECT_VERSION = 548;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 547;
+				CURRENT_PROJECT_VERSION = 548;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Storage/Errors/Error+DiagnosticDescription.swift
+++ b/KMReader/Core/Storage/Errors/Error+DiagnosticDescription.swift
@@ -1,0 +1,25 @@
+//
+// Error+DiagnosticDescription.swift
+//
+//
+
+import Foundation
+
+extension Error {
+  /// True for pure Swift errors that do not implement `LocalizedError` and
+  /// bridge to NSError with a generic "The operation couldn't be completed.
+  /// (Module.Type error N.)" message that drops the case name and its payload
+  /// (e.g. `LibArchive.ArchiveError`).
+  nonisolated var isGenericBridgedSwiftError: Bool {
+    guard !(self is LocalizedError) else { return false }
+    return (self as NSError).domain == String(reflecting: type(of: self))
+  }
+
+  /// Description for logs and diagnostics. For generic bridged Swift errors,
+  /// returns the full `String(describing:)` dump (e.g.
+  /// `readFailed(message: "Truncated ZIP file body")`) instead of the generic
+  /// bridged message.
+  nonisolated var diagnosticDescription: String {
+    isGenericBridgedSwiftError ? String(describing: self) : localizedDescription
+  }
+}

--- a/KMReader/Core/Storage/Errors/ErrorManager.swift
+++ b/KMReader/Core/Storage/Errors/ErrorManager.swift
@@ -77,6 +77,12 @@ class ErrorManager {
       return appError.description
     }
 
+    // Pure Swift errors without LocalizedError (e.g. LibArchive.ArchiveError)
+    // bridge to a generic message that hides the case name and payload.
+    if error.isGenericBridgedSwiftError {
+      return String(describing: error)
+    }
+
     // Convert NSError to AppErrorType and handle
     if let nsError = error as NSError? {
       let appError = AppErrorType.from(nsError)

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -1036,7 +1036,7 @@ actor OfflineManager {
         try? await DatabaseOperator.database().updateBookDownloadStatus(
           bookId: info.bookId,
           instanceId: instanceId,
-          status: .failed(error: error.localizedDescription)
+          status: .failed(error: error.diagnosticDescription)
         )
         await postDownloadProjectionDidChange(bookId: info.bookId, instanceId: instanceId)
         await refreshQueueStatus(instanceId: instanceId)
@@ -1392,7 +1392,7 @@ actor OfflineManager {
             try? await DatabaseOperator.database().updateBookDownloadStatus(
               bookId: info.bookId,
               instanceId: instanceId,
-              status: .failed(error: error.localizedDescription)
+              status: .failed(error: error.diagnosticDescription)
             )
             await self.postDownloadProjectionDidChange(bookId: info.bookId, instanceId: instanceId)
             await self.refreshQueueStatus(instanceId: instanceId)
@@ -1689,12 +1689,21 @@ actor OfflineManager {
     }
 
     try Task.checkCancellation()
-    try extractEpubToWebPub(
-      epubFile: epubFile,
-      bookId: info.bookId,
-      manifest: manifest,
-      bookDir: bookDir
-    )
+    do {
+      try extractEpubToWebPub(
+        epubFile: epubFile,
+        bookId: info.bookId,
+        manifest: manifest,
+        bookDir: bookDir
+      )
+    } catch {
+      let fileSize =
+        (try? epubFile.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? -1
+      logger.error(
+        "❌ EPUB WebPub extraction failed for book \(info.bookId), epubFile=\(epubFile.lastPathComponent), epubFileSize=\(fileSize), error=\(error.diagnosticDescription)"
+      )
+      throw error
+    }
     try Task.checkCancellation()
     do {
       try FileManager.default.removeItem(at: epubFile)
@@ -2193,7 +2202,7 @@ actor OfflineManager {
       try? await DatabaseOperator.database().updateBookDownloadStatus(
         bookId: bookId,
         instanceId: info.instanceId,
-        status: .failed(error: error.localizedDescription)
+        status: .failed(error: error.diagnosticDescription)
       )
       await postDownloadProjectionDidChange(bookId: bookId, instanceId: info.instanceId)
       await refreshQueueStatus(instanceId: info.instanceId)

--- a/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
+++ b/KMReader/Features/Reader/ViewModels/EpubReaderViewModel.swift
@@ -348,12 +348,12 @@
         loadingStage = .idle
         isLoading = false
       } catch {
-        let message = error.localizedDescription
+        let message = error.diagnosticDescription
         errorMessage = message
         ErrorManager.shared.alert(error: error)
         loadingStage = .idle
         isLoading = false
-        logger.error("WebPub load failed: \(message)")
+        logger.error("WebPub load failed for book \(bookId): \(error.diagnosticDescription)")
       }
     }
 


### PR DESCRIPTION
## Problem

A user reported that opening EPUB files fails with a bare `LibArchive.ArchiveError` message on iPad, while the same books open fine in the Komga WebUI and other readers.

`LibArchive.ArchiveError` is a pure Swift error enum without `LocalizedError`, so it bridges to a generic "The operation couldn't be completed. (LibArchive.ArchiveError error N.)" message. The failing case (corrupt download, disk-full write failure, unsafe entry path, etc.) and the underlying libarchive reason are dropped everywhere — in the reader error view, in `ErrorManager` alerts, in persisted download failure messages, and even in the app logs on the reader-open path (which logged only `localizedDescription`).

## Changes

- New `Error.isGenericBridgedSwiftError` / `Error.diagnosticDescription`: detects pure Swift errors that bridge to the generic NSError message and returns the full case dump instead (e.g. `readFailed(message: "Truncated ZIP file body")`). All other errors keep their existing localized text.
- `ErrorManager.handleError` shows the full case detail in alerts for these errors, so user screenshots and reports carry the actual cause.
- The EPUB reader's error message and load-failure log use `diagnosticDescription`, and the log now includes the bookId.
- `prepareOfflineWebPubIfNeeded` logs extraction failures with bookId, epub file name, and file size before rethrowing.
- The three persisted download `.failed(error:)` messages store `diagnosticDescription`, so the offline tasks view and reader-open recovery errors show the detail too.

## Validation

- `make build-ios`, `make build-macos`, `make build-tvos` all succeed.
