### PR TITLE
chore(offline): log epub file size and magic bytes on extraction failure

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 548;
+				CURRENT_PROJECT_VERSION = 549;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 548;
+				CURRENT_PROJECT_VERSION = 549;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 548;
+				CURRENT_PROJECT_VERSION = 549;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 548;
+				CURRENT_PROJECT_VERSION = 549;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Features/Offline/Services/OfflineManager.swift
+++ b/KMReader/Features/Offline/Services/OfflineManager.swift
@@ -1699,8 +1699,15 @@ actor OfflineManager {
     } catch {
       let fileSize =
         (try? epubFile.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? -1
+      var magicHex = "unreadable"
+      if let handle = try? FileHandle(forReadingFrom: epubFile) {
+        if let head = try? handle.read(upToCount: 16), !head.isEmpty {
+          magicHex = head.map { String(format: "%02x", $0) }.joined()
+        }
+        try? handle.close()
+      }
       logger.error(
-        "❌ EPUB WebPub extraction failed for book \(info.bookId), epubFile=\(epubFile.lastPathComponent), epubFileSize=\(fileSize), error=\(error.diagnosticDescription)"
+        "❌ EPUB WebPub extraction failed for book \(info.bookId), epubFile=\(epubFile.lastPathComponent), epubFileSize=\(fileSize), magic=\(magicHex), error=\(error.diagnosticDescription)"
       )
       throw error
     }


### PR DESCRIPTION
## Context

Follow-up to #1031. A user on iPadOS 17 reports every EPUB failing to open with `LibArchive.ArchiveError error 1`. That code maps to `cannotOpenArchive` — the downloaded `.epub` on the device cannot be opened as an archive at all (truncated/corrupt file, or content that is not a ZIP). The same files (including a stock Project Gutenberg EPUB) extract fine locally, and HTTP status is already validated during download, so the remaining unknown is what actually landed on disk.

## Change

When EPUB WebPub extraction fails, the error log now also records the downloaded file's size and its first 16 bytes (hex). A valid EPUB starts with `504b0304` (PK\x03\x04); a leading `3c` (`<`) means an HTML error page was saved as `.epub`; a valid header with a short file means truncation. Together with the full `cannotOpenArchive(path:, message:)` case detail from #1031, one log export pinpoints the failure.

## Validation

- `make build-ios` succeeds.
