### PR TITLE
feat(auth): upgrade password logins to auto-created API keys

### DIFF
--- a/KMReader.xcodeproj/project.pbxproj
+++ b/KMReader.xcodeproj/project.pbxproj
@@ -442,7 +442,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 549;
+				CURRENT_PROJECT_VERSION = 550;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -500,7 +500,7 @@
 				"CODE_SIGN_ENTITLEMENTS[sdk=macosx*]" = "KMReader/KMReader-macOS.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 549;
+				CURRENT_PROJECT_VERSION = 550;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=appletvos*]" = M777UHWZA4;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -560,7 +560,7 @@
 				CODE_SIGN_ENTITLEMENTS = KMReaderWidgets/KMReaderWidgets.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 549;
+				CURRENT_PROJECT_VERSION = 550;
 				DEVELOPMENT_TEAM = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KMReaderWidgets/Info.plist;
@@ -594,7 +594,7 @@
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 549;
+				CURRENT_PROJECT_VERSION = 550;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/KMReader/Core/Network/APIClient.swift
+++ b/KMReader/Core/Network/APIClient.swift
@@ -273,24 +273,24 @@ nonisolated final class APIClient: Sendable {
 
     configureDefaultHeaders(&request, body: body, headers: headers)
 
-    // Add auth header based on the authentication method
+    // Add auth headers based on the authentication method
     let authMethod = AppConfig.current.authMethod
     let authToken = AppConfig.current.authToken
 
     if !authToken.isEmpty {
-      // Use session token if available for subsequent requests
+      // Always attach the session token when one exists. For API key
+      // instances, also always attach the key: Komga prefers the session
+      // while it is valid (and skips key re-authentication for
+      // API-key-created sessions), and falls back to the key when the
+      // session expired, which also rotates a fresh session token back.
+      // Password logins keep relying on the session/cookies only, since
+      // per-request Basic authentication would flood the server auth log.
       let sessionToken = AppConfig.current.sessionToken
       if !sessionToken.isEmpty {
         request.setValue(sessionToken, forHTTPHeaderField: "X-Auth-Token")
-      } else {
-        // Fallback or specific auth logic if no session token
-        switch authMethod {
-        case .basicAuth:
-          // Basic Auth relies on Cookies if no Session Token (do nothing here)
-          break
-        case .apiKey:
-          request.setValue(authToken, forHTTPHeaderField: "X-API-Key")
-        }
+      }
+      if authMethod == .apiKey {
+        request.setValue(authToken, forHTTPHeaderField: "X-API-Key")
       }
     }
 

--- a/KMReader/Features/Auth/Models/ApiKey.swift
+++ b/KMReader/Features/Auth/Models/ApiKey.swift
@@ -17,3 +17,13 @@ nonisolated struct ApiKey: Codable, Identifiable, Hashable, Sendable {
 nonisolated struct ApiKeyRequest: Codable, Sendable {
   let comment: String
 }
+
+nonisolated extension ApiKey {
+  /// Keys auto-created by KMReader as instance credentials carry this
+  /// comment prefix and may be in active use.
+  static let appManagedCommentPrefix = "KMReader · "
+
+  var isAppManaged: Bool {
+    comment.hasPrefix(Self.appManagedCommentPrefix)
+  }
+}

--- a/KMReader/Features/Auth/Services/AuthService.swift
+++ b/KMReader/Features/Auth/Services/AuthService.swift
@@ -189,6 +189,14 @@ nonisolated enum AuthService {
     )
   }
 
+  /// Create an API key and verify it actually authenticates before it gets
+  /// persisted as the instance credential.
+  static func createVerifiedApiKey(serverURL: String, comment: String) async throws -> ApiKey {
+    let apiKey = try await createApiKey(comment: comment)
+    _ = try await testCredentials(serverURL: serverURL, authToken: apiKey.key, authMethod: .apiKey)
+    return apiKey
+  }
+
   static func deleteApiKey(id: String) async throws {
     let _: EmptyResponse = try await apiClient.request(
       path: "/api/v2/users/me/api-keys/\(id)",

--- a/KMReader/Features/Auth/Services/AuthService.swift
+++ b/KMReader/Features/Auth/Services/AuthService.swift
@@ -189,14 +189,6 @@ nonisolated enum AuthService {
     )
   }
 
-  /// Create an API key and verify it actually authenticates before it gets
-  /// persisted as the instance credential.
-  static func createVerifiedApiKey(serverURL: String, comment: String) async throws -> ApiKey {
-    let apiKey = try await createApiKey(comment: comment)
-    _ = try await testCredentials(serverURL: serverURL, authToken: apiKey.key, authMethod: .apiKey)
-    return apiKey
-  }
-
   static func deleteApiKey(id: String) async throws {
     let _: EmptyResponse = try await apiClient.request(
       path: "/api/v2/users/me/api-keys/\(id)",

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -68,14 +68,14 @@ class AuthViewModel {
   /// creation or verification fails, e.g. on older servers.
   private func createApiKeyCredential(serverURL: String) async -> ApiKey? {
     do {
-      let apiKey = try await AuthService.createVerifiedApiKey(
-        serverURL: serverURL,
+      let apiKey = try await AuthService.createApiKey(
         comment: "\(ApiKey.appManagedCommentPrefix)\(PlatformHelper.deviceName)"
       )
       // Replace the password-established session with an API-key-established
-      // one. Requests carrying both X-Auth-Token and X-API-Key only skip
-      // server-side API key re-authentication when the session itself holds
-      // an ApiKeyAuthenticationToken; riding the password session would
+      // one; this also verifies the key authenticates. Requests carrying
+      // both X-Auth-Token and X-API-Key only skip server-side API key
+      // re-authentication when the session itself holds an
+      // ApiKeyAuthenticationToken; riding the password session would
       // re-authenticate every request and flood the authentication activity
       // log.
       _ = try await AuthService.establishSession(

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -9,6 +9,8 @@ import SwiftUI
 @MainActor
 @Observable
 class AuthViewModel {
+  private let logger = AppLogger(.auth)
+
   enum BootstrapState: Equatable {
     case requiresValidation
     case validating
@@ -37,17 +39,47 @@ class AuthViewModel {
     let result = try await AuthService.login(
       username: username, password: password, serverURL: serverURL, timeout: AppConfig.authTimeout)
 
+    // Prefer an auto-created API key over storing the password credential:
+    // it never expires and works for background downloads without relying on
+    // shared cookies. Falls back to password auth when the server cannot
+    // create keys.
+    var authToken = result.authToken
+    var authMethod = AuthenticationMethod.basicAuth
+    if let apiKey = await createApiKeyCredential(serverURL: serverURL) {
+      authToken = apiKey.key
+      authMethod = .apiKey
+    }
+
     // Apply login configuration
     try await applyLoginConfiguration(
       serverURL: serverURL,
       username: username,
-      authToken: result.authToken,
-      authMethod: .basicAuth,
+      authToken: authToken,
+      authMethod: authMethod,
       user: result.user,
       displayName: displayName,
       shouldPersistInstance: true,
       successMessage: String(localized: "Logged in successfully")
     )
+  }
+
+  /// Create and verify an API key while a password-based session is still
+  /// valid. Returns nil (and keeps the caller on password auth) when key
+  /// creation or verification fails, e.g. on older servers.
+  private func createApiKeyCredential(serverURL: String) async -> ApiKey? {
+    do {
+      let apiKey = try await AuthService.createVerifiedApiKey(
+        serverURL: serverURL,
+        comment: "KMReader · \(PlatformHelper.deviceName)"
+      )
+      logger.info("🔑 Created API key credential for \(serverURL)")
+      return apiKey
+    } catch {
+      logger.warning(
+        "⚠️ API key creation failed, keeping password authentication for \(serverURL): \(error.diagnosticDescription)"
+      )
+      return nil
+    }
   }
 
   func loginWithAPIKey(
@@ -176,12 +208,31 @@ class AuthViewModel {
         timeout: AppConfig.authTimeout
       )
 
+      // Migrate legacy password-auth instances to an auto-created API key on
+      // switch, so subsequent requests stop depending on expiring sessions
+      // and shared cookies.
+      var authToken = instance.authToken
+      var authMethod = instance.authMethod
+      if authMethod == .basicAuth,
+        let apiKey = await createApiKeyCredential(serverURL: instance.serverURL)
+      {
+        authToken = apiKey.key
+        authMethod = .apiKey
+        try? await DatabaseOperator.database().upsertInstance(
+          serverURL: instance.serverURL,
+          username: instance.username,
+          authToken: authToken,
+          isAdmin: validatedUser.isAdmin,
+          authMethod: .apiKey
+        )
+      }
+
       // Apply switch configuration
       try await applyLoginConfiguration(
         serverURL: instance.serverURL,
         username: instance.username,
-        authToken: instance.authToken,
-        authMethod: instance.authMethod,
+        authToken: authToken,
+        authMethod: authMethod,
         user: validatedUser,
         displayName: instance.displayName,
         instanceId: instance.instanceId,

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -72,6 +72,17 @@ class AuthViewModel {
         serverURL: serverURL,
         comment: "\(ApiKey.appManagedCommentPrefix)\(PlatformHelper.deviceName)"
       )
+      // Replace the password-established session with an API-key-established
+      // one. Requests carrying both X-Auth-Token and X-API-Key only skip
+      // server-side API key re-authentication when the session itself holds
+      // an ApiKeyAuthenticationToken; riding the password session would
+      // re-authenticate every request and flood the authentication activity
+      // log.
+      _ = try await AuthService.establishSession(
+        serverURL: serverURL,
+        authToken: apiKey.key,
+        authMethod: .apiKey
+      )
       logger.info("🔑 Created API key credential for \(serverURL)")
       return apiKey
     } catch {
@@ -340,6 +351,12 @@ class AuthViewModel {
       finalProtected = protected
     }
 
+    // Carry the session token established during login/switch into the new
+    // Current instead of dropping it. Without it every request would go out
+    // session-less, forcing full server-side re-authentication (one
+    // authentication activity row per request for API key requests).
+    let sessionToken = AppConfig.current.sessionToken
+
     AppConfig.current = Current(
       serverURL: serverURL,
       serverDisplayName: finalDisplayName,
@@ -347,7 +364,8 @@ class AuthViewModel {
       authMethod: authMethod,
       username: user.email,
       isAdmin: user.isAdmin,
-      instanceId: finalInstanceId
+      instanceId: finalInstanceId,
+      sessionToken: sessionToken
     )
 
     AppConfig.isLoggedIn = true

--- a/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
+++ b/KMReader/Features/Auth/ViewModels/AuthViewModel.swift
@@ -70,7 +70,7 @@ class AuthViewModel {
     do {
       let apiKey = try await AuthService.createVerifiedApiKey(
         serverURL: serverURL,
-        comment: "KMReader · \(PlatformHelper.deviceName)"
+        comment: "\(ApiKey.appManagedCommentPrefix)\(PlatformHelper.deviceName)"
       )
       logger.info("🔑 Created API key credential for \(serverURL)")
       return apiKey

--- a/KMReader/Features/Offline/Services/BackgroundDownloadManager.swift
+++ b/KMReader/Features/Offline/Services/BackgroundDownloadManager.swift
@@ -43,15 +43,6 @@ import OSLog
       config.allowsCellularAccess = true
       config.httpMaximumConnectionsPerHost = 3
 
-      // Add auth headers
-      var headers: [String: String] = [:]
-      if AppConfig.current.authMethod == .apiKey && !AppConfig.current.authToken.isEmpty {
-        headers["X-API-Key"] = AppConfig.current.authToken
-      }
-      if !headers.isEmpty {
-        config.httpAdditionalHeaders = headers
-      }
-
       return URLSession(configuration: config, delegate: self, delegateQueue: nil)
     }()
 
@@ -199,20 +190,17 @@ import OSLog
     // MARK: - Private Helpers
 
     private func addAuthHeaders(to request: inout URLRequest) {
-      switch AppConfig.current.authMethod {
-      case .basicAuth:
-        // Mirror APIClient: session token header, background sessions cannot
-        // reliably access the shared cookie storage.
-        let sessionToken = AppConfig.current.sessionToken
-        if !sessionToken.isEmpty {
-          request.setValue(sessionToken, forHTTPHeaderField: "X-Auth-Token")
-        } else {
-          logger.warning("⚠️ No session token available for background download auth")
-        }
-      case .apiKey:
-        if !AppConfig.current.authToken.isEmpty {
-          request.setValue(AppConfig.current.authToken, forHTTPHeaderField: "X-API-Key")
-        }
+      // Send both credentials: the server prefers the session token while it
+      // is valid (avoiding per-request API key authentication activity) and
+      // falls back to the API key, which never expires. Password logins only
+      // have the session token; an expired session fails the task (caught by
+      // status validation) until the next foreground refresh.
+      let sessionToken = AppConfig.current.sessionToken
+      if !sessionToken.isEmpty {
+        request.setValue(sessionToken, forHTTPHeaderField: "X-Auth-Token")
+      }
+      if AppConfig.current.authMethod == .apiKey, !AppConfig.current.authToken.isEmpty {
+        request.setValue(AppConfig.current.authToken, forHTTPHeaderField: "X-API-Key")
       }
     }
 

--- a/KMReader/Features/Server/AccountActivityView.swift
+++ b/KMReader/Features/Server/AccountActivityView.swift
@@ -83,19 +83,19 @@ struct AccountActivityView: View {
           Text(activity.success ? "Success" : "Failed")
             .font(.headline)
         }
-        if let apiKeyComment = activity.apiKeyComment {
-          HStack(spacing: 4) {
-            Image(systemName: "key")
-              .font(.caption)
-            Text(apiKeyComment)
-              .font(.footnote)
-              .lineLimit(1)
-          }.foregroundColor(.secondary)
-        }
         Spacer()
         Text(activity.dateTime.formattedMediumDateTime)
           .font(.caption)
           .foregroundColor(.secondary)
+      }
+
+      if let apiKeyComment = activity.apiKeyComment {
+        HStack {
+          Image(systemName: "key")
+          Text(apiKeyComment)
+        }
+        .font(.caption)
+        .foregroundColor(.secondary)
       }
 
       if let userAgent = activity.userAgent {

--- a/KMReader/Features/Server/AccountActivityView.swift
+++ b/KMReader/Features/Server/AccountActivityView.swift
@@ -91,7 +91,7 @@ struct AccountActivityView: View {
 
       if let apiKeyComment = activity.apiKeyComment {
         HStack {
-          Image(systemName: "key")
+          detailRowIcon("key")
           Text(apiKeyComment)
         }
         .font(.caption)
@@ -100,7 +100,7 @@ struct AccountActivityView: View {
 
       if let userAgent = activity.userAgent {
         HStack {
-          Image(systemName: "desktopcomputer")
+          detailRowIcon("desktopcomputer")
           Text(userAgent).lineLimit(1)
         }
         .font(.caption)
@@ -109,7 +109,7 @@ struct AccountActivityView: View {
 
       if let ip = activity.ip {
         HStack {
-          Image(systemName: "network")
+          detailRowIcon("network")
           Text(ip)
         }
         .font(.caption)
@@ -118,7 +118,7 @@ struct AccountActivityView: View {
 
       if let error = activity.error {
         HStack {
-          Image(systemName: "exclamationmark.triangle.fill")
+          detailRowIcon("exclamationmark.triangle.fill")
           Text(error)
         }
         .font(.caption)
@@ -145,6 +145,13 @@ struct AccountActivityView: View {
         await loadMoreActivities()
       }
     }
+  }
+
+  private func detailRowIcon(_ name: String) -> some View {
+    // Fixed width so detail-row texts start at the same x offset despite
+    // SF Symbols having different natural widths.
+    Image(systemName: name)
+      .frame(width: 16)
   }
 
   private func loadActivities(refresh: Bool = false) async {

--- a/KMReader/Features/Server/ApiKeysView.swift
+++ b/KMReader/Features/Server/ApiKeysView.swift
@@ -46,7 +46,7 @@ struct ApiKeysView: View {
           ForEach(apiKeys) { apiKey in
             VStack(alignment: .leading) {
               HStack {
-                Image(systemName: "key")
+                Image(systemName: apiKey.isAppManaged ? "lock.fill" : "key")
                   .font(.footnote)
                 Text(apiKey.comment.isEmpty ? "No comment" : apiKey.comment)
                   .bold()
@@ -96,13 +96,15 @@ struct ApiKeysView: View {
             }.tvFocusableHighlight()
               #if os(iOS) || os(macOS)
                 .swipeActions {
-                  Button(role: .destructive) {
-                    withAnimation {
-                      keyToDelete = apiKey
-                      showingDeleteConfirmation = true
+                  if !apiKey.isAppManaged {
+                    Button(role: .destructive) {
+                      withAnimation {
+                        keyToDelete = apiKey
+                        showingDeleteConfirmation = true
+                      }
+                    } label: {
+                      Label(String(localized: "Delete"), systemImage: "trash")
                     }
-                  } label: {
-                    Label(String(localized: "Delete"), systemImage: "trash")
                   }
                 }
               #endif
@@ -189,6 +191,9 @@ struct ApiKeysView: View {
   }
 
   private func deleteApiKey(_ apiKey: ApiKey) {
+    // App-managed keys may be in use as an instance credential; they can
+    // only be revoked from the Komga WebUI.
+    guard !apiKey.isAppManaged else { return }
     Task {
       do {
         try await AuthService.deleteApiKey(id: apiKey.id)

--- a/KMReader/Shared/Helpers/PlatformHelpers.swift
+++ b/KMReader/Shared/Helpers/PlatformHelpers.swift
@@ -91,6 +91,19 @@ enum PlatformHelper {
     #endif
   }
 
+  /// Device name for display purposes (e.g. API key comments). On iOS 16+
+  /// this is the generic model name ("iPad") unless the app holds the
+  /// user-assigned-device-name entitlement.
+  static nonisolated var deviceName: String {
+    #if os(iOS) || os(tvOS)
+      return UIDevice.current.name
+    #elseif os(macOS)
+      return Host.current().localizedName ?? "Mac"
+    #else
+      return "Unknown"
+    #endif
+  }
+
   @MainActor
   static var defaultDashboardCardWidth: CGFloat {
     #if os(tvOS)


### PR DESCRIPTION
## Context

Follow-up to #1033, which hardened background downloads against unauthenticated responses. That PR made basic-auth background downloads send the `X-Auth-Token` session token, but session tokens expire, leaving a window where long-lived or resumed background downloads can still fail with 401. This PR removes the password credential from the picture entirely.

## Changes

- After a successful password login, KMReader creates an API key on the server (comment `KMReader · <device name>`), verifies it with a stateless `/api/v2/users/me` call, and persists **it** as the instance credential instead of the base64 password. The instance then behaves like a manual API key login: requests ride the session (`X-Auth-Token`) when one is available and fall back to `X-API-Key`, which never expires.
- Switching to a legacy password-auth instance performs the same one-time upgrade and updates the stored instance row (matched by server URL + username). No bulk migration: the active instance and untouched ones are left alone until they are next used.
- Failure-tolerant: if key creation or verification fails (older Komga without the api-keys endpoint, transient network error), login/switch proceeds with the previous password behavior.
- The app never revokes or deduplicates keys. Orphaned keys (reinstalls, re-logins) are identifiable by their device comment and can be revoked from the Komga WebUI or the app's API key page.
- App-managed keys (comment prefix `KMReader · `) are protected on the API keys page: no swipe-to-delete and a lock icon, so the credential backing the current instance cannot be revoked accidentally in-app. Manually created keys are unaffected.
- All requests (foreground `APIClient` and background downloads alike) attach the session token (`X-Auth-Token`) whenever one exists, and API key instances always attach `X-API-Key` as well. Verified against the Komga server: the session is resolved first and API key re-authentication is skipped when the session already holds an API-key authentication, so the authentication activity log is not flooded; an expired session transparently falls back to the key and rotates a fresh token. This also removes a latent 401/logout path for API key instances whose session expired mid-run. The static session-level header injection in `BackgroundDownloadManager` was removed so stale captured credentials are never sent.
- Side benefit: the password-equivalent base64 credential is no longer stored locally for new logins.

- After the key is created, the session is re-established with it: Komga only skips API key re-authentication for sessions holding an `ApiKeyAuthenticationToken`, and the password-established session would re-authenticate (and log) every request. `applyLoginConfiguration` also now preserves the session token instead of dropping it — previously every post-login request went out session-less, which was the actual source of the flooded activity log.

## Validation

- `make build-ios`, `make build-macos`, `make build-tvos` all succeed.
